### PR TITLE
Render inline timer annotations as interactive countdown pills

### DIFF
--- a/packages/recipe-domain/src/recipe.ts
+++ b/packages/recipe-domain/src/recipe.ts
@@ -72,6 +72,7 @@ export const RecipeInstructionSdkSchema = z.object({
   cookwareDisplayValues: z.array(z.string()),
   inlineQuantityDisplayValues: z.array(z.string()),
   timerDisplayValues: z.array(z.string()),
+  timerDurationSeconds: z.array(z.number().nullable()),
 });
 
 export type RecipeInstructionSdk = z.infer<typeof RecipeInstructionSdkSchema>;

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -48,6 +48,8 @@ export function InlineTimer({
 }) {
   const [state, setState] = useState<TimerState>("idle");
   const [remaining, setRemaining] = useState(durationSeconds ?? 0);
+  const remainingRef = useRef(remaining);
+  remainingRef.current = remaining;
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
 
@@ -80,21 +82,21 @@ export function InlineTimer({
     };
   }, [clearTimer, releaseWakeLock]);
 
+  useEffect(() => {
+    if (state === "running" && remaining <= 0) {
+      clearTimer();
+      releaseWakeLock();
+      setState("completed");
+      playAlertTone();
+    }
+  }, [remaining, state, clearTimer, releaseWakeLock]);
+
   const startCountdown = useCallback(() => {
     clearTimer();
     intervalRef.current = setInterval(() => {
-      setRemaining((prev) => {
-        if (prev <= 1) {
-          clearTimer();
-          releaseWakeLock();
-          setState("completed");
-          playAlertTone();
-          return 0;
-        }
-        return prev - 1;
-      });
+      setRemaining(remainingRef.current - 1);
     }, 1000);
-  }, [clearTimer, releaseWakeLock]);
+  }, [clearTimer]);
 
   const reset = useCallback(() => {
     clearTimer();

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -2,7 +2,8 @@
 
 import { Pause, RotateCcw, Timer, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Badge } from "@/components/ui/badge";
+import { badgeVariants } from "@/components/ui/badge";
+import { cn } from "@/lib/generic/styles";
 
 type TimerState = "idle" | "running" | "paused" | "completed";
 
@@ -153,10 +154,12 @@ export function InlineTimer({
 
   if (durationSeconds === null) {
     return (
-      <Badge variant="outline" className="align-baseline">
+      <span
+        className={cn(badgeVariants({ variant: "outline" }), "align-baseline")}
+      >
         <Timer className="size-3" />
         {label}
-      </Badge>
+      </span>
     );
   }
 
@@ -167,44 +170,53 @@ export function InlineTimer({
         ? "default"
         : "outline";
 
+  const showReset = state === "running" || state === "paused";
+
   return (
-    <Badge
-      variant={variant}
-      interactive
-      active={state === "running"}
-      onClick={handleClick}
-      className={`align-baseline ${state === "completed" ? "animate-pulse" : ""}`}
-      aria-label={
-        state === "idle"
-          ? `Start ${label} timer`
-          : state === "running"
-            ? `Pause timer, ${formatCountdown(remaining)} remaining`
-            : state === "paused"
-              ? `Resume timer, ${formatCountdown(remaining)} remaining`
-              : "Timer complete, click to reset"
-      }
-    >
-      {state === "paused" ? (
-        <Pause className="size-3" />
-      ) : state === "completed" ? (
-        <RotateCcw className="size-3" />
-      ) : (
-        <Timer className="size-3" />
+    <span
+      className={cn(
+        badgeVariants({
+          variant,
+          interactive: true,
+          active: state === "running",
+        }),
+        "align-baseline",
+        state === "completed" && "animate-pulse",
       )}
-      {state === "idle" ? label : formatCountdown(remaining)}
-      {(state === "running" || state === "paused") && (
+    >
+      <button
+        type="button"
+        onClick={handleClick}
+        className="inline-flex items-center gap-1"
+        aria-label={
+          state === "idle"
+            ? `Start ${label} timer`
+            : state === "running"
+              ? `Pause timer, ${formatCountdown(remaining)} remaining`
+              : state === "paused"
+                ? `Resume timer, ${formatCountdown(remaining)} remaining`
+                : "Timer complete, click to reset"
+        }
+      >
+        {state === "paused" ? (
+          <Pause className="size-3" />
+        ) : state === "completed" ? (
+          <RotateCcw className="size-3" />
+        ) : (
+          <Timer className="size-3" />
+        )}
+        {state === "idle" ? label : formatCountdown(remaining)}
+      </button>
+      {showReset && (
         <button
           type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            reset();
-          }}
+          onClick={reset}
           className="ml-0.5 rounded-sm opacity-60 hover:opacity-100"
           aria-label="Reset timer"
         >
           <X className="size-3" />
         </button>
       )}
-    </Badge>
+    </span>
   );
 }

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { Pause, RotateCcw, Timer, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+
+type TimerState = "idle" | "running" | "paused" | "completed";
+
+function formatCountdown(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const mm = String(m).padStart(h > 0 ? 2 : 1, "0");
+  const ss = String(s).padStart(2, "0");
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+function playAlertTone() {
+  try {
+    const ctx = new AudioContext();
+    const beep = (startTime: number, freq: number, duration: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.frequency.value = freq;
+      osc.type = "sine";
+      gain.gain.setValueAtTime(0.3, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
+      osc.start(startTime);
+      osc.stop(startTime + duration);
+    };
+    const now = ctx.currentTime;
+    beep(now, 880, 0.15);
+    beep(now + 0.2, 880, 0.15);
+    beep(now + 0.4, 1100, 0.3);
+  } catch {
+    // Audio not available
+  }
+}
+
+export function InlineTimer({
+  durationSeconds,
+  label,
+}: {
+  durationSeconds: number | null;
+  label: string;
+}) {
+  const [state, setState] = useState<TimerState>("idle");
+  const [remaining, setRemaining] = useState(durationSeconds ?? 0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const releaseWakeLock = useCallback(() => {
+    wakeLockRef.current?.release().catch(() => {});
+    wakeLockRef.current = null;
+  }, []);
+
+  const requestWakeLock = useCallback(async () => {
+    if ("wakeLock" in navigator) {
+      try {
+        wakeLockRef.current = await navigator.wakeLock.request("screen");
+      } catch {
+        // Wake lock not available (e.g., tab not visible)
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearTimer();
+      releaseWakeLock();
+    };
+  }, [clearTimer, releaseWakeLock]);
+
+  const startCountdown = useCallback(() => {
+    clearTimer();
+    intervalRef.current = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clearTimer();
+          releaseWakeLock();
+          setState("completed");
+          playAlertTone();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, [clearTimer, releaseWakeLock]);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    releaseWakeLock();
+    setRemaining(durationSeconds ?? 0);
+    setState("idle");
+  }, [clearTimer, releaseWakeLock, durationSeconds]);
+
+  const handleClick = useCallback(() => {
+    if (durationSeconds === null) return;
+
+    switch (state) {
+      case "idle":
+        setRemaining(durationSeconds);
+        setState("running");
+        startCountdown();
+        requestWakeLock();
+        break;
+      case "running":
+        clearTimer();
+        setState("paused");
+        break;
+      case "paused":
+        setState("running");
+        startCountdown();
+        break;
+      case "completed":
+        reset();
+        break;
+    }
+  }, [
+    state,
+    durationSeconds,
+    startCountdown,
+    clearTimer,
+    requestWakeLock,
+    reset,
+  ]);
+
+  if (durationSeconds === null) {
+    return (
+      <Badge variant="outline" className="align-baseline">
+        <Timer className="size-3" />
+        {label}
+      </Badge>
+    );
+  }
+
+  const variant =
+    state === "completed"
+      ? "destructive"
+      : state === "running" || state === "paused"
+        ? "default"
+        : "outline";
+
+  return (
+    <Badge
+      variant={variant}
+      interactive
+      active={state === "running"}
+      onClick={handleClick}
+      className={`align-baseline ${state === "completed" ? "animate-pulse" : ""}`}
+      aria-label={
+        state === "idle"
+          ? `Start ${label} timer`
+          : state === "running"
+            ? `Pause timer, ${formatCountdown(remaining)} remaining`
+            : state === "paused"
+              ? `Resume timer, ${formatCountdown(remaining)} remaining`
+              : "Timer complete, click to reset"
+      }
+    >
+      {state === "paused" ? (
+        <Pause className="size-3" />
+      ) : state === "completed" ? (
+        <RotateCcw className="size-3" />
+      ) : (
+        <Timer className="size-3" />
+      )}
+      {state === "idle" ? label : formatCountdown(remaining)}
+      {(state === "running" || state === "paused") && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            reset();
+          }}
+          className="ml-0.5 rounded-sm opacity-60 hover:opacity-100"
+          aria-label="Reset timer"
+        >
+          <X className="size-3" />
+        </button>
+      )}
+    </Badge>
+  );
+}

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -82,6 +82,19 @@ export function InlineTimer({
   }, [clearTimer, releaseWakeLock]);
 
   useEffect(() => {
+    if (state !== "running") return;
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        requestWakeLock();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [state, requestWakeLock]);
+
+  useEffect(() => {
     if (state === "running" && remaining <= 0) {
       clearTimer();
       releaseWakeLock();

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -15,28 +15,23 @@ function formatCountdown(seconds: number): string {
   return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
 }
 
-function playAlertTone() {
-  try {
-    const ctx = new AudioContext();
-    const beep = (startTime: number, freq: number, duration: number) => {
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      osc.frequency.value = freq;
-      osc.type = "sine";
-      gain.gain.setValueAtTime(0.3, startTime);
-      gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
-      osc.start(startTime);
-      osc.stop(startTime + duration);
-    };
-    const now = ctx.currentTime;
-    beep(now, 880, 0.15);
-    beep(now + 0.2, 880, 0.15);
-    beep(now + 0.4, 1100, 0.3);
-  } catch {
-    // Audio not available
-  }
+function playAlertTone(ctx: AudioContext) {
+  const beep = (startTime: number, freq: number, duration: number) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.frequency.value = freq;
+    osc.type = "sine";
+    gain.gain.setValueAtTime(0.3, startTime);
+    gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
+    osc.start(startTime);
+    osc.stop(startTime + duration);
+  };
+  const now = ctx.currentTime;
+  beep(now, 880, 0.15);
+  beep(now + 0.2, 880, 0.15);
+  beep(now + 0.4, 1100, 0.3);
 }
 
 export function InlineTimer({
@@ -52,6 +47,7 @@ export function InlineTimer({
   remainingRef.current = remaining;
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
 
   const clearTimer = useCallback(() => {
     if (intervalRef.current !== null) {
@@ -79,6 +75,8 @@ export function InlineTimer({
     return () => {
       clearTimer();
       releaseWakeLock();
+      audioCtxRef.current?.close().catch(() => {});
+      audioCtxRef.current = null;
     };
   }, [clearTimer, releaseWakeLock]);
 
@@ -87,7 +85,9 @@ export function InlineTimer({
       clearTimer();
       releaseWakeLock();
       setState("completed");
-      playAlertTone();
+      if (audioCtxRef.current) {
+        playAlertTone(audioCtxRef.current);
+      }
     }
   }, [remaining, state, clearTimer, releaseWakeLock]);
 
@@ -105,8 +105,22 @@ export function InlineTimer({
     setState("idle");
   }, [clearTimer, releaseWakeLock, durationSeconds]);
 
+  const ensureAudioContext = useCallback(() => {
+    try {
+      if (!audioCtxRef.current) {
+        audioCtxRef.current = new AudioContext();
+      }
+      if (audioCtxRef.current.state === "suspended") {
+        audioCtxRef.current.resume().catch(() => {});
+      }
+    } catch {
+      // Web Audio not available
+    }
+  }, []);
+
   const handleClick = useCallback(() => {
     if (durationSeconds === null) return;
+    ensureAudioContext();
 
     switch (state) {
       case "idle":
@@ -134,6 +148,7 @@ export function InlineTimer({
     clearTimer,
     requestWakeLock,
     reset,
+    ensureAudioContext,
   ]);
 
   if (durationSeconds === null) {

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -44,8 +44,7 @@ export function InlineTimer({
 }) {
   const [state, setState] = useState<TimerState>("idle");
   const [remaining, setRemaining] = useState(durationSeconds ?? 0);
-  const remainingRef = useRef(remaining);
-  remainingRef.current = remaining;
+  const endTimeMsRef = useRef(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
   const wakeLockEpochRef = useRef(0);
@@ -88,10 +87,17 @@ export function InlineTimer({
     };
   }, [clearTimer, releaseWakeLock]);
 
+  const syncRemaining = useCallback(() => {
+    setRemaining(
+      Math.max(0, Math.ceil((endTimeMsRef.current - Date.now()) / 1000)),
+    );
+  }, []);
+
   useEffect(() => {
     if (state !== "running") return;
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") {
+        syncRemaining();
         requestWakeLock();
       }
     };
@@ -99,7 +105,7 @@ export function InlineTimer({
     return () => {
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [state, requestWakeLock]);
+  }, [state, requestWakeLock, syncRemaining]);
 
   useEffect(() => {
     if (state === "running" && remaining <= 0) {
@@ -112,12 +118,14 @@ export function InlineTimer({
     }
   }, [remaining, state, clearTimer, releaseWakeLock]);
 
-  const startCountdown = useCallback(() => {
-    clearTimer();
-    intervalRef.current = setInterval(() => {
-      setRemaining(remainingRef.current - 1);
-    }, 1000);
-  }, [clearTimer]);
+  const startCountdown = useCallback(
+    (seconds: number) => {
+      clearTimer();
+      endTimeMsRef.current = Date.now() + seconds * 1000;
+      intervalRef.current = setInterval(syncRemaining, 1000);
+    },
+    [clearTimer, syncRemaining],
+  );
 
   const reset = useCallback(() => {
     clearTimer();
@@ -147,7 +155,7 @@ export function InlineTimer({
       case "idle":
         setRemaining(durationSeconds);
         setState("running");
-        startCountdown();
+        startCountdown(durationSeconds);
         requestWakeLock();
         break;
       case "running":
@@ -157,7 +165,7 @@ export function InlineTimer({
         break;
       case "paused":
         setState("running");
-        startCountdown();
+        startCountdown(remaining);
         requestWakeLock();
         break;
       case "completed":
@@ -166,6 +174,7 @@ export function InlineTimer({
     }
   }, [
     state,
+    remaining,
     durationSeconds,
     startCountdown,
     clearTimer,

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -159,6 +159,7 @@ export function InlineTimer({
         requestWakeLock();
         break;
       case "running":
+        syncRemaining();
         clearTimer();
         releaseWakeLock();
         setState("paused");
@@ -177,6 +178,7 @@ export function InlineTimer({
     remaining,
     durationSeconds,
     startCountdown,
+    syncRemaining,
     clearTimer,
     releaseWakeLock,
     requestWakeLock,

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -48,6 +48,7 @@ export function InlineTimer({
   remainingRef.current = remaining;
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+  const wakeLockEpochRef = useRef(0);
   const audioCtxRef = useRef<AudioContext | null>(null);
 
   const clearTimer = useCallback(() => {
@@ -58,17 +59,23 @@ export function InlineTimer({
   }, []);
 
   const releaseWakeLock = useCallback(() => {
+    wakeLockEpochRef.current += 1;
     wakeLockRef.current?.release().catch(() => {});
     wakeLockRef.current = null;
   }, []);
 
   const requestWakeLock = useCallback(async () => {
-    if ("wakeLock" in navigator) {
-      try {
-        wakeLockRef.current = await navigator.wakeLock.request("screen");
-      } catch {
-        // Wake lock not available (e.g., tab not visible)
+    if (!("wakeLock" in navigator)) return;
+    const epoch = ++wakeLockEpochRef.current;
+    try {
+      const sentinel = await navigator.wakeLock.request("screen");
+      if (wakeLockEpochRef.current !== epoch) {
+        sentinel.release().catch(() => {});
+        return;
       }
+      wakeLockRef.current = sentinel;
+    } catch {
+      // Wake lock not available (e.g., tab not visible)
     }
   }, []);
 

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -132,11 +132,13 @@ export function InlineTimer({
         break;
       case "running":
         clearTimer();
+        releaseWakeLock();
         setState("paused");
         break;
       case "paused":
         setState("running");
         startCountdown();
+        requestWakeLock();
         break;
       case "completed":
         reset();
@@ -147,6 +149,7 @@ export function InlineTimer({
     durationSeconds,
     startCountdown,
     clearTimer,
+    releaseWakeLock,
     requestWakeLock,
     reset,
     ensureAudioContext,

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -2,6 +2,7 @@
 
 import { Clock, Minus, Plus, Timer, Users } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { InlineTimer } from "@/components/recipes/inline-timer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatIngredientName } from "@/lib/domain/recipe/ingredientText";
@@ -347,10 +348,19 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
                 <li key={i} className="leading-relaxed pl-2">
                   {tokens.map((token, tokenIndex) => (
                     <span key={tokenIndex}>
-                      {token.type === "ingredient" &&
-                      repeatedInstructionIngredients.has(token.canonicalName)
-                        ? formatInstructionIngredientToken(token, scale)
-                        : token.value}
+                      {token.type === "timer" ? (
+                        <InlineTimer
+                          durationSeconds={token.durationSeconds}
+                          label={token.value}
+                        />
+                      ) : token.type === "ingredient" &&
+                        repeatedInstructionIngredients.has(
+                          token.canonicalName,
+                        ) ? (
+                        formatInstructionIngredientToken(token, scale)
+                      ) : (
+                        token.value
+                      )}
                     </span>
                   ))}
                 </li>

--- a/ui/lib/content/cooklang.ts
+++ b/ui/lib/content/cooklang.ts
@@ -109,16 +109,19 @@ function timerDurationSeconds(timer: Timer): number | null {
   switch (unit) {
     case "s":
     case "sec":
+    case "secs":
     case "second":
     case "seconds":
       return qty;
     case "m":
     case "min":
+    case "mins":
     case "minute":
     case "minutes":
       return qty * 60;
     case "h":
     case "hr":
+    case "hrs":
     case "hour":
     case "hours":
       return qty * 3600;

--- a/ui/lib/content/cooklang.ts
+++ b/ui/lib/content/cooklang.ts
@@ -102,6 +102,31 @@ function formatTimerDisplay(timer: Timer): string {
     .trim();
 }
 
+function timerDurationSeconds(timer: Timer): number | null {
+  const qty = resolveQuantityValue(timer.quantity);
+  if (qty === undefined) return null;
+  const unit = getQuantityUnit(timer.quantity)?.toLowerCase();
+  switch (unit) {
+    case "s":
+    case "sec":
+    case "second":
+    case "seconds":
+      return qty;
+    case "m":
+    case "min":
+    case "minute":
+    case "minutes":
+      return qty * 60;
+    case "h":
+    case "hr":
+    case "hour":
+    case "hours":
+      return qty * 3600;
+    default:
+      return null;
+  }
+}
+
 function formatCookwareDisplay(cookware: Cookware): string {
   return cookware_display_name(cookware);
 }
@@ -335,6 +360,7 @@ export function parseCookFile(
   const cookwareDisplayValues = cookware.map(formatCookwareDisplay);
   const inlineQuantityDisplayValues = inlineQuantities;
   const timerDisplayValues = timers.map(formatTimerDisplay);
+  const timerDurations = timers.map(timerDurationSeconds);
 
   for (const section of sections) {
     // Cooklang `== Name ==` sections map to ingredient groups
@@ -402,6 +428,7 @@ export function parseCookFile(
       cookwareDisplayValues,
       inlineQuantityDisplayValues,
       timerDisplayValues,
+      timerDurationSeconds: timerDurations,
     },
   });
 }

--- a/ui/lib/domain/recipe/instructionTokens.ts
+++ b/ui/lib/domain/recipe/instructionTokens.ts
@@ -23,6 +23,7 @@ export type InstructionDisplayToken =
   | {
       type: "timer";
       value: string;
+      durationSeconds: number | null;
     };
 
 export type InstructionTokenizationResult =
@@ -134,7 +135,9 @@ export function tokenizeInstructionSdk(
               reason: `Malformed timer item index: ${item.index}`,
             };
           }
-          tokens.push({ type: "timer", value: timer });
+          const durationSeconds =
+            instructionSdk.timerDurationSeconds[item.index] ?? null;
+          tokens.push({ type: "timer", value: timer, durationSeconds });
           continue;
         }
 

--- a/ui/tests/lib/domain/recipe/instructionTokens.test.ts
+++ b/ui/tests/lib/domain/recipe/instructionTokens.test.ts
@@ -13,6 +13,7 @@ function makeSdk(
     cookwareDisplayValues: ["oven"],
     inlineQuantityDisplayValues: ["200°C"],
     timerDisplayValues: ["10 min"],
+    timerDurationSeconds: [600],
     sections: [
       {
         name: null,
@@ -53,7 +54,7 @@ describe("tokenizeInstructionSdk", () => {
             unit: "piece",
           },
           { type: "text", value: " for " },
-          { type: "timer", value: "10 min" },
+          { type: "timer", value: "10 min", durationSeconds: 600 },
         ],
       ]);
     }


### PR DESCRIPTION
## Summary
- Timer annotations (`~{25%minutes}`) in recipe instructions now render as clickable Badge pills instead of plain text
- Tapping starts a countdown timer with pause/resume and reset (X) controls
- Plays a Web Audio alert tone on completion and uses the Wake Lock API to keep the screen awake during active timers
- Adds `timerDurationSeconds` to the recipe SDK schema, computed at build time from the cooklang timer quantity and unit

## Test plan
- [x] Unit tests updated and passing (155/155)
- [x] Build passes
- [x] Visit a recipe with timers (e.g. chicken-quesadillas) and verify pill renders inline
- [x] Click pill to start countdown, click to pause, click to resume
- [x] Click X to reset a running/paused timer
- [x] Let timer complete — verify audio alert and visual pulse
- [ ] Verify Wake Lock keeps screen on during countdown (mobile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive inline timers in recipe instructions: click a timer badge to start, pause, resume or reset a countdown. Unknown durations show a static timer icon. Active timers try to keep the screen awake and play an alert when complete.
* **Tests**
  * Unit tests updated to cover timer duration handling in instruction tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->