### PR TITLE
[codex] Add detail-view scores to recipe parsing viz

### DIFF
--- a/ml-pipelines/recipe-parsing/tools/viz/src/components/ScoresPanel.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/components/ScoresPanel.tsx
@@ -1,27 +1,40 @@
-import type { EntryScores } from "../types/review";
+import type { DetailScoreBreakdown } from "../lib/detailScores";
 import { ScoreBadge } from "./ScoreBadge";
 import { scoreBarColor } from "../lib/scores";
 
 interface ScoresPanelProps {
-  scores: EntryScores;
+  scores: DetailScoreBreakdown;
 }
 
 export function ScoresPanel({ scores }: ScoresPanelProps) {
   const items = [
     { label: "Structured Score", value: scores.overall },
-    { label: "Scalar Fields", value: scores.scalarFields },
-    { label: "Ingredients", value: scores.ingredientParsing },
-    { label: "Instructions", value: scores.instructions },
+    ...(scores.scalarFields != null
+      ? [{ label: "Scalar Fields", value: scores.scalarFields }]
+      : []),
+    ...(scores.ingredientParsing != null
+      ? [{ label: "Ingredients", value: scores.ingredientParsing }]
+      : []),
+    ...(scores.instructions != null
+      ? [{ label: "Instructions", value: scores.instructions }]
+      : []),
     ...(scores.equipmentParsing != null
       ? [{ label: "Equipment", value: scores.equipmentParsing }]
       : []),
   ];
 
+  const componentLabels = items
+    .slice(1)
+    .map((item) => item.label.toLowerCase())
+    .join(", ");
+
   return (
     <div className="bg-white rounded-lg border border-gray-200 p-4">
       <h3 className="text-sm font-semibold mb-1">Structured Score</h3>
       <p className="mb-3 text-xs text-gray-500">
-        Composite over scalar fields, ingredients, equipment, and instructions.
+        {componentLabels
+          ? `Composite over this stage's active metrics: ${componentLabels}.`
+          : "Composite over this stage's active metrics."}
       </p>
       <div className="space-y-2">
         {items.map((item) => (

--- a/ml-pipelines/recipe-parsing/tools/viz/src/lib/detailScores.ts
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/lib/detailScores.ts
@@ -1,0 +1,54 @@
+import type { ParsedRecipe } from "recipe-domain";
+import {
+  CANONICALIZATION_SCORING_PROFILE,
+  EXTRACTION_SCORING_PROFILE,
+  NORMALIZATION_SCORING_PROFILE,
+  type ScoringProfile,
+  computeEntryScores,
+  evaluateEquipmentParsing,
+  evaluateIngredientParsing,
+  evaluateInstructions,
+  evaluateScalarFields,
+} from "../../../../src/evaluation/metrics.js";
+import { extractionToRecipe } from "../../../../src/lib/extraction-to-recipe.js";
+import type { ExtractionRecipe } from "../types/extraction";
+import type { EntryScores as ReviewEntryScores } from "../types/review";
+
+type ScoreBreakdown = ReviewEntryScores;
+
+function scoreRecipes(
+  predicted: ParsedRecipe,
+  expected: ParsedRecipe,
+  profile: ScoringProfile,
+): ScoreBreakdown {
+  const scalar = evaluateScalarFields(predicted as never, expected as never);
+  const ingredients = evaluateIngredientParsing(predicted as never, expected as never);
+  const instructions = evaluateInstructions(predicted as never, expected as never);
+  const equipment = evaluateEquipmentParsing(predicted as never, expected as never);
+  return computeEntryScores(scalar, ingredients, instructions, equipment, profile);
+}
+
+export function computeExtractionDetailScores(
+  predicted: ExtractionRecipe,
+  expected: ExtractionRecipe,
+): ScoreBreakdown {
+  return scoreRecipes(
+    extractionToRecipe(predicted) as never,
+    extractionToRecipe(expected) as never,
+    EXTRACTION_SCORING_PROFILE,
+  );
+}
+
+export function computeNormalizationDetailScores(
+  predicted: ParsedRecipe,
+  expected: ParsedRecipe,
+): ScoreBreakdown {
+  return scoreRecipes(predicted, expected, NORMALIZATION_SCORING_PROFILE);
+}
+
+export function computeCanonicalizationDetailScores(
+  predicted: ParsedRecipe,
+  expected: ParsedRecipe,
+): ScoreBreakdown {
+  return scoreRecipes(predicted, expected, CANONICALIZATION_SCORING_PROFILE);
+}

--- a/ml-pipelines/recipe-parsing/tools/viz/src/lib/detailScores.ts
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/lib/detailScores.ts
@@ -3,6 +3,7 @@ import {
   CANONICALIZATION_SCORING_PROFILE,
   EXTRACTION_SCORING_PROFILE,
   NORMALIZATION_SCORING_PROFILE,
+  type ScalarFieldScores,
   type ScoringProfile,
   computeEntryScores,
   evaluateEquipmentParsing,
@@ -12,26 +13,63 @@ import {
 } from "../../../../src/evaluation/metrics.js";
 import { extractionToRecipe } from "../../../../src/lib/extraction-to-recipe.js";
 import type { ExtractionRecipe } from "../types/extraction";
-import type { EntryScores as ReviewEntryScores } from "../types/review";
 
-type ScoreBreakdown = ReviewEntryScores;
+export interface DetailScoreBreakdown {
+  overall: number;
+  scalarFields?: number;
+  ingredientParsing?: number;
+  instructions?: number;
+  equipmentParsing?: number;
+}
+
+function weightedAverage(values: Array<{ value: number; weight: number }>): number | undefined {
+  const active = values.filter(({ weight }) => weight > 0);
+  if (active.length === 0) return undefined;
+  const totalWeight = active.reduce((sum, { weight }) => sum + weight, 0);
+  if (totalWeight === 0) return undefined;
+  return active.reduce((sum, { value, weight }) => sum + value * weight, 0) / totalWeight;
+}
+
+function scoreActiveScalarFields(
+  scalar: ScalarFieldScores,
+  profile: ScoringProfile,
+): number | undefined {
+  return weightedAverage([
+    { value: scalar.title.f1, weight: profile.weights.title ?? 0 },
+    { value: scalar.description.f1, weight: profile.weights.description ?? 0 },
+    { value: scalar.cuisine.f1, weight: profile.weights.cuisine ?? 0 },
+    { value: scalar.servings.accuracy, weight: profile.weights.servings ?? 0 },
+    { value: scalar.prepTime.accuracy, weight: profile.weights.prepTime ?? 0 },
+    { value: scalar.cookTime.accuracy, weight: profile.weights.cookTime ?? 0 },
+  ]);
+}
 
 function scoreRecipes(
   predicted: ParsedRecipe,
   expected: ParsedRecipe,
   profile: ScoringProfile,
-): ScoreBreakdown {
+): DetailScoreBreakdown {
   const scalar = evaluateScalarFields(predicted as never, expected as never);
   const ingredients = evaluateIngredientParsing(predicted as never, expected as never);
   const instructions = evaluateInstructions(predicted as never, expected as never);
   const equipment = evaluateEquipmentParsing(predicted as never, expected as never);
-  return computeEntryScores(scalar, ingredients, instructions, equipment, profile);
+  const scores = computeEntryScores(scalar, ingredients, instructions, equipment, profile);
+  return {
+    overall: scores.overall,
+    scalarFields: scoreActiveScalarFields(scalar, profile),
+    ingredientParsing:
+      (profile.weights.ingredientParsing ?? 0) > 0 ? scores.ingredientParsing : undefined,
+    instructions:
+      (profile.weights.instructions ?? 0) > 0 ? scores.instructions : undefined,
+    equipmentParsing:
+      (profile.weights.equipmentParsing ?? 0) > 0 ? scores.equipmentParsing : undefined,
+  };
 }
 
 export function computeExtractionDetailScores(
   predicted: ExtractionRecipe,
   expected: ExtractionRecipe,
-): ScoreBreakdown {
+): DetailScoreBreakdown {
   return scoreRecipes(
     extractionToRecipe(predicted) as never,
     extractionToRecipe(expected) as never,
@@ -42,13 +80,13 @@ export function computeExtractionDetailScores(
 export function computeNormalizationDetailScores(
   predicted: ParsedRecipe,
   expected: ParsedRecipe,
-): ScoreBreakdown {
+): DetailScoreBreakdown {
   return scoreRecipes(predicted, expected, NORMALIZATION_SCORING_PROFILE);
 }
 
 export function computeCanonicalizationDetailScores(
   predicted: ParsedRecipe,
   expected: ParsedRecipe,
-): ScoreBreakdown {
+): DetailScoreBreakdown {
   return scoreRecipes(predicted, expected, CANONICALIZATION_SCORING_PROFILE);
 }

--- a/ml-pipelines/recipe-parsing/tools/viz/src/lib/detailScores.ts
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/lib/detailScores.ts
@@ -1,4 +1,3 @@
-import type { ParsedRecipe } from "recipe-domain";
 import {
   CANONICALIZATION_SCORING_PROFILE,
   EXTRACTION_SCORING_PROFILE,
@@ -12,6 +11,7 @@ import {
   evaluateScalarFields,
 } from "../../../../src/evaluation/metrics.js";
 import { extractionToRecipe } from "../../../../src/lib/extraction-to-recipe.js";
+import type { Recipe } from "../../../../src/schemas/ground-truth.js";
 import type { ExtractionRecipe } from "../types/extraction";
 
 export interface DetailScoreBreakdown {
@@ -45,14 +45,14 @@ function scoreActiveScalarFields(
 }
 
 function scoreRecipes(
-  predicted: ParsedRecipe,
-  expected: ParsedRecipe,
+  predicted: Recipe,
+  expected: Recipe,
   profile: ScoringProfile,
 ): DetailScoreBreakdown {
-  const scalar = evaluateScalarFields(predicted as never, expected as never);
-  const ingredients = evaluateIngredientParsing(predicted as never, expected as never);
-  const instructions = evaluateInstructions(predicted as never, expected as never);
-  const equipment = evaluateEquipmentParsing(predicted as never, expected as never);
+  const scalar = evaluateScalarFields(predicted, expected);
+  const ingredients = evaluateIngredientParsing(predicted, expected);
+  const instructions = evaluateInstructions(predicted, expected);
+  const equipment = evaluateEquipmentParsing(predicted, expected);
   const scores = computeEntryScores(scalar, ingredients, instructions, equipment, profile);
   return {
     overall: scores.overall,
@@ -71,22 +71,22 @@ export function computeExtractionDetailScores(
   expected: ExtractionRecipe,
 ): DetailScoreBreakdown {
   return scoreRecipes(
-    extractionToRecipe(predicted) as never,
-    extractionToRecipe(expected) as never,
+    extractionToRecipe(predicted),
+    extractionToRecipe(expected),
     EXTRACTION_SCORING_PROFILE,
   );
 }
 
 export function computeNormalizationDetailScores(
-  predicted: ParsedRecipe,
-  expected: ParsedRecipe,
+  predicted: Recipe,
+  expected: Recipe,
 ): DetailScoreBreakdown {
   return scoreRecipes(predicted, expected, NORMALIZATION_SCORING_PROFILE);
 }
 
 export function computeCanonicalizationDetailScores(
-  predicted: ParsedRecipe,
-  expected: ParsedRecipe,
+  predicted: Recipe,
+  expected: Recipe,
 ): DetailScoreBreakdown {
   return scoreRecipes(predicted, expected, CANONICALIZATION_SCORING_PROFILE);
 }

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/CanonicalizeDetailView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/CanonicalizeDetailView.tsx
@@ -17,6 +17,8 @@ import { ImageViewer } from "../components/ImageViewer";
 import { ParsedRecipeEditor } from "../components/ParsedRecipeEditor";
 import { RecipePanel } from "../components/RecipePanel";
 import { ParsedRecipeDiff } from "../components/ParsedRecipeDiff";
+import { ScoresPanel } from "../components/ScoresPanel";
+import { computeCanonicalizationDetailScores } from "../lib/detailScores";
 
 interface CanonicalizeDetailViewProps {
   entryIndex: number;
@@ -131,6 +133,14 @@ export function CanonicalizeDetailView({
   }, [validationResult]);
 
   const expectedCanonicalized = validationResult?.success ? validationResult.data : null;
+
+  const scoreBreakdown = useMemo(() => {
+    if (!expectedCanonicalized || !predictedCanonicalized) return null;
+    return computeCanonicalizationDetailScores(
+      predictedCanonicalized,
+      expectedCanonicalized,
+    );
+  }, [expectedCanonicalized, predictedCanonicalized]);
 
   const handleSave = useCallback(async () => {
     if (!groundTruth || !edited) return;
@@ -373,6 +383,7 @@ export function CanonicalizeDetailView({
 
         {/* Right: diff */}
         <div className="space-y-4">
+          {scoreBreakdown && <ScoresPanel scores={scoreBreakdown} />}
           {expectedCanonicalized && predictedCanonicalized ? (
             <ParsedRecipeDiff
               expected={expectedCanonicalized}

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/ExtractionDetailView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/ExtractionDetailView.tsx
@@ -12,6 +12,8 @@ import {
   computeWordErrorRate,
 } from "../../../../src/evaluation/metrics.js";
 import { flattenExtractionText } from "../../../../src/lib/extraction-text.js";
+import { ScoresPanel } from "../components/ScoresPanel";
+import { computeExtractionDetailScores } from "../lib/detailScores";
 import type {
   ExtractionPredictionsDataset,
   ExtractionRecipe,
@@ -225,6 +227,11 @@ export function ExtractionDetailView({
     };
   }, [gtEntry?.expectedExtraction, predictedExtraction]);
 
+  const scoreBreakdown = useMemo(() => {
+    if (!predictedExtraction || !gtEntry?.expectedExtraction) return null;
+    return computeExtractionDetailScores(predictedExtraction, gtEntry.expectedExtraction);
+  }, [gtEntry?.expectedExtraction, predictedExtraction]);
+
   if (error) {
     return (
       <div className="bg-red-50 border border-red-200 rounded-lg p-6">
@@ -315,6 +322,11 @@ export function ExtractionDetailView({
 
         {/* Right: diff or individual panels */}
         <div>
+          {scoreBreakdown && (
+            <div className="mb-4">
+              <ScoresPanel scores={scoreBreakdown} />
+            </div>
+          )}
           {textFidelity && (
             <div className="mb-4">
               <TextFidelityCard

--- a/ml-pipelines/recipe-parsing/tools/viz/src/views/NormalizationDetailView.tsx
+++ b/ml-pipelines/recipe-parsing/tools/viz/src/views/NormalizationDetailView.tsx
@@ -22,6 +22,8 @@ import { CooklangEditor } from "../components/CooklangEditor";
 import { ImageViewer } from "../components/ImageViewer";
 import { ParsedRecipeDiff } from "../components/ParsedRecipeDiff";
 import { RecipePanel } from "../components/RecipePanel";
+import { ScoresPanel } from "../components/ScoresPanel";
+import { computeNormalizationDetailScores } from "../lib/detailScores";
 
 interface NormalizationDetailViewProps {
   entryIndex: number;
@@ -233,6 +235,11 @@ export function NormalizationDetailView({
     return livePreview?.diagnostics ?? [];
   }, [edited, livePreview?.diagnostics]);
 
+  const scoreBreakdown = useMemo(() => {
+    if (!expectedNormalized || !predictedNormalization) return null;
+    return computeNormalizationDetailScores(predictedNormalization, expectedNormalized);
+  }, [expectedNormalized, predictedNormalization]);
+
   if (error) {
     return (
       <div className="bg-red-50 border border-red-200 rounded-lg p-6">
@@ -391,6 +398,7 @@ export function NormalizationDetailView({
 
         {/* Right: diff (when editing) or empty prompt */}
         <div className="space-y-4">
+          {scoreBreakdown && <ScoresPanel scores={scoreBreakdown} />}
           {edited && expectedNormalized && predictedNormalization ? (
             <ParsedRecipeDiff
               expected={expectedNormalized}


### PR DESCRIPTION
## What changed
Adds per-recipe score breakdowns directly to the recipe parsing viz detail pages for extraction, normalization, and canonicalization.

This introduces a shared `detailScores` helper that computes the stage-appropriate score breakdown for a single expected/predicted pair, and renders the existing `ScoresPanel` inline in each detail view.

## Why it changed
The list pages already showed recipe scores, but the individual detail pages did not. That forced review work to bounce back to the list just to recover score context.

## Impact
Reviewers can now stay in the detail view and still see the structured score context for the current recipe.

The score panel is computed from the data currently loaded in the detail page, so it stays aligned with the active expected/predicted pair instead of depending only on the last pipeline artifact.

## Root cause
Score rendering existed at the list-view level, but the detail views never computed or displayed the same per-entry breakdown.

## Validation
- `npm run build` in `ml-pipelines/recipe-parsing/tools/viz`