### PR TITLE
[codex] Show recipe count on recipes page

### DIFF
--- a/ui/app/recipes/page.tsx
+++ b/ui/app/recipes/page.tsx
@@ -15,9 +15,7 @@ export const metadata: Metadata = {
 export default function RecipesPage() {
   const recipes = getAllRecipes();
   const jsonLd = buildRecipeListJsonLd(recipes, siteConfig.url);
-  const recipeCountLabel = `${recipes.length} ${
-    recipes.length === 1 ? "recipe" : "recipes"
-  }`;
+  const recipeCountLabel = recipes.length.toLocaleString() + " " + (recipes.length === 1 ? "recipe" : "recipes");
 
   return (
     <div className="container mx-auto px-4 py-12 min-h-screen max-w-6xl">

--- a/ui/app/recipes/page.tsx
+++ b/ui/app/recipes/page.tsx
@@ -15,6 +15,9 @@ export const metadata: Metadata = {
 export default function RecipesPage() {
   const recipes = getAllRecipes();
   const jsonLd = buildRecipeListJsonLd(recipes, siteConfig.url);
+  const recipeCountLabel = `${recipes.length} ${
+    recipes.length === 1 ? "recipe" : "recipes"
+  }`;
 
   return (
     <div className="container mx-auto px-4 py-12 min-h-screen max-w-6xl">
@@ -23,6 +26,9 @@ export default function RecipesPage() {
         <h1 className="text-4xl md:text-5xl font-bold mb-4">Recipes</h1>
         <p className="text-xl text-muted-foreground">
           A collection of my favorite recipes
+        </p>
+        <p className="mt-2 text-sm font-medium text-muted-foreground">
+          {recipeCountLabel}
         </p>
       </div>
 


### PR DESCRIPTION
## What changed
Adds the total number of recipes to the `/recipes` page header so the full count is visible without having to apply a search or filter first.

## Why
The total was only visible indirectly through the existing filtered summary (`X of Y recipes`), which made the full recipe count hard to discover.

## Impact
Users can now see the total recipe count immediately when they land on the recipe list page, while the existing filtered-state summary remains unchanged.

## Validation
- `pnpm --dir ui test -- ui/tests/components/recipes/recipe-list.test.tsx`