### PR TITLE
Add previous and next navigation to recipe pages

### DIFF
--- a/ui/app/recipes/[slug]/page.tsx
+++ b/ui/app/recipes/[slug]/page.tsx
@@ -2,9 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { RecipeContent } from "@/components/recipes/recipe-content";
+import { RecipePagination } from "@/components/recipes/recipe-pagination";
 import {
   getAllRecipeSlugs,
   getRecipeBySlug,
+  getRecipeNavigation,
   type RecipeDetailView,
 } from "@/lib/api/recipes";
 
@@ -43,6 +45,8 @@ export default async function RecipePage(props: PageProps) {
     notFound();
   }
 
+  const { prevRecipe, nextRecipe } = getRecipeNavigation(slug);
+
   return (
     <article className="container mx-auto px-4 py-12 max-w-4xl">
       <Link
@@ -53,6 +57,12 @@ export default async function RecipePage(props: PageProps) {
       </Link>
 
       <RecipeContent recipe={recipe} />
+
+      <RecipePagination
+        prevRecipe={prevRecipe}
+        nextRecipe={nextRecipe}
+        className="mt-12"
+      />
     </article>
   );
 }

--- a/ui/components/recipes/recipe-pagination.tsx
+++ b/ui/components/recipes/recipe-pagination.tsx
@@ -1,0 +1,70 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import Link from "next/link";
+import type { RecipeCardView } from "@/lib/api/recipes";
+import { cn } from "@/lib/generic/styles";
+
+interface RecipePaginationProps {
+  prevRecipe?: RecipeCardView;
+  nextRecipe?: RecipeCardView;
+  className?: string;
+}
+
+export function RecipePagination({
+  prevRecipe,
+  nextRecipe,
+  className,
+}: RecipePaginationProps) {
+  if (!prevRecipe && !nextRecipe) return null;
+
+  const hasBothDirections = Boolean(prevRecipe && nextRecipe);
+
+  return (
+    <nav
+      aria-label="Recipe navigation"
+      className={cn("border-t border-border/60 pt-8", className)}
+    >
+      <div className="mb-4 text-sm font-medium text-muted-foreground">
+        More recipes
+      </div>
+
+      <div
+        className={cn(
+          "grid w-full gap-3",
+          hasBothDirections ? "sm:grid-cols-2" : "sm:grid-cols-1",
+        )}
+      >
+        {prevRecipe ? (
+          <Link href={`/recipes/${prevRecipe.slug}`} className="block min-w-0">
+            <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">
+              <ArrowLeft className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="min-w-0 flex-1">
+                <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                  Previous
+                </div>
+                <div className="overflow-hidden text-sm font-medium break-words">
+                  {prevRecipe.title}
+                </div>
+              </div>
+            </div>
+          </Link>
+        ) : null}
+
+        {nextRecipe ? (
+          <Link href={`/recipes/${nextRecipe.slug}`} className="block min-w-0">
+            <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">
+              <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground sm:order-2" />
+              <div className="min-w-0 flex-1 sm:text-right">
+                <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                  Next
+                </div>
+                <div className="overflow-hidden text-sm font-medium break-words">
+                  {nextRecipe.title}
+                </div>
+              </div>
+            </div>
+          </Link>
+        ) : null}
+      </div>
+    </nav>
+  );
+}

