### PR TITLE
chore(deps): add Dependabot ignore rules for major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,13 @@ updates:
     open-pull-requests-limit: 1
     commit-message:
       prefix: "deps(ui)"
+    ignore:
+      # Dependabot doesn't respect semver ranges in package.json
+      # See: https://github.com/dependabot/dependabot-core/issues/5176
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
     groups:
       all:
         patterns:


### PR DESCRIPTION
Dependabot doesn't respect semver ranges in package.json when proposing
updates. It will still try to update ^15.5.6 → ^16.0.1.

This is a known limitation:
https://github.com/dependabot/dependabot-core/issues/5176

The ignore rules are required to prevent major version bumps for:
- Next.js 16 (breaking changes to async APIs, caching, middleware)
- Vitest 4 (vi.importActual breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to refine version update policies for select packages.

---

**Note:** This release contains no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->