### PR TITLE
chore(deps): use semver ranges to prevent major version bumps

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -22,11 +22,11 @@
     "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.546.0",
-    "next": "15.5.6",
+    "next": "^15.5.6",
     "next-mdx-remote": "^5.0.0",
     "next-themes": "^0.4.6",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "reading-time": "^1.5.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-pretty-code": "^0.14.1",
@@ -36,7 +36,7 @@
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.0",
+    "@biomejs/biome": "^2.3.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
@@ -49,6 +49,6 @@
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
-    "vitest": "3.2.4"
+    "vitest": "^3.2.4"
   }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -33,7 +33,7 @@ importers:
         specifier: ^0.546.0
         version: 0.546.0(react@19.2.0)
       next:
-        specifier: 15.5.6
+        specifier: ^15.5.6
         version: 15.5.6(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       next-mdx-remote:
         specifier: ^5.0.0
@@ -42,10 +42,10 @@ importers:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
-        specifier: 19.2.0
+        specifier: ^19.2.0
         version: 19.2.0
       react-dom:
-        specifier: 19.2.0
+        specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
       reading-time:
         specifier: ^1.5.0
@@ -70,7 +70,7 @@ importers:
         version: 3.3.1
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.0
+        specifier: ^2.3.0
         version: 2.3.0
       '@tailwindcss/postcss':
         specifier: ^4
@@ -109,7 +109,7 @@ importers:
         specifier: ^5
         version: 5.9.3
       vitest:
-        specifier: 3.2.4
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(jsdom@27.0.1(postcss@8.5.6))(lightningcss@1.30.2)(yaml@2.8.1)
 
 packages:


### PR DESCRIPTION
Changes:
- Add ^ prefix to next, react, react-dom, vitest, and @biomejs/biome
- This allows minor/patch updates (e.g., 15.5.6 → 15.6.0)
- Blocks major version jumps (e.g., 15.x → 16.x, 3.x → 4.x)

This prevents breaking changes from:
- Next.js 16 (async APIs, caching changes, middleware → proxy)
- Vitest 4 (vi.importActual breaking changes)
- React 20 (future breaking changes)

Dependabot will respect these ranges automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed dependency version pins to caret ranges for core runtime and developer tooling, allowing safe minor and patch updates while preserving compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->