### PR TITLE
feat: add dark mode support with theme toggle

### DIFF
--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import Link from "next/link";
+import { ThemeProvider } from "@/components/theme-provider";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 
 export const metadata: Metadata = {
@@ -14,24 +16,32 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className="antialiased">
-        <header className="border-b">
-          <nav className="container mx-auto px-4 py-4 flex items-center justify-between">
-            <Link href="/" className="text-xl font-bold hover:text-primary">
-              Robbie Palmer
-            </Link>
-            <div className="flex gap-6">
-              <Button variant="ghost" asChild>
-                <Link href="/blog">Blog</Link>
-              </Button>
-              <Button variant="ghost" asChild>
-                <Link href="/experience">Experience</Link>
-              </Button>
-            </div>
-          </nav>
-        </header>
-        <main>{children}</main>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <header className="border-b">
+            <nav className="container mx-auto px-4 py-4 flex items-center justify-between">
+              <Link href="/" className="text-xl font-bold hover:text-primary">
+                Robbie Palmer
+              </Link>
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" asChild>
+                  <Link href="/blog">Blog</Link>
+                </Button>
+                <Button variant="ghost" asChild>
+                  <Link href="/experience">Experience</Link>
+                </Button>
+                <ThemeToggle />
+              </div>
+            </nav>
+          </header>
+          <main>{children}</main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/ui/components/theme-provider.tsx
+++ b/ui/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type * as React from "react";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/ui/components/theme-toggle.tsx
+++ b/ui/components/theme-toggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+
+  // Avoid hydration mismatch
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <Button variant="ghost" size="icon" disabled />;
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+      aria-label="Toggle theme"
+    >
+      {theme === "light" ? (
+        <Moon className="h-5 w-5" />
+      ) : (
+        <Sun className="h-5 w-5" />
+      )}
+    </Button>
+  );
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
     "lucide-react": "^0.546.0",
     "next": "15.5.6",
     "next-mdx-remote": "^5.0.0",
+    "next-themes": "^0.4.6",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "rehype-autolink-headings": "^7.1.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       next-mdx-remote:
         specifier: ^5.0.0
         version: 5.0.0(@types/react@19.2.2)(react@19.2.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: 19.2.0
         version: 19.2.0
@@ -1711,6 +1714,12 @@ packages:
     engines: {node: '>=14', npm: '>=7'}
     peerDependencies:
       react: '>=16'
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@15.5.6:
     resolution: {integrity: sha512-zTxsnI3LQo3c9HSdSf91O1jMNsEzIXDShXd4wVdg9y5shwLqBXi4ZtUUJyB86KGVSJLZx0PFONvO54aheGX8QQ==}
@@ -4000,6 +4009,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
+
+  next-themes@0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   next@15.5.6(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:


### PR DESCRIPTION
## Summary

- Adds system-aware dark mode with manual theme toggle
- Implements ThemeProvider wrapper using next-themes
- Creates toggle button with sun/moon icons in header navigation
- Theme persists across sessions and respects system preference
- Proper hydration handling to avoid flash of unstyled content

## Changes

- Installed `next-themes` package
- Created `components/theme-provider.tsx` for client-side theme management
- Created `components/theme-toggle.tsx` button component with sun/moon icons
- Updated `app/layout.tsx` to wrap app in ThemeProvider and add toggle to header
- Added `suppressHydrationWarning` to html element for proper SSR handling

## Test Plan

- [x] Toggle switches between light and dark modes
- [x] Theme persists after page refresh
- [x] System preference is respected on first visit
- [x] No hydration mismatch warnings in console
- [x] All pages render correctly in both themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added theme toggle functionality enabling users to seamlessly switch between light and dark modes.
* New theme toggle button integrated into the header alongside existing navigation options.
* Application now detects and respects system theme preferences for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->