### PR TITLE
feat(recipe-parsing): extend recipe dataset, improve evaluation scoring and fix viz tool

### DIFF
--- a/ml-pipelines/recipe-parsing/data/canonical-ingredients.json
+++ b/ml-pipelines/recipe-parsing/data/canonical-ingredients.json
@@ -285,6 +285,10 @@
       "category": "grain"
     },
     {
+      "slug": "pasta-water",
+      "category": "liquid"
+    },
+    {
       "slug": "peanut-butter",
       "category": "condiment"
     },

--- a/ml-pipelines/recipe-parsing/data/ground-truth.json.dvc
+++ b/ml-pipelines/recipe-parsing/data/ground-truth.json.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e65f82442db702954f67a8bf49519489
-  size: 81766
+- md5: 453624cc8a601be47ad35ae494cb1046
+  size: 97861
   hash: md5
   path: ground-truth.json

--- a/ml-pipelines/recipe-parsing/data/ground-truth.json.dvc
+++ b/ml-pipelines/recipe-parsing/data/ground-truth.json.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 77673dd8ad9a0d055fe863d2185cd58f
-  size: 57961
+- md5: e65f82442db702954f67a8bf49519489
+  size: 81766
   hash: md5
   path: ground-truth.json

--- a/ml-pipelines/recipe-parsing/data/recipe-images.dvc
+++ b/ml-pipelines/recipe-parsing/data/recipe-images.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: c016e91ef929d55fd41a2fb90521e92b.dir
-  size: 84063465
-  nfiles: 14
+- md5: 4c9ad5f2d822b850cdd7fe44e443de6f.dir
+  size: 125945245
+  nfiles: 22
   hash: md5
   path: recipe-images

--- a/ml-pipelines/recipe-parsing/dvc.lock
+++ b/ml-pipelines/recipe-parsing/dvc.lock
@@ -5,13 +5,13 @@ stages:
     deps:
     - path: data/ground-truth.json
       hash: md5
-      md5: 77673dd8ad9a0d055fe863d2185cd58f
-      size: 57961
+      md5: e65f82442db702954f67a8bf49519489
+      size: 81766
     - path: data/recipe-images
       hash: md5
-      md5: c016e91ef929d55fd41a2fb90521e92b.dir
-      size: 84063465
-      nfiles: 14
+      md5: 4c9ad5f2d822b850cdd7fe44e443de6f.dir
+      size: 125945245
+      nfiles: 22
     - path: src/lib/io.ts
       hash: md5
       md5: 06f1d1ef3debf05262f8fb45cad309ee
@@ -27,12 +27,12 @@ stages:
     outs:
     - path: outputs/image-entries.json
       hash: md5
-      md5: c00291aab748d378f01404b3c19788c4
-      size: 934
+      md5: d8974063c263db27431e5785714ce43e
+      size: 1504
     - path: outputs/prepared.json
       hash: md5
-      md5: 77673dd8ad9a0d055fe863d2185cd58f
-      size: 57961
+      md5: e65f82442db702954f67a8bf49519489
+      size: 81766
   parse:
     cmd: pnpm exec tsx src/stages/parse.ts
     deps:
@@ -115,12 +115,12 @@ stages:
     deps:
     - path: outputs/extraction-predictions.json
       hash: md5
-      md5: 434ea27a55425c86a5274664a23f5e14
-      size: 13733
+      md5: 12a27c4eeeeb11015c6add604ed7d949
+      size: 22240
     - path: outputs/prepared.json
       hash: md5
-      md5: 77673dd8ad9a0d055fe863d2185cd58f
-      size: 57961
+      md5: e65f82442db702954f67a8bf49519489
+      size: 81766
     - path: src/evaluation/metrics.ts
       hash: md5
       md5: 141a402b303341b4d1932a9c565074a4
@@ -156,12 +156,12 @@ stages:
     outs:
     - path: outputs/extraction-metrics.json
       hash: md5
-      md5: bb2d81c042bcd2d3263a6caf0134e0c6
-      size: 1535
+      md5: 33cb79985126f31732cfc8d720da61c7
+      size: 1580
     - path: outputs/extraction-per-image-scores.json
       hash: md5
-      md5: 3efa04b66dafd816f869bdccc396daea
-      size: 4556
+      md5: 03cfb039b995aa1a6a9f5b8ab53b32c5
+      size: 7096
   canonicalize:
     cmd: pnpm exec tsx src/stages/canonicalize.ts
     deps:
@@ -171,8 +171,8 @@ stages:
       size: 7321
     - path: outputs/predictions.json
       hash: md5
-      md5: 3f5ef93d2b05a6e792bab2a3ff4eeb50
-      size: 28254
+      md5: d290edd18d5b1d208e5edc06bcfabb27
+      size: 47387
     - path: src/lib/cuisine-normalization.ts
       hash: md5
       md5: 40c86e63898ed17a7cbfeb2c1b410db3
@@ -229,23 +229,23 @@ stages:
     outs:
     - path: outputs/canonicalization-decisions.json
       hash: md5
-      md5: d7ac42f3ef9525263bc4e864f6a8b164
-      size: 56457
+      md5: cd0553a3632486c443d6ec3a3c5a87a4
+      size: 96822
     - path: outputs/predictions-canonicalized.json
       hash: md5
