### PR TITLE
[codex] Add recipe equipment filter

### DIFF
--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Clock, Globe, Leaf, Timer, UtensilsCrossed } from "lucide-react";
+import {
+  ChefHat,
+  Clock,
+  Globe,
+  Leaf,
+  Timer,
+  UtensilsCrossed,
+} from "lucide-react";
 import Link from "next/link";
 import type React from "react";
 import { Badge } from "@/components/ui/badge";
@@ -101,6 +108,7 @@ export function RecipeList({ recipes }: RecipeListProps) {
     filters: [
       { paramName: "cuisine", isMulti: true },
       { paramName: "ingredient", isMulti: true },
+      { paramName: "equipment", isMulti: true },
       { paramName: "prepTime", isMulti: true },
       { paramName: "totalTime", isMulti: true },
     ],
@@ -121,6 +129,7 @@ export function RecipeList({ recipes }: RecipeListProps) {
           { name: "description", weight: 2 },
           { name: "cuisine", weight: 2 },
           { name: "ingredientNames", weight: 1 },
+          { name: "cookware", weight: 1 },
         ],
         threshold: 0.1,
       }}
@@ -142,6 +151,15 @@ export function RecipeList({ recipes }: RecipeListProps) {
           icon: <Leaf className="h-4 w-4" />,
           getValueLabel: (value) => value,
           getOptionIcon: () => <Leaf className="h-3 w-3" />,
+        },
+        {
+          paramName: "equipment",
+          isMulti: true,
+          label: "Equipment",
+          getItemValues: (recipe) => recipe.cookware,
+          icon: <ChefHat className="h-4 w-4" />,
+          getValueLabel: (value) => value,
+          getOptionIcon: () => <ChefHat className="h-3 w-3" />,
         },
         {
           paramName: "prepTime",

--- a/ui/lib/domain/recipe/recipeViews.ts
+++ b/ui/lib/domain/recipe/recipeViews.ts
@@ -40,6 +40,7 @@ type BaseRecipeView = {
 
 export type RecipeCardView = BaseRecipeView & {
   ingredientNames: string[];
+  cookware: string[];
 };
 
 export type RecipeDetailView = BaseRecipeView & {
@@ -117,6 +118,7 @@ export function toRecipeCardView(
     image: recipe.image,
     imageAlt: recipe.imageAlt,
     ingredientNames: extractIngredientNames(recipe, ingredients),
+    cookware: recipe.cookware,
   };
 }
 

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RecipeList } from "@/components/recipes/recipe-list";
+import type { RecipeCardView } from "@/lib/api/recipes";
+
+const replaceMock = vi.fn();
+
+let currentSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/recipes",
+  useRouter: () => ({
+    replace: replaceMock,
+  }),
+  useSearchParams: () => currentSearchParams,
+}));
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/integrations/cloudflare-images", () => ({
+  getImageUrl: (image: string) => image,
+}));
+
+const recipes: RecipeCardView[] = [
+  {
+    slug: "slow-cooker-mexican-chicken",
+    title: "Slow Cooker Mexican Chicken",
+    description: "Slow cooker chicken for tacos.",
+    date: "2026-02-12",
+    cuisine: "Mexican",
+    servings: 4,
+    prepTime: 15,
+    cookTime: 240,
+    totalTime: 255,
+    ingredientNames: ["chicken breast", "white onion"],
+    cookware: ["fork", "oven", "slow cooker"],
+  },
+  {
+    slug: "chicken-quesadillas",
+    title: "Chicken Quesadillas",
+    description: "Crisp quesadillas with chipotle mayo.",
+    date: "2026-02-10",
+    cuisine: "Mexican",
+    servings: 4,
+    prepTime: 20,
+    cookTime: 30,
+    totalTime: 50,
+    ingredientNames: ["chicken breast", "cheddar cheese"],
+    cookware: ["baking tray", "bowl", "fork", "frying pan", "oven", "spoon"],
+  },
+  {
+    slug: "creamy-pesto-risotto",
+    title: "Creamy Pesto Risotto",
+    description: "Creamy risotto with pesto.",
+    date: "2026-02-08",
+    cuisine: "Italian",
+    servings: 4,
+    prepTime: 10,
+    cookTime: 30,
+    totalTime: 40,
+    ingredientNames: ["arborio rice", "pesto"],
+    cookware: ["bowl", "saucepan"],
+  },
+];
+
+describe("RecipeList", () => {
+  beforeEach(() => {
+    currentSearchParams = new URLSearchParams();
+    replaceMock.mockReset();
+  });
+
+  it("shows an equipment filter with cookware options", async () => {
+    const user = userEvent.setup();
+
+    render(<RecipeList recipes={recipes} />);
+
+    const equipmentLabel = screen.getByText("Equipment:");
+    const equipmentFilter = equipmentLabel.closest('[role="combobox"]');
+    expect(equipmentFilter).not.toBeNull();
+
+    await user.click(equipmentFilter!);
+
+    expect(screen.getByRole("button", { name: "fork" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "slow cooker" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "saucepan" }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies the equipment filter via the equipment query param", () => {
+    currentSearchParams = new URLSearchParams("equipment=slow cooker");
+
+    render(<RecipeList recipes={recipes} />);
+
+    expect(screen.getByText("Showing 1 of 3 recipes")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Slow Cooker Mexican Chicken" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Chicken Quesadillas" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Creamy Pesto Risotto" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/tests/lib/domain/recipe/recipeQueries.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeQueries.test.ts
@@ -88,6 +88,7 @@ const curryRecipe = makeRecipe({
   slug: "curry",
   title: "Chicken Curry",
   cuisine: "Asian",
+  cookware: ["frying pan", "saucepan"],
   ingredientGroups: [
     {
       items: [
@@ -103,6 +104,7 @@ const risottoRecipe = makeRecipe({
   slug: "risotto",
   title: "Chorizo Risotto",
   cuisine: "Italian",
+  cookware: ["bowl", "saucepan"],
   ingredientGroups: [
     {
       items: [
@@ -124,6 +126,7 @@ describe("recipe queries", () => {
       expect(card?.title).toBe("Chicken Curry");
       expect(card?.cuisine).toBe("Asian");
       expect(card?.servings).toBe(4);
+      expect(card?.cookware).toEqual(["frying pan", "saucepan"]);
     });
 
     it("returns null for a non-existent recipe", () => {
@@ -162,6 +165,7 @@ describe("recipe queries", () => {
       const slugs = cards.map((c) => c.slug);
       expect(slugs).toContain("curry");
       expect(slugs).toContain("risotto");
+      expect(cards[0]?.cookware.length).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary
Adds equipment as a filterable dimension on the recipe listing page, matching the existing cuisine, ingredient, and time filter pattern.

## What changed
- exposed `cookware` on `RecipeCardView` so recipe cards can participate in list filtering and search
- added an `Equipment` multi-select filter to the recipes page using the existing shared filter grid
- included cookware values in recipe search
- added domain and component tests covering the new equipment filter behavior

## Why
Recipe content already includes parsed cookware, but the recipe list dropped that data at the card-view layer. That meant equipment could not be surfaced in the existing filter system even though the source data already existed.

## Validation
- `pnpm vitest run tests/lib/domain/recipe/recipeQueries.test.ts tests/components/recipes/recipe-list.test.tsx`
- `pnpm tsc --noEmit`