--- a/ui/components/recipes/recipe-pagination.tsx
+++ b/ui/components/recipes/recipe-pagination.tsx
@@ -36,7 +36,10 @@ export function RecipePagination({
         {prevRecipe ? (
           <Link href={`/recipes/${prevRecipe.slug}`} className="block min-w-0">
             <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">
-              <ArrowLeft className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <ArrowLeft
+                aria-hidden="true"
+                className="h-4 w-4 shrink-0 text-muted-foreground"
+              />
               <div className="min-w-0 flex-1">
                 <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
                   Previous
@@ -52,7 +55,10 @@ export function RecipePagination({
         {nextRecipe ? (
           <Link href={`/recipes/${nextRecipe.slug}`} className="block min-w-0">
             <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">
-              <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground sm:order-2" />
+              <ArrowRight
+                aria-hidden="true"
+                className="h-4 w-4 shrink-0 text-muted-foreground sm:order-2"
+              />
               <div className="min-w-0 flex-1 sm:text-right">
                 <div className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
                   Next

--- a/ui/lib/api/recipes.ts
+++ b/ui/lib/api/recipes.ts
@@ -1,4 +1,5 @@
 import {
+  compareRecipesByDateAndSlug,
   getAllRecipeCards,
   getRecipeDetail,
   getRecipeNeighbors,
@@ -24,9 +25,7 @@ export function getRecipeBySlug(slug: string): RecipeDetailView {
 }
 
 export function getAllRecipes(): RecipeCardView[] {
-  return getAllRecipeCards(repository).sort((a, b) => {
-    return new Date(b.date).getTime() - new Date(a.date).getTime();
-  });
+  return getAllRecipeCards(repository).sort(compareRecipesByDateAndSlug);
 }
 
 export function getRecipeNavigation(slug: string): {

--- a/ui/lib/api/recipes.ts
+++ b/ui/lib/api/recipes.ts
@@ -1,6 +1,7 @@
 import {
   getAllRecipeCards,
   getRecipeDetail,
+  getRecipeNeighbors,
   loadRecipeRepository,
   type RecipeCardView,
   type RecipeDetailView,
@@ -26,4 +27,11 @@ export function getAllRecipes(): RecipeCardView[] {
   return getAllRecipeCards(repository).sort((a, b) => {
     return new Date(b.date).getTime() - new Date(a.date).getTime();
   });
+}
+
+export function getRecipeNavigation(slug: string): {
+  prevRecipe?: RecipeCardView;
+  nextRecipe?: RecipeCardView;
+} {
+  return getRecipeNeighbors(repository, slug);
 }

--- a/ui/lib/domain/recipe/recipeQueries.ts
+++ b/ui/lib/domain/recipe/recipeQueries.ts
@@ -34,6 +34,23 @@ export function getAllRecipeCards(
   );
 }
 
+type RecipeSortable = {
+  date: string;
+  slug: string;
+};
+
+export function compareRecipesByDateAndSlug<T extends RecipeSortable>(
+  a: T,
+  b: T,
+): number {
+  const dateComparison = b.date.localeCompare(a.date);
+  if (dateComparison !== 0) {
+    return dateComparison;
+  }
+
+  return a.slug.localeCompare(b.slug);
+}
+
 export function getRecipeNeighbors(
   repository: RecipeRepository,
   slug: RecipeSlug,
@@ -41,19 +58,26 @@ export function getRecipeNeighbors(
   prevRecipe?: RecipeCardView;
   nextRecipe?: RecipeCardView;
 } {
-  const recipes = getAllRecipeCards(repository).sort((a, b) => {
-    return new Date(b.date).getTime() - new Date(a.date).getTime();
-  });
+  const recipes = Array.from(repository.recipes.values()).sort(
+    compareRecipesByDateAndSlug,
+  );
 
   const currentIndex = recipes.findIndex((recipe) => recipe.slug === slug);
   if (currentIndex === -1) {
     return {};
   }
 
+  const prevRecipe = currentIndex > 0 ? recipes[currentIndex - 1] : undefined;
+  const nextRecipe =
+    currentIndex < recipes.length - 1 ? recipes[currentIndex + 1] : undefined;
+
   return {
-    prevRecipe: currentIndex > 0 ? recipes[currentIndex - 1] : undefined,
-    nextRecipe:
-      currentIndex < recipes.length - 1 ? recipes[currentIndex + 1] : undefined,
+    prevRecipe: prevRecipe
+      ? toRecipeCardView(prevRecipe, repository.ingredients)
+      : undefined,
+    nextRecipe: nextRecipe
+      ? toRecipeCardView(nextRecipe, repository.ingredients)
+      : undefined,
   };
 }
 

--- a/ui/lib/domain/recipe/recipeQueries.ts
+++ b/ui/lib/domain/recipe/recipeQueries.ts
@@ -34,6 +34,29 @@ export function getAllRecipeCards(
   );
 }
 
+export function getRecipeNeighbors(
+  repository: RecipeRepository,
+  slug: RecipeSlug,
+): {
+  prevRecipe?: RecipeCardView;
+  nextRecipe?: RecipeCardView;
+} {
+  const recipes = getAllRecipeCards(repository).sort((a, b) => {
+    return new Date(b.date).getTime() - new Date(a.date).getTime();
+  });
+
+  const currentIndex = recipes.findIndex((recipe) => recipe.slug === slug);
+  if (currentIndex === -1) {
+    return {};
+  }
+
+  return {
+    prevRecipe: currentIndex > 0 ? recipes[currentIndex - 1] : undefined,
+    nextRecipe:
+      currentIndex < recipes.length - 1 ? recipes[currentIndex + 1] : undefined,
+  };
+}
+
 export function getRecipesByCuisine(
   repository: RecipeRepository,
   cuisine: string,

--- a/ui/tests/components/recipes/recipe-pagination.test.tsx
+++ b/ui/tests/components/recipes/recipe-pagination.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RecipePagination } from "@/components/recipes/recipe-pagination";
+import type { RecipeCardView } from "@/lib/api/recipes";
+
+function makeRecipe(slug: string, title: string): RecipeCardView {
+  return {
+    slug,
+    title,
+    description: "Test recipe",
+    date: "2026-02-10",
+    servings: 4,
+    ingredientNames: [],
+    cookware: [],
+  };
+}
+
+describe("RecipePagination", () => {
+  it("renders previous and next recipe links when both neighbors exist", () => {
+    render(
+      <RecipePagination
+        prevRecipe={makeRecipe("previous-recipe", "Previous Recipe")}
+        nextRecipe={makeRecipe("next-recipe", "Next Recipe")}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /previous previous recipe/i }),
+    ).toHaveAttribute("href", "/recipes/previous-recipe");
+    expect(
+      screen.getByRole("link", { name: /next next recipe/i }),
+    ).toHaveAttribute("href", "/recipes/next-recipe");
+  });
+
+  it("renders only the available navigation control at the start of the list", () => {
+    render(
+      <RecipePagination
+        nextRecipe={makeRecipe("next-recipe", "Next Recipe")}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("link", { name: /previous/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /next next recipe/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no neighbors", () => {
+    const { container } = render(<RecipePagination />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/tests/components/recipes/recipe-pagination.test.tsx
+++ b/ui/tests/components/recipes/recipe-pagination.test.tsx
@@ -47,6 +47,21 @@ describe("RecipePagination", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders only the available navigation control at the end of the list", () => {
+    render(
+      <RecipePagination
+        prevRecipe={makeRecipe("previous-recipe", "Previous Recipe")}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /previous previous recipe/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /next/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("renders nothing when there are no neighbors", () => {
     const { container } = render(<RecipePagination />);
 

--- a/ui/tests/lib/domain/recipe/recipeQueries.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeQueries.test.ts
@@ -6,6 +6,7 @@ import type {
 import type { Recipe, RecipeSlug } from "@/lib/domain/recipe/recipe";
 import { buildRecipeContentGraph } from "@/lib/domain/recipe/recipeGraph";
 import {
+  compareRecipesByDateAndSlug,
   getAllCuisines,
   getAllRecipeCards,
   getAllUsedIngredientSlugs,
@@ -274,6 +275,53 @@ describe("recipe queries", () => {
 
       expect(neighbors.prevRecipe?.date).toBe("2026-02-12");
       expect(neighbors.nextRecipe?.date).toBe("2026-02-08");
+    });
+
+    it("uses slug as a deterministic tie-breaker for recipes on the same date", () => {
+      const sameDateA = makeRecipe({
+        slug: "alpha",
+        title: "Alpha",
+        date: "2026-02-10",
+      });
+      const sameDateB = makeRecipe({
+        slug: "beta",
+        title: "Beta",
+        date: "2026-02-10",
+      });
+
+      const tiedRepo = buildTestRepository(
+        [sameDateB, curryRecipe, sameDateA],
+        ingredients,
+      );
+
+      const neighbors = getRecipeNeighbors(tiedRepo, "alpha");
+
+      expect(neighbors.prevRecipe).toBeUndefined();
+      expect(neighbors.nextRecipe?.slug).toBe("beta");
+    });
+  });
+
+  describe("compareRecipesByDateAndSlug", () => {
+    it("orders newer recipes first", () => {
+      const recipes = [
+        { slug: "older", date: "2026-02-08" },
+        { slug: "newer", date: "2026-02-10" },
+      ];
+
+      recipes.sort(compareRecipesByDateAndSlug);
+
+      expect(recipes.map((recipe) => recipe.slug)).toEqual(["newer", "older"]);
+    });
+
+    it("falls back to slug ordering when dates match", () => {
+      const recipes = [
+        { slug: "beta", date: "2026-02-10" },
+        { slug: "alpha", date: "2026-02-10" },
+      ];
+
+      recipes.sort(compareRecipesByDateAndSlug);
+
+      expect(recipes.map((recipe) => recipe.slug)).toEqual(["alpha", "beta"]);
     });
   });
 });

--- a/ui/tests/lib/domain/recipe/recipeQueries.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeQueries.test.ts
@@ -11,6 +11,7 @@ import {
   getAllUsedIngredientSlugs,
   getRecipeCard,
   getRecipeDetail,
+  getRecipeNeighbors,
   getRecipesByCuisine,
   getRecipesByIngredient,
 } from "@/lib/domain/recipe/recipeQueries";
@@ -87,6 +88,7 @@ const ingredients: [IngredientSlug, Ingredient][] = [
 const curryRecipe = makeRecipe({
   slug: "curry",
   title: "Chicken Curry",
+  date: "2026-02-10",
   cuisine: "Asian",
   cookware: ["frying pan", "saucepan"],
   ingredientGroups: [
@@ -103,6 +105,7 @@ const curryRecipe = makeRecipe({
 const risottoRecipe = makeRecipe({
   slug: "risotto",
   title: "Chorizo Risotto",
+  date: "2026-02-08",
   cuisine: "Italian",
   cookware: ["bowl", "saucepan"],
   ingredientGroups: [
@@ -230,6 +233,47 @@ describe("recipe queries", () => {
       );
       const used = getAllUsedIngredientSlugs(repoWithUnused);
       expect(used).not.toContain("saffron");
+    });
+  });
+
+  describe("getRecipeNeighbors", () => {
+    const newestRecipe = makeRecipe({
+      slug: "jambalaya",
+      title: "Sausage Jambalaya",
+      date: "2026-02-12",
+    });
+
+    const orderedRepo = buildTestRepository(
+      [newestRecipe, curryRecipe, risottoRecipe],
+      ingredients,
+    );
+
+    it("returns both previous and next recipes for a middle recipe", () => {
+      const neighbors = getRecipeNeighbors(orderedRepo, "curry");
+
+      expect(neighbors.prevRecipe?.slug).toBe("jambalaya");
+      expect(neighbors.nextRecipe?.slug).toBe("risotto");
+    });
+
+    it("omits the previous recipe for the first recipe in canonical order", () => {
+      const neighbors = getRecipeNeighbors(orderedRepo, "jambalaya");
+
+      expect(neighbors.prevRecipe).toBeUndefined();
+      expect(neighbors.nextRecipe?.slug).toBe("curry");
+    });
+
+    it("omits the next recipe for the last recipe in canonical order", () => {
+      const neighbors = getRecipeNeighbors(orderedRepo, "risotto");
+
+      expect(neighbors.prevRecipe?.slug).toBe("curry");
+      expect(neighbors.nextRecipe).toBeUndefined();
+    });
+
+    it("uses newest-first date ordering to compute neighbors", () => {
+      const neighbors = getRecipeNeighbors(orderedRepo, "curry");
+
+      expect(neighbors.prevRecipe?.date).toBe("2026-02-12");
+      expect(neighbors.nextRecipe?.date).toBe("2026-02-08");
     });
   });
 });


### PR DESCRIPTION
## Summary
- add previous/next recipe navigation based on canonical newest-first recipe order
- render recipe navigation at the bottom of recipe detail pages with a mobile-friendly layout
- add tests for recipe neighbor lookup and pagination rendering

## Testing
- `pnpm --dir ui exec vitest run tests/lib/domain/recipe/recipeQueries.test.ts tests/components/recipes/recipe-pagination.test.tsx tests/components/recipes/recipe-list.test.tsx`
- `pnpm --dir ui exec tsc --noEmit`
- `pnpm --dir ui exec biome check app/recipes/[slug]/page.tsx components/recipes/recipe-pagination.tsx lib/api/recipes.ts lib/domain/recipe/recipeQueries.ts tests/lib/domain/recipe/recipeQueries.test.ts tests/components/recipes/recipe-pagination.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipe navigation to recipe detail pages, allowing users to browse to the previous and next recipes in chronological order via "Previous" and "Next" links displayed at the bottom of each recipe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->