### PR TITLE
Normalize SDK ingredient slugs for annotation lookups in recipe content

### DIFF
--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -22,10 +22,15 @@ function buildIngredientAnnotationMap(
 
   for (const group of ingredientGroups) {
     for (const item of group.items) {
-      annotations.set(item.ingredient, {
+      const annotation = {
         preparation: item.preparation,
         note: item.note,
-      });
+      };
+      annotations.set(item.ingredient, annotation);
+      const normalized = normalizeSlug(item.name);
+      if (normalized && normalized !== item.ingredient) {
+        annotations.set(normalized, annotation);
+      }
     }
   }
 

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Clock, Minus, Plus, Timer, Users } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatIngredientName } from "@/lib/domain/recipe/ingredientText";
@@ -32,22 +32,25 @@ function buildIngredientAnnotationMap(
   return annotations;
 }
 
+function hasAnnotation(a: IngredientAnnotation): boolean {
+  return a.preparation != null || a.note != null;
+}
+
 function resolveIngredientAnnotation(
   item: RecipeIngredientView,
   annotations: Map<string, IngredientAnnotation>,
 ): IngredientAnnotation {
   const fromIngredientSlug = annotations.get(item.ingredient);
-  if (fromIngredientSlug) {
+  if (fromIngredientSlug && hasAnnotation(fromIngredientSlug)) {
     return fromIngredientSlug;
   }
 
   const parsedNameSlug = normalizeSlug(item.name);
   const fromParsedName = annotations.get(parsedNameSlug);
-  if (fromParsedName) {
+  if (fromParsedName && hasAnnotation(fromParsedName)) {
     return fromParsedName;
   }
 
-  // Deterministic fallback: no matching annotation means plain ingredient text.
   return {};
 }
 
@@ -106,12 +109,15 @@ function formatIngredient(
 
   parts.push(formatIngredientName(item, scale));
 
-  if (annotation?.preparation) {
-    parts.push(`(${annotation.preparation})`);
+  const effectivePreparation = item.preparation ?? annotation?.preparation;
+  const effectiveNote = item.note ?? annotation?.note;
+
+  if (effectivePreparation) {
+    parts.push(`(${effectivePreparation})`);
   }
 
-  if (annotation?.note) {
-    parts.push(`\u2013 ${annotation.note}`);
+  if (effectiveNote) {
+    parts.push(`\u2013 ${effectiveNote}`);
   }
 
   return parts.join(" ");
@@ -160,8 +166,9 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
   const baseServings = Math.max(1, recipe.servings);
   const [portions, setPortions] = useState(baseServings);
   const scale = portions / baseServings;
-  const ingredientAnnotations = buildIngredientAnnotationMap(
-    recipe.ingredientGroups,
+  const ingredientAnnotations = useMemo(
+    () => buildIngredientAnnotationMap(recipe.ingredientGroups),
+    [recipe.ingredientGroups],
   );
 
   return (

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -11,6 +11,45 @@ import type {
   RecipeIngredientView,
 } from "@/lib/domain/recipe/recipeViews";
 import { UNIT_LABELS } from "@/lib/domain/recipe/unit";
+import { normalizeSlug } from "@/lib/generic/slugs";
+
+type IngredientAnnotation = Pick<RecipeIngredientView, "preparation" | "note">;
+
+function buildIngredientAnnotationMap(
+  ingredientGroups: IngredientGroupView[],
+): Map<string, IngredientAnnotation> {
+  const annotations = new Map<string, IngredientAnnotation>();
+
+  for (const group of ingredientGroups) {
+    for (const item of group.items) {
+      annotations.set(item.ingredient, {
+        preparation: item.preparation,
+        note: item.note,
+      });
+    }
+  }
+
+  return annotations;
+}
+
+function resolveIngredientAnnotation(
+  item: RecipeIngredientView,
+  annotations: Map<string, IngredientAnnotation>,
+): IngredientAnnotation {
+  const fromIngredientSlug = annotations.get(item.ingredient);
+  if (fromIngredientSlug) {
+    return fromIngredientSlug;
+  }
+
+  const parsedNameSlug = normalizeSlug(item.name);
+  const fromParsedName = annotations.get(parsedNameSlug);
+  if (fromParsedName) {
+    return fromParsedName;
+  }
+
+  // Deterministic fallback: no matching annotation means plain ingredient text.
+  return {};
+}
 
 function formatScaled(value: number): string {
   return parseFloat(value.toPrecision(2)).toString();
@@ -45,7 +84,11 @@ function formatAmount(item: RecipeIngredientView, scale: number): string {
   return parts.join(" ");
 }
 
-function formatIngredient(item: RecipeIngredientView, scale: number): string {
+function formatIngredient(
+  item: RecipeIngredientView,
+  scale: number,
+  annotation?: IngredientAnnotation,
+): string {
   const isPiece = item.unit === "piece";
   const amount = isPiece
     ? item.amount != null
@@ -63,12 +106,12 @@ function formatIngredient(item: RecipeIngredientView, scale: number): string {
 
   parts.push(formatIngredientName(item, scale));
 
-  if (item.preparation) {
-    parts.push(`(${item.preparation})`);
+  if (annotation?.preparation) {
+    parts.push(`(${annotation.preparation})`);
   }
 
-  if (item.note) {
-    parts.push(`\u2013 ${item.note}`);
+  if (annotation?.note) {
+    parts.push(`\u2013 ${annotation.note}`);
   }
 
   return parts.join(" ");
@@ -84,9 +127,11 @@ function formatTime(minutes: number): string {
 function IngredientGroup({
   group,
   scale,
+  annotations,
 }: {
   group: IngredientGroupView;
   scale: number;
+  annotations: Map<string, IngredientAnnotation>;
 }) {
   return (
     <div>
@@ -97,7 +142,13 @@ function IngredientGroup({
         {group.items.map((item) => (
           <li key={item.ingredient} className="flex items-start gap-2">
             <span className="text-muted-foreground mt-1.5 h-1.5 w-1.5 rounded-full bg-current flex-shrink-0" />
-            <span>{formatIngredient(item, scale)}</span>
+            <span>
+              {formatIngredient(
+                item,
+                scale,
+                resolveIngredientAnnotation(item, annotations),
+              )}
+            </span>
           </li>
         ))}
       </ul>
@@ -109,6 +160,9 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
   const baseServings = Math.max(1, recipe.servings);
   const [portions, setPortions] = useState(baseServings);
   const scale = portions / baseServings;
+  const ingredientAnnotations = buildIngredientAnnotationMap(
+    recipe.ingredientGroups,
+  );
 
   return (
     <>
@@ -179,6 +233,7 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
               key={group.name ?? i}
               group={group}
               scale={scale}
+              annotations={ingredientAnnotations}
             />
           ))}
         </div>


### PR DESCRIPTION
### Motivation
- SDK-parsed ingredient names can differ from canonical ingredient slugs, preventing front-end render from picking up `preparation`/`note` annotations.
- Normalize parsed names and prefer canonical slug lookups so SDK-rendered ingredient tokens/lines show the same annotations as authored ingredient groups.

### Description
- Import `normalizeSlug` and add `buildIngredientAnnotationMap` to construct a map of annotations keyed by `ingredient` slug from `recipe.ingredientGroups[*].items`.
- Add `resolveIngredientAnnotation` which first checks the item `ingredient` slug, then `normalizeSlug(item.name)` to resolve SDK-parsed names to canonical annotations, with a deterministic empty-object fallback when no match exists.
- Update `formatIngredient` to accept a resolved annotation and apply its `preparation`/`note` instead of relying solely on the local item fields.
- Wire the annotation map into `RecipeContent` and pass it into `IngredientGroup` so rendered ingredient lines use resolved annotations.

### Testing
- Ran TypeScript check with `pnpm -C ui exec tsc --noEmit`, which completed successfully.
- An initial incorrect vitest invocation failed due to a command path mistake, but the corrected test run `pnpm -C ui exec vitest run tests/lib/domain/recipe/recipeQueries.test.ts` completed successfully with `1 file passed` and `14 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0891efe40832ea766398d0639443e)