### PR TITLE
Replace low-level Parser with CooklangParser wrapper

### DIFF
--- a/packages/recipe-domain/src/unit.ts
+++ b/packages/recipe-domain/src/unit.ts
@@ -69,17 +69,3 @@ export const UNIT_CATEGORIES: Record<Unit, UnitCategory> = {
   cube: "discrete",
   sachet: "discrete",
 };
-
-// Conversion factors to base unit within each category
-// Weight base: g, Volume base: ml, Spoon base: tsp
-export const UNIT_CONVERSIONS: Partial<
-  Record<Unit, { baseUnit: Unit; factor: number }>
-> = {
-  g: { baseUnit: "g", factor: 1 },
-  kg: { baseUnit: "g", factor: 1000 },
-  ml: { baseUnit: "ml", factor: 1 },
-  l: { baseUnit: "ml", factor: 1000 },
-  tsp: { baseUnit: "tsp", factor: 1 },
-  tbsp: { baseUnit: "tsp", factor: 3 },
-  cup: { baseUnit: "ml", factor: 250 },
-};

--- a/ui/hooks/use-cooklang-recipe.ts
+++ b/ui/hooks/use-cooklang-recipe.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import type { Parser } from "@cooklang/cooklang";
+import type { CooklangParser, CooklangRecipe } from "@cooklang/cooklang";
 import { useEffect, useState } from "react";
 
-type ParsedRecipe = ReturnType<Parser["parse"]>["recipe"];
+type ParsedRecipe = CooklangRecipe;
 
 export interface UseCooklangRecipeState {
   recipe: ParsedRecipe | null;
@@ -11,7 +11,7 @@ export interface UseCooklangRecipeState {
   error: Error | null;
 }
 
-let parserPromise: Promise<Parser> | null = null;
+let parserPromise: Promise<CooklangParser> | null = null;
 const MAX_PARSE_CACHE_SIZE = 50;
 const parsePromiseCache = new Map<string, Promise<ParsedRecipe>>();
 
@@ -19,7 +19,7 @@ function getCacheKey(cookBody: string, scale?: number): string {
   return `${scale ?? "default"}::${cookBody}`;
 }
 
-async function getParser(): Promise<Parser> {
+async function getParser(): Promise<CooklangParser> {
   if (parserPromise) {
     return parserPromise;
   }
@@ -27,7 +27,7 @@ async function getParser(): Promise<Parser> {
   parserPromise = (async () => {
     try {
       const module = await import("@cooklang/cooklang");
-      return new module.Parser();
+      return new module.CooklangParser();
     } catch (error) {
       parserPromise = null;
       throw error;
@@ -50,7 +50,7 @@ function getMemoizedParsePromise(
   const parsePromise = (async () => {
     try {
       const parser = await getParser();
-      const { recipe } = parser.parse(cookBody, scale);
+      const [recipe] = parser.parse(cookBody, scale);
       return recipe;
     } catch (error) {
       parsePromiseCache.delete(cacheKey);

--- a/ui/lib/content/cooklang.ts
+++ b/ui/lib/content/cooklang.ts
@@ -1,10 +1,16 @@
-import type { Cookware, Ingredient, Step, Timer } from "@cooklang/cooklang";
+import type {
+  Cookware,
+  Ingredient,
+  Quantity,
+  Step,
+  Timer,
+} from "@cooklang/cooklang";
 import {
+  CooklangParser,
   cookware_display_name,
   getQuantityUnit,
   getQuantityValue,
   ingredient_display_name,
-  Parser,
   quantity_display,
 } from "@cooklang/cooklang";
 import { readdirSync, readFileSync } from "fs";
@@ -49,7 +55,7 @@ type GroupAccumulator = {
   itemIndexByIngredient: Map<IngredientSlug, number>;
 };
 
-const _parser = new Parser();
+const _parser = new CooklangParser();
 
 // getQuantityValue returns NaN for fractions — resolve them from the raw structure.
 function resolveQuantityValue(
@@ -170,8 +176,8 @@ function formatInstructionIngredient(
   return `${amount} ${displayValue}`;
 }
 
-function formatInlineQuantityDisplay(quantity: unknown): string {
-  return quantity_display(quantity as Parameters<typeof quantity_display>[0]);
+function formatInlineQuantityDisplay(quantity: Quantity): string {
+  return quantity_display(quantity);
 }
 
 function buildIngredientGroupItem(
@@ -328,10 +334,10 @@ export function parseCookFile(
   const fm = data as CookFrontmatter;
   const annotations = fm.ingredientAnnotations ?? {};
 
-  const { recipe } = _parser.parse(body);
-  const inlineQuantities = (
-    (recipe as { inline_quantities?: unknown[] }).inline_quantities ?? []
-  ).map(formatInlineQuantityDisplay);
+  const [recipe] = _parser.parse(body);
+  const inlineQuantities = recipe.inlineQuantities.map(
+    formatInlineQuantityDisplay,
+  );
   const { sections, ingredients, cookware, timers } = recipe;
 
   const getOrCreateNamedGroup = (

--- a/ui/lib/domain/recipe/unit.ts
+++ b/ui/lib/domain/recipe/unit.ts
@@ -1,7 +1,2 @@
 export type { Unit, UnitCategory, UnitLabel } from "recipe-domain";
-export {
-  UNIT_CATEGORIES,
-  UNIT_CONVERSIONS,
-  UNIT_LABELS,
-  UnitSchema,
-} from "recipe-domain";
+export { UNIT_CATEGORIES, UNIT_LABELS, UnitSchema } from "recipe-domain";


### PR DESCRIPTION
## Summary
- Replace `new Parser()` with `new CooklangParser()` in both build-time parsing (`cooklang.ts`) and client-side hook (`use-cooklang-recipe.ts`)
- Destructure the tuple return `[recipe]` instead of object `{ recipe }` from `CooklangParser.parse()`
- Use typed `recipe.inlineQuantities` (`Quantity[]`) instead of casting through `unknown[]`
- Remove unused `UNIT_CONVERSIONS` export — SDK handles unit conversion during scaling

## Test plan
- [x] All 175 existing tests pass
- [x] Full Next.js build succeeds with all 18 recipe pages generated
- [x] Zero TypeScript diagnostics
- [ ] Manually verify a recipe page renders correctly (ingredients, instructions, timers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety and consistency across recipe parsing by modernising internal parser implementations and updating recipe handling logic throughout the system.
  * Streamlined the unit system architecture by removing redundant references and refining quantity formatting processes.
  * Improved overall code maintainability and clarity through targeted internal structural updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->