### PR TITLE
Promote ML recipes into site content

### DIFF
--- a/ui/content/recipes/cajun-sausage-pasta.cook
+++ b/ui/content/recipes/cajun-sausage-pasta.cook
@@ -8,7 +8,7 @@ prepTime: 10
 cookTime: 20
 tags: ["creamy"]
 ingredientAnnotations:
-  pork-sausages:
+  pork-sausage:
     preparation: "deskinned"
     note: "Tesco finest work best"
   red-onion:
@@ -28,7 +28,7 @@ Cook the @pasta{320%g} according to package instructions in a #saucepan{}, ensur
 
 While the pasta is cooking, heat @olive oil{} in a separate #frying pan{} over a medium heat.
 
-Add the deskinned @pork sausages{6%piece}, @red onion{1%piece}, @cajun seasoning{4%tsp}, and @smoked paprika{2%tsp}, then cook for ~{5%minutes}, breaking up the sausages as they cook.
+Add the deskinned @pork sausage|pork sausages{6%piece}, @red onion{1%piece}, @cajun seasoning{4%tsp}, and @smoked paprika{2%tsp}, then cook for ~{5%minutes}, breaking up the sausages as they cook.
 
 Add @garlic puree{4%tsp}, @dried parsley{4%tsp}, @fresh tomatoes|tomatoes{4%piece}, and @tomato puree{2%tbsp}, then cook for ~{2%minutes}.
 

--- a/ui/content/recipes/chicken-chorizo-and-potato-stew.cook
+++ b/ui/content/recipes/chicken-chorizo-and-potato-stew.cook
@@ -5,7 +5,7 @@ date: "2023-10-27"
 cuisine: ["Spanish"]
 servings: 4
 cookTime: 42
-tags: ["stew", "chicken", "chorizo", "one-pot"]
+tags: ["one-pot"]
 ingredientAnnotations:
   red-onion:
     preparation: "chopped"

--- a/ui/content/recipes/chicken-chorizo-and-potato-stew.cook
+++ b/ui/content/recipes/chicken-chorizo-and-potato-stew.cook
@@ -1,0 +1,40 @@
+---
+title: "Chicken, Chorizo and Potato Stew"
+description: "A hearty, rustic stew combining tender chicken, smoky chorizo, and fluffy potatoes in a rich tomato and vegetable stock base."
+date: "2023-10-27"
+cuisine: ["Spanish"]
+servings: 4
+cookTime: 42
+tags: ["stew", "chicken", "chorizo", "one-pot"]
+ingredientAnnotations:
+  red-onion:
+    preparation: "chopped"
+  chicken-breast:
+    preparation: "cut into chunks"
+  garlic:
+    preparation: "crushed"
+  chorizo:
+    preparation: "chopped"
+  bell-pepper:
+    preparation: "chopped"
+  chickpeas:
+    preparation: "drained and rinsed"
+  potato:
+    preparation: "cut into 3cm pieces"
+  fresh-parsley:
+    preparation: "roughly chopped"
+---
+
+Heat @olive oil{1%tbsp} in a large #saucepan{} and fry the @red onion|red onions{2%medium} over a medium-high heat for ~{4%minutes} to ~{5%minutes}.
+
+Add the @chicken breast|chicken breasts{3.5%pieces} and @garlic{3%clove}, cook for ~{5%minutes} until chicken isn't pink.
+
+Add the @chorizo{225%g} and @bell pepper|peppers{2%pieces} and cook for ~{1%minute}.
+
+Stir in the @chopped tomatoes{400%g}, @chickpeas{400%g}, @potato|potatoes{500%g}, @paprika{0.5%tsp} and @vegetable stock{400%ml}, ensuring the potatoes are fully covered by the liquid.
+
+Bring to the boil, then lower heat and simmer, partly covered for ~{25%minutes} to ~{30%minutes} or until the chicken is cooked through, stirring occasionally.
+
+Season to taste and stir in chopped @fresh parsley|flat leaf parsley{5%tbsp}.
+
+Serve with @bread|crusty bread{}.

--- a/ui/content/recipes/chicken-quesadillas.cook
+++ b/ui/content/recipes/chicken-quesadillas.cook
@@ -48,7 +48,7 @@ Prepare the guacamole: Cut the @avocado{1%piece} in half and remove the stone. S
 
 In a small #bowl{}, combine @mayonnaise{0.5%cup} with @chipotle paste{2%tbsp} to make chipotle mayo.
 