-      md5: 4908ec3ea7ef498f535fbbf3fc4c1061
-      size: 28217
+      md5: 7dfa3ed748bd44cdf09544f266cbf492
+      size: 47363
   evaluate:
     cmd: pnpm exec tsx src/stages/evaluate.ts
     deps:
     - path: outputs/predictions-canonicalized.json
       hash: md5
-      md5: 4908ec3ea7ef498f535fbbf3fc4c1061
-      size: 28217
+      md5: 7dfa3ed748bd44cdf09544f266cbf492
+      size: 47363
     - path: outputs/prepared.json
       hash: md5
-      md5: 77673dd8ad9a0d055fe863d2185cd58f
-      size: 57961
+      md5: e65f82442db702954f67a8bf49519489
+      size: 81766
     - path: src/evaluation/metrics.ts
       hash: md5
       md5: 141a402b303341b4d1932a9c565074a4
@@ -265,24 +265,24 @@ stages:
     outs:
     - path: outputs/metrics.json
       hash: md5
-      md5: 251fc5d44b8eb449e3084dd906146605
-      size: 1444
+      md5: 48f46bf9b3cc855ddb8cdcc983292ac1
+      size: 1590
     - path: outputs/per-entry-score-plot.json
       hash: md5
-      md5: a1aa4e3f70c82e141d7e2cd3eb80c325
-      size: 3845
+      md5: e0aa405204e0205a646197391cf8bebb
+      size: 6394
   dataset_stats:
     cmd: pnpm exec tsx src/stages/dataset-stats.ts
     deps:
     - path: data/recipe-images
       hash: md5
-      md5: c016e91ef929d55fd41a2fb90521e92b.dir
-      size: 84063465
-      nfiles: 14
+      md5: 4c9ad5f2d822b850cdd7fe44e443de6f.dir
+      size: 125945245
+      nfiles: 22
     - path: outputs/prepared.json
       hash: md5
-      md5: 77673dd8ad9a0d055fe863d2185cd58f
-      size: 57961
+      md5: e65f82442db702954f67a8bf49519489
+      size: 81766
     - path: src/lib/io.ts
       hash: md5
       md5: 06f1d1ef3debf05262f8fb45cad309ee
@@ -302,28 +302,28 @@ stages:
       size: 401
     - path: outputs/dataset-stats.json
       hash: md5
-      md5: d35dee61022e453f0f049489db8e98ee
-      size: 1686
+      md5: ab38828a5f010e3ce3484bed96e42e7c
+      size: 1690
     - path: outputs/images-per-recipe-histogram.json
       hash: md5
-      md5: 7d2601cf4ca64943a2967f4670727f76
-      size: 109
+      md5: b9bc6491b9d336d2a5e759dfef3302df
+      size: 110
     - path: outputs/top-ingredients.json
       hash: md5
-      md5: e71eec0eb667ea227f26289e67791d47
-      size: 1119
+      md5: 1ff4512bad53316b91fdc73c81e952a4
+      size: 1123
   extract:
     cmd: pnpm exec tsx src/stages/extract.ts
     deps:
     - path: data/recipe-images
       hash: md5
-      md5: c016e91ef929d55fd41a2fb90521e92b.dir
-      size: 84063465
-      nfiles: 14
+      md5: 4c9ad5f2d822b850cdd7fe44e443de6f.dir
+      size: 125945245
+      nfiles: 22
     - path: outputs/image-entries.json
       hash: md5
-      md5: c00291aab748d378f01404b3c19788c4
-      size: 934
+      md5: d8974063c263db27431e5785714ce43e
+      size: 1504
     - path: src/lib/env.ts
       hash: md5
       md5: 1ad5cf2fca9426a8faa637e965f84001
@@ -386,15 +386,15 @@ stages:
       size: 20
     - path: outputs/extraction-predictions.json
       hash: md5
-      md5: 434ea27a55425c86a5274664a23f5e14
-      size: 13733
+      md5: 12a27c4eeeeb11015c6add604ed7d949
+      size: 22240
   normalize:
     cmd: pnpm exec tsx src/stages/normalize.ts
     deps:
     - path: outputs/extraction-predictions.json
       hash: md5
-      md5: 434ea27a55425c86a5274664a23f5e14
-      size: 13733
+      md5: 12a27c4eeeeb11015c6add604ed7d949
+      size: 22240
     - path: src/lib/cooklang.ts
       hash: md5
       md5: 34b6817b49c4025659604a11aefb5724
@@ -463,27 +463,27 @@ stages:
     outs:
     - path: outputs/cooklang-recipes.json
       hash: md5
-      md5: 15da67f8ca8836d92a43dc7f26a79b8d
-      size: 47276
+      md5: cf897aa9129caf1a417cb3f789ff7e2c
+      size: 79030
     - path: outputs/normalize-failures.json
       hash: md5
       md5: 49e4c30c06bf51cc81392193d431c87d
       size: 20
     - path: outputs/predictions.json
       hash: md5
-      md5: 3f5ef93d2b05a6e792bab2a3ff4eeb50
-      size: 28254
+      md5: d290edd18d5b1d208e5edc06bcfabb27
+      size: 47387
   evaluate_normalization:
     cmd: pnpm exec tsx src/stages/evaluate-normalization.ts
     deps:
     - path: outputs/predictions.json
       hash: md5
