### PR TITLE
fix(infra): skip terraform installation in Cloudflare Pages builds

### DIFF
--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -22,7 +22,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cf_images_account_hash: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
       TF_VAR_posthog_key: ${{ secrets.POSTHOG_KEY }}
-      TF_VAR_github_token: ${{ secrets.GITHUB_TOKEN_MISE }}
+      TF_VAR_github_token: ${{ secrets.MISE_GITHUB_TOKEN }}
     defaults:
       run:
         working-directory: infra/cloudflare

--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -22,6 +22,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cf_images_account_hash: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
       TF_VAR_posthog_key: ${{ secrets.POSTHOG_KEY }}
+      TF_VAR_github_token: ${{ secrets.GITHUB_TOKEN_MISE }}
     defaults:
       run:
         working-directory: infra/cloudflare
@@ -39,6 +40,7 @@ jobs:
           export TF_TOKEN_app_terraform_io="${TF_TOKEN_app_terraform_io}"
           export TF_VAR_cf_images_account_hash="${TF_VAR_cf_images_account_hash}"
           export TF_VAR_posthog_key="${TF_VAR_posthog_key}"
+          export TF_VAR_github_token="${TF_VAR_github_token}"
           EOF
 
       - name: Terraform Plan

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -20,7 +20,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cf_images_account_hash: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
       TF_VAR_posthog_key: ${{ secrets.POSTHOG_KEY }}
-      TF_VAR_github_token: ${{ secrets.GITHUB_TOKEN_MISE }}
+      TF_VAR_github_token: ${{ secrets.MISE_GITHUB_TOKEN }}
     defaults:
       run:
         working-directory: infra/cloudflare

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -20,6 +20,7 @@ jobs:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cf_images_account_hash: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
       TF_VAR_posthog_key: ${{ secrets.POSTHOG_KEY }}
+      TF_VAR_github_token: ${{ secrets.GITHUB_TOKEN_MISE }}
     defaults:
       run:
         working-directory: infra/cloudflare
@@ -37,6 +38,7 @@ jobs:
           export TF_TOKEN_app_terraform_io="${TF_TOKEN_app_terraform_io}"
           export TF_VAR_cf_images_account_hash="${TF_VAR_cf_images_account_hash}"
           export TF_VAR_posthog_key="${TF_VAR_posthog_key}"
+          export TF_VAR_github_token="${TF_VAR_github_token}"
           EOF
 
       - name: Check Terraform formatting

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -18,7 +18,7 @@ resource "cloudflare_pages_project" "personal_site" {
 
   build_config {
     build_caching   = true
-    build_command   = "curl https://mise.run | sh && export PATH=\"$HOME/.local/bin:$PATH\" && MISE_IGNORED_CONFIG_PATHS=~/.tool-versions MISE_EXPERIMENTAL=1 MISE_DISABLE_TOOLS=terraform mise run //ui:build"
+    build_command   = "curl https://mise.run | sh && export PATH=\"$HOME/.local/bin:$PATH\" && MISE_IGNORED_CONFIG_PATHS=\"$HOME/.tool-versions\" MISE_EXPERIMENTAL=1 MISE_DISABLE_TOOLS=terraform MISE_YES=1 mise run //ui:build"
     destination_dir = "ui/out"
     root_dir        = ""
   }

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -17,7 +17,7 @@ resource "cloudflare_pages_project" "personal_site" {
 
   build_config {
     build_caching   = true
-    build_command   = "curl https://mise.run | sh && export PATH=\"$HOME/.local/bin:$PATH\" && MISE_IGNORED_CONFIG_PATHS=~/.tool-versions MISE_EXPERIMENTAL=1 mise run //ui:build"
+    build_command   = "curl https://mise.run | sh && export PATH=\"$HOME/.local/bin:$PATH\" && MISE_IGNORED_CONFIG_PATHS=~/.tool-versions MISE_EXPERIMENTAL=1 MISE_DISABLE_TOOLS=terraform mise run //ui:build"
     destination_dir = "ui/out"
     root_dir        = ""
   }

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -7,6 +7,7 @@ locals {
     NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH = var.cf_images_account_hash
     NEXT_PUBLIC_POSTHOG_KEY            = var.posthog_key
     NEXT_PUBLIC_POSTHOG_HOST           = var.posthog_host
+    GITHUB_TOKEN                       = var.github_token
   }
 }
 

--- a/infra/cloudflare/variables.tf
+++ b/infra/cloudflare/variables.tf
@@ -51,6 +51,13 @@ variable "r2_map_tiles_subdomain" {
 variable "posthog_key" {
   description = "PostHog project API key"
   type        = string
+  sensitive   = true
+}
+
+variable "github_token" {
+  description = "GitHub personal access token for mise tool downloads in Cloudflare Pages builds"
+  type        = string
+  sensitive   = true
 }
 
 variable "posthog_host" {


### PR DESCRIPTION
## Summary
- Adds `MISE_DISABLE_TOOLS=terraform` to the Cloudflare Pages build command
- The UI build only needs node and pnpm — terraform was being downloaded and installed unnecessarily on every build

## Test plan
- [ ] Verify Cloudflare Pages build succeeds
- [ ] Confirm terraform is not installed during build (check build logs)