### PR TITLE
Add Claude Code project permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,13 @@
       "Read(**/terraform.tfstate.backup)",
       "Read(**/terraform.tfvars)",
       "Read(**/*.tfvars)",
+      "Read(**/.aws/credentials)",
+      "Read(**/.ssh/id_*)",
+      "Read(**/.ssh/authorized_keys)",
+      "Read(**/service-account*.json)",
+      "Read(**/*-service-account*.json)",
+      "Read(**/.npmrc)",
+      "Read(**/.docker/config.json)",
       "Edit(**/.env)",
       "Edit(**/.env.*)",
       "Edit(**/secrets/**)",
@@ -35,7 +42,16 @@
       "Edit(**/terraform.tfstate)",
       "Edit(**/terraform.tfstate.backup)",
       "Edit(**/terraform.tfvars)",
-      "Edit(**/*.tfvars)"
+      "Edit(**/*.tfvars)",
+      "Edit(**/.aws/credentials)",
+      "Edit(**/.aws/config)",
+      "Edit(**/.ssh/id_*)",
+      "Edit(**/.ssh/config)",
+      "Edit(**/.ssh/authorized_keys)",
+      "Edit(**/service-account*.json)",
+      "Edit(**/*-service-account*.json)",
+      "Edit(**/.npmrc)",
+      "Edit(**/.docker/config.json)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Adds Claude Code permissions configuration to ensure contributors have a smooth experience while maintaining security.

## Changes
- Add `.claude/settings.json` with safe auto-approved commands and deny rules

### Auto-Approved Commands
Commands that don't require permission prompts:
- **Git read-only operations**: `status`, `diff`, `log`, `show`, `branch --list`, `remote -v`
- **Basic system info**: `pwd`, `which`, `whoami`

All write operations (commits, pushes, installs, file edits) still require approval.

### Protected Files
Automatically deny access to sensitive files:
- Environment variables: `.env`, `.env.*`
- Secrets directory: `secrets/**`
- Credentials: `credentials.json`
- Cryptographic keys: `*.pem`, `*.key`, `*-key.json`
- Terraform state/vars: `*.tfstate`, `*.tfvars`

## Benefits
- **Smooth workflow**: No permission prompts for common read-only operations
- **Team consistency**: All contributors get the same baseline permissions
- **Security by default**: Sensitive files are protected even if contributors haven't configured global deny rules
- **Self-documenting**: Shows team conventions for naming sensitive files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new static settings file that defines access controls: a whitelist permitting specific shell commands and a deny list blocking access to sensitive items (environment variables, secrets, credentials, keys, infrastructure state, service account and registry configs).
  * No runtime code changes; configuration only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->