### PR TITLE
feat(seo): add sitemap.xml and robots.txt

### DIFF
--- a/ui/app/robots.ts
+++ b/ui/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+import { siteConfig } from "@/lib/site-config";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteConfig.url}/sitemap.xml`,
+  };
+}

--- a/ui/app/sitemap.ts
+++ b/ui/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+import { getAllPosts } from "@/lib/blog";
+import { siteConfig } from "@/lib/site-config";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const posts = getAllPosts();
+
+  const blogPosts = posts.map((post) => ({
+    url: `${siteConfig.url}/blog/${post.slug}`,
+    lastModified: post.updated || post.date,
+    priority: 0.8,
+  }));
+
+  return [
+    {
+      url: siteConfig.url,
+      lastModified: new Date().toISOString(),
+      priority: 1,
+    },
+    {
+      url: `${siteConfig.url}/blog`,
+      lastModified: posts[0]?.date || new Date().toISOString(),
+      priority: 0.9,
+    },
+    {
+      url: `${siteConfig.url}/experience`,
+      lastModified: new Date().toISOString(),
+      priority: 0.7,
+    },
+    ...blogPosts,
+  ];
+}


### PR DESCRIPTION
## Summary

- Add sitemap.xml for improved search engine discovery and indexing
- Add robots.txt to allow all crawlers and reference sitemap
- Implement using Next.js built-in `sitemap.ts` and `robots.ts` support

## Implementation Details

**Sitemap (`app/sitemap.ts`):**
- Includes homepage, blog listing, experience page, and all blog posts
- Priority values: homepage (1.0), blog (0.9), posts (0.8), experience (0.7)
- Uses `post.updated` or `post.date` for lastModified timestamps
- Omits `changeFrequency` field (largely ignored by modern search engines)
- Auto-generates to `out/sitemap.xml` at build time

**Robots.txt (`app/robots.ts`):**
- Allows all user agents to crawl all pages (`User-Agent: *, Allow: /`)
- References sitemap location
- Auto-generates to `out/robots.txt` at build time

**Static Export Compatibility:**
- Added `export const dynamic = "force-static"` to both files
- Required for Next.js static export mode

## Test Plan

- [x] Build succeeds locally
- [x] Sitemap.xml generated correctly with all pages
- [x] Robots.txt generated correctly with sitemap reference
- [x] Verify files accessible at `/sitemap.xml` and `/robots.txt` on preview deployment
- [x] Validate sitemap XML format with online validator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Implemented robots.txt configuration to manage search engine crawling behaviour.
* Added dynamic sitemap generation covering all blog posts and key pages with metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->