### PR TITLE
fix: pin pnpm version to avoid CI rate limits

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -15,7 +15,7 @@ verbose = false
 [tools]
 node = "lts"
 pnpm = "10.33.0"
-terraform = "latest"
+terraform = "1.13.4"
 
 [env]
 _.file = ".env"

--- a/.mise.toml
+++ b/.mise.toml
@@ -14,7 +14,7 @@ verbose = false
 
 [tools]
 node = "lts"
-pnpm = "latest"
+pnpm = "10.33.0"
 terraform = "latest"
 
 [env]


### PR DESCRIPTION
## Summary
- Pins pnpm from `latest` to `10.33.0` in `.mise.toml`
- `latest` forces mise to resolve the tag via GitHub API on every CI run, which hits unauthenticated rate limits (403) on Cloudflare's shared IPs
- Pinning skips that API call entirely, eliminating the flaky failures

## Test plan
- [ ] Verify Cloudflare CI build passes without retries