### PR TITLE
feat(recipes): SEO attribution for derived recipes

### DIFF
--- a/packages/recipe-domain/src/recipe.ts
+++ b/packages/recipe-domain/src/recipe.ts
@@ -105,6 +105,7 @@ export const RecipeContentSchema = ParsedRecipeSchema.extend({
     .regex(/^recipes\/[a-z0-9_-]+-\d{4}-\d{2}-\d{2}$/)
     .optional(),
   imageAlt: z.string().min(1).optional(),
+  canonical: z.string().url().optional(),
 });
 
 export type RecipeContent = z.infer<typeof RecipeContentSchema>;

--- a/ui/app/recipes/[slug]/page.tsx
+++ b/ui/app/recipes/[slug]/page.tsx
@@ -26,9 +26,6 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { slug } = params;
   try {
     const recipe = getRecipeBySlug(slug);
-    // Use external canonical URL if specified (derived content), otherwise
-    // production URL. Canonical URLs always point to production, even in
-    // preview deployments.
     const canonicalUrl =
       recipe.canonical || `${siteConfig.url}/recipes/${slug}`;
     return {

--- a/ui/app/recipes/[slug]/page.tsx
+++ b/ui/app/recipes/[slug]/page.tsx
@@ -26,9 +26,17 @@ export async function generateMetadata(props: PageProps): Promise<Metadata> {
   const { slug } = params;
   try {
     const recipe = getRecipeBySlug(slug);
+    // Use external canonical URL if specified (derived content), otherwise
+    // production URL. Canonical URLs always point to production, even in
+    // preview deployments.
+    const canonicalUrl =
+      recipe.canonical || `${siteConfig.url}/recipes/${slug}`;
     return {
       title: recipe.title,
       description: recipe.description,
+      alternates: {
+        canonical: canonicalUrl,
+      },
     };
   } catch (_e) {
     return {

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -326,6 +326,7 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
             Adapted from{" "}
             <a
               href={recipe.canonical}
+              target="_blank"
               rel="noopener"
               className="underline hover:text-foreground"
             >

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -321,6 +321,20 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
           {recipe.description}
         </p>
 
+        {recipe.canonical && (
+          <p className="text-sm text-muted-foreground italic mb-4">
+            Adapted from{" "}
+            <a
+              href={recipe.canonical}
+              rel="noopener"
+              className="underline hover:text-foreground"
+            >
+              the original recipe
+            </a>
+            .
+          </p>
+        )}
+
         <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-1">
             <Users className="h-4 w-4" />

--- a/ui/content/recipes/chicken-quesadillas.cook
+++ b/ui/content/recipes/chicken-quesadillas.cook
@@ -7,6 +7,7 @@ servings: 2
 prepTime: 10
 cookTime: 40
 tags: []
+canonical: "https://gran.luchito.com/recipes/quesadillas/chicken-quesadilla/"
 ingredientAnnotations:
   vine-tomato:
     preparation: "diced"

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -421,6 +421,7 @@ export function buildRecipeContentFromParsed(
     cookware: parts.cookware,
     image: frontmatter.image,
     imageAlt: frontmatter.imageAlt,
+    canonical: frontmatter.canonical,
     ingredientGroups: parts.ingredientGroups,
     instructions: parts.instructions,
     instructionSdk: parts.instructionSdk,

--- a/ui/lib/domain/recipe/recipeViews.ts
+++ b/ui/lib/domain/recipe/recipeViews.ts
@@ -37,6 +37,7 @@ type BaseRecipeView = {
   totalTime?: number;
   image?: string;
   imageAlt?: string;
+  canonical?: string;
 };
 
 export type RecipeCardView = BaseRecipeView & {
@@ -119,6 +120,7 @@ export function toRecipeCardView(
     totalTime: computeTotalTime(recipe),
     image: recipe.image,
     imageAlt: recipe.imageAlt,
+    canonical: recipe.canonical,
     ingredientNames: extractIngredientNames(recipe, ingredients),
     cookware: recipe.cookware,
   };

--- a/ui/lib/seo/recipe-jsonld.ts
+++ b/ui/lib/seo/recipe-jsonld.ts
@@ -15,6 +15,11 @@ export type SchemaOrgHowToStep = {
   text: string;
 };
 
+export type SchemaOrgCreativeWorkRef = {
+  "@type": "Recipe";
+  url: string;
+};
+
 export type SchemaOrgRecipe = {
   "@context": "https://schema.org";
   "@type": "Recipe";
@@ -31,6 +36,7 @@ export type SchemaOrgRecipe = {
   keywords?: string;
   recipeIngredient: string[];
   recipeInstructions: SchemaOrgHowToStep[];
+  isBasedOn?: SchemaOrgCreativeWorkRef;
 };
 
 export type SchemaOrgListItem = {
@@ -165,6 +171,9 @@ export function buildRecipeJsonLd(
   const keywordParts = [...recipe.tags, ...recipe.cuisine];
   if (keywordParts.length > 0) {
     jsonLd.keywords = keywordParts.join(", ");
+  }
+  if (recipe.canonical) {
+    jsonLd.isBasedOn = { "@type": "Recipe", url: recipe.canonical };
   }
 
   return jsonLd;


### PR DESCRIPTION
## Summary

Mirrors the blog post pattern (`canonical:` frontmatter → `<link rel="canonical">`) for recipe pages, so derived recipes attribute SEO traffic to the original source rather than competing with it in search results.

- Optional `canonical` URL field on recipe frontmatter, threaded through `RecipeContentSchema` → `RecipeDetailView`
- `alternates.canonical` set in `app/recipes/[slug]/page.tsx` metadata when present (otherwise falls back to the production self-canonical)
- `isBasedOn: { "@type": "Recipe", url: ... }` added to the schema.org Recipe JSON-LD when present
- Subtle italic "Adapted from the original recipe" link rendered under the description (frontmatter-driven, independent of the Cooklang body)
- `chicken-quesadillas.cook` now attributes [gran.luchito.com](https://gran.luchito.com/recipes/quesadillas/chicken-quesadilla/)

## Test plan

- [x] Inspect the Cloudflare preview: `/recipes/chicken-quesadillas` shows the "Adapted from the original recipe" line under the description, above the servings/time row
- [x] View source on the preview: `<link rel="canonical" href="https://gran.luchito.com/recipes/quesadillas/chicken-quesadilla/">` is present in `<head>`
- [x] View source on any other recipe (e.g. `/recipes/cajun-sausage-pasta`): canonical still points to the production self-URL, no attribution line rendered
- [x] Inspect the recipe JSON-LD `<script type="application/ld+json">` on the chicken quesadillas page: includes `"isBasedOn": { "@type": "Recipe", "url": "https://gran.luchito.com/..." }`
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 180/180 pass
- [x] `pnpm lint` — no new warnings

https://claude.ai/code/session_01MpVitVgqMaTecEEVzVjycd

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpVitVgqMaTecEEVzVjycd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added canonical URL support for recipes, enabling recipes to reference and link to their original sources
* Recipe pages now display prominent "Adapted from" citations that link to the original recipe source when applicable
* Enhanced SEO metadata including canonical URLs and improved schema.org JSON-LD structured data for recipe attribution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Robbie-Palmer/personal-site/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->