### PR TITLE
Enable multiple job titles per company

### DIFF
--- a/ui/components/experience/experience-card.tsx
+++ b/ui/components/experience/experience-card.tsx
@@ -44,6 +44,7 @@ export function ExperienceCard({
   blogs = [],
 }: ExperienceCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const titleTimeline = getTitleTimeline(experience);
 
   useEffect(() => {
     if (!id || typeof window === "undefined") return;
@@ -243,35 +244,31 @@ export function ExperienceCard({
           {/* Expanded details */}
           {isExpanded && (
             <CardContent className="space-y-4 pt-0 animate-in fade-in duration-100">
-              {(() => {
-                const timeline = getTitleTimeline(experience);
-                if (!timeline) return null;
-                return (
-                  <div className="space-y-2">
-                    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                      Title History
-                    </p>
-                    <div className="space-y-1">
-                      {timeline.map((entry) => (
-                        <div key={entry.title}>
-                          <p
-                            className={`text-sm ${
-                              entry.isCurrent
-                                ? "font-medium"
-                                : "text-muted-foreground"
-                            }`}
-                          >
-                            {entry.title}
-                          </p>
-                          <p className="text-xs text-muted-foreground/60">
-                            {entry.dateRange}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
+              {titleTimeline && (
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Title History
+                  </p>
+                  <div className="space-y-1">
+                    {titleTimeline.map((entry) => (
+                      <div key={`${entry.title}-${entry.dateRange}`}>
+                        <p
+                          className={`text-sm ${
+                            entry.isCurrent
+                              ? "font-medium"
+                              : "text-muted-foreground"
+                          }`}
+                        >
+                          {entry.title}
+                        </p>
+                        <p className="text-xs text-muted-foreground/60">
+                          {entry.dateRange}
+                        </p>
+                      </div>
+                    ))}
                   </div>
-                );
-              })()}
+                </div>
+              )}
               <ul className="space-y-1.5 text-sm">
                 {experience.responsibilities.map((responsibility) => (
                   <li key={responsibility} className="flex gap-2 items-start">

--- a/ui/components/experience/experience-card.tsx
+++ b/ui/components/experience/experience-card.tsx
@@ -112,17 +112,17 @@ export function ExperienceCard({
               <div className="flex-1 space-y-3">
                 <div className="space-y-1">
                   <CardTitle className="text-2xl">{experience.title}</CardTitle>
-                  {experience.previousTitles &&
-                    experience.previousTitles.length > 0 && (
-                      <p className="text-sm text-muted-foreground">
-                        <span className="text-muted-foreground/60">
-                          previously{" "}
-                        </span>
-                        {experience.previousTitles
-                          .map((prev) => prev.title)
-                          .join(" · ")}
-                      </p>
-                    )}
+                  {titleTimeline && titleTimeline.length > 1 && (
+                    <p className="text-sm text-muted-foreground">
+                      <span className="text-muted-foreground/60">
+                        previously{" "}
+                      </span>
+                      {titleTimeline
+                        .slice(1)
+                        .map((entry) => entry.title)
+                        .join(" · ")}
+                    </p>
+                  )}
                 </div>
                 <CardDescription className="text-base flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
                   <a

--- a/ui/components/experience/experience-card.tsx
+++ b/ui/components/experience/experience-card.tsx
@@ -21,7 +21,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { Experience } from "@/lib/api/experience";
-import { formatDateRange } from "@/lib/api/experience";
+import { formatDateRange, getTitleTimeline } from "@/lib/api/experience";
 import { hasTechIcon, TechIcon } from "@/lib/api/tech-icons";
 import type { BlogListItemView } from "@/lib/domain/blog/blogViews";
 import type { ProjectListItemView } from "@/lib/domain/project/projectViews";
@@ -109,7 +109,20 @@ export function ExperienceCard({
           >
             <div className="flex items-start justify-between gap-4">
               <div className="flex-1 space-y-3">
-                <CardTitle className="text-2xl">{experience.title}</CardTitle>
+                <div className="space-y-1">
+                  <CardTitle className="text-2xl">{experience.title}</CardTitle>
+                  {experience.previousTitles &&
+                    experience.previousTitles.length > 0 && (
+                      <p className="text-sm text-muted-foreground">
+                        <span className="text-muted-foreground/60">
+                          previously{" "}
+                        </span>
+                        {experience.previousTitles
+                          .map((prev) => prev.title)
+                          .join(" · ")}
+                      </p>
+                    )}
+                </div>
                 <CardDescription className="text-base flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
                   <a
                     href={experience.companyUrl}
@@ -230,6 +243,35 @@ export function ExperienceCard({
           {/* Expanded details */}
           {isExpanded && (
             <CardContent className="space-y-4 pt-0 animate-in fade-in duration-100">
+              {(() => {
+                const timeline = getTitleTimeline(experience);
+                if (!timeline) return null;
+                return (
+                  <div className="space-y-2">
+                    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Title History
+                    </p>
+                    <div className="space-y-1">
+                      {timeline.map((entry) => (
+                        <div key={entry.title}>
+                          <p
+                            className={`text-sm ${
+                              entry.isCurrent
+                                ? "font-medium"
+                                : "text-muted-foreground"
+                            }`}
+                          >
+                            {entry.title}
+                          </p>
+                          <p className="text-xs text-muted-foreground/60">
+                            {entry.dateRange}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
               <ul className="space-y-1.5 text-sm">
                 {experience.responsibilities.map((responsibility) => (
                   <li key={responsibility} className="flex gap-2 items-start">

--- a/ui/content/experience.ts
+++ b/ui/content/experience.ts
@@ -5,7 +5,14 @@ export const experiences: JobRoleContent[] = [
     company: "Terminal Industries",
     companyUrl: "https://terminal-industries.com/",
     logoPath: "/company-logos/terminal-industries.png",
-    title: "Principal Software Engineer",
+    title: "Engineering Manager",
+    previousTitles: [
+      {
+        title: "Principal Software Engineer",
+        startDate: "2024-05",
+        endDate: "2026-03",
+      },
+    ],
     location: "Belfast, UK",
     startDate: "2024-05",
     description:
@@ -136,8 +143,19 @@ export const experiences: JobRoleContent[] = [
     companyUrl:
       "https://www.philips.co.uk/healthcare/specialty/health-informatics",
     logoPath: "/company-logos/philips.png",
-    title:
-      "Graduate Software Engineer → Software Engineer → Senior Software Engineer",
+    title: "Senior Software Engineer",
+    previousTitles: [
+      {
+        title: "Software Engineer",
+        startDate: "2018-04",
+        endDate: "2019-09",
+      },
+      {
+        title: "Graduate Software Engineer",
+        startDate: "2017-07",
+        endDate: "2018-04",
+      },
+    ],
     location: "Belfast, UK",
     startDate: "2017-07",
     endDate: "2020-03",

--- a/ui/lib/api/experience.ts
+++ b/ui/lib/api/experience.ts
@@ -86,10 +86,14 @@ export function getTitleTimeline(
   experience: Experience,
 ): TitleWithDateRange[] | undefined {
   const { previousTitles } = experience;
-  const mostRecentPrevious = previousTitles?.[0];
-  if (!previousTitles || !mostRecentPrevious) return undefined;
+  if (!previousTitles || previousTitles.length === 0) return undefined;
 
-  const currentTitleStart = mostRecentPrevious.endDate;
+  // Sort by endDate descending so most-recent previous title is first
+  const sorted = [...previousTitles].sort((a, b) =>
+    b.endDate.localeCompare(a.endDate),
+  );
+
+  const currentTitleStart = sorted[0]!.endDate;
   return [
     {
       title: experience.title,
@@ -99,7 +103,7 @@ export function getTitleTimeline(
       ),
       isCurrent: !experience.endDate,
     },
-    ...previousTitles.map((prev) => ({
+    ...sorted.map((prev) => ({
       title: prev.title,
       dateRange: formatExperienceDateRange(prev.startDate, prev.endDate),
       isCurrent: false,

--- a/ui/lib/api/experience.ts
+++ b/ui/lib/api/experience.ts
@@ -76,6 +76,37 @@ function formatDuration(start: Date, end: Date): string {
   return `${years} ${years === 1 ? "year" : "years"}, ${remainingMonths} ${remainingMonths === 1 ? "month" : "months"}`;
 }
 
+export type TitleWithDateRange = {
+  title: string;
+  dateRange: string;
+  isCurrent: boolean;
+};
+
+export function getTitleTimeline(
+  experience: Experience,
+): TitleWithDateRange[] | undefined {
+  const { previousTitles } = experience;
+  const mostRecentPrevious = previousTitles?.[0];
+  if (!previousTitles || !mostRecentPrevious) return undefined;
+
+  const currentTitleStart = mostRecentPrevious.endDate;
+  return [
+    {
+      title: experience.title,
+      dateRange: formatExperienceDateRange(
+        currentTitleStart,
+        experience.endDate,
+      ),
+      isCurrent: !experience.endDate,
+    },
+    ...previousTitles.map((prev) => ({
+      title: prev.title,
+      dateRange: formatExperienceDateRange(prev.startDate, prev.endDate),
+      isCurrent: false,
+    })),
+  ];
+}
+
 export function getAllExperience(): Experience[] {
   return experiences;
 }

--- a/ui/lib/domain/models.ts
+++ b/ui/lib/domain/models.ts
@@ -4,6 +4,7 @@ import {
   ADRStatusSchema,
   ADRSchema as BaseADRSchema,
 } from "./adr/adr";
+import { PreviousTitleSchema } from "./role/jobRole";
 import { ADRRefSchema as CanonicalADRRefSchema } from "./slugs";
 
 export const TechnologySlugSchema = z.string().min(1);
@@ -111,12 +112,6 @@ export const ProjectSchema = z.object({
 });
 
 export type Project = z.infer<typeof ProjectSchema>;
-
-const PreviousTitleSchema = z.object({
-  title: z.string().min(1),
-  startDate: z.string().regex(/^\d{4}-\d{2}$/),
-  endDate: z.string().regex(/^\d{4}-\d{2}$/),
-});
 
 export const JobRoleSchema = z.object({
   slug: RoleSlugSchema,

--- a/ui/lib/domain/models.ts
+++ b/ui/lib/domain/models.ts
@@ -112,12 +112,19 @@ export const ProjectSchema = z.object({
 
 export type Project = z.infer<typeof ProjectSchema>;
 
+const PreviousTitleSchema = z.object({
+  title: z.string().min(1),
+  startDate: z.string().regex(/^\d{4}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}$/),
+});
+
 export const JobRoleSchema = z.object({
   slug: RoleSlugSchema,
   company: z.string().min(1),
   companyUrl: z.string().url(),
   logoPath: z.string().min(1),
   title: z.string().min(1),
+  previousTitles: z.array(PreviousTitleSchema).optional(),
   location: z.string().min(1),
   startDate: z.string().regex(/^\d{4}-\d{2}$/),
   endDate: z

--- a/ui/lib/domain/role/jobRole.ts
+++ b/ui/lib/domain/role/jobRole.ts
@@ -4,11 +4,20 @@ import { RoleSlugSchema, TechnologySlugSchema } from "../slugs";
 
 export type { RoleSlug };
 
+const PreviousTitleSchema = z.object({
+  title: z.string().min(1),
+  startDate: z.string().regex(/^\d{4}-\d{2}$/),
+  endDate: z.string().regex(/^\d{4}-\d{2}$/),
+});
+
+export type PreviousTitle = z.infer<typeof PreviousTitleSchema>;
+
 export const JobRoleContentSchema = z.object({
   company: z.string().min(1),
   companyUrl: z.string().url(),
   logoPath: z.string().min(1),
   title: z.string().min(1),
+  previousTitles: z.array(PreviousTitleSchema).optional(),
   location: z.string().min(1),
   startDate: z.string().regex(/^\d{4}-\d{2}$/),
   endDate: z
@@ -29,6 +38,7 @@ export const JobRoleSchema = z.object({
   companyUrl: z.string().url(),
   logoPath: z.string().min(1),
   title: z.string().min(1),
+  previousTitles: z.array(PreviousTitleSchema).optional(),
   location: z.string().min(1),
   startDate: z.string().regex(/^\d{4}-\d{2}$/),
   endDate: z

--- a/ui/lib/domain/role/jobRole.ts
+++ b/ui/lib/domain/role/jobRole.ts
@@ -4,7 +4,7 @@ import { RoleSlugSchema, TechnologySlugSchema } from "../slugs";
 
 export type { RoleSlug };
 
-const PreviousTitleSchema = z.object({
+export const PreviousTitleSchema = z.object({
   title: z.string().min(1),
   startDate: z.string().regex(/^\d{4}-\d{2}$/),
   endDate: z.string().regex(/^\d{4}-\d{2}$/),

--- a/ui/lib/domain/role/roleViews.ts
+++ b/ui/lib/domain/role/roleViews.ts
@@ -1,5 +1,5 @@
 import type { TechnologyBadgeView } from "../technology/technologyViews";
-import type { JobRole } from "./jobRole";
+import type { JobRole, PreviousTitle } from "./jobRole";
 
 export type RoleCardView = {
   slug: string;
@@ -7,6 +7,7 @@ export type RoleCardView = {
   companyUrl: string;
   logoPath: string;
   title: string;
+  previousTitles?: PreviousTitle[];
   location: string;
   startDate: string;
   endDate?: string;
@@ -34,6 +35,7 @@ export function toRoleCardView(
     companyUrl: role.companyUrl,
     logoPath: role.logoPath,
     title: role.title,
+    previousTitles: role.previousTitles,
     location: role.location,
     startDate: role.startDate,
     endDate: role.endDate,

--- a/ui/lib/repository/repository.ts
+++ b/ui/lib/repository/repository.ts
@@ -590,6 +590,7 @@ export function loadJobRoles(): RoleLoadResult {
       companyUrl: exp.companyUrl,
       logoPath: exp.logoPath,
       title: exp.title,
+      previousTitles: exp.previousTitles,
       location: exp.location,
       startDate: exp.startDate,
       endDate: exp.endDate,

--- a/ui/tests/lib/domain/models.test.ts
+++ b/ui/tests/lib/domain/models.test.ts
@@ -497,5 +497,82 @@ describe("Domain Model Schemas", () => {
         });
       }
     });
+
+    it("should validate a role with previousTitles", () => {
+      const roleWithProgression = {
+        slug: "philips",
+        company: "Philips",
+        companyUrl: "https://philips.com",
+        logoPath: "/logo.png",
+        title: "Senior Software Engineer",
+        previousTitles: [
+          {
+            title: "Software Engineer",
+            startDate: "2018-04",
+            endDate: "2019-09",
+          },
+          {
+            title: "Graduate Software Engineer",
+            startDate: "2017-07",
+            endDate: "2018-04",
+          },
+        ],
+        location: "Belfast, UK",
+        startDate: "2017-07",
+        endDate: "2020-03",
+        description: "Led development",
+        responsibilities: ["Built stuff"],
+        relations: { technologies: ["python"] },
+      };
+
+      const result = JobRoleSchema.safeParse(roleWithProgression);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.previousTitles).toHaveLength(2);
+      }
+    });
+
+    it("should validate a role without previousTitles (backward compatible)", () => {
+      const singleTitleRole = {
+        slug: "bestomer",
+        company: "Bestomer",
+        companyUrl: "https://bestomer.com",
+        logoPath: "/logo.png",
+        title: "ML Lead",
+        location: "Remote",
+        startDate: "2023-05",
+        endDate: "2024-02",
+        description: "Led ML",
+        responsibilities: ["ML stuff"],
+        relations: { technologies: [] },
+      };
+
+      const result = JobRoleSchema.safeParse(singleTitleRole);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.previousTitles).toBeUndefined();
+      }
+    });
+
+    it("should reject previousTitles with invalid date format", () => {
+      const invalidRole = {
+        slug: "bad",
+        company: "Bad Co",
+        companyUrl: "https://bad.com",
+        logoPath: "/logo.png",
+        title: "Engineer",
+        previousTitles: [
+          { title: "Junior", startDate: "2020-01-01", endDate: "2021-01" },
+        ],
+        location: "Remote",
+        startDate: "2020-01",
+        description: "Desc",
+        responsibilities: ["Work"],
+        relations: { technologies: [] },
+      };
+
+      const result = JobRoleSchema.safeParse(invalidRole);
+      expect(result.success).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds an optional `previousTitles` field to the job role schema, enabling structured title progression per company
- Replaces the Philips arrow-syntax hack (`Graduate → Software → Senior`) with proper structured data
- Adds "Engineering Manager" as the new current title at Terminal Industries, with "Principal Software Engineer" as a previous title
- ExperienceCard renders previous titles inline when collapsed ("previously X · Y") and shows a full title history with date ranges when expanded

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (171 tests including 3 new schema validation tests)
- [x] Integration tests pass (content validates against updated schemas)
- [x] Visual check: Terminal Industries card shows "Engineering Manager" with "previously Principal Software Engineer"
- [x] Visual check: Philips card shows "Senior Software Engineer" with "previously Software Engineer · Graduate Software Engineer"
- [x] Visual check: Expanding both cards shows title history with per-title date ranges
- [x] Visual check: All other experience cards render identically to before
- [x] Visual check: Home page experience cards still show correct current titles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experience cards now display an expandable title history section, showing all previous roles with their corresponding start and end dates. When collapsed, a preview of previous titles appears as a subtitle beneath the current role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->