### PR TITLE
feat(ui): add memoized client cooklang parsing hook

### DIFF
--- a/ui/biome.json
+++ b/ui/biome.json
@@ -11,6 +11,7 @@
       "app/**",
       "components/**",
       "content/**",
+      "hooks/**",
       "lib/**",
       "tests/**",
       "*.ts",

--- a/ui/hooks/use-cooklang-recipe.ts
+++ b/ui/hooks/use-cooklang-recipe.ts
@@ -12,6 +12,7 @@ export interface UseCooklangRecipeState {
 }
 
 let parserPromise: Promise<Parser> | null = null;
+const MAX_PARSE_CACHE_SIZE = 50;
 const parsePromiseCache = new Map<string, Promise<ParsedRecipe>>();
 
 function getCacheKey(cookBody: string, scale?: number): string {
@@ -58,6 +59,9 @@ function getMemoizedParsePromise(
   })();
 
   parsePromiseCache.set(cacheKey, parsePromise);
+  if (parsePromiseCache.size > MAX_PARSE_CACHE_SIZE) {
+    parsePromiseCache.delete(parsePromiseCache.keys().next().value!);
+  }
   return parsePromise;
 }
 
@@ -78,7 +82,7 @@ export function useCooklangRecipe(
     }
 
     let isActive = true;