-      md5: 3f5ef93d2b05a6e792bab2a3ff4eeb50
-      size: 28254
+      md5: d290edd18d5b1d208e5edc06bcfabb27
+      size: 47387
     - path: outputs/prepared.json
       hash: md5
-      md5: 77673dd8ad9a0d055fe863d2185cd58f
-      size: 57961
+      md5: e65f82442db702954f67a8bf49519489
+      size: 81766
     - path: src/evaluation/metrics.ts
       hash: md5
       md5: 141a402b303341b4d1932a9c565074a4
@@ -507,9 +507,9 @@ stages:
     outs:
     - path: outputs/normalization-metrics.json
       hash: md5
-      md5: e76bc8a6d71666b98125ad8d74aa1fe5
-      size: 1414
+      md5: c4b3c4bb76debcbc15d91394a514d872
+      size: 1519
     - path: outputs/normalization-per-image-scores.json
       hash: md5
-      md5: c663ffeeadb59b13c9eb44be9adef9c6
-      size: 2883
+      md5: 81c0685eb49c010c63a3d4de4df03a98
+      size: 4789

--- a/ml-pipelines/recipe-parsing/dvc.lock
+++ b/ml-pipelines/recipe-parsing/dvc.lock
@@ -5,8 +5,8 @@ stages:
     deps:
     - path: data/ground-truth.json
       hash: md5
-      md5: e65f82442db702954f67a8bf49519489
-      size: 81766
+      md5: 453624cc8a601be47ad35ae494cb1046
+      size: 97861
     - path: data/recipe-images
       hash: md5
       md5: 4c9ad5f2d822b850cdd7fe44e443de6f.dir
@@ -31,8 +31,8 @@ stages:
       size: 1504
     - path: outputs/prepared.json
       hash: md5
-      md5: e65f82442db702954f67a8bf49519489
-      size: 81766
+      md5: 453624cc8a601be47ad35ae494cb1046
+      size: 97861
   parse:
     cmd: pnpm exec tsx src/stages/parse.ts
     deps:
@@ -119,12 +119,12 @@ stages:
       size: 22240
     - path: outputs/prepared.json
       hash: md5
-      md5: e65f82442db702954f67a8bf49519489
-      size: 81766
+      md5: 453624cc8a601be47ad35ae494cb1046
+      size: 97861
     - path: src/evaluation/metrics.ts
       hash: md5
-      md5: 141a402b303341b4d1932a9c565074a4
-      size: 18093
+      md5: e53301b35804d314772e3443f20cbd45
+      size: 19612
     - path: src/lib/cooklang.ts
       hash: md5
       md5: 34b6817b49c4025659604a11aefb5724
@@ -151,24 +151,24 @@ stages:
       size: 4131
     - path: src/stages/evaluate-extraction.ts
       hash: md5
-      md5: 32d884799513c5789aabf8da5da189de
-      size: 5884
+      md5: c9918ff7cbdc9686e70e23ec6d74fff4
+      size: 5839
     outs:
     - path: outputs/extraction-metrics.json
       hash: md5
-      md5: 33cb79985126f31732cfc8d720da61c7
+      md5: 72eabc2e1b4e17e8f37c8337eac661e1
       size: 1580
     - path: outputs/extraction-per-image-scores.json
       hash: md5
-      md5: 03cfb039b995aa1a6a9f5b8ab53b32c5
-      size: 7096
+      md5: 28aa01f4b7398a4ff40df38ff35e5aae
+      size: 7082
   canonicalize:
     cmd: pnpm exec tsx src/stages/canonicalize.ts
     deps:
     - path: data/canonical-ingredients.json
       hash: md5
-      md5: 7733791d46234cc8c20e4f524a3edc93
-      size: 7321
+      md5: 5f72da6a81572a0b25067c5204febc6b
+      size: 7390
     - path: outputs/predictions.json
       hash: md5
       md5: d290edd18d5b1d208e5edc06bcfabb27
@@ -229,8 +229,8 @@ stages:
     outs:
     - path: outputs/canonicalization-decisions.json
       hash: md5
-      md5: cd0553a3632486c443d6ec3a3c5a87a4
-      size: 96822
+      md5: b57f955e9bb5d52606be35a744ac87cc
+      size: 96513
     - path: outputs/predictions-canonicalized.json
       hash: md5
       md5: 7dfa3ed748bd44cdf09544f266cbf492
@@ -244,12 +244,12 @@ stages:
       size: 47363
     - path: outputs/prepared.json
       hash: md5
-      md5: e65f82442db702954f67a8bf49519489
-      size: 81766
+      md5: 453624cc8a601be47ad35ae494cb1046
+      size: 97861
     - path: src/evaluation/metrics.ts
       hash: md5
-      md5: 141a402b303341b4d1932a9c565074a4
-      size: 18093
+      md5: e53301b35804d314772e3443f20cbd45
+      size: 19612
     - path: src/lib/image-key.ts
       hash: md5
       md5: 116109e930c80c186e78c1946e9f03b1
@@ -265,12 +265,12 @@ stages:
     outs:
     - path: outputs/metrics.json
       hash: md5
-      md5: 48f46bf9b3cc855ddb8cdcc983292ac1
-      size: 1590
+      md5: b00e88464c211d883cd9bab5a7f6f779
+      size: 1518
     - path: outputs/per-entry-score-plot.json
       hash: md5
