### PR TITLE
Add guarded SDK instruction adapter with canonical fallback

### DIFF
--- a/packages/recipe-domain/src/recipe.ts
+++ b/packages/recipe-domain/src/recipe.ts
@@ -22,6 +22,55 @@ export const IngredientGroupSchema = z.object({
 
 export type IngredientGroup = z.infer<typeof IngredientGroupSchema>;
 
+export const RecipeInstructionItemSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("text"), value: z.string() }),
+  z.object({ type: z.literal("ingredient"), index: z.number().int().nonnegative() }),
+  z.object({ type: z.literal("timer"), index: z.number().int().nonnegative() }),
+  z.object({ type: z.literal("cookware"), index: z.number().int().nonnegative() }),
+  z.object({
+    type: z.literal("inlineQuantity"),
+    index: z.number().int().nonnegative(),
+  }),
+]);
+
+export type RecipeInstructionItem = z.infer<typeof RecipeInstructionItemSchema>;
+
+export const RecipeInstructionStepSchema = z.object({
+  number: z.number().int().positive(),
+  items: z.array(RecipeInstructionItemSchema),
+});
+
+export type RecipeInstructionStep = z.infer<typeof RecipeInstructionStepSchema>;
+
+export const RecipeInstructionSectionContentSchema = z.discriminatedUnion(
+  "type",
+  [
+    z.object({ type: z.literal("text"), value: z.string() }),
+    z.object({ type: z.literal("step"), value: RecipeInstructionStepSchema }),
+  ],
+);
+
+export type RecipeInstructionSectionContent = z.infer<
+  typeof RecipeInstructionSectionContentSchema
+>;
+
+export const RecipeInstructionSectionSchema = z.object({
+  name: z.string().nullable(),
+  content: z.array(RecipeInstructionSectionContentSchema),
+});
+
+export type RecipeInstructionSection = z.infer<
+  typeof RecipeInstructionSectionSchema
+>;
+
+export const RecipeInstructionSdkSchema = z.object({
+  sections: z.array(RecipeInstructionSectionSchema),
+  ingredientNames: z.array(z.string()),
+  timerDisplayValues: z.array(z.string()),
+});
+
+export type RecipeInstructionSdk = z.infer<typeof RecipeInstructionSdkSchema>;
+
 export const ParsedRecipeSchema = z.object({
   title: z.string().min(1),
   description: z.string().min(1),
@@ -31,6 +80,7 @@ export const ParsedRecipeSchema = z.object({
   cookTime: z.number().int().nonnegative().optional(),
   ingredientGroups: z.array(IngredientGroupSchema).min(1),
   instructions: z.array(z.string().min(1)).min(1),
+  instructionSdk: RecipeInstructionSdkSchema.optional(),
 });
 
 export type ParsedRecipe = z.infer<typeof ParsedRecipeSchema>;

--- a/packages/recipe-domain/src/recipe.ts
+++ b/packages/recipe-domain/src/recipe.ts
@@ -36,7 +36,7 @@ export const RecipeInstructionItemSchema = z.discriminatedUnion("type", [
 export type RecipeInstructionItem = z.infer<typeof RecipeInstructionItemSchema>;
 
 export const RecipeInstructionStepSchema = z.object({
-  number: z.number().int().positive(),
+  number: z.number().int().positive().optional(),
   items: z.array(RecipeInstructionItemSchema),
 });
 

--- a/packages/recipe-domain/src/recipe.ts
+++ b/packages/recipe-domain/src/recipe.ts
@@ -80,7 +80,6 @@ export const ParsedRecipeSchema = z.object({
   cookTime: z.number().int().nonnegative().optional(),
   ingredientGroups: z.array(IngredientGroupSchema).min(1),
   instructions: z.array(z.string().min(1)).min(1),
-  instructionSdk: RecipeInstructionSdkSchema.optional(),
 });
 
 export type ParsedRecipe = z.infer<typeof ParsedRecipeSchema>;
@@ -88,6 +87,7 @@ export type ParsedRecipe = z.infer<typeof ParsedRecipeSchema>;
 export const RecipeContentSchema = ParsedRecipeSchema.extend({
   slug: RecipeSlugSchema.optional(),
   cookBody: z.string().min(1),
+  instructionSdk: RecipeInstructionSdkSchema.optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   tags: z.array(z.string()).default([]),
   image: z

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -177,9 +177,13 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
     [recipe.ingredientGroups],
   );
 
-  const instructionTokenization = recipe.instructionSdk
-    ? tokenizeInstructionSdk(recipe.instructionSdk)
-    : null;
+  const instructionTokenization = useMemo(
+    () =>
+      recipe.instructionSdk
+        ? tokenizeInstructionSdk(recipe.instructionSdk)
+        : null,
+    [recipe.instructionSdk],
+  );
   const shouldUseSdkInstructions = instructionTokenization?.ok === true;
 
   useEffect(() => {

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Clock, Minus, Plus, Timer, Users } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatIngredientName } from "@/lib/domain/recipe/ingredientText";
@@ -182,15 +182,17 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
     : null;
   const shouldUseSdkInstructions = instructionTokenization?.ok === true;
 
-  if (
-    process.env.NODE_ENV !== "production" &&
-    recipe.instructionSdk &&
-    instructionTokenization?.ok === false
-  ) {
-    console.debug(
-      `[RecipeContent] Falling back to canonical instructions for "${recipe.slug}": ${instructionTokenization.reason}`,
-    );
-  }
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== "production" &&
+      recipe.instructionSdk &&
+      instructionTokenization?.ok === false
+    ) {
+      console.debug(
+        `[RecipeContent] Falling back to canonical instructions for "${recipe.slug}": ${instructionTokenization.reason}`,
+      );
+    }
+  }, [recipe.instructionSdk, recipe.slug, instructionTokenization]);
 
   return (
     <>

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatIngredientName } from "@/lib/domain/recipe/ingredientText";
+import { tokenizeInstructionSdk } from "@/lib/domain/recipe/instructionTokens";
 import type {
   IngredientGroupView,
   RecipeDetailView,
@@ -176,6 +177,21 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
     [recipe.ingredientGroups],
   );
 
+  const instructionTokenization = recipe.instructionSdk
+    ? tokenizeInstructionSdk(recipe.instructionSdk)
+    : null;
+  const shouldUseSdkInstructions = instructionTokenization?.ok === true;
+
+  if (
+    process.env.NODE_ENV !== "production" &&
+    recipe.instructionSdk &&
+    instructionTokenization?.ok === false
+  ) {
+    console.debug(
+      `[RecipeContent] Falling back to canonical instructions for "${recipe.slug}": ${instructionTokenization.reason}`,
+    );
+  }
+
   return (
     <>
       <header className="mb-8">
@@ -254,11 +270,19 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
       <section>
         <h2 className="text-2xl font-bold mb-4">Instructions</h2>
         <ol className="space-y-3 list-decimal list-inside">
-          {recipe.instructions.map((step, i) => (
-            <li key={i} className="leading-relaxed pl-2">
-              {step}
-            </li>
-          ))}
+          {shouldUseSdkInstructions
+            ? instructionTokenization.steps.map((tokens, i) => (
+                <li key={i} className="leading-relaxed pl-2">
+                  {tokens.map((token, tokenIndex) => (
+                    <span key={tokenIndex}>{token.value}</span>
+                  ))}
+                </li>
+              ))
+            : recipe.instructions.map((step, i) => (
+                <li key={i} className="leading-relaxed pl-2">
+                  {step}
+                </li>
+              ))}
         </ol>
       </section>
     </>

--- a/ui/lib/content/cooklang.ts
+++ b/ui/lib/content/cooklang.ts
@@ -72,6 +72,15 @@ function isIngredientOnlyStep(step: Step): boolean {
   return hasIngredient;
 }
 
+function formatTimerDisplay(timer: Timer): string {
+  const qty = getQuantityValue(timer.quantity);
+  const unit = getQuantityUnit(timer.quantity);
+  return [qty !== null ? String(qty) : null, unit]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
 function stepToText(
   step: Step,
   ingredients: Ingredient[],
@@ -84,15 +93,8 @@ function stepToText(
           return item.value;
         case "ingredient":
           return ingredients[item.index]!.name;
-        case "timer": {
-          const timer = timers[item.index]!;
-          const qty = getQuantityValue(timer.quantity);
-          const unit = getQuantityUnit(timer.quantity);
-          return [qty !== null ? String(qty) : null, unit]
-            .filter(Boolean)
-            .join(" ")
-            .trim();
-        }
+        case "timer":
+          return formatTimerDisplay(timers[item.index]!);
         default:
           return "";
       }
@@ -127,14 +129,7 @@ export function parseCookFile(
   const groups: GroupAccumulator[] = [currentGroup];
   const instructions: string[] = [];
   const ingredientNames = ingredients.map((ingredient) => ingredient.name);
-  const timerDisplayValues = timers.map((timer) => {
-    const qty = getQuantityValue(timer.quantity);
-    const unit = getQuantityUnit(timer.quantity);
-    return [qty !== null ? String(qty) : null, unit]
-      .filter(Boolean)
-      .join(" ")
-      .trim();
-  });
+  const timerDisplayValues = timers.map(formatTimerDisplay);
 
   for (const section of sections) {
     // Cooklang `== Name ==` sections map to ingredient groups
@@ -198,7 +193,12 @@ export function parseCookFile(
     ingredientGroups,
     instructions,
     instructionSdk: {
-      sections,
+      sections: sections.map((s) => ({
+        ...s,
+        content: s.content.filter(
+          (c) => c.type !== "step" || !isIngredientOnlyStep(c.value),
+        ),
+      })),
       ingredientNames,
       timerDisplayValues,
     },

--- a/ui/lib/content/cooklang.ts
+++ b/ui/lib/content/cooklang.ts
@@ -126,6 +126,15 @@ export function parseCookFile(
   let currentGroup: GroupAccumulator = { name: undefined, items: [] };
   const groups: GroupAccumulator[] = [currentGroup];
   const instructions: string[] = [];
+  const ingredientNames = ingredients.map((ingredient) => ingredient.name);
+  const timerDisplayValues = timers.map((timer) => {
+    const qty = getQuantityValue(timer.quantity);
+    const unit = getQuantityUnit(timer.quantity);
+    return [qty !== null ? String(qty) : null, unit]
+      .filter(Boolean)
+      .join(" ")
+      .trim();
+  });
 
   for (const section of sections) {
     // Cooklang `== Name ==` sections map to ingredient groups
@@ -188,6 +197,11 @@ export function parseCookFile(
     imageAlt: fm.imageAlt,
     ingredientGroups,
     instructions,
+    instructionSdk: {
+      sections,
+      ingredientNames,
+      timerDisplayValues,
+    },
   });
 }
 

--- a/ui/lib/content/cooklang.ts
+++ b/ui/lib/content/cooklang.ts
@@ -73,9 +73,9 @@ function isIngredientOnlyStep(step: Step): boolean {
 }
 
 function formatTimerDisplay(timer: Timer): string {
-  const qty = getQuantityValue(timer.quantity);
+  const qty = resolveQuantityValue(timer.quantity);
   const unit = getQuantityUnit(timer.quantity);
-  return [qty !== null ? String(qty) : null, unit]
+  return [qty !== undefined ? String(qty) : null, unit]
     .filter(Boolean)
     .join(" ")
     .trim();

--- a/ui/lib/domain/recipe/instructionTokens.ts
+++ b/ui/lib/domain/recipe/instructionTokens.ts
@@ -1,0 +1,99 @@
+import type { RecipeInstructionSdk } from "@/lib/domain/recipe/recipe";
+
+export type InstructionDisplayToken = {
+  type: "text";
+  value: string;
+};
+
+export type InstructionTokenizationResult =
+  | { ok: true; steps: InstructionDisplayToken[][] }
+  | { ok: false; reason: string };
+
+function fromIndex(values: string[], index: number): string | null {
+  const value = values[index];
+  return typeof value === "string" ? value : null;
+}
+
+export function tokenizeInstructionSdk(
+  instructionSdk: RecipeInstructionSdk,
+): InstructionTokenizationResult {
+  const steps: InstructionDisplayToken[][] = [];
+
+  for (const section of instructionSdk.sections) {
+    for (const content of section.content) {
+      if (content.type === "text") {
+        continue;
+      }
+
+      if (content.type !== "step") {
+        return {
+          ok: false,
+          reason: `Unknown section content type: ${String((content as { type?: unknown }).type)}`,
+        };
+      }
+
+      const tokens: InstructionDisplayToken[] = [];
+
+      for (const item of content.value.items) {
+        if (item.type === "text") {
+          tokens.push({ type: "text", value: item.value });
+          continue;
+        }
+
+        if (item.type === "ingredient") {
+          const ingredient = fromIndex(
+            instructionSdk.ingredientNames,
+            item.index,
+          );
+          if (!ingredient) {
+            return {
+              ok: false,
+              reason: `Malformed ingredient item index: ${item.index}`,
+            };
+          }
+          tokens.push({ type: "text", value: ingredient });
+          continue;
+        }
+
+        if (item.type === "timer") {
+          const timer = fromIndex(
+            instructionSdk.timerDisplayValues,
+            item.index,
+          );
+          if (!timer) {
+            return {
+              ok: false,
+              reason: `Malformed timer item index: ${item.index}`,
+            };
+          }
+          tokens.push({ type: "text", value: timer });
+          continue;
+        }
+
+        return {
+          ok: false,
+          reason: `Unknown step item type: ${String((item as { type?: unknown }).type)}`,
+        };
+      }
+
+      const rendered = tokens
+        .map((token) => token.value)
+        .join("")
+        .trim();
+      if (rendered.length === 0) {
+        continue;
+      }
+
+      steps.push(tokens);
+    }
+  }
+
+  if (steps.length === 0) {
+    return {
+      ok: false,
+      reason: "No instruction steps produced from SDK sections",
+    };
+  }
+
+  return { ok: true, steps };
+}

--- a/ui/lib/domain/recipe/instructionTokens.ts
+++ b/ui/lib/domain/recipe/instructionTokens.ts
@@ -76,11 +76,29 @@ export function tokenizeInstructionSdk(
         };
       }
 
-      const rendered = tokens
-        .map((token) => token.value)
-        .join("")
-        .trim();
-      if (rendered.length === 0) {
+      // Trim leading/trailing whitespace from boundary text tokens
+      // to match the canonical stepToText output
+      let first = tokens[0];
+      while (first?.type === "text" && first.value.trimStart() === "") {
+        tokens.shift();
+        first = tokens[0];
+      }
+      if (first?.type === "text") {
+        tokens[0] = { type: "text", value: first.value.trimStart() };
+      }
+      let last = tokens[tokens.length - 1];
+      while (last?.type === "text" && last.value.trimEnd() === "") {
+        tokens.pop();
+        last = tokens[tokens.length - 1];
+      }
+      if (last?.type === "text") {
+        tokens[tokens.length - 1] = {
+          type: "text",
+          value: last.value.trimEnd(),
+        };
+      }
+
+      if (tokens.length === 0) {
         continue;
       }
 

--- a/ui/lib/domain/recipe/instructionTokens.ts
+++ b/ui/lib/domain/recipe/instructionTokens.ts
@@ -45,7 +45,7 @@ export function tokenizeInstructionSdk(
             instructionSdk.ingredientNames,
             item.index,
           );
-          if (!ingredient) {
+          if (ingredient === null) {
             return {
               ok: false,
               reason: `Malformed ingredient item index: ${item.index}`,
@@ -60,7 +60,7 @@ export function tokenizeInstructionSdk(
             instructionSdk.timerDisplayValues,
             item.index,
           );
-          if (!timer) {
+          if (timer === null) {
             return {
               ok: false,
               reason: `Malformed timer item index: ${item.index}`,

--- a/ui/lib/domain/recipe/recipe.ts
+++ b/ui/lib/domain/recipe/recipe.ts
@@ -4,6 +4,11 @@ export type {
   Recipe,
   RecipeContent,
   RecipeIngredient,
+  RecipeInstructionItem,
+  RecipeInstructionSdk,
+  RecipeInstructionSection,
+  RecipeInstructionSectionContent,
+  RecipeInstructionStep,
   RecipeSlug,
 } from "recipe-domain";
 export {
@@ -11,5 +16,10 @@ export {
   ParsedRecipeSchema,
   RecipeContentSchema,
   RecipeIngredientSchema,
+  RecipeInstructionItemSchema,
+  RecipeInstructionSdkSchema,
+  RecipeInstructionSectionContentSchema,
+  RecipeInstructionSectionSchema,
+  RecipeInstructionStepSchema,
   RecipeSlugSchema,
 } from "recipe-domain";

--- a/ui/lib/domain/recipe/recipeViews.ts
+++ b/ui/lib/domain/recipe/recipeViews.ts
@@ -1,5 +1,10 @@
 import type { Ingredient, IngredientSlug } from "./ingredient";
-import type { IngredientGroup, Recipe, RecipeIngredient } from "./recipe";
+import type {
+  IngredientGroup,
+  Recipe,
+  RecipeIngredient,
+  RecipeInstructionSdk,
+} from "./recipe";
 import type { RecipeRepository } from "./recipeRepository";
 import type { Unit } from "./unit";
 
@@ -41,6 +46,7 @@ export type RecipeDetailView = BaseRecipeView & {
   cookBody: string;
   ingredientGroups: IngredientGroupView[];
   instructions: string[];
+  instructionSdk?: RecipeInstructionSdk;
 };
 
 function toIngredientView(
@@ -124,5 +130,6 @@ export function toRecipeDetailView(
       toIngredientGroupView(group, repository.ingredients),
     ),
     instructions: recipe.instructions,
+    instructionSdk: recipe.instructionSdk,
   };
 }

--- a/ui/tests/lib/domain/recipe/instructionTokens.test.ts
+++ b/ui/tests/lib/domain/recipe/instructionTokens.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { tokenizeInstructionSdk } from "@/lib/domain/recipe/instructionTokens";
+import type { RecipeInstructionSdk } from "@/lib/domain/recipe/recipe";
+
+function makeSdk(
+  overrides: Partial<RecipeInstructionSdk> = {},
+): RecipeInstructionSdk {
+  return {
+    ingredientNames: ["onion"],
+    timerDisplayValues: ["10 min"],
+    sections: [
+      {
+        name: null,
+        content: [
+          {
+            type: "step",
+            value: {
+              number: 1,
+              items: [
+                { type: "text", value: "Cook " },
+                { type: "ingredient", index: 0 },
+                { type: "text", value: " for " },
+                { type: "timer", index: 0 },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("tokenizeInstructionSdk", () => {
+  it("tokenizes supported step items", () => {
+    const result = tokenizeInstructionSdk(makeSdk());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.steps).toEqual([
+        [
+          { type: "text", value: "Cook " },
+          { type: "text", value: "onion" },
+          { type: "text", value: " for " },
+          { type: "text", value: "10 min" },
+        ],
+      ]);
+    }
+  });
+
+  it("fails for unknown item types so caller can fallback", () => {
+    const sdk = makeSdk({
+      sections: [
+        {
+          name: null,
+          content: [
+            {
+              type: "step",
+              value: {
+                number: 1,
+                items: [{ type: "cookware", index: 0 }],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = tokenizeInstructionSdk(sdk);
+    expect(result).toEqual({
+      ok: false,
+      reason: "Unknown step item type: cookware",
+    });
+  });
+
+  it("fails for malformed indexes so caller can fallback", () => {
+    const sdk = makeSdk({
+      sections: [
+        {
+          name: null,
+          content: [
+            {
+              type: "step",
+              value: {
+                number: 1,
+                items: [{ type: "ingredient", index: 4 }],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = tokenizeInstructionSdk(sdk);
+    expect(result).toEqual({
+      ok: false,
+      reason: "Malformed ingredient item index: 4",
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Preserve the existing, stable SSG `recipe.instructions` render path while enabling richer SDK-backed instruction rendering. 
- Centralize all SDK shape assumptions in a small adapter so SDK parsing/shape changes are isolated. 
- Make SDK rendering opt-in and safe by detecting malformed or unknown SDK content and falling back to the canonical instructions for stability. 

### Description
- Extend recipe domain schemas/types with an optional `instructionSdk` payload to carry SDK `sections`, `ingredientNames`, and `timerDisplayValues` alongside existing `instructions`. (see `packages/recipe-domain/src/recipe.ts`).
- Persist SDK instruction payload during Cooklang parsing while still producing the canonical `instructions` array for fallback (`ui/lib/content/cooklang.ts`).
- Add `tokenizeInstructionSdk` adapter that converts supported SDK items (`text`, `ingredient`, `timer`) into display tokens and returns explicit failures for unknown item types or malformed indexes (`ui/lib/domain/recipe/instructionTokens.ts`).
- Wire the adapter into the UI so `RecipeContent` attempts SDK rendering behind a guard, logs a dev-only debug message when the adapter fails, and falls back to `recipe.instructions` when needed (`ui/components/recipes/recipe-content.tsx` and view/type threading in `ui/lib/domain/recipe/*`).
- Add focused unit tests for the adapter covering success, unknown item type fallback, and malformed index fallback (`ui/tests/lib/domain/recipe/instructionTokens.test.ts`).

### Testing
- Ran the adapter unit tests with `pnpm --filter ui test -- tests/lib/domain/recipe/instructionTokens.test.ts`, and they passed. 
- Ran TypeScript checks with `pnpm --filter ui typecheck`, and type checking succeeded. 
- Pre-commit formatting/lint-staged tasks ran as part of the commit; `pnpm --filter ui lint` initially surfaced unrelated repo-wide Biome/config diagnostics but formatting fixes were applied during the pre-commit step and did not block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e0892023c0832ebdc19c8dd90b8a5d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipe instructions now support an enhanced structured format with comprehensive validation and automatic fallback to traditional formatting when processing fails.

* **Tests**
  * Added tests validating instruction format processing, including success scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->