### PR TITLE
chore(deps): enable auto-merge for GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],
+      "excludeManagers": ["github-actions"],
       "dependencyDashboardApproval": true
     },
     {
@@ -20,9 +21,9 @@
       "automerge": true
     },
     {
-      "description": "Auto-merge GitHub Actions (non-major)",
+      "description": "Auto-merge GitHub Actions (all updates)",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "major"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
- Add 'major' to GitHub Actions auto-merge rule
- Exclude GitHub Actions from general major update approval requirement
- GitHub Actions will now auto-merge on successful CI for all update types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Modified dependency automation configuration for GitHub Actions to include major version updates alongside minor and patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->