### PR TITLE
feat: add favicon and app icons with cyan RP monogram

### DIFF
--- a/ui/app/apple-icon.svg
+++ b/ui/app/apple-icon.svg
@@ -1,0 +1,4 @@
+<svg width="180" height="180" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="28" fill="#18181b" stroke="#06b6d4" stroke-width="2.5"/>
+  <text x="32" y="42" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700" fill="#06b6d4" text-anchor="middle">RP</text>
+</svg>

--- a/ui/app/icon.svg
+++ b/ui/app/icon.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="32" cy="32" r="28" fill="#18181b" stroke="#06b6d4" stroke-width="2.5"/>
+  <text x="32" y="42" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700" fill="#06b6d4" text-anchor="middle">RP</text>
+</svg>


### PR DESCRIPTION
Added SVG favicon and Apple touch icon featuring a circular RP monogram in cyan (#06b6d4) on transparent background. The clean, modern design matches the site's aesthetic and stands out in browser tabs.