-Make your quesadillas: Lay out the @tortilla wraps|wraps{4%piece}. Add half of the shredded chicken to one wrap, then top with @cheddar cheese{150%g} and @spring onion|spring onions{3%piece}. Add a few spoonfuls of the chipotle mayo over the top and cover with another wrap.
+Make your quesadillas: Lay out the @tortilla wrap|wraps{4%piece}. Add half of the shredded chicken to one wrap, then top with @cheddar cheese{150%g} and @spring onion|spring onions{3%piece}. Add a few spoonfuls of the chipotle mayo over the top and cover with another wrap.
 
 Heat a #frying pan{}, brush your quesadilla with a little @olive oil{}, and warm it in the pan, allowing the cheese to melt and the wraps to toast on both sides.
 

--- a/ui/content/recipes/ingredients.ts
+++ b/ui/content/recipes/ingredients.ts
@@ -6,12 +6,7 @@ export const ingredients: IngredientContent[] = [
   { name: "turkey mince", category: "protein" },
   { name: "chorizo", category: "protein" },
   { name: "bacon", category: "protein" },
-  {
-    name: "pork sausage",
-    pluralName: "pork sausages",
-    slug: "pork-sausage",
-    category: "protein",
-  },
+  { name: "pork sausage", category: "protein" },
 
   // Vegetables
   { name: "white onion", category: "vegetable" },
@@ -72,12 +67,7 @@ export const ingredients: IngredientContent[] = [
   { name: "pasta", category: "grain" },
   { name: "long grain rice", category: "grain" },
   { name: "paella rice", category: "grain" },
-  {
-    name: "tortilla wrap",
-    pluralName: "tortilla wraps",
-    slug: "tortilla-wrap",
-    category: "grain",
-  },
+  { name: "tortilla wrap", category: "grain" },
   { name: "farfalle", category: "grain" },
   { name: "plain flour", category: "grain" },
   { name: "bread flour", category: "grain" },
@@ -85,12 +75,7 @@ export const ingredients: IngredientContent[] = [
   { name: "semolina", category: "grain" },
   { name: "bread", category: "grain" },
   { name: "noodles", category: "grain" },
-  {
-    name: "burger bap",
-    pluralName: "burger baps",
-    slug: "bap",
-    category: "grain",
-  },
+  { name: "bap", category: "grain" },
   { name: "rolled oats", category: "grain" },
 
   // Herbs

--- a/ui/content/recipes/ingredients.ts
+++ b/ui/content/recipes/ingredients.ts
@@ -6,7 +6,12 @@ export const ingredients: IngredientContent[] = [
   { name: "turkey mince", category: "protein" },
   { name: "chorizo", category: "protein" },
   { name: "bacon", category: "protein" },
-  { name: "pork sausages", category: "protein" },
+  {
+    name: "pork sausage",
+    pluralName: "pork sausages",
+    slug: "pork-sausage",
+    category: "protein",
+  },
 
   // Vegetables
   { name: "white onion", category: "vegetable" },
@@ -23,12 +28,16 @@ export const ingredients: IngredientContent[] = [
   { name: "garlic puree", category: "vegetable" },
   { name: "tomato puree", category: "vegetable" },
   { name: "frozen peas", category: "vegetable" },
+  { name: "frozen peppers", category: "vegetable" },
   { name: "spinach", category: "vegetable" },
   { name: "vine tomato", category: "vegetable" },
   { name: "spring onion", category: "vegetable" },
   { name: "leek", category: "vegetable" },
   { name: "potato", category: "vegetable" },
   { name: "cherry tomato", category: "vegetable" },
+  { name: "carrot", category: "vegetable" },
+  { name: "sweet potato", category: "vegetable" },
+  { name: "lettuce", category: "vegetable" },
 
   // Legumes
   { name: "mixed beans", category: "legume" },
@@ -41,6 +50,7 @@ export const ingredients: IngredientContent[] = [
 
   // Dairy
   { name: "butter", category: "dairy" },
+  { name: "unsalted butter", category: "dairy" },
   { name: "double cream", category: "dairy" },
   { name: "single cream", category: "dairy" },
   { name: "creme fraiche", category: "dairy" },
@@ -62,12 +72,26 @@ export const ingredients: IngredientContent[] = [
   { name: "pasta", category: "grain" },
   { name: "long grain rice", category: "grain" },
   { name: "paella rice", category: "grain" },
-  { name: "tortilla wraps", category: "grain" },
+  {
+    name: "tortilla wrap",
+    pluralName: "tortilla wraps",
+    slug: "tortilla-wrap",
+    category: "grain",
+  },
   { name: "farfalle", category: "grain" },
   { name: "plain flour", category: "grain" },
   { name: "bread flour", category: "grain" },
   { name: "cornflour", category: "grain" },
   { name: "semolina", category: "grain" },
+  { name: "bread", category: "grain" },
+  { name: "noodles", category: "grain" },
+  {
+    name: "burger bap",
+    pluralName: "burger baps",
+    slug: "bap",
+    category: "grain",
+  },
+  { name: "rolled oats", category: "grain" },
 
   // Herbs
   { name: "fresh basil", category: "herb" },
@@ -75,6 +99,8 @@ export const ingredients: IngredientContent[] = [
   { name: "fresh parsley", category: "herb" },
   { name: "fresh coriander", category: "herb" },
   { name: "oregano", category: "herb" },
+  { name: "thyme", category: "herb" },
+  { name: "italian herbs", category: "herb" },
 
   // Spices & Seasonings
   { name: "curry powder", category: "spice" },
@@ -87,10 +113,13 @@ export const ingredients: IngredientContent[] = [
   { name: "chilli flakes", category: "spice" },
   { name: "tikka curry powder", category: "spice" },
   { name: "italian seasoning", category: "spice" },
+  { name: "red chilli powder", category: "spice" },
   { name: "salt", category: "spice" },
+  { name: "sea salt", category: "spice" },
   { name: "black pepper", category: "spice" },
   { name: "peri peri salt", category: "spice" },
   { name: "cajun seasoning", category: "spice" },
+  { name: "taco seasoning", category: "spice" },
   { name: "MSG", category: "spice" },
   { name: "five spice", category: "spice" },
   { name: "white pepper", category: "spice" },
@@ -99,8 +128,11 @@ export const ingredients: IngredientContent[] = [
   { name: "saffron", category: "spice" },
   { name: "cumin", category: "spice" },
   { name: "garlic granules", category: "spice" },
+  { name: "garlic powder", category: "spice" },
   { name: "onion salt", category: "spice" },
   { name: "fajita and taco mix", category: "spice" },
+  { name: "chilli powder", category: "spice" },
+  { name: "ginger", category: "spice" },
 
   // Condiments & Sauces
   { name: "basil pesto", category: "condiment" },
@@ -113,6 +145,12 @@ export const ingredients: IngredientContent[] = [
   { name: "mayonnaise", category: "condiment" },
   { name: "guacamole mix", category: "condiment" },
   { name: "sun-dried tomato pesto", category: "condiment" },
+  { name: "hoisin sauce", category: "condiment" },
+  { name: "dark soy sauce", category: "condiment" },
+  { name: "light soy sauce", category: "condiment" },
+  { name: "rice wine vinegar", category: "condiment" },
+  { name: "peri peri sauce", category: "condiment" },
+  { name: "harissa paste", category: "condiment" },
 
   // Sweets
   { name: "sugar", category: "sweets" },
@@ -128,12 +166,15 @@ export const ingredients: IngredientContent[] = [
   { name: "olive oil", category: "oil-fat" },
   { name: "extra virgin olive oil", category: "oil-fat" },
   { name: "coconut milk", category: "oil-fat" },
+  { name: "margarine", category: "oil-fat" },
 
   // Liquids
   { name: "chicken stock", category: "liquid" },
   { name: "vegetable stock", category: "liquid" },
+  { name: "pasta water", category: "liquid" },
   { name: "white wine", category: "liquid" },
   { name: "water", category: "liquid" },
+  { name: "orange juice", category: "liquid" },
 
   // Other
   { name: "dry yeast", category: "other" },

--- a/ui/content/recipes/lentil-soup.cook
+++ b/ui/content/recipes/lentil-soup.cook
@@ -1,0 +1,36 @@
+---
+title: "Lentil Soup"
+description: "A hearty and nutritious red lentil soup packed with sweet potato, spinach, and aromatic spices."
+date: "2023-10-27"
+cuisine: ["Indian"]
+servings: 4
+cookTime: 30
+tags: ["soup", "lentils", "healthy", "vegetable"]
+ingredientAnnotations:
+  sweet-potato:
+    preparation: "cubed"
+  garlic:
+    preparation: "crushed"
+  red-lentils:
+    preparation: "rinsed"
+  white-onion:
+    preparation: "diced"
+  carrot:
+    preparation: "halved and sliced"
+---
+
+Heat @olive oil{} in a large #pot{} over a medium heat.
+
+Add the @carrot|carrots{2}, @white onion{1} and @sweet potato{1} and saute for around ~{5%minutes}.
+
+Add the @garlic{4%clove}, @curry powder{1%tbsp}, @cumin{1%tsp}, @thyme{1%tsp} and @salt{}. Cook until fragrant, around ~{1%minute}.
+
+Add the @red lentils{2%cup}, @chopped tomatoes{1%tin} and @chicken stock{1.5%l}. Stir to combine and bring to a simmer.
+
+Cover and reduce the heat to maintain a gentle simmer.
+
+Cook, stirring occasionally, until the lentils are tender, around ~{20%minutes}.
+
+Remove from the heat and stir through the @spinach{0.5%bag} until wilted.
+
+Season with @black pepper|pepper{}.

--- a/ui/content/recipes/lentil-soup.cook
+++ b/ui/content/recipes/lentil-soup.cook
@@ -5,7 +5,7 @@ date: "2023-10-27"
 cuisine: ["Indian"]
 servings: 4
 cookTime: 30
-tags: ["soup", "lentils", "healthy", "vegetable"]
+tags: []
 ingredientAnnotations:
   sweet-potato:
     preparation: "cubed"

--- a/ui/content/recipes/millies-shortbread.cook
+++ b/ui/content/recipes/millies-shortbread.cook
@@ -5,7 +5,7 @@ date: "2024-05-20"
 cuisine: ["Scottish", "British"]
 servings: 12
 cookTime: 10
-tags: ["biscuits", "shortbread", "sweet", "baked"]
+tags: []
 ---
 
 Preheat #oven{} to 170°C.

--- a/ui/content/recipes/millies-shortbread.cook
+++ b/ui/content/recipes/millies-shortbread.cook
@@ -1,0 +1,19 @@
+---
+title: "Millie's Shortbread"
+description: "A classic, crumbly shortbread recipe using a blend of butter and margarine for texture and cornflour for a delicate melt-in-the-mouth finish."
+date: "2024-05-20"
+cuisine: ["Scottish", "British"]
+servings: 12
+cookTime: 10
+tags: ["biscuits", "shortbread", "sweet", "baked"]
+---
+
+Preheat #oven{} to 170°C.
+
+In a #mixing bowl{}, beat together @icing sugar{4%oz}, @butter{4%oz}, and @margarine{4%oz}.
+
+Add @plain flour{8%oz} and @cornflour{4%oz}, and beat together until a dough forms.
+
+Knead the mixture into a ball, then roll it out on a lightly floured surface and cut into shapes.
+
+Place on a #baking tray{} and cook in the oven for ~{10%minutes}.

--- a/ui/content/recipes/moroccan-chickpea-sweet-potato-stew.cook
+++ b/ui/content/recipes/moroccan-chickpea-sweet-potato-stew.cook
@@ -1,0 +1,26 @@
+---
+title: "Moroccan Chickpea & Sweet Potato Stew"
+description: "A hearty and warming Moroccan-inspired stew featuring protein-rich chickpeas, red lentils, and tender sweet potatoes in a spiced tomato broth."
+date: "2024-05-20"
+cuisine: ["Moroccan"]
+servings: 4
+cookTime: 62
+tags: ["stew", "vegan", "vegetarian", "healthy", "middle-eastern"]
+ingredientAnnotations:
+  white-onion:
+    preparation: "chopped"
+  carrot:
+    preparation: "chopped"
+  garlic:
+    preparation: "crushed"
+  chickpeas:
+    preparation: "drained and rinsed"
+---
+
+Heat the @olive oil{1%tbsp} in a large #pan{} and fry the @white onion{2}, @carrot{1}, and @garlic{4%clove} for around ~{5%minutes}.
+
+Add the @harissa paste{2%tbsp} and @chilli powder{1%tsp} and fry for ~{2%minutes} more.
+
+Add the @chickpeas{1%tin}, @red lentils{100%g}, @vegetable stock{700%ml}, and @tomato passata{500%g} and simmer for ~{15%minutes}.
+
+Add the @sweet potato{300%g}, cover, and simmer for ~{35%minutes} until the sauce has thickened and reduced.

--- a/ui/content/recipes/moroccan-chickpea-sweet-potato-stew.cook
+++ b/ui/content/recipes/moroccan-chickpea-sweet-potato-stew.cook
@@ -5,7 +5,7 @@ date: "2024-05-20"
 cuisine: ["Moroccan"]
 servings: 4
 cookTime: 62
-tags: ["stew", "vegan", "vegetarian", "healthy", "middle-eastern"]
+tags: ["vegetarian"]
 ingredientAnnotations:
   white-onion:
     preparation: "chopped"

--- a/ui/content/recipes/overnight-pizza.cook
+++ b/ui/content/recipes/overnight-pizza.cook
@@ -6,10 +6,10 @@ cuisine: ["Italian"]
 servings: 2
 prepTime: 1440
 cookTime: 9
-tags: ["pizza", "dough", "no-knead", "overnight"]
+tags: []
 ingredientAnnotations:
   bread-flour:
-    preparation: "plus extra for dusting"
+    note: "plus extra for dusting"
   tomato-passata:
     note: "can be substituted with crushed tomatoes"
 ---

--- a/ui/content/recipes/overnight-pizza.cook
+++ b/ui/content/recipes/overnight-pizza.cook
@@ -1,0 +1,43 @@
+---
+title: "Overnight Pizza"
+description: "A slow-fermented, no-knead pizza dough that develops deep flavor overnight, paired with a simple seasoned tomato sauce."
+date: "2023-10-27"
+cuisine: ["Italian"]
+servings: 2
+prepTime: 1440
+cookTime: 9
+tags: ["pizza", "dough", "no-knead", "overnight"]
+ingredientAnnotations:
+  bread-flour:
+    preparation: "plus extra for dusting"
+  tomato-passata:
+    note: "can be substituted with crushed tomatoes"
+---
+
+== Dough ==
+
+Mix @bread flour{250%g}, @salt{8%g}, @dry yeast|active dry yeast{0.5%g}, and @water{175%ml} in a #bowl{} until a messy dough forms.
+
+Cover the bowl with #cling film{} and leave at room temperature for between ~{18%hours} and ~{24%hours}.
+
+Reserve @semolina{} for dusting the pizza peel before baking.
+
+== Pizza Sauce ==
+
+Combine @tomato passata{250%ml}, @olive oil{0.5%tsp}, @salt|sea salt{0.5%tsp}, @sugar|white sugar{0.5%tsp}, @garlic powder{0.5%tsp}, @oregano|dried oregano{0.5%tsp}, and @italian seasoning|dried italian herbs{0.5%tsp} in a #saucepan{}.
+
+Simmer the sauce over a low heat until thickened.
+
+Preheat the #oven{} to 220°C with a #pizza stone{} inside.
+
+Flour a worktop and divide the dough into 2 pieces.
+
+Pat one piece down into the general shape of a pizza, then pick it up and stretch the dough over your knuckles into a larger pizza. Repeat with the second piece.
+
+Dust a #pizza peel{} with the semolina and place the dough on top.
+
+== Toppings ==
+
+Top with the prepared sauce, @mozzarella{}, and other toppings as desired.
+
+Bake in the oven for between ~{7%minutes} and ~{9%minutes} until the crust is golden and cheese is bubbly.

--- a/ui/content/recipes/piri-piri-chicken-burger.cook
+++ b/ui/content/recipes/piri-piri-chicken-burger.cook
@@ -6,7 +6,7 @@ cuisine: ["Portuguese", "African"]
 servings: 2
 prepTime: 30
 cookTime: 15
-tags: ["chicken breast", "burger", "spicy", "lunch", "dinner"]
+tags: ["spicy"]
 ingredientAnnotations:
   red-onion:
     preparation: "chopped"

--- a/ui/content/recipes/piri-piri-chicken-burger.cook
+++ b/ui/content/recipes/piri-piri-chicken-burger.cook
@@ -1,0 +1,29 @@
+---
+title: "Piri Piri Chicken Burger"
+description: "A spicy and juicy chicken burger marinated in piri piri sauce, topped with grilled peppers and onions."
+date: "2024-05-20"
+cuisine: ["Portuguese", "African"]
+servings: 2
+prepTime: 30
+cookTime: 15
+tags: ["chicken breast", "burger", "spicy", "lunch", "dinner"]
+ingredientAnnotations:
+  red-onion:
+    preparation: "chopped"
+  red-pepper:
+    preparation: "sliced"
+  chicken-breast:
+    preparation: "flattened"
+---
+
+Place @chicken breast|chicken breasts{2} between two sheets of #cling film{} and flatten with a #tenderizer{}.
+
+Put the chicken in a #bowl{} and pour over the @peri peri sauce{6%tbsp}. Leave to marinate for at least ~{30%minutes}.
+
+Preheat a #griddle pan{} over a medium heat. Cook the @red onion{0.5} and @red pepper|pepper{1} for ~{3.5%minutes}. Remove them and keep warm.
+
+Fry the chicken for ~{5%minutes} on each side or until cooked through.
+
+Toast the @bap|burger baps{2}, add @mayonnaise{}, @lettuce{}, chicken, and top with the onion and pepper.
+
+Serve with chips.

--- a/ui/content/recipes/piri-piri-chicken-burger.cook
+++ b/ui/content/recipes/piri-piri-chicken-burger.cook
@@ -26,4 +26,4 @@ Fry the chicken for ~{5%minutes} on each side or until cooked through.
 
 Toast the @bap|burger baps{2}, add @mayonnaise{}, @lettuce{}, chicken, and top with the onion and pepper.
 
-Serve with chips.
+Serve with @chips{}.

--- a/ui/content/recipes/salted-caramel-carmelitas.cook
+++ b/ui/content/recipes/salted-caramel-carmelitas.cook
@@ -1,0 +1,42 @@
+---
+title: "Salted Caramel Carmelitas"
+description: "Rich and chewy oatmeal bars layered with salted caramel and melted chocolate chunks."
+date: "2023-10-27"
+cuisine: ["American"]
+servings: 16
+cookTime: 30
+tags: ["baking", "dessert", "caramel", "oats", "chocolate"]
+ingredientAnnotations:
+  butter:
+    preparation: "melted"
+  dark-chocolate:
+    preparation: "chopped into chunks"
+  milk-chocolate:
+    preparation: "chopped into chunks"
+  caramel:
+    note: "carnations brand"
+---
+
+Preheat #oven{} to 180°C and line a 9x9 inch #baking tin{} with #baking paper{}.
+
+In a large #bowl{}, combine @rolled oats{225%g}, @plain flour{250%g}, @salt|sea salt{1/4%tsp}, and @brown sugar|light soft brown sugar{350%g}.
+
+Stir in the @butter|unsalted butter{250%g}.
+
+Spoon about 2/3 of the mixture into the lined #baking tin{} and press down with a #spoon{}.
+
+Bake in the #oven{} for ~{10%minutes} until golden.
+
+== Caramel ==
+
+In a small #bowl{} mix the @salt|sea salt{1/2%tsp} into the @caramel{397%g}.
+
+Remove the #baking tin{} from the #oven{} and sprinkle over the @dark chocolate{125%g} and @milk chocolate{125%g}.
+
+Drizzle over the salted caramel and make sure it is spread evenly.
+
+Crumble over the remaining oat topping and bake for ~{15-20%minutes} until golden.
+
+Melt a little extra @dark chocolate{} and drizzle over the top, then add a pinch of @salt|sea salt{}.
+
+Leave to cool for at least ~{4%hours}, preferably overnight.

--- a/ui/content/recipes/salted-caramel-carmelitas.cook
+++ b/ui/content/recipes/salted-caramel-carmelitas.cook
@@ -5,7 +5,7 @@ date: "2023-10-27"
 cuisine: ["American"]
 servings: 16
 cookTime: 30
-tags: ["baking", "dessert", "caramel", "oats", "chocolate"]
+tags: ["dessert"]
 ingredientAnnotations:
   butter:
     preparation: "melted"

--- a/ui/content/recipes/salted-caramel-carmelitas.cook
+++ b/ui/content/recipes/salted-caramel-carmelitas.cook
@@ -35,7 +35,9 @@ Remove the #baking tin{} from the #oven{} and sprinkle over the @dark chocolate{
 
 Drizzle over the salted caramel and make sure it is spread evenly.
 
-Crumble over the remaining oat topping and bake for ~{15-20%minutes} until golden.
+Crumble over the remaining oat topping and bake for ~{15%minutes}.
+
+Check whether the topping is golden, then bake for up to another ~{5%minutes} if needed.
 
 Melt a little extra @dark chocolate{} and drizzle over the top, then add a pinch of @salt|sea salt{}.
 

--- a/ui/content/recipes/sausage-jambalaya.cook
+++ b/ui/content/recipes/sausage-jambalaya.cook
@@ -8,7 +8,7 @@ prepTime: 10
 cookTime: 25
 tags: ["one-pot"]
 ingredientAnnotations:
-  pork-sausages:
+  pork-sausage:
     preparation: "cut into pieces"
   white-onion:
     preparation: "finely chopped"
@@ -28,7 +28,7 @@ ingredientAnnotations:
 
 Put the @long grain rice{200%g} in a #sieve{} and rinse it thoroughly.
 
-Heat the @olive oil{1%tbsp} in a large #frying pan{} and brown the @pork sausages{8%piece} for ~{2%minutes}.
+Heat the @olive oil{1%tbsp} in a large #frying pan{} and brown the @pork sausage|pork sausages{8%piece} for ~{2%minutes}.
 
 Stir in the @cajun seasoning{1.5%tbsp} and @white onion{1%piece}, then cook for ~{2%minutes}.
 

--- a/ui/content/recipes/slow-cooker-chicken-curry.cook
+++ b/ui/content/recipes/slow-cooker-chicken-curry.cook
@@ -1,0 +1,26 @@
+---
+title: "Slow Cooker Chicken Curry"
+description: "An easy, set-and-forget slow cooker chicken curry with a creamy coconut base and garden peas."
+date: "2024-05-23"
+cuisine: ["Indian", "British"]
+servings: 4
+cookTime: 245
+tags: ["slow-cooker", "chicken", "curry"]
+ingredientAnnotations:
+  chicken-breast:
+    preparation: "diced"
+  white-onion:
+    preparation: "chopped"
+  garlic:
+    preparation: "crushed"
+---
+
+Add the @chicken breast{4}, @coconut milk{1%tin}, @tomato puree{2%tbsp}, @ground coriander{1%tsp}, @turmeric{1%tbsp}, @curry powder{2%tbsp}, @chilli powder|chili powder{1%tsp}, @white onion{1}, @garlic{4%clove}, @ginger{1%tsp}, @five spice|Chinese five spice{0.5%tsp}, @salt{}, and @black pepper|pepper{} to the #slow cooker{}.
+
+Cook on HIGH for ~{4%hour}.
+
+Stir the curry and drain the @peas|garden peas{1%tin}.
+
+Add the @peas|garden peas{} to the #slow cooker{} for ~{5%minutes}.
+
+Serve with @rice{}.

--- a/ui/content/recipes/slow-cooker-chicken-curry.cook
+++ b/ui/content/recipes/slow-cooker-chicken-curry.cook
@@ -5,7 +5,7 @@ date: "2024-05-23"
 cuisine: ["Indian", "British"]
 servings: 4
 cookTime: 245
-tags: ["slow-cooker", "chicken", "curry"]
+tags: []
 ingredientAnnotations:
   chicken-breast:
     preparation: "diced"

--- a/ui/content/recipes/slow-cooker-chicken-satay-noodles.cook
+++ b/ui/content/recipes/slow-cooker-chicken-satay-noodles.cook
@@ -1,0 +1,22 @@
+---
+title: "Slow Cooker Chicken Satay & Noodles"
+description: "A creamy and convenient slow cooker chicken satay served with tender egg noodles."
+date: "2024-05-22"
+cuisine: ["Thai", "Asian"]
+servings: 4
+cookTime: 170
+tags: ["slow-cooker", "chicken", "satay", "noodles"]
+ingredientAnnotations:
+  chicken-breast:
+    preparation: "cut into strips"
+  white-onion:
+    preparation: "diced"
+---
+
+Add @chicken breast|chicken{400%g}, @curry powder{1%tbsp}, @soy sauce{1%tbsp}, @white onion|onion{1}, @peanut butter{3%tbsp}, @lime juice{1.5%tbsp}, @coconut milk{1%tin}, @chilli{1%tsp}, @honey{2%tbsp}, @garlic{4%clove}, and @frozen vegetables|vegetable mix{} to the #slow cooker{}.
+
+Cook on HIGH for ~{150%minutes}.
+
+Add @chicken stock{250%ml} and @noodles|dry egg noodles{200%g} to the #slow cooker{}.
+
+Cook for a further ~{20%minutes} before serving.

--- a/ui/content/recipes/slow-cooker-chicken-satay-noodles.cook
+++ b/ui/content/recipes/slow-cooker-chicken-satay-noodles.cook
@@ -5,7 +5,7 @@ date: "2024-05-22"
 cuisine: ["Thai", "Asian"]
 servings: 4
 cookTime: 170
-tags: ["slow-cooker", "chicken", "satay", "noodles"]
+tags: []
 ingredientAnnotations:
   chicken-breast:
     preparation: "cut into strips"

--- a/ui/content/recipes/slow-cooker-honey-chilli-chicken-noodles.cook
+++ b/ui/content/recipes/slow-cooker-honey-chilli-chicken-noodles.cook
@@ -1,0 +1,24 @@
+---
+title: "Slow Cooker Honey Chilli Chicken Noodles"
+description: "A sweet and spicy slow-cooked chicken dish served with egg noodles in a rich honey and soy glaze."
+date: "2024-05-22"
+cuisine: ["Chinese"]
+servings: 4
+cookTime: 170
+tags: ["slow-cooker", "chicken", "noodles", "honey-chilli"]
+ingredientAnnotations:
+  red-pepper:
+    preparation: "chopped"
+  garlic:
+    preparation: "crushed"
+---
+
+Add the @chicken breast|chicken{400%g}, @cornflour{1%tbsp}, @dark soy sauce{4%tbsp}, @light soy sauce{5%tbsp}, @orange juice{3%tbsp}, @hoisin sauce{2%tbsp}, @chilli flakes{2%tsp}, @garlic{5%clove}, @rice wine vinegar{2%tsp}, and @honey{4%tbsp} to the #slow cooker{}.
+
+Cook on HIGH for ~{150%minutes}.
+
+Then add the @noodles|egg noodles{200%g}, @red pepper{1}, and @chicken stock{300%ml}.
+
+Cook for ~{20%minutes}.
+
+Stir after ~{10%minutes}.

--- a/ui/content/recipes/slow-cooker-honey-chilli-chicken-noodles.cook
+++ b/ui/content/recipes/slow-cooker-honey-chilli-chicken-noodles.cook
@@ -5,7 +5,7 @@ date: "2024-05-22"
 cuisine: ["Chinese"]
 servings: 4
 cookTime: 170
-tags: ["slow-cooker", "chicken", "noodles", "honey-chilli"]
+tags: []
 ingredientAnnotations:
   red-pepper:
     preparation: "chopped"

--- a/ui/content/recipes/slow-cooker-mexican-chicken.cook
+++ b/ui/content/recipes/slow-cooker-mexican-chicken.cook
@@ -13,7 +13,7 @@ ingredientAnnotations:
   bell-pepper:
     preparation: "sliced"
     note: "red and yellow"
-  tortilla-wraps:
+  tortilla-wrap:
     note: "to serve"
   cheddar-cheese:
     note: "to serve"
@@ -29,6 +29,6 @@ Cook on high for ~{4%hours} or low for ~{8%hours}.
 
 Once cooked, shred the chicken with two #fork{}s.
 
-Add the shredded chicken to @tortilla wraps{} or boats.
+Add the shredded chicken to @tortilla wrap|tortilla wraps{} or boats.
 
 Cover with @cheddar cheese{} and melt it in the #oven{}.

--- a/ui/content/recipes/slow-cooker-teriyaki-chicken.cook
+++ b/ui/content/recipes/slow-cooker-teriyaki-chicken.cook
@@ -5,7 +5,7 @@ date: "2024-05-20"
 cuisine: ["Japanese", "American"]
 servings: 4
 cookTime: 480
-tags: ["slow-cooker", "chicken", "teriyaki"]
+tags: []
 ingredientAnnotations:
   garlic:
     preparation: "crushed"

--- a/ui/content/recipes/slow-cooker-teriyaki-chicken.cook
+++ b/ui/content/recipes/slow-cooker-teriyaki-chicken.cook
@@ -1,0 +1,22 @@
+---
+title: "Slow Cooker Teriyaki Chicken"
+description: "A simple and delicious slow-cooked chicken dish with a savory hoisin and soy glaze."
+date: "2024-05-20"
+cuisine: ["Japanese", "American"]
+servings: 4
+cookTime: 480
+tags: ["slow-cooker", "chicken", "teriyaki"]
+ingredientAnnotations:
+  garlic:
+    preparation: "crushed"
+  spring-onion:
+    preparation: "chopped"
+---
+
+Add the @olive oil{1%tbsp}, @chicken breast{3%piece}, @soy sauce{1/3%cup}, @hoisin sauce{1/2%cup}, and @garlic{4%clove} to the #slow cooker{} in that order.
+
+Cook on low for ~{8%hours}.
+
+Shred the @chicken breast{} using two #forks.
+
+Serve with @rice{} and garnish with chopped @spring onion|scallions{}.


### PR DESCRIPTION
## What changed
- added 11 recipe `.cook` files from the ML recipe ground-truth set into the site content
- promoted the missing canonical ingredient entries needed by those recipes into `ui/content/recipes/ingredients.ts`
- normalized singular canonical slugs in existing recipe content where needed and kept plural instruction text via Cooklang aliases
- renamed `Overnight Pizza Dough` to `Overnight Pizza` and cleaned up its ingredient-group structure
- fixed stale `ingredientAnnotations` keys so annotations still apply after the slug normalization

## Why it changed
The recipe site had the original published set, while the ML pipeline contained additional normalized ground-truth recipe outputs that were not yet available in the site content. This PR promotes those recipes into the UI content model and aligns the site ingredient catalog with the ML pipeline's current canonical ingredient set.

## Impact
- the recipe site gains 11 additional recipes
- imported recipes now validate against the site ingredient registry
- existing affected recipes keep correct display text while using the canonical singular slugs required for annotation matching

## Validation
- `pnpm build` in `ui/` passed
- manual review of recipe annotation keys against body ingredient slugs returned clean

## Notes
- ML dataset `image` / `imageAlt` fields were intentionally not copied because those source images are import inputs, not site hero images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ten new recipes spanning slow-cooker dishes, baking, and international cuisine, including lentil soup, shortbread, chicken satay noodles, and teriyaki chicken
  * Expanded ingredient database with additional vegetables, spices, condiments, oils, and pantry staples
  * Standardised ingredient naming conventions and preparation annotations across recipes for improved consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robbie-Palmer/personal-site/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->