-      md5: e0aa405204e0205a646197391cf8bebb
-      size: 6394
+      md5: 88aaecc54948c469011ab1e77c64d1ab
+      size: 6635
   dataset_stats:
     cmd: pnpm exec tsx src/stages/dataset-stats.ts
     deps:
@@ -281,8 +281,8 @@ stages:
       nfiles: 22
     - path: outputs/prepared.json
       hash: md5
-      md5: e65f82442db702954f67a8bf49519489
-      size: 81766
+      md5: 453624cc8a601be47ad35ae494cb1046
+      size: 97861
     - path: src/lib/io.ts
       hash: md5
       md5: 06f1d1ef3debf05262f8fb45cad309ee
@@ -298,20 +298,20 @@ stages:
     outs:
     - path: outputs/cuisine-distribution.json
       hash: md5
-      md5: 96cb88779b437960a26ee9ed92f0876b
-      size: 401
+      md5: 2fb15e72b453c5c92468e8d2b8496ed4
+      size: 497
     - path: outputs/dataset-stats.json
       hash: md5
-      md5: ab38828a5f010e3ce3484bed96e42e7c
-      size: 1690
+      md5: 7bd54b878ac5bc088e0b503fa207a956
+      size: 1824
     - path: outputs/images-per-recipe-histogram.json
       hash: md5
       md5: b9bc6491b9d336d2a5e759dfef3302df
       size: 110
     - path: outputs/top-ingredients.json
       hash: md5
-      md5: 1ff4512bad53316b91fdc73c81e952a4
-      size: 1123
+      md5: 95e0c0a6833ed809a084a1fb78de4159
+      size: 1118
   extract:
     cmd: pnpm exec tsx src/stages/extract.ts
     deps:
@@ -482,12 +482,12 @@ stages:
       size: 47387
     - path: outputs/prepared.json
       hash: md5
-      md5: e65f82442db702954f67a8bf49519489
-      size: 81766
+      md5: 453624cc8a601be47ad35ae494cb1046
+      size: 97861
     - path: src/evaluation/metrics.ts
       hash: md5
-      md5: 141a402b303341b4d1932a9c565074a4
-      size: 18093
+      md5: e53301b35804d314772e3443f20cbd45
+      size: 19612
     - path: src/lib/image-key.ts
       hash: md5
       md5: 116109e930c80c186e78c1946e9f03b1
@@ -507,9 +507,9 @@ stages:
     outs:
     - path: outputs/normalization-metrics.json
       hash: md5
-      md5: c4b3c4bb76debcbc15d91394a514d872
-      size: 1519
+      md5: 11130c6af3ab80e502646b2dbb84e4ef
+      size: 1516
     - path: outputs/normalization-per-image-scores.json
       hash: md5
-      md5: 81c0685eb49c010c63a3d4de4df03a98
-      size: 4789
+      md5: f74e2a74eccaf236786c6bf17f939bc0
+      size: 4858

--- a/ml-pipelines/recipe-parsing/src/evaluation/metrics.ts
+++ b/ml-pipelines/recipe-parsing/src/evaluation/metrics.ts
@@ -94,6 +94,20 @@ export const FULL_RECIPE_SCORING_PROFILE: ScoringProfile = {
   },
 };
 
+export const EXTRACTION_SCORING_PROFILE: ScoringProfile = {
+  name: "extraction",
+  weights: {
+    title: 1,
+    description: 1,
+    cuisine: 1,
+    servings: 1,
+    prepTime: 1,
+    cookTime: 1,
+    ingredientParsing: 6,
+    instructions: 6,
+  },
+};
+
 export const CANONICALIZATION_SCORING_PROFILE: ScoringProfile = {
   name: "canonicalization",
   weights: {
@@ -373,14 +387,27 @@ export function evaluateIngredientParsing(
     }
   }
 
+  const fieldScores = {
+    name: avgF1(nameScores),
+    amount: { accuracy: avg(amountAccuracies) },
+    unit: { accuracy: avg(unitAccuracies) },
+    preparation: avgF1(prepScores),
+  };
+
+  // Scale the identity F1 by field quality so that incorrect amounts, units,
+  // and preparation text penalise the overall ingredient score.  Field quality
+  // can reduce the score by up to half (FIELD_QUALITY_WEIGHT = 0.5).
+  const FIELD_QUALITY_WEIGHT = 0.5;
+  const fieldQuality = nameScores.length > 0
+    ? avg([fieldScores.amount.accuracy, fieldScores.unit.accuracy, fieldScores.preparation.f1])
+    : 1;
+  const fieldScale = 1 - FIELD_QUALITY_WEIGHT + FIELD_QUALITY_WEIGHT * fieldQuality;
+
   return {
-    ...idF1,
-    fieldScores: {
-      name: avgF1(nameScores),
-      amount: { accuracy: avg(amountAccuracies) },
-      unit: { accuracy: avg(unitAccuracies) },
-      preparation: avgF1(prepScores),
-    },
+    precision: idF1.precision * fieldScale,
+    recall: idF1.recall * fieldScale,
+    f1: idF1.f1 * fieldScale,
+    fieldScores,
   };
 }
 