-    setState({ recipe: null, loading: true, error: null });
+    setState((prev) => ({ ...prev, loading: true, error: null }));
 
     (async () => {
       try {

--- a/ui/hooks/use-cooklang-recipe.ts
+++ b/ui/hooks/use-cooklang-recipe.ts
@@ -1,0 +1,113 @@
+"use client";
+
+import type { Parser } from "@cooklang/cooklang";
+import { useEffect, useState } from "react";
+
+type ParsedRecipe = ReturnType<Parser["parse"]>["recipe"];
+
+export interface UseCooklangRecipeState {
+  recipe: ParsedRecipe | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+let parserPromise: Promise<Parser> | null = null;
+const parsePromiseCache = new Map<string, Promise<ParsedRecipe>>();
+
+function getCacheKey(cookBody: string, scale?: number): string {
+  return `${scale ?? "default"}::${cookBody}`;
+}
+
+async function getParser(): Promise<Parser> {
+  if (parserPromise) {
+    return parserPromise;
+  }
+
+  parserPromise = (async () => {
+    try {
+      const module = await import("@cooklang/cooklang");
+      return new module.Parser();
+    } catch (error) {
+      parserPromise = null;
+      throw error;
+    }
+  })();
+
+  return parserPromise;
+}
+
+function getMemoizedParsePromise(
+  cookBody: string,
+  scale?: number,
+): Promise<ParsedRecipe> {
+  const cacheKey = getCacheKey(cookBody, scale);
+  const existingPromise = parsePromiseCache.get(cacheKey);
+  if (existingPromise) {
+    return existingPromise;
+  }
+
+  const parsePromise = (async () => {
+    try {
+      const parser = await getParser();
+      const { recipe } = parser.parse(cookBody, scale);
+      return recipe;
+    } catch (error) {
+      parsePromiseCache.delete(cacheKey);
+      throw error;
+    }
+  })();
+
+  parsePromiseCache.set(cacheKey, parsePromise);
+  return parsePromise;
+}
+
+export function useCooklangRecipe(
+  cookBody: string,
+  scale?: number,
+): UseCooklangRecipeState {
+  const [state, setState] = useState<UseCooklangRecipeState>({
+    recipe: null,
+    loading: Boolean(cookBody),
+    error: null,
+  });
+
+  useEffect(() => {
+    if (!cookBody) {
+      setState({ recipe: null, loading: false, error: null });
+      return;
+    }
+
+    let isActive = true;
+    setState({ recipe: null, loading: true, error: null });
+
+    (async () => {
+      try {
+        const recipe = await getMemoizedParsePromise(cookBody, scale);
+        if (!isActive) {
+          return;
+        }
+
+        setState({ recipe, loading: false, error: null });
+      } catch (error) {
+        if (!isActive) {
+          return;
+        }
+
+        setState({
+          recipe: null,
+          loading: false,
+          error:
+            error instanceof Error
+              ? error
+              : new Error("Failed to parse Cooklang recipe"),
+        });
+      }
+    })();
+
+    return () => {
+      isActive = false;
+    };
+  }, [cookBody, scale]);
+
+  return state;
+}

--- a/ui/hooks/use-debounced-search-tracking.ts
+++ b/ui/hooks/use-debounced-search-tracking.ts
@@ -2,45 +2,45 @@ import posthog from "posthog-js";
 import { useEffect, useRef } from "react";
 
 export function useDebouncedSearchTracking({
-    searchQuery,
-    resultCount,
-    location,
-    delay = 1000,
+  searchQuery,
+  resultCount,
+  location,
+  delay = 1000,
 }: {
-    searchQuery: string;
-    resultCount: number;
-    location: string;
-    delay?: number;
+  searchQuery: string;
+  resultCount: number;
+  location: string;
+  delay?: number;
 }) {
-    const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const resultCountRef = useRef(resultCount);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resultCountRef = useRef(resultCount);
 
-    // Sync ref with latest resultCount without triggering effects
-    useEffect(() => {
-        resultCountRef.current = resultCount;
-    }, [resultCount]);
+  // Sync ref with latest resultCount without triggering effects
+  useEffect(() => {
+    resultCountRef.current = resultCount;
+  }, [resultCount]);
 
-    useEffect(() => {
-        if (searchTimerRef.current) {
-            clearTimeout(searchTimerRef.current);
-        }
+  useEffect(() => {
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+    }
 
-        if (!searchQuery.trim()) {
-            return;
-        }
+    if (!searchQuery.trim()) {
+      return;
+    }
 
-        searchTimerRef.current = setTimeout(() => {
-            posthog.capture("search_used", {
-                query: searchQuery,
-                result_count: resultCountRef.current,
-                location,
-            });
-        }, delay);
+    searchTimerRef.current = setTimeout(() => {
+      posthog.capture("search_used", {
+        query: searchQuery,
+        result_count: resultCountRef.current,
+        location,
+      });
+    }, delay);
 
-        return () => {
-            if (searchTimerRef.current) {
-                clearTimeout(searchTimerRef.current);
-            }
-        };
-    }, [searchQuery, location, delay]);
+    return () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+    };
+  }, [searchQuery, location, delay]);
 }

--- a/ui/hooks/use-navbar-visibility.ts
+++ b/ui/hooks/use-navbar-visibility.ts
@@ -5,41 +5,41 @@ import { useMediaQuery } from "react-responsive";
 import { BREAKPOINTS } from "@/lib/generic/breakpoints";
 
 export function useNavbarVisibility() {
-    const [isVisible, setIsVisible] = useState(true);
-    const lastScrollYRef = useRef(0);
-    const isMobile = useMediaQuery({ maxWidth: BREAKPOINTS.md - 1 });
+  const [isVisible, setIsVisible] = useState(true);
+  const lastScrollYRef = useRef(0);
+  const isMobile = useMediaQuery({ maxWidth: BREAKPOINTS.md - 1 });
 
-    useEffect(() => {
-        const handleScroll = () => {
-            const currentScrollY = window.scrollY;
-            // Don't hide if we're near the top (within 100px)
-            if (currentScrollY < 100) {
-                setIsVisible(true);
-                lastScrollYRef.current = currentScrollY;
-                return;
-            }
-            // Higher threshold on mobile (120px) vs desktop (80px) to accommodate swipe gestures
-            const scrollThreshold = isMobile ? 120 : 80;
-            // Check scroll direction with a threshold to avoid jank
-            if (Math.abs(currentScrollY - lastScrollYRef.current) < scrollThreshold) {
-                return;
-            }
-            if (currentScrollY > lastScrollYRef.current) {
-                // Scrolling down - hide navbar
-                setIsVisible(false);
-            } else {
-                // Scrolling up - show navbar
-                setIsVisible(true);
-            }
-            lastScrollYRef.current = currentScrollY;
-        };
+  useEffect(() => {
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+      // Don't hide if we're near the top (within 100px)
+      if (currentScrollY < 100) {
+        setIsVisible(true);
+        lastScrollYRef.current = currentScrollY;
+        return;
+      }
+      // Higher threshold on mobile (120px) vs desktop (80px) to accommodate swipe gestures
+      const scrollThreshold = isMobile ? 120 : 80;
+      // Check scroll direction with a threshold to avoid jank
+      if (Math.abs(currentScrollY - lastScrollYRef.current) < scrollThreshold) {
+        return;
+      }
+      if (currentScrollY > lastScrollYRef.current) {
+        // Scrolling down - hide navbar
+        setIsVisible(false);
+      } else {
+        // Scrolling up - show navbar
+        setIsVisible(true);
+      }
+      lastScrollYRef.current = currentScrollY;
+    };
 
-        // Passive listener for better scroll performance
-        window.addEventListener("scroll", handleScroll, { passive: true });
-        return () => {
-            window.removeEventListener("scroll", handleScroll);
-        };
-    }, [isMobile]);
+    // Passive listener for better scroll performance
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [isMobile]);
 
-    return isVisible;
+  return isVisible;
 }


### PR DESCRIPTION
### Motivation

- Provide a client-side React hook to parse Cooklang recipe bodies safely and efficiently for UI components that need runtime parsing and scaling.
- Avoid recreating the WASM-backed parser per component and prevent duplicate concurrent parses for identical inputs.
- Ensure robust behavior across failures and component unmounts so the UI can fall back to SSG content if parsing fails.

### Description

- Add a new client hook `useCooklangRecipe` at `ui/hooks/use-cooklang-recipe.ts` that exposes state `{ recipe, loading, error }` and accepts `(cookBody, scale)`.
- Cache the parser instance at module scope with a singleton `parserPromise` so the `@cooklang/cooklang` `Parser` is reused across components.
- Memoize parse work with `parsePromiseCache` keyed by `(cookBody, scale)` to deduplicate in-flight and repeated parses and evict failed attempts.
- Wrap dynamic import and parse calls in `try/catch` and guard async state updates with an `isActive` flag to prevent updates after unmount.
- Update `ui/biome.json` to include `hooks/**` so the new hook is covered by formatting and lint tasks.

### Testing

- Ran formatting on the new file with `pnpm -C ui format hooks/use-cooklang-recipe.ts` and it succeeded.
- Ran TypeScript checks with `pnpm -C ui typecheck` and there were no type errors.
- Pre-commit checks (lint-staged and repo formatters) ran and passed during commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0891cda30832eaa3fcfdaaa81f5fb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side recipe parsing for the Cooklang format with asynchronous loading and dynamic scaling support.

* **Style**
  * Normalised formatting and indentation for search-tracking and navbar-visibility hooks without changing behaviour.

* **Chores**
  * Expanded project configuration to include additional directories in linting/formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->