### PR TITLE
Add RSS feeds for site content

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.7)
+      feed:
+        specifier: ^5.2.1
+        version: 5.2.1
       fuse.js:
         specifier: ^7.1.0
         version: 7.4.2
@@ -4309,6 +4312,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@5.2.1:
+    resolution: {integrity: sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
@@ -6088,6 +6095,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -6952,6 +6963,10 @@ packages:
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -10584,6 +10599,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  feed@5.2.1:
+    dependencies:
+      xml-js: 1.6.11
+
   fflate@0.4.8: {}
 
   fill-range@7.1.1:
@@ -13002,6 +13021,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.6.0: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -13886,6 +13907,10 @@ snapshots:
   xdg-basedir@3.0.0: {}
 
   xdg-basedir@5.1.0: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
 
   xml-name-validator@5.0.0: {}
 

--- a/ui/app/(site)/blog/layout.tsx
+++ b/ui/app/(site)/blog/layout.tsx
@@ -1,3 +1,5 @@
+import { siteConfig } from "@/lib/config/site-config";
+
 export default function BlogLayout({
   children,
 }: {
@@ -10,6 +12,12 @@ export default function BlogLayout({
         rel="preconnect"
         href="https://imagedelivery.net"
         crossOrigin="anonymous"
+      />
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        title={`${siteConfig.name} — ${siteConfig.blog.title}`}
+        href="/blog/feed.xml"
       />
       {children}
     </>

--- a/ui/app/(site)/blog/page.tsx
+++ b/ui/app/(site)/blog/page.tsx
@@ -1,7 +1,10 @@
+import { Rss } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { preload } from "react-dom";
 import { BlogList } from "@/components/blog/blog-list";
+import { Button } from "@/components/ui/button";
 import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
 import { getAllPosts } from "@/lib/api/blog";
 import { siteConfig } from "@/lib/config/site-config";
@@ -55,11 +58,19 @@ export default function BlogPage() {
 
   return (
     <div className="container mx-auto px-4 py-12 min-h-screen max-w-6xl">
-      <div className="mb-8">
-        <h1 className="text-4xl md:text-5xl font-bold mb-4">Blog</h1>
-        <p className="text-xl text-muted-foreground">
-          Thoughts on technology, finance, and whatever else I'm exploring
-        </p>
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Blog</h1>
+          <p className="text-xl text-muted-foreground">
+            Thoughts on technology, finance, and whatever else I'm exploring
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm" className="shrink-0">
+          <Link href="/blog/feed.xml" target="_blank" rel="noopener noreferrer">
+            <Rss className="h-4 w-4" />
+            Subscribe
+          </Link>
+        </Button>
       </div>
 
       <Suspense fallback={<CardGridSkeleton />}>

--- a/ui/app/(site)/experience/page.tsx
+++ b/ui/app/(site)/experience/page.tsx
@@ -1,7 +1,9 @@
-import { Briefcase, Layers } from "lucide-react";
+import { Briefcase, Layers, Rss } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 import { ExperienceCard } from "@/components/experience/experience-card";
 import { SearchableTechnologyGrid } from "@/components/experience/searchable-technology-grid";
+import { Button } from "@/components/ui/button";
 import { getAllExperience, getExperienceSlug } from "@/lib/api/experience";
 import { siteConfig } from "@/lib/config/site-config";
 import { loadDomainRepository } from "@/lib/domain";
@@ -29,6 +31,19 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: `${siteConfig.url}/experience`,
+    types: {
+      "application/rss+xml": [
+        { url: "/feed.xml", title: `${siteConfig.name} RSS Feed` },
+        {
+          url: "/experience/feed.xml",
+          title: `${siteConfig.name} — Experience`,
+        },
+        {
+          url: "/technologies/feed.xml",
+          title: `${siteConfig.name} — Technologies`,
+        },
+      ],
+    },
   },
 };
 
@@ -45,10 +60,24 @@ export default function ExperiencePage() {
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-6xl">
-      <h1 className="text-4xl md:text-5xl font-bold mb-4">Experience</h1>
-      <p className="text-xl text-muted-foreground mb-8">
-        Professional experience and career history
-      </p>
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Experience</h1>
+          <p className="text-xl text-muted-foreground">
+            Professional experience and career history
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm" className="shrink-0">
+          <Link
+            href="/experience/feed.xml"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Rss className="h-4 w-4" />
+            Subscribe
+          </Link>
+        </Button>
+      </div>
 
       <section className="mb-16">
         <h2 className="text-3xl font-semibold mb-8 flex items-center gap-2">
@@ -82,10 +111,22 @@ export default function ExperiencePage() {
       </section>
 
       <section id="technologies" className="mb-16 scroll-mt-24">
-        <h2 className="text-3xl font-semibold mb-8 flex items-center gap-2">
-          <Layers className="w-7 h-7 text-primary" />
-          Technologies
-        </h2>
+        <div className="mb-8 flex items-center justify-between gap-4">
+          <h2 className="text-3xl font-semibold flex items-center gap-2">
+            <Layers className="w-7 h-7 text-primary" />
+            Technologies
+          </h2>
+          <Button asChild variant="outline" size="sm" className="shrink-0">
+            <Link
+              href="/technologies/feed.xml"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Rss className="h-4 w-4" />
+              Subscribe
+            </Link>
+          </Button>
+        </div>
         <SearchableTechnologyGrid technologies={rankedTechnologies} />
       </section>
     </div>

--- a/ui/app/(site)/projects/[slug]/adrs/layout.tsx
+++ b/ui/app/(site)/projects/[slug]/adrs/layout.tsx
@@ -2,7 +2,6 @@ import { notFound } from "next/navigation";
 import { ADRMobileNav } from "@/components/projects/adr-mobile-nav";
 import { ADRStickySidebar } from "@/components/projects/adr-sticky-sidebar";
 import { getProject, type ProjectWithADRs } from "@/lib/api/projects";
-import { siteConfig } from "@/lib/config/site-config";
 
 interface ADRLayoutProps {
   children: React.ReactNode;
@@ -19,13 +18,6 @@ export default async function ADRLayout({ children, params }: ADRLayoutProps) {
   }
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
-      <link
-        rel="alternate"
-        type="application/rss+xml"
-        title={`${siteConfig.name} — Architecture Decision Records`}
-        href="/adrs/feed.xml"
-      />
-
       <div className="lg:grid lg:grid-cols-[280px_1fr] list-none gap-8 items-start">
         {/* Mobile Navigation Trigger - Renders via Portal */}
         <ADRMobileNav project={project} />

--- a/ui/app/(site)/projects/[slug]/adrs/layout.tsx
+++ b/ui/app/(site)/projects/[slug]/adrs/layout.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { ADRMobileNav } from "@/components/projects/adr-mobile-nav";
 import { ADRStickySidebar } from "@/components/projects/adr-sticky-sidebar";
 import { getProject, type ProjectWithADRs } from "@/lib/api/projects";
+import { siteConfig } from "@/lib/config/site-config";
 
 interface ADRLayoutProps {
   children: React.ReactNode;
@@ -18,6 +19,13 @@ export default async function ADRLayout({ children, params }: ADRLayoutProps) {
   }
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        title={`${siteConfig.name} — Architecture Decision Records`}
+        href="/adrs/feed.xml"
+      />
+
       <div className="lg:grid lg:grid-cols-[280px_1fr] list-none gap-8 items-start">
         {/* Mobile Navigation Trigger - Renders via Portal */}
         <ADRMobileNav project={project} />

--- a/ui/app/(site)/projects/layout.tsx
+++ b/ui/app/(site)/projects/layout.tsx
@@ -1,0 +1,19 @@
+import { siteConfig } from "@/lib/config/site-config";
+
+export default function ProjectsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        title={`${siteConfig.name} — Projects & ADRs`}
+        href="/projects/feed.xml"
+      />
+      {children}
+    </>
+  );
+}

--- a/ui/app/(site)/projects/page.tsx
+++ b/ui/app/(site)/projects/page.tsx
@@ -1,9 +1,12 @@
+import { Rss } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { Markdown } from "@/components/markdown";
 import { ProjectList } from "@/components/projects/project-list";
 import { ProjectTabsSkeleton } from "@/components/projects/project-tabs-skeleton";
 import { ProjectsPageTabs } from "@/components/projects/projects-page-tabs";
+import { Button } from "@/components/ui/button";
 import { getAllProjects, getBuildingPhilosophy } from "@/lib/api/projects";
 
 export const metadata: Metadata = {
@@ -18,13 +21,25 @@ export default async function ProjectsPage() {
 
   return (
     <div className="container mx-auto px-4 py-12 max-w-6xl">
-      <div className="mb-8">
-        <h1 className="text-4xl md:text-5xl font-bold mb-4">Projects</h1>
-        <p className="text-xl text-muted-foreground">
-          A collection of my work, featuring architectural decision records
-          (ADRs), source code links, and the building philosophy that guides
-          them
-        </p>
+      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">Projects</h1>
+          <p className="text-xl text-muted-foreground">
+            A collection of my work, featuring architectural decision records
+            (ADRs), source code links, and the building philosophy that guides
+            them
+          </p>
+        </div>
+        <Button asChild variant="outline" size="sm" className="shrink-0">
+          <Link
+            href="/projects/feed.xml"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Rss className="h-4 w-4" />
+            Subscribe
+          </Link>
+        </Button>
       </div>
 
       <Suspense fallback={<ProjectTabsSkeleton />}>

--- a/ui/app/(site)/technologies/layout.tsx
+++ b/ui/app/(site)/technologies/layout.tsx
@@ -1,5 +1,6 @@
 import { TechMobileNav } from "@/components/technology/tech-mobile-nav";
 import { TechStickySidebar } from "@/components/technology/tech-sticky-sidebar";
+import { siteConfig } from "@/lib/config/site-config";
 import { loadDomainRepository } from "@/lib/domain";
 import { getAllTechnologyBadgesSorted } from "@/lib/domain/technology";
 
@@ -13,6 +14,12 @@ export default function TechnologyLayout({ children }: TechnologyLayoutProps) {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-7xl">
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        title={`${siteConfig.name} — Technologies`}
+        href="/technologies/feed.xml"
+      />
       <div className="lg:grid lg:grid-cols-[280px_1fr] list-none gap-8 items-start">
         {/* Mobile Navigation Trigger - Renders via Portal */}
         <TechMobileNav technologies={technologies} />

--- a/ui/app/apple-icon.svg
+++ b/ui/app/apple-icon.svg
@@ -1,4 +1,5 @@
 <svg width="180" height="180" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <title>Robbie Palmer</title>
   <circle cx="32" cy="32" r="28" fill="#18181b" stroke="#06b6d4" stroke-width="2.5"/>
   <text x="32" y="42" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700" fill="#06b6d4" text-anchor="middle">RP</text>
 </svg>

--- a/ui/app/icon.svg
+++ b/ui/app/icon.svg
@@ -1,4 +1,5 @@
 <svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <title>Robbie Palmer</title>
   <circle cx="32" cy="32" r="28" fill="#18181b" stroke="#06b6d4" stroke-width="2.5"/>
   <text x="32" y="42" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700" fill="#06b6d4" text-anchor="middle">RP</text>
 </svg>

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -11,6 +11,11 @@ export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
   alternates: {
     canonical: siteConfig.url,
+    types: {
+      "application/rss+xml": [
+        { url: "/feed.xml", title: `${siteConfig.name} RSS Feed` },
+      ],
+    },
   },
   title: {
     default: siteConfig.name,

--- a/ui/components/footer-links.tsx
+++ b/ui/components/footer-links.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Github, Linkedin } from "lucide-react";
+import { Github, Linkedin, Rss } from "lucide-react";
 import Link from "next/link";
 import posthog from "posthog-js";
 
@@ -49,6 +49,21 @@ export function FooterLinks({
           }
         >
           <Linkedin className="h-6 w-6" />
+        </Link>
+        <Link
+          href="/feed.xml"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-foreground hover:opacity-60 transition-opacity"
+          aria-label="RSS feed"
+          onClick={() =>
+            posthog.capture("rss_feed_clicked", {
+              feed: "global",
+              location: "footer",
+            })
+          }
+        >
+          <Rss className="h-6 w-6" />
         </Link>
       </div>
 

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -2,36 +2,42 @@ import type { TechnologyContent } from "@/lib/domain/technology/technology";
 export const technologies: TechnologyContent[] = [
   {
     name: "React",
+    added: "2025-12-26",
     description: "Component-based UI development for JS/TS",
     website: "https://react.dev",
     type: "library",
   },
   {
     name: "Next.js",
+    added: "2026-01-04",
     description: "Full-stack web development built on React",
     website: "https://nextjs.org",
     type: "library",
   },
   {
     name: "TypeScript",
+    added: "2025-12-26",
     description: "TypeScript is JavaScript with syntax for types",
     website: "https://www.typescriptlang.org",
     type: "language",
   },
   {
     name: "Tailwind CSS",
+    added: "2026-01-04",
     description: "A utility-first CSS framework",
     website: "https://tailwindcss.com",
     type: "library",
   },
   {
     name: "AWS",
+    added: "2026-01-04",
     description: "Amazon Web Services - Cloud computing platform",
     website: "https://aws.amazon.com",
     type: "platform",
   },
   {
     name: "Java",
+    added: "2026-01-04",
     description:
       "A statically typed, object-oriented language running on the JVM",
     website: "https://www.java.com",
@@ -39,6 +45,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Python",
+    added: "2026-01-04",
     description:
       "A dynamically typed language widely used for ML, data, and automation",
     website: "https://www.python.org",
@@ -46,18 +53,21 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "pnpm",
+    added: "2026-01-04",
     description: "Fast, disk space efficient package manager",
     website: "https://pnpm.io",
     type: "tool",
   },
   {
     name: "Vitest",
+    added: "2026-01-04",
     description: "Modern unit testing for JS/TS with a familiar Jest-style API",
     website: "https://vitest.dev",
     type: "library",
   },
   {
     name: "shadcn/ui",
+    added: "2026-01-04",
     description:
       "Beautifully designed components built with Radix UI and Tailwind CSS",
     website: "https://ui.shadcn.com",
@@ -65,12 +75,14 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "GitHub",
+    added: "2026-01-04",
     description: "Development platform for version control and collaboration",
     website: "https://github.com",
     type: "platform",
   },
   {
     name: "GitHub Actions",
+    added: "2026-01-04",
     description:
       "A workflow automation platform integrated with GitHub repositories",
     website: "https://github.com/features/actions",
@@ -78,6 +90,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Terraform",
+    added: "2026-01-04",
     description:
       "Infrastructure as code for building, changing, and versioning cloud resources",
     website: "https://www.terraform.io",
@@ -85,54 +98,63 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Cloudflare Pages",
+    added: "2026-01-04",
     description: "JAMstack platform for frontend developers",
     website: "https://pages.cloudflare.com",
     type: "platform",
   },
   {
     name: "MDX",
+    added: "2026-01-04",
     description: "Markdown for the component era",
     website: "https://mdxjs.com",
     type: "library",
   },
   {
     name: "Shiki",
+    added: "2026-01-04",
     description: "A beautiful and powerful code syntax highlighter",
     website: "https://shiki.style",
     type: "library",
   },
   {
     name: "Fuse.js",
+    added: "2026-01-04",
     description: "Lightweight, client-side, fuzzy-search library",
     website: "https://www.fusejs.io",
     type: "library",
   },
   {
     name: "Zod",
+    added: "2026-01-04",
     description: "TypeScript-first schema validation",
     website: "https://zod.dev",
     type: "library",
   },
   {
     name: "Neo4j",
+    added: "2026-01-04",
     description: "Graph database management system",
     website: "https://neo4j.com",
     type: "database",
   },
   {
     name: "Embla Carousel",
+    added: "2026-01-04",
     description: "A lightweight carousel library with fluid motion",
     website: "https://www.embla-carousel.com",
     type: "library",
   },
   {
     name: "Claude Code",
+    added: "2026-01-04",
     description: "AI-powered coding assistant",
     website: "https://claude.ai",
     type: "tool",
   },
   {
     name: "Mise",
+    added: "2026-01-04",
     description:
       "Tool version management, env var automation, and task execution for projects",
     website: "https://mise.jdx.dev",
@@ -140,36 +162,42 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "C#",
+    added: "2026-01-04",
     description: "A statically typed, object-oriented language running on .NET",
     website: "https://docs.microsoft.com/en-us/dotnet/csharp/",
     type: "language",
   },
   {
     name: "Weaviate",
+    added: "2026-01-04",
     description: "Open-source vector database",
     website: "https://weaviate.io",
     type: "database",
   },
   {
     name: "Doppler",
+    added: "2026-01-04",
     description: "SecretOps platform for managing environment variables",
     website: "https://www.doppler.com",
     type: "tool",
   },
   {
     name: "Recharts",
+    added: "2026-01-04",
     description: "A composable charting library built on React components",
     website: "https://recharts.org",
     type: "library",
   },
   {
     name: "Mermaid",
+    added: "2026-01-04",
     description: "JavaScript based diagramming and charting tool",
     website: "https://mermaid.js.org",
     type: "library",
   },
   {
     name: "Lucide React",
+    added: "2026-01-04",
     description: "Beautiful & consistent icon toolkit",
     website: "https://lucide.dev",
     iconSlug: "lucide",
@@ -177,60 +205,70 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Renovate",
+    added: "2026-01-04",
     description: "Automated dependency updates",
     website: "https://docs.renovatebot.com",
     type: "tool",
   },
   {
     name: "CodeRabbit",
+    added: "2026-01-04",
     description: "AI-powered code review assistant",
     website: "https://coderabbit.ai",
     type: "tool",
   },
   {
     name: "CLA Assistant",
+    added: "2026-01-11",
     description: "Contributor License Agreement automation for GitHub",
     website: "https://cla-assistant.io",
     type: "tool",
   },
   {
     name: "Dependabot",
+    added: "2026-01-04",
     description: "Automated dependency updates for GitHub",
     website: "https://github.com/dependabot",
     type: "tool",
   },
   {
     name: "CodeQL",
+    added: "2026-01-04",
     description: "Semantic code analysis engine",
     website: "https://codeql.github.com",
     type: "tool",
   },
   {
     name: "Husky",
+    added: "2026-01-04",
     description: "Git hooks made easy",
     website: "https://typicode.github.io/husky",
     type: "tool",
   },
   {
     name: "Turbopack",
+    added: "2026-01-04",
     description: "Incremental bundler optimized for JavaScript and TypeScript",
     website: "https://turbo.build/pack",
     type: "tool",
   },
   {
     name: "CCPM",
+    added: "2026-01-04",
     description: "Claude Code Project Management",
     website: "https://github.com/automazeio/ccpm/",
     type: "tool",
   },
   {
     name: "Shortcut",
+    added: "2026-01-04",
     description: "Project management platform",
     website: "https://shortcut.com",
     type: "tool",
   },
   {
     name: "GitHub Secrets",
+    added: "2026-01-04",
     description: "Encrypted environment variables for GitHub Actions",
     website:
       "https://docs.github.com/en/actions/security-guides/encrypted-secrets",
@@ -239,6 +277,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Cloudflare Terraform Provider",
+    added: "2026-01-04",
     website:
       "https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs",
     iconSlug: "cloudflare",
@@ -246,12 +285,14 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Cloudflare DNS",
+    added: "2026-01-04",
     website: "https://www.cloudflare.com/dns",
     iconSlug: "cloudflare",
     type: "platform",
   },
   {
     name: "Cloudflare Rulesets",
+    added: "2026-01-11",
     description: "Rules for transforming and routing HTTP requests at the edge",
     website: "https://developers.cloudflare.com/ruleset-engine/",
     iconSlug: "cloudflare",
@@ -259,6 +300,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Cloudflare Images",
+    added: "2026-01-04",
     description: "Image optimization and delivery service",
     website: "https://www.cloudflare.com/products/images",
     iconSlug: "cloudflare",
@@ -266,6 +308,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Cloudflare R2",
+    added: "2026-02-14",
     description: "S3-compatible object storage with zero egress fees",
     website: "https://www.cloudflare.com/products/r2",
     iconSlug: "cloudflare",
@@ -273,6 +316,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Terraform Cloud",
+    added: "2026-01-04",
     description:
       "A SaaS platform for running Terraform and managing infrastructure state",
     website: "https://www.hashicorp.com/products/terraform",
@@ -281,14 +325,21 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Tailwind CSS Typography",
+    added: "2026-01-04",
     description: "Beautiful typographic defaults for HTML you don't control",
     website: "https://github.com/tailwindlabs/tailwindcss-typography",
     iconSlug: "tailwindcss",
     type: "library",
   },
-  { name: ".NET", website: "https://dotnet.microsoft.com", type: "platform" },
+  {
+    name: ".NET",
+    added: "2026-01-04",
+    website: "https://dotnet.microsoft.com",
+    type: "platform",
+  },
   {
     name: "Ansible",
+    added: "2026-01-04",
     description:
       "A tool for automating configuration, deployment, and orchestration",
     website: "https://www.ansible.com",
@@ -296,6 +347,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Kafka",
+    added: "2026-01-04",
     description: "Distributed event streaming platform",
     website: "https://kafka.apache.org",
     iconSlug: "apachekafka",
@@ -303,6 +355,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Arduino",
+    added: "2026-01-04",
     description:
       "Microcontroller boards and tools for building interactive electronic projects",
     website: "https://www.arduino.cc",
@@ -310,25 +363,34 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Bitbucket Pipelines",
+    added: "2026-01-04",
     description: "CI/CD service built into Bitbucket",
     website: "https://bitbucket.org/product/features/pipelines",
     type: "tool",
   },
-  { name: "C++", website: "https://isocpp.org", type: "language" },
+  {
+    name: "C++",
+    added: "2026-01-04",
+    website: "https://isocpp.org",
+    type: "language",
+  },
   {
     name: "Cloudflare Workers",
+    added: "2026-01-04",
     description: "Serverless execution environment",
     website: "https://workers.cloudflare.com",
     type: "platform",
   },
   {
     name: "DVC",
+    added: "2026-01-04",
     description: "Data Version Control for machine learning projects",
     website: "https://dvc.org",
     type: "tool",
   },
   {
     name: "Docker",
+    added: "2026-01-04",
     description:
       "A platform for packaging, distributing, and running applications in containers",
     website: "https://www.docker.com",
@@ -336,18 +398,21 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "FastAPI",
+    added: "2026-01-04",
     description: "Modern, fast web framework for building APIs with Python",
     website: "https://fastapi.tiangolo.com",
     type: "library",
   },
   {
     name: "Fastify",
+    added: "2026-01-04",
     description: "Fast and low overhead web framework for Node.js",
     website: "https://www.fastify.io",
     type: "library",
   },
   {
     name: "Flink",
+    added: "2026-01-04",
     description:
       "A distributed system for stateful, high-throughput, low-latency data processing",
     website: "https://flink.apache.org",
@@ -356,12 +421,14 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "GeoPandas",
+    added: "2026-01-04",
     description: "Python library for working with geospatial data",
     website: "https://geopandas.org",
     type: "library",
   },
   {
     name: "Go",
+    added: "2026-01-04",
     description:
       "A statically typed, compiled language designed for simplicity and concurrency",
     website: "https://go.dev",
@@ -369,30 +436,35 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Google BigQuery",
+    added: "2026-01-04",
     description: "Serverless, highly scalable data warehouse",
     website: "https://cloud.google.com/bigquery",
     type: "database",
   },
   {
     name: "Google Gemini",
+    added: "2026-01-04",
     description: "A cloud-based multimodal large language model",
     website: "https://deepmind.google/technologies/gemini/",
     type: "tool",
   },
   {
     name: "Grafana",
+    added: "2026-01-04",
     description: "Open source analytics and monitoring platform",
     website: "https://grafana.com",
     type: "tool",
   },
   {
     name: "Hugging Face",
+    added: "2026-01-04",
     description: "AI community and model hub",
     website: "https://huggingface.co",
     type: "library",
   },
   {
     name: "Jenkins",
+    added: "2026-01-04",
     description:
       "A CI/CD platform for automating software development workflows",
     website: "https://www.jenkins.io",
@@ -400,12 +472,14 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Keras",
+    added: "2026-01-04",
     description: "A Python library for designing and training neural networks",
     website: "https://keras.io",
     type: "library",
   },
   {
     name: "Kotlin",
+    added: "2026-01-04",
     description:
       "A modern JVM language blending OOP and functional programming",
     website: "https://kotlinlang.org",
@@ -413,31 +487,41 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Leaflet",
+    added: "2026-01-04",
     description: "A JavaScript library for interactive maps on the web",
     website: "https://leafletjs.com",
     type: "library",
   },
   {
     name: "Node.js",
+    added: "2026-01-04",
     description: "JavaScript runtime built on Chrome's V8 engine",
     website: "https://nodejs.org",
     type: "platform",
   },
-  { name: "OpenAI", website: "https://openai.com", type: "tool" },
+  {
+    name: "OpenAI",
+    added: "2026-01-04",
+    website: "https://openai.com",
+    type: "tool",
+  },
   {
     name: "OpenCV",
+    added: "2026-01-04",
     description: "Open source computer vision library",
     website: "https://opencv.org",
     type: "library",
   },
   {
     name: "OpenRouter",
+    added: "2026-01-04",
     description: "Unified API for LLM inference",
     website: "https://openrouter.ai",
     type: "tool",
   },
   {
     name: "Plotly",
+    added: "2026-01-04",
     description:
       "A Python (and JS) library for building interactive charts and dashboards",
     website: "https://plotly.com",
@@ -445,6 +529,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "PostgreSQL",
+    added: "2026-01-04",
     description:
       "A relational database optimized for extensibility and advanced data management",
     website: "https://www.postgresql.org",
@@ -452,24 +537,28 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Prisma",
+    added: "2026-01-04",
     description: "A TypeScript and Node.js ORM",
     website: "https://www.prisma.io",
     type: "library",
   },
   {
     name: "Prometheus",
+    added: "2026-01-04",
     description: "A time-series database for collecting and querying metrics",
     website: "https://prometheus.io",
     type: "database",
   },
   {
     name: "Pulumi",
+    added: "2026-01-04",
     description: "Infrastructure as code using general-purpose languages",
     website: "https://www.pulumi.com",
     type: "library",
   },
   {
     name: "PyTorch",
+    added: "2026-01-04",
     description:
       "A Python library for designing, training, and running neural networks",
     website: "https://pytorch.org",
@@ -477,18 +566,21 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "RabbitMQ",
+    added: "2026-01-04",
     description: "A broker for asynchronous messaging and task distribution",
     website: "https://www.rabbitmq.com",
     type: "platform",
   },
   {
     name: "SQL",
+    added: "2026-01-04",
     description: "Domain-specific language for managing relational databases",
     website: "https://en.wikipedia.org/wiki/SQL",
     type: "language",
   },
   {
     name: "SemaphoreCI",
+    added: "2026-01-04",
     description:
       "A cloud-based CI/CD platform for automating software development workflows",
     website: "https://semaphoreci.com",
@@ -497,12 +589,14 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Stanford NLP",
+    added: "2026-01-04",
     description: "Natural language processing toolkit",
     website: "https://nlp.stanford.edu/software/",
     type: "library",
   },
   {
     name: "Swift",
+    added: "2026-01-04",
     description:
       "A compiled, type-safe language for developing applications across Apple platforms",
     website: "https://www.swift.org",
@@ -510,52 +604,61 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "T-SQL",
+    added: "2026-01-04",
     description: "Microsoft's extension of SQL",
     website: "https://docs.microsoft.com/en-us/sql/t-sql/",
     type: "language",
   },
   {
     name: "TensorRT",
+    added: "2026-01-04",
     description: "SDK for high-performance deep learning inference",
     website: "https://developer.nvidia.com/tensorrt",
     type: "library",
   },
   {
     name: "ksqlDB",
+    added: "2026-01-04",
     description: "Database purpose-built for stream processing",
     website: "https://ksqldb.io",
     type: "tool",
   },
   {
     name: "spaCy",
+    added: "2026-01-04",
     description: "Industrial-strength natural language processing",
     website: "https://spacy.io",
     type: "library",
   },
   {
     name: "Shapely",
+    added: "2026-01-04",
     description: "An SDK for embedded geospatial operations",
     website: "https://shapely.readthedocs.io/en/latest/",
     type: "library",
   },
   {
     name: "OpenSlide",
+    added: "2026-01-04",
     description: "An SDK for reading pathology image formats",
     website: "https://github.com/openslide/openslide-python",
     type: "library",
   },
   {
     name: "R",
+    added: "2026-01-04",
     website: "https://www.r-project.org/",
     type: "language",
   },
   {
     name: "Shiny",
+    added: "2026-01-04",
     website: "https://shiny.posit.co/",
     type: "library",
   },
   {
     name: "AWS Textract",
+    added: "2026-01-04",
     description:
       "Machine learning service that automatically extracts text, handwriting, and data from scanned documents",
     website: "https://aws.amazon.com/textract/",
@@ -563,18 +666,21 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "PyPika",
+    added: "2026-01-04",
     description: "A Python SQL query builder",
     website: "https://github.com/kayak/pypika",
     type: "library",
   },
   {
     name: "Sigma.js",
+    added: "2026-02-12",
     description: "WebGL-powered graph visualization for the web",
     website: "https://www.sigmajs.org",
     type: "library",
   },
   {
     name: "PostHog",
+    added: "2026-02-14",
     description:
       "Open source product analytics, session replay, and experimentation",
     website: "https://posthog.com",
@@ -582,6 +688,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "cooklang-rs",
+    added: "2026-02-28",
     description:
       "Rust parser and scaling engine for the Cooklang recipe format, with WASM/TypeScript bindings for in-browser use",
     website: "https://github.com/cooklang/cooklang-rs",
@@ -589,6 +696,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Better Auth",
+    added: "2026-05-27",
     description:
       "TypeScript-first, self-hosted authentication library with config-as-code",
     website: "https://better-auth.com",
@@ -596,6 +704,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Drizzle",
+    added: "2026-05-28",
     description:
       "TypeScript ORM with type-safe queries and dialect-specific schema definitions",
     website: "https://orm.drizzle.team",
@@ -603,6 +712,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Hono",
+    added: "2026-05-28",
     description:
       "Lightweight HTTP framework for Cloudflare Workers, Node.js, Deno, and Bun",
     website: "https://hono.dev",
@@ -610,6 +720,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Hyperdrive",
+    added: "2026-05-28",
     description:
       "Cloudflare connection pooling service for Workers connecting to external databases",
     website: "https://developers.cloudflare.com/hyperdrive/",
@@ -618,6 +729,7 @@ export const technologies: TechnologyContent[] = [
   },
   {
     name: "Neon",
+    added: "2026-05-28",
     description:
       "Serverless Postgres with scale-to-zero, branching, and a generous free tier",
     website: "https://neon.com",

--- a/ui/lib/domain/technology/technology.ts
+++ b/ui/lib/domain/technology/technology.ts
@@ -50,6 +50,11 @@ const TechnologyContentSchema = z.object({
   website: z.string().url(),
   iconSlug: z.string().optional(), // Only when icon slug differs from what's derived from name
   type: TechnologyTypeSchema.optional(),
+  // Date (YYYY-MM-DD) the technology was added to the catalogue.
+  added: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "added must be in YYYY-MM-DD format")
+    .optional(),
 });
 
 export type TechnologyContent = z.infer<typeof TechnologyContentSchema>;

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "dev:qr": "node scripts/qr-dev.mjs && pnpm run dev",
-    "build": "next build && tsx scripts/generate-agent-markdown.ts",
+    "build": "next build && tsx scripts/generate-agent-markdown.ts && tsx scripts/generate-rss.ts",
     "generate:agent-markdown": "tsx scripts/generate-agent-markdown.ts",
+    "generate:rss": "tsx scripts/generate-rss.ts",
     "start": "next start",
     "test": "vitest run --exclude 'tests/integration/**'",
     "test:integration": "vitest run --no-file-parallelism tests/integration",
@@ -40,6 +41,7 @@
     "embla-carousel": "^8.6.0",
     "embla-carousel-auto-scroll": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
+    "feed": "^5.2.1",
     "fuse.js": "^7.1.0",
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",

--- a/ui/scripts/generate-rss.ts
+++ b/ui/scripts/generate-rss.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env tsx
+
+/**
+ * Writes RSS 2.0 feeds into the static export directory (out/): a combined
+ * feed of all dated content, a blog-only feed, and an ADR-only feed.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+// Import order matters: registers .wasm loading before content imports
+import "./lib/register-wasm";
+import { Feed } from "feed";
+import { getAllPosts } from "@/lib/api/blog";
+import { getAllExperience, getExperienceSlug } from "@/lib/api/experience";
+import { getAllADRs, getAllProjects } from "@/lib/api/projects";
+import { siteConfig } from "@/lib/config/site-config";
+import { loadDomainRepository } from "@/lib/domain";
+
+const OUT_DIR = path.join(process.cwd(), "out");
+const MAX_ITEMS = 50;
+
+type FeedEntry = {
+  title: string;
+  url: string;
+  description: string;
+  date: Date;
+  categories: string[];
+};
+
+const day = (date: string): Date => new Date(`${date}T00:00:00Z`);
+const month = (value: string): Date => new Date(`${value}-01T00:00:00Z`);
+
+function blogEntries(): FeedEntry[] {
+  return getAllPosts().map((post) => {
+    const updated = Boolean(post.updated && post.updated !== post.date);
+    return {
+      title: post.title,
+      url: `${siteConfig.url}/blog/${post.slug}`,
+      description: post.description,
+      date: day(post.updated || post.date),
+      categories: ["Blog", ...(updated ? ["Updated"] : []), ...post.tags],
+    };
+  });
+}
+
+function projectEntries(): FeedEntry[] {
+  return getAllProjects().map((project) => {
+    const updated = Boolean(project.updated && project.updated !== project.date);
+    return {
+      title: project.title,
+      url: `${siteConfig.url}/projects/${project.slug}`,
+      description: project.description,
+      date: day(project.updated || project.date),
+      categories: ["Project", ...(updated ? ["Updated"] : []), ...project.tags],
+    };
+  });
+}
+
+function adrEntries(): FeedEntry[] {
+  // Inherited ADRs restate a decision recorded elsewhere; keep each once.
+  return getAllADRs()
+    .filter((adr) => !adr.isInherited)
+    .map((adr) => ({
+      title: `${adr.projectTitle}: ${adr.title}`,
+      url: `${siteConfig.url}/projects/${adr.projectSlug}/adrs/${adr.slug}`,
+      description: `Architecture decision record (${adr.status}) for ${adr.projectTitle}.`,
+      date: day(adr.date),
+      categories: ["ADR", adr.projectTitle],
+    }));
+}
+
+function roleEntries(): FeedEntry[] {
+  return getAllExperience().map((role) => ({
+    title: `${role.title} at ${role.company}`,
+    url: `${siteConfig.url}/experience#${getExperienceSlug(role)}`,
+    description: role.description,
+    date: month(role.startDate),
+    categories: ["Experience", role.company],
+  }));
+}
+
+function technologyEntries(): FeedEntry[] {
+  const repository = loadDomainRepository();
+  return Array.from(repository.technologies.values())
+    .filter((tech): tech is typeof tech & { added: string } => Boolean(tech.added))
+    .map((tech) => ({
+      title: tech.name,
+      url: `${siteConfig.url}/technologies/${tech.slug}`,
+      description: tech.description ?? tech.name,
+      date: day(tech.added),
+      categories: ["Technology", ...(tech.type ? [tech.type] : [])],
+    }));
+}
+
+function buildFeed(
+  meta: { title: string; description: string; feedPath: string },
+  entries: FeedEntry[],
+): string {
+  const items = [...entries]
+    .sort((a, b) => b.date.getTime() - a.date.getTime())
+    .slice(0, MAX_ITEMS);
+
+  const feed = new Feed({
+    title: meta.title,
+    description: meta.description,
+    id: siteConfig.url,
+    link: siteConfig.url,
+    language: "en",
+    copyright: `© ${new Date().getFullYear()} ${siteConfig.author.name}`,
+    updated: items[0]?.date ?? new Date(),
+    feedLinks: { rss: `${siteConfig.url}${meta.feedPath}` },
+    author: { name: siteConfig.author.name, link: siteConfig.url },
+  });
+
+  for (const entry of items) {
+    feed.addItem({
+      title: entry.title,
+      id: entry.url,
+      link: entry.url,
+      description: entry.description,
+      date: entry.date,
+      category: entry.categories.map((name) => ({ name })),
+    });
+  }
+
+  return feed.rss2();
+}
+
+function write(relativePath: string, content: string): void {
+  const filePath = path.join(OUT_DIR, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+function main(): void {
+  if (!fs.existsSync(OUT_DIR)) {
+    console.error(
+      "out/ directory not found. Run `next build` first (this script runs as part of `pnpm build`).",
+    );
+    process.exit(1);
+  }
+
+  const blog = blogEntries();
+  const adrs = adrEntries();
+  const combined = [
+    ...blog,
+    ...projectEntries(),
+    ...adrs,
+    ...roleEntries(),
+    ...technologyEntries(),
+  ];
+
+  write(
+    "feed.xml",
+    buildFeed(
+      {
+        title: siteConfig.name,
+        description: `Updates from ${siteConfig.name} — posts, projects, architecture decisions, roles, and technologies.`,
+        feedPath: "/feed.xml",
+      },
+      combined,
+    ),
+  );
+  write(
+    "blog/feed.xml",
+    buildFeed(
+      {
+        title: `${siteConfig.name} — ${siteConfig.blog.title}`,
+        description: siteConfig.blog.description,
+        feedPath: "/blog/feed.xml",
+      },
+      blog,
+    ),
+  );
+  write(
+    "adrs/feed.xml",
+    buildFeed(
+      {
+        title: `${siteConfig.name} — Architecture Decision Records`,
+        description: `Architecture decision records from ${siteConfig.name}'s projects.`,
+        feedPath: "/adrs/feed.xml",
+      },
+      adrs,
+    ),
+  );
+
+  console.log("Generated feed.xml, blog/feed.xml, and adrs/feed.xml in out/");
+}
+
+main();

--- a/ui/scripts/generate-rss.ts
+++ b/ui/scripts/generate-rss.ts
@@ -17,7 +17,10 @@ import { siteConfig } from "@/lib/config/site-config";
 import { loadDomainRepository } from "@/lib/domain";
 
 const OUT_DIR = path.join(process.cwd(), "out");
+// Section feeds stay a tight rolling window; the global feed is the firehose
+// of everything, so it keeps a much larger cap.
 const MAX_ITEMS = 50;
+const GLOBAL_MAX_ITEMS = 200;
 
 type FeedEntry = {
   title: string;
@@ -96,10 +99,11 @@ function technologyEntries(): FeedEntry[] {
 function buildFeed(
   meta: { title: string; description: string; feedPath: string },
   entries: FeedEntry[],
+  max: number = MAX_ITEMS,
 ): string {
   const items = [...entries]
     .sort((a, b) => b.date.getTime() - a.date.getTime())
-    .slice(0, MAX_ITEMS);
+    .slice(0, max);
 
   const feed = new Feed({
     title: meta.title,
@@ -146,19 +150,24 @@ function main(): void {
   const adrs = adrEntries();
   const roles = roleEntries();
   const technologies = technologyEntries();
-  // Technologies have their own feed; the bulk-imported catalogue would
-  // otherwise swamp the combined feed, so it carries the narrative content.
-  const combined = [...blog, ...projects, ...adrs, ...roles];
+  const combined = [
+    ...blog,
+    ...projects,
+    ...adrs,
+    ...roles,
+    ...technologies,
+  ];
 
   write(
     "feed.xml",
     buildFeed(
       {
         title: siteConfig.name,
-        description: `Updates from ${siteConfig.name} — posts, projects, architecture decisions, and roles.`,
+        description: `Everything from ${siteConfig.name} — posts, projects, architecture decisions, roles, and technologies.`,
         feedPath: "/feed.xml",
       },
       combined,
+      GLOBAL_MAX_ITEMS,
     ),
   );
   write(

--- a/ui/scripts/generate-rss.ts
+++ b/ui/scripts/generate-rss.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env tsx
 
 /**
- * Writes RSS 2.0 feeds into the static export directory (out/): a combined
- * feed of all dated content, a blog-only feed, and an ADR-only feed.
+ * Writes the site's RSS 2.0 feeds into the static export directory (out/):
+ * a combined feed of all dated content plus per-section feeds.
  */
 
 import fs from "node:fs";
@@ -27,7 +27,8 @@ type FeedEntry = {
   categories: string[];
 };
 
-const day = (date: string): Date => new Date(`${date}T00:00:00Z`);
+const day = (date: string): Date =>
+  date.includes("T") ? new Date(date) : new Date(`${date}T00:00:00Z`);
 const month = (value: string): Date => new Date(`${value}-01T00:00:00Z`);
 
 function blogEntries(): FeedEntry[] {
@@ -107,7 +108,7 @@ function buildFeed(
     link: siteConfig.url,
     language: "en",
     copyright: `© ${new Date().getFullYear()} ${siteConfig.author.name}`,
-    updated: items[0]?.date ?? new Date(),
+    updated: items[0]?.date ?? new Date(0),
     feedLinks: { rss: `${siteConfig.url}${meta.feedPath}` },
     author: { name: siteConfig.author.name, link: siteConfig.url },
   });

--- a/ui/scripts/generate-rss.ts
+++ b/ui/scripts/generate-rss.ts
@@ -143,20 +143,18 @@ function main(): void {
   const blog = blogEntries();
   const projects = projectEntries();
   const adrs = adrEntries();
-  const combined = [
-    ...blog,
-    ...projects,
-    ...adrs,
-    ...roleEntries(),
-    ...technologyEntries(),
-  ];
+  const roles = roleEntries();
+  const technologies = technologyEntries();
+  // Technologies have their own feed; the bulk-imported catalogue would
+  // otherwise swamp the combined feed, so it carries the narrative content.
+  const combined = [...blog, ...projects, ...adrs, ...roles];
 
   write(
     "feed.xml",
     buildFeed(
       {
         title: siteConfig.name,
-        description: `Updates from ${siteConfig.name} — posts, projects, architecture decisions, roles, and technologies.`,
+        description: `Updates from ${siteConfig.name} — posts, projects, architecture decisions, and roles.`,
         feedPath: "/feed.xml",
       },
       combined,
@@ -184,8 +182,32 @@ function main(): void {
       [...projects, ...adrs],
     ),
   );
+  write(
+    "experience/feed.xml",
+    buildFeed(
+      {
+        title: `${siteConfig.name} — Experience`,
+        description: `Roles and career updates from ${siteConfig.name}.`,
+        feedPath: "/experience/feed.xml",
+      },
+      roles,
+    ),
+  );
+  write(
+    "technologies/feed.xml",
+    buildFeed(
+      {
+        title: `${siteConfig.name} — Technologies`,
+        description: `Technologies ${siteConfig.name} has added to the stack.`,
+        feedPath: "/technologies/feed.xml",
+      },
+      technologies,
+    ),
+  );
 
-  console.log("Generated feed.xml, blog/feed.xml, and projects/feed.xml in out/");
+  console.log(
+    "Generated feed.xml, blog/feed.xml, projects/feed.xml, experience/feed.xml, and technologies/feed.xml in out/",
+  );
 }
 
 main();

--- a/ui/scripts/generate-rss.ts
+++ b/ui/scripts/generate-rss.ts
@@ -141,10 +141,11 @@ function main(): void {
   }
 
   const blog = blogEntries();
+  const projects = projectEntries();
   const adrs = adrEntries();
   const combined = [
     ...blog,
-    ...projectEntries(),
+    ...projects,
     ...adrs,
     ...roleEntries(),
     ...technologyEntries(),
@@ -173,18 +174,18 @@ function main(): void {
     ),
   );
   write(
-    "adrs/feed.xml",
+    "projects/feed.xml",
     buildFeed(
       {
-        title: `${siteConfig.name} — Architecture Decision Records`,
-        description: `Architecture decision records from ${siteConfig.name}'s projects.`,
-        feedPath: "/adrs/feed.xml",
+        title: `${siteConfig.name} — Projects & ADRs`,
+        description: `New projects and architecture decision records from ${siteConfig.name}.`,
+        feedPath: "/projects/feed.xml",
       },
-      adrs,
+      [...projects, ...adrs],
     ),
   );
 
-  console.log("Generated feed.xml, blog/feed.xml, and adrs/feed.xml in out/");
+  console.log("Generated feed.xml, blog/feed.xml, and projects/feed.xml in out/");
 }
 
 main();


### PR DESCRIPTION
## Summary

Adds RSS feeds for the site, generated at build time into the static export (`out/`) — `output: "export"` rules out request-time route handlers.

## Feeds

- **`/feed.xml`** — the global firehose: every content type (blog posts, projects, ADRs, roles, and technologies), dated at its effective date (`updated || published`). Larger cap (200) so it stays comprehensive.
- **`/blog/feed.xml`** — blog posts only.
- **`/projects/feed.xml`** — projects and ADRs.
- **`/experience/feed.xml`** — roles / career updates.
- **`/technologies/feed.xml`** — technologies added to the stack.

Each item uses its curated one-line description as the summary and carries `<category>` tags by content type (plus an `Updated` category when republished). Section feeds keep the 50 most-recent items; the global feed keeps 200.

## Discovery & UI

- Auto-discovery `<link rel="alternate">` tags: the global feed site-wide, and each section feed across its section (blog, projects, experience, technologies).
- An RSS icon in the global footer (global feed) and "Subscribe" buttons on the blog list, projects list, and the experience page's Roles and Technologies sections.

## Content model

- Adds an `added` (YYYY-MM-DD) date to the technology schema, backfilled for the existing catalogue from each entry's first commit, so technologies carry a feed date.

## Also

- Fixes a pre-existing `noSvgWithoutTitle` lint error on `icon.svg` / `apple-icon.svg` that was failing the `format:check` CI task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)