--- a/ml-pipelines/recipe-parsing/src/evaluation/metrics.ts
+++ b/ml-pipelines/recipe-parsing/src/evaluation/metrics.ts
@@ -372,12 +372,29 @@ export function evaluateIngredientParsing(
   const prepScores: F1Scores[] = [];
 
   for (const slug of commonSlugs) {
-    const preds = predIngredients.get(slug)!;
+    const preds = [...predIngredients.get(slug)!];
     const exps = expIngredients.get(slug)!;
     const pairCount = Math.min(preds.length, exps.length);
-    for (let i = 0; i < pairCount; i++) {
-      const pred = preds[i]!;
-      const exp = exps[i]!;
+
+    // Greedy best-match pairing: for each expected entry, find the predicted
+    // entry with the highest field similarity to avoid order-sensitive mismatches
+    // when a slug appears more than once.
+    for (let e = 0; e < pairCount; e++) {
+      const exp = exps[e]!;
+      let bestIdx = 0;
+      let bestScore = -1;
+      for (let p = 0; p < preds.length; p++) {
+        const pred = preds[p]!;
+        const score =
+          exactMatch(pred.amount, exp.amount) +
+          exactMatch(pred.unit, exp.unit) +
+          computeWordOverlapF1(pred.preparation ?? "", exp.preparation ?? "").f1;
+        if (score > bestScore) {
+          bestScore = score;
+          bestIdx = p;
+        }
+      }
+      const pred = preds.splice(bestIdx, 1)[0]!;
       nameScores.push({ precision: 1, recall: 1, f1: 1 });
       amountAccuracies.push(exactMatch(pred.amount, exp.amount));
       unitAccuracies.push(exactMatch(pred.unit, exp.unit));
@@ -398,7 +415,7 @@ export function evaluateIngredientParsing(
   // and preparation text penalise the overall ingredient score.  Field quality
   // can reduce the score by up to half (FIELD_QUALITY_WEIGHT = 0.5).
   const FIELD_QUALITY_WEIGHT = 0.5;
-  const fieldQuality = nameScores.length > 0
+  const fieldQuality = commonSlugs.size > 0
     ? avg([fieldScores.amount.accuracy, fieldScores.unit.accuracy, fieldScores.preparation.f1])
     : 1;
   const fieldScale = 1 - FIELD_QUALITY_WEIGHT + FIELD_QUALITY_WEIGHT * fieldQuality;

--- a/ml-pipelines/recipe-parsing/src/stages/evaluate-extraction.ts
+++ b/ml-pipelines/recipe-parsing/src/stages/evaluate-extraction.ts
@@ -10,6 +10,7 @@ import {
   computeCharErrorRate,
   computeRougeL,
   computeWordErrorRate,
+  EXTRACTION_SCORING_PROFILE,
 } from "../evaluation/metrics";
 import { imageSetKey } from "../lib/image-key.js";
 import { flattenExtractionText } from "../lib/extraction-text.js";
@@ -76,6 +77,7 @@ async function main() {
   const { metrics, perEntry } = aggregateMetrics(
     matchedPredictions,
     groundTruthForEval,
+    EXTRACTION_SCORING_PROFILE,
   );
 
   // Attach per-entry text fidelity scores
@@ -151,9 +153,6 @@ async function main() {
   );
   console.log(
     `  Instructions F1:         ${metrics.byCategory.instructions.f1.toFixed(3)}`,
-  );
-  console.log(
-    `  Equipment F1:            ${metrics.byCategory.equipmentParsing.f1.toFixed(3)}`,
   );
   if (metricsWithDiagnostics.diagnostics?.extractionText) {
     console.log(

--- a/ml-pipelines/recipe-parsing/tests/evaluation/metrics.test.ts
+++ b/ml-pipelines/recipe-parsing/tests/evaluation/metrics.test.ts
@@ -321,7 +321,9 @@ describe("aggregateMetrics", () => {
         );
 
         expect(defaultScores.overall).toBeLessThan(1);
-        expect(canonicalizationScores.overall).toBe(1);
+        // Ingredient name matches but amount (100 vs 250) and unit (g vs cup)
+        // differ, so field quality penalises the canonicalization score.
+        expect(canonicalizationScores.overall).toBeCloseTo(0.8, 5);
         expect(canonicalizationScores.instructions).toBeLessThan(1);
         expect(canonicalizationScores.equipmentParsing).toBe(1);
     });
@@ -381,9 +383,11 @@ describe("aggregateMetrics", () => {
             CANONICALIZATION_SCORING_PROFILE,
         );
 
-        expect(aggregate.metrics.byCategory.ingredientParsing.f1).toBe(1);
+        // Ingredient name matches but amount (100 vs 999) and unit (g vs cup)
+        // differ, so field quality reduces ingredient F1 from 1.0.
+        expect(aggregate.metrics.byCategory.ingredientParsing.f1).toBeCloseTo(0.667, 2);
         expect(aggregate.metrics.byCategory.scalarFields.cuisine.f1).toBe(1);
         expect(aggregate.metrics.byCategory.equipmentParsing.f1).toBe(0);
-        expect(aggregate.metrics.overall.score).toBeCloseTo(0.7);
+        expect(aggregate.metrics.overall.score).toBeCloseTo(0.5, 1);
     });
 });

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/NormalizationListView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/NormalizationListView.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import {
-  loadCooklangPredictions,
   loadGroundTruth,
   loadPredictions,
 } from "../lib/data";
@@ -13,7 +12,6 @@ import {
   evaluateScalarFields,
 } from "../../../../src/evaluation/metrics.js";
 import type {
-  CooklangPredictionsDataset,
   GroundTruthDataset,
   PredictionsDataset,
 } from "../types/extraction";
@@ -28,13 +26,11 @@ export function NormalizationListView({
 }: NormalizationListViewProps) {
   const [groundTruth, setGroundTruth] = useState<GroundTruthDataset | null>(null);
   const [predictions, setPredictions] = useState<PredictionsDataset | null>(null);
-  const [cooklangPredictions, setCooklangPredictions] = useState<CooklangPredictionsDataset | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     loadGroundTruth().then(setGroundTruth).catch((e) => setError(String(e)));
     loadPredictions().then(setPredictions).catch(() => {});
-    loadCooklangPredictions().then(setCooklangPredictions).catch(() => {});
   }, []);
 
   const entries = useMemo(() => {
@@ -43,19 +39,16 @@ export function NormalizationListView({
       const key = gt.images.join("\0");
       const predicted =
         predictions?.entries.find((e) => e.images.join("\0") === key)?.predicted ?? null;
-      const cooklangPred =
-        cooklangPredictions?.entries.find((e) => e.images.join("\0") === key)?.cooklang ?? null;
       const annotated = gt.expectedNormalization != null;
 
       let score: number | null = null;
-      if (annotated && cooklangPred) {
-        const predDerived = deriveNormalizedRecipe(cooklangPred).recipe;
+      if (annotated && predicted) {
         const expDerived = deriveNormalizedRecipe(gt.expectedNormalization!).recipe;
-        if (predDerived && expDerived) {
-          const scalar = evaluateScalarFields(predDerived, expDerived);
-          const ingredients = evaluateIngredientParsing(predDerived, expDerived);
-          const instructions = evaluateInstructions(predDerived, expDerived);
-          const equipment = evaluateEquipmentParsing(predDerived, expDerived);
+        if (expDerived) {
+          const scalar = evaluateScalarFields(predicted, expDerived);
+          const ingredients = evaluateIngredientParsing(predicted, expDerived);
+          const instructions = evaluateInstructions(predicted, expDerived);
+          const equipment = evaluateEquipmentParsing(predicted, expDerived);
           score = computeEntryScores(
             scalar,
             ingredients,
@@ -73,7 +66,7 @@ export function NormalizationListView({
         annotated,
       };
     });
-  }, [groundTruth, predictions, cooklangPredictions]);
+  }, [groundTruth, predictions]);
 
   const annotatedCount = entries.filter((e) => e.annotated).length;
 

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/NormalizationListView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/NormalizationListView.tsx
@@ -39,23 +39,23 @@ export function NormalizationListView({
       const key = gt.images.join("\0");
       const predicted =
         predictions?.entries.find((e) => e.images.join("\0") === key)?.predicted ?? null;
-      const annotated = gt.expectedNormalization != null;
+      const expDerived = gt.expectedNormalization
+        ? deriveNormalizedRecipe(gt.expectedNormalization).recipe
+        : null;
+      const annotated = expDerived != null;
 
       let score: number | null = null;
       if (annotated && predicted) {
-        const expDerived = deriveNormalizedRecipe(gt.expectedNormalization!).recipe;
-        if (expDerived) {
-          const scalar = evaluateScalarFields(predicted, expDerived);
-          const ingredients = evaluateIngredientParsing(predicted, expDerived);
-          const instructions = evaluateInstructions(predicted, expDerived);
-          const equipment = evaluateEquipmentParsing(predicted, expDerived);
-          score = computeEntryScores(
-            scalar,
-            ingredients,
-            instructions,
-            equipment,
-          ).overall;
-        }
+        const scalar = evaluateScalarFields(predicted, expDerived);
+        const ingredients = evaluateIngredientParsing(predicted, expDerived);
+        const instructions = evaluateInstructions(predicted, expDerived);
+        const equipment = evaluateEquipmentParsing(predicted, expDerived);
+        score = computeEntryScores(
+          scalar,
+          ingredients,
+          instructions,
+          equipment,
+        ).overall;
       }
 
       return {

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/StatsView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/StatsView.tsx
@@ -27,14 +27,10 @@ import { deriveNormalizedRecipe } from "../lib/cooklang";
 import {
   aggregateMetrics,
   CANONICALIZATION_SCORING_PROFILE,
+  EXTRACTION_SCORING_PROFILE,
   computeCharErrorRate,
-  computeEntryScores,
   computeRougeL,
   computeWordErrorRate,
-  evaluateEquipmentParsing,
-  evaluateIngredientParsing,
-  evaluateInstructions,
-  evaluateScalarFields,
 } from "../../../../src/evaluation/metrics.js";
 import { extractionToRecipe } from "../../../../src/lib/extraction-to-recipe.js";
 import { flattenExtractionText } from "../../../../src/lib/extraction-text.js";
@@ -838,6 +834,7 @@ export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
       const { metrics } = aggregateMetrics(
         predictions as never,
         gtForEval as never,
+        EXTRACTION_SCORING_PROFILE,
       );
 
       // Attach text-fidelity diagnostics
@@ -885,68 +882,30 @@ export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
   }, [groundTruth, extractionPredictions]);
 
   const normalizationClientMetrics: StageMetrics | null = useMemo(() => {
-    if (!groundTruth || !cooklangPredictions) return null;
-    const predMap = new Map(
-      cooklangPredictions.entries.map((e) => [e.images.join("\0"), e.cooklang]),
-    );
-    const allScalar: ReturnType<typeof evaluateScalarFields>[] = [];
-    const allIngredients: ReturnType<typeof evaluateIngredientParsing>[] = [];
-    const allInstructions: ReturnType<typeof evaluateInstructions>[] = [];
-    const allEquipment: ReturnType<typeof evaluateEquipmentParsing>[] = [];
-    const allOverall: number[] = [];
+    if (!groundTruth || !normalizedPredictions) return null;
 
+    // Build ground truth with expected derived from expectedNormalization,
+    // matching the pipeline's evaluate-normalization stage.
+    const groundTruthForEval: { images: string[]; expected: ReturnType<typeof deriveNormalizedRecipe>["recipe"] }[] = [];
     for (const gt of groundTruth.entries) {
       if (!gt.expectedNormalization) continue;
-      const pred = predMap.get(gt.images.join("\0"));
-      if (!pred) continue;
-      const predDerived = deriveNormalizedRecipe(pred).recipe;
       const expDerived = deriveNormalizedRecipe(gt.expectedNormalization).recipe;
-      if (!predDerived || !expDerived) continue;
-
-      const scalar = evaluateScalarFields(predDerived, expDerived);
-      const ingredients = evaluateIngredientParsing(predDerived, expDerived);
-      const instructions = evaluateInstructions(predDerived, expDerived);
-      const equipment = evaluateEquipmentParsing(predDerived, expDerived);
-      const scores = computeEntryScores(
-        scalar,
-        ingredients,
-        instructions,
-        equipment,
-      );
-
-      allScalar.push(scalar);
-      allIngredients.push(ingredients);
-      allInstructions.push(instructions);
-      allEquipment.push(equipment);
-      allOverall.push(scores.overall);
+      if (!expDerived) continue;
+      groundTruthForEval.push({ images: gt.images, expected: expDerived });
     }
 
-    if (allOverall.length === 0) return null;
-    const avg = (vals: number[]) => vals.reduce((a, b) => a + b, 0) / vals.length;
-    const avgF1 = (vals: { f1: number; precision: number; recall: number }[]) => ({
-      f1: avg(vals.map((v) => v.f1)),
-      precision: avg(vals.map((v) => v.precision)),
-      recall: avg(vals.map((v) => v.recall)),
-    });
+    if (groundTruthForEval.length === 0) return null;
 
-    return {
-      overall: { score: avg(allOverall) },
-      byCategory: {
-        scalarFields: {
-          title: avgF1(allScalar.map((s) => s.title)),
-          description: avgF1(allScalar.map((s) => s.description)),
-          cuisine: avgF1(allScalar.map((s) => s.cuisine)),
-          servings: { accuracy: avg(allScalar.map((s) => s.servings.accuracy)) },
-          prepTime: { accuracy: avg(allScalar.map((s) => s.prepTime.accuracy)) },
-          cookTime: { accuracy: avg(allScalar.map((s) => s.cookTime.accuracy)) },
-        },
-        ingredientParsing: avgF1(allIngredients),
-        equipmentParsing: avgF1(allEquipment),
-        instructions: avgF1(allInstructions),
-      },
-      entryCount: allOverall.length,
-    };
-  }, [groundTruth, cooklangPredictions]);
+    try {
+      const { metrics } = aggregateMetrics(
+        normalizedPredictions.entries as never,
+        groundTruthForEval as never,
+      );
+      return metrics as unknown as StageMetrics;
+    } catch {
+      return null;
+    }
+  }, [groundTruth, normalizedPredictions]);
 
   const pipelineNormalizationSkipped =
     normalizationMetrics != null && "skipped" in normalizationMetrics;

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/StatsView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/StatsView.tsx
@@ -32,6 +32,10 @@ import {
   computeRougeL,
   computeWordErrorRate,
 } from "../../../../src/evaluation/metrics.js";
+import type {
+  GroundTruthEntry as MetricsGroundTruthEntry,
+  PredictionEntry as MetricsPredictionEntry,
+} from "../../../../src/schemas/ground-truth.js";
 import { extractionToRecipe } from "../../../../src/lib/extraction-to-recipe.js";
 import { flattenExtractionText } from "../../../../src/lib/extraction-text.js";
 import type {
@@ -832,8 +836,8 @@ export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
 
     try {
       const { metrics } = aggregateMetrics(
-        predictions as never,
-        gtForEval as never,
+        predictions as MetricsPredictionEntry[],
+        gtForEval as MetricsGroundTruthEntry[],
         EXTRACTION_SCORING_PROFILE,
       );
 
@@ -886,7 +890,7 @@ export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
 
     // Build ground truth with expected derived from expectedNormalization,
     // matching the pipeline's evaluate-normalization stage.
-    const groundTruthForEval: { images: string[]; expected: ReturnType<typeof deriveNormalizedRecipe>["recipe"] }[] = [];
+    const groundTruthForEval: MetricsGroundTruthEntry[] = [];
     for (const gt of groundTruth.entries) {
       if (!gt.expectedNormalization) continue;
       const expDerived = deriveNormalizedRecipe(gt.expectedNormalization).recipe;
@@ -898,8 +902,8 @@ export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
 
     try {
       const { metrics } = aggregateMetrics(
-        normalizedPredictions.entries as never,
-        groundTruthForEval as never,
+        normalizedPredictions.entries as MetricsPredictionEntry[],
+        groundTruthForEval,
       );
       return metrics as unknown as StageMetrics;
     } catch {

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/StatsView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/StatsView.tsx
@@ -13,7 +13,6 @@ import {
 } from "recharts";
 import {
   loadCanonicalizedPredictions,
-  loadCooklangPredictions,
   loadExtractionMetrics,
   loadExtractionPredictions,
   loadFinalMetrics,
@@ -39,7 +38,6 @@ import type {
 import { extractionToRecipe } from "../../../../src/lib/extraction-to-recipe.js";
 import { flattenExtractionText } from "../../../../src/lib/extraction-text.js";
 import type {
-  CooklangPredictionsDataset,
   ExtractionPredictionsDataset,
   GroundTruthDataset,
   PerImageScoreEntry,
@@ -785,7 +783,7 @@ function RecipeDeltaChart({
 export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
   const [groundTruth, setGroundTruth] = useState<GroundTruthDataset | null>(null);
   const [extractionPredictions, setExtractionPredictions] = useState<ExtractionPredictionsDataset | null>(null);
-  const [cooklangPredictions, setCooklangPredictions] = useState<CooklangPredictionsDataset | null>(null);
+
   const [normalizedPredictions, setNormalizedPredictions] = useState<PredictionsDataset | null>(null);
   const [canonicalizedPredictions, setCanonicalizedPredictions] = useState<PredictionsDataset | null>(null);
   const [extractionMetrics, setExtractionMetrics] = useState<StageMetrics | { skipped: true } | null>(null);
@@ -798,7 +796,7 @@ export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
   useEffect(() => {
     loadGroundTruth().then(setGroundTruth).catch(() => {});
     loadExtractionPredictions().then(setExtractionPredictions).catch(() => {});
-    loadCooklangPredictions().then(setCooklangPredictions).catch(() => {});
+
     loadPredictions().then(setNormalizedPredictions).catch(() => {});
     loadCanonicalizedPredictions().then(setCanonicalizedPredictions).catch(() => {});
     loadExtractionMetrics().then(setExtractionMetrics).catch(() => {});
@@ -900,15 +898,11 @@ export function StatsView({ onSelectCanonicalizeEntry }: StatsViewProps) {
 
     if (groundTruthForEval.length === 0) return null;
 
-    try {
-      const { metrics } = aggregateMetrics(
-        normalizedPredictions.entries as MetricsPredictionEntry[],
-        groundTruthForEval,
-      );
-      return metrics as unknown as StageMetrics;
-    } catch {
-      return null;
-    }
+    const { metrics } = aggregateMetrics(
+      normalizedPredictions.entries as MetricsPredictionEntry[],
+      groundTruthForEval,
+    );
+    return metrics as unknown as StageMetrics;
   }, [groundTruth, normalizedPredictions]);
 
   const pipelineNormalizationSkipped =

--- a/packages/recipe-domain/src/unit.ts
+++ b/packages/recipe-domain/src/unit.ts
@@ -7,6 +7,7 @@ export const UnitSchema = z.enum([
   // Volume
   "ml",
   "l",
+  "pint",
   // Spoon measures
   "tsp",
   "tbsp",
@@ -37,6 +38,7 @@ export const UNIT_LABELS: Record<Unit, UnitLabel> = {
   kg: { singular: "kg", plural: "kg", noSpace: true },
   ml: { singular: "ml", plural: "ml", noSpace: true },
   l: { singular: "l", plural: "l", noSpace: true },
+  pint: { singular: "pint", plural: "pints" },
   tsp: { singular: "tsp", plural: "tsp" },
   tbsp: { singular: "tbsp", plural: "tbsp" },
   cup: { singular: "cup", plural: "cups" },
@@ -57,6 +59,7 @@ export const UNIT_CATEGORIES: Record<Unit, UnitCategory> = {
   kg: "weight",
   ml: "volume",
   l: "volume",
+  pint: "volume",
   tsp: "spoon",
   tbsp: "spoon",
   cup: "volume",


### PR DESCRIPTION
## Summary
- Add new recipe images and update ground truth annotations (DVC tracked)
- Fix normalization structured score mismatch between viz tool and pipeline — the viz tool was re-deriving predictions from cooklang and silently skipping entries where derivation failed, inflating the score (~91%) vs the pipeline's actual score (~77%)
- Exclude equipment parsing from extraction stage scoring via a new `EXTRACTION_SCORING_PROFILE`
- Factor ingredient field quality (unit, amount, preparation) into the ingredient parsing F1 so incorrect units/amounts penalise the overall structured score (up to 50% reduction)
- Add `pint` unit to `recipe-domain` UnitSchema, UNIT_LABELS, and UNIT_CATEGORIES

## Test plan
- [ ] Run `dvc repro` and verify extraction score no longer includes equipment
- [ ] Open viz tool and confirm normalization structured score matches pipeline output
- [x] Verify `pint` appears as a unit option in the viz tool ingredient editor
- [x] Check that incorrect ingredient units now reduce per-entry scores

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "pint" as a supported measurement unit with singular and plural labels
  * Added "pasta-water" to the canonical ingredients dataset as a liquid ingredient
  
* **Improvements**
  * Enhanced ingredient parsing evaluation to better account for field-quality metrics, improving accuracy of recipe analysis

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robbie-Palmer/personal-site/pull/448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->