### PR TITLE
[codex] Add recipe OAuth sign-in flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ package-lock.json
 
 # Next.js
 .next/
+.next-dev/
 out/
 build/
 .vercel/

--- a/.mise.toml
+++ b/.mise.toml
@@ -85,6 +85,96 @@ description = "Run pre-commit checks (called by Husky)"
 run = "pnpm lint-staged"
 depends = ["//:install"]
 
+[tasks.dev]
+description = "Start full local dev: Next.js (with auth rewrite) + recipe-api Worker"
+depends = ["//:install"]
+run = """
+#!/usr/bin/env bash
+set -e
+
+check_port() {
+  local port="$1"
+  local service="$2"
+  local listeners
+
+  listeners=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true)
+  if [ -n "$listeners" ]; then
+    echo "Cannot start $service: port $port is already in use."
+    echo "$listeners"
+    echo "Stop that process, then run 'mise run //:dev' again."
+    exit 1
+  fi
+}
+
+check_port 8787 "recipe-api Worker"
+check_port 3000 "Next.js"
+
+# Wrangler needs this env var to emulate the Hyperdrive binding locally.
+# Read DATABASE_URL from the Worker's .dev.vars if not already set.
+if [ -z "$CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE" ]; then
+  DB_URL=$(grep '^DATABASE_URL=' workers/recipe-api/.dev.vars | cut -d'=' -f2-)
+  if [ -n "$DB_URL" ]; then
+    export CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="$DB_URL"
+  fi
+fi
+
+NEXT_PID=""
+WORKER_PID=""
+CLEANED_UP=0
+
+terminate_tree() {
+  local parent_pid="$1"
+  local child_pid
+
+  while read -r child_pid; do
+    if [ -n "$child_pid" ]; then
+      terminate_tree "$child_pid"
+    fi
+  done < <(pgrep -P "$parent_pid" 2>/dev/null || true)
+
+  kill -TERM "$parent_pid" 2>/dev/null || true
+}
+
+cleanup() {
+  if [ "$CLEANED_UP" -eq 1 ]; then
+    return
+  fi
+  CLEANED_UP=1
+  trap - EXIT INT TERM
+
+  echo ""
+  echo "Shutting down..."
+
+  if [ -n "$NEXT_PID" ]; then
+    terminate_tree "$NEXT_PID"
+  fi
+  if [ -n "$WORKER_PID" ]; then
+    terminate_tree "$WORKER_PID"
+  fi
+
+  wait "$NEXT_PID" "$WORKER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'cleanup; exit 0' INT TERM
+
+echo "Starting recipe-api Worker on :8787..."
+pnpm --filter recipe-api dev --port 8787 &
+WORKER_PID=$!
+
+echo "Starting Next.js dev server on :3000..."
+echo "Open http://localhost:3000 to test"
+pnpm --filter ui dev --port 3000 &
+NEXT_PID=$!
+
+set +e
+wait -n "$WORKER_PID" "$NEXT_PID"
+STATUS=$?
+set -e
+
+cleanup
+exit "$STATUS"
+"""
+
 [tasks.install]
 description = "Install all dependencies (root and workspaces)"
 run = "pnpm install"

--- a/.mise.toml
+++ b/.mise.toml
@@ -92,6 +92,12 @@ run = """
 #!/usr/bin/env bash
 set -e
 
+if ! command -v lsof >/dev/null 2>&1; then
+  echo "Cannot start local development: lsof is required."
+  echo "Install it with your package manager, then run 'mise run //:dev' again."
+  exit 1
+fi
+
 check_port() {
   local port="$1"
   local service="$2"
@@ -112,7 +118,10 @@ check_port 3000 "Next.js"
 # Wrangler needs this env var to emulate the Hyperdrive binding locally.
 # Read DATABASE_URL from the Worker's .dev.vars if not already set.
 if [ -z "$CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE" ]; then
-  DB_URL=$(grep '^DATABASE_URL=' workers/recipe-api/.dev.vars | cut -d'=' -f2-)
+  DB_URL=""
+  if [ -f workers/recipe-api/.dev.vars ]; then
+    DB_URL=$(grep '^DATABASE_URL=' workers/recipe-api/.dev.vars | cut -d'=' -f2-)
+  fi
   if [ -n "$DB_URL" ]; then
     export CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="$DB_URL"
   fi
@@ -166,9 +175,34 @@ echo "Open http://localhost:3000 to test"
 pnpm --filter ui dev --port 3000 &
 NEXT_PID=$!
 
+# Give both commands time to fail fast before entering the monitoring loop.
+sleep 2
+
+if ! kill -0 "$WORKER_PID" 2>/dev/null; then
+  echo "recipe-api Worker failed to start."
+  cleanup
+  exit 1
+fi
+
+if ! kill -0 "$NEXT_PID" 2>/dev/null; then
+  echo "Next.js failed to start."
+  cleanup
+  exit 1
+fi
+
+# Poll for the first exit instead of using `wait -n`, which requires Bash 4.3.
+while kill -0 "$WORKER_PID" 2>/dev/null && kill -0 "$NEXT_PID" 2>/dev/null; do
+  sleep 1
+done
+
 set +e
-wait -n "$WORKER_PID" "$NEXT_PID"
-STATUS=$?
+if ! kill -0 "$WORKER_PID" 2>/dev/null; then
+  wait "$WORKER_PID"
+  STATUS=$?
+else
+  wait "$NEXT_PID"
+  STATUS=$?
+fi
 set -e
 
 cleanup

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Personal website with blog and interactive resume.
 
 Visit [http://localhost:3000](http://localhost:3000)
 
+To run the frontend together with the recipe API Worker for OAuth development,
+configure `workers/recipe-api/.dev.vars` as described in the
+[recipe API setup guide](workers/recipe-api/README.md), then run:
+
+```bash
+mise run //:dev
+```
+
 ## Repository Structure
 
 ```text

--- a/functions/README.md
+++ b/functions/README.md
@@ -8,6 +8,15 @@ directory. No additional configuration is required.
 
 ## Functions
 
+### `/api/auth/*` - Recipe Authentication Proxy
+
+**File:** `api/auth/[[path]].ts`
+
+Proxies same-origin Better Auth requests to the recipe API Worker. Keeping the
+browser-facing auth URL on `robbiepalmer.me` means OAuth callbacks and session
+cookies use the site origin even though the auth handler runs in a separate
+Worker. `RECIPE_API_URL` can override the deployed Worker URL.
+
 ### `_middleware.ts` - Markdown Content Negotiation
 
 Serves each page's agent-friendly Markdown twin from its canonical URL

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -28,7 +28,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   if (request.method !== "GET" && request.method !== "HEAD") {
     return context.next();
   }
-  if (url.pathname.startsWith("/ingest")) {
+  if (url.pathname.startsWith("/ingest") || url.pathname.startsWith("/api")) {
     return context.next();
   }
 

--- a/functions/api/auth/[[path]].ts
+++ b/functions/api/auth/[[path]].ts
@@ -10,20 +10,33 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   const destination = `${apiBase}${url.pathname}${url.search}`;
 
   const headers = new Headers(context.request.headers);
+  headers.delete("host");
 
   console.log(
-    `[Auth Proxy] ${context.request.method} ${url.pathname}${url.search} -> ${destination}`,
+    JSON.stringify({
+      message: "Auth proxy request",
+      method: context.request.method,
+      path: url.pathname,
+      destination: `${apiBase}${url.pathname}`,
+    }),
   );
+
+  const hasBody = !["GET", "HEAD"].includes(context.request.method);
 
   const response = await fetch(
     new Request(destination, {
       method: context.request.method,
       headers,
-      body: context.request.body,
+      body: hasBody ? context.request.body : undefined,
       redirect: "manual",
     }),
   );
 
-  console.log(`[Auth Proxy] Response: ${response.status}`);
+  console.log(
+    JSON.stringify({
+      message: "Auth proxy response",
+      status: response.status,
+    }),
+  );
   return response;
 };

--- a/functions/api/auth/[[path]].ts
+++ b/functions/api/auth/[[path]].ts
@@ -1,0 +1,29 @@
+interface Env {
+  RECIPE_API_URL?: string;
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const apiBase =
+    context.env.RECIPE_API_URL || "https://recipe-api.robbiepalmer95.workers.dev";
+
+  const url = new URL(context.request.url);
+  const destination = `${apiBase}${url.pathname}${url.search}`;
+
+  const headers = new Headers(context.request.headers);
+
+  console.log(
+    `[Auth Proxy] ${context.request.method} ${url.pathname}${url.search} -> ${destination}`,
+  );
+
+  const response = await fetch(
+    new Request(destination, {
+      method: context.request.method,
+      headers,
+      body: context.request.body,
+      redirect: "manual",
+    }),
+  );
+
+  console.log(`[Auth Proxy] Response: ${response.status}`);
+  return response;
+};

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -8,6 +8,7 @@ locals {
     NEXT_PUBLIC_POSTHOG_KEY            = var.posthog_key
     NEXT_PUBLIC_POSTHOG_HOST           = var.posthog_host
     GITHUB_TOKEN                       = var.github_token
+    RECIPE_API_URL                     = var.recipe_api_url
   }
 }
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -72,6 +72,12 @@ variable "r2_dvc_bucket_name" {
   default     = "dvc"
 }
 
+variable "recipe_api_url" {
+  description = "URL of the recipe-api Worker for the auth proxy"
+  type        = string
+  default     = "https://recipe-api.robbiepalmer95.workers.dev"
+}
+
 # Neon
 
 variable "neon_org_id" {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.20(tailwindcss@4.3.1)
+      better-auth:
+        specifier: ^1.6.19
+        version: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(gel@2.2.0)(kysely@0.29.2)(postgres@3.4.9))(next@15.5.19(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { AuthButton } from "@/components/recipes/auth-button";
 import { AnimatedThemeToggler } from "@/components/ui/animated-theme-toggler";
 import { siteConfig } from "@/lib/config/site-config";
 
@@ -29,12 +30,7 @@ export default function RecipesLayout({
             Robbie's Recipes
           </Link>
           <div className="flex items-center gap-2">
-            <Link
-              href="/"
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Main Site
-            </Link>
+            <AuthButton />
             <AnimatedThemeToggler />
           </div>
         </nav>
@@ -46,12 +42,6 @@ export default function RecipesLayout({
         <div className="container mx-auto px-4 py-8">
           <div className="flex flex-col items-center gap-4">
             <p className="text-sm text-muted-foreground">
-              <Link
-                href="/"
-                className="hover:text-foreground transition-colors underline decoration-dotted underline-offset-4"
-              >
-                Back to Main Site
-              </Link>
               {" · "}© {currentYear} {siteConfig.author.name}
             </p>
           </div>

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -42,7 +42,7 @@ export default function RecipesLayout({
         <div className="container mx-auto px-4 py-8">
           <div className="flex flex-col items-center gap-4">
             <p className="text-sm text-muted-foreground">
-              {" · "}© {currentYear} {siteConfig.author.name}
+              © {currentYear} {siteConfig.author.name}
             </p>
           </div>
         </div>

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { ChevronDown, LoaderCircle, LogIn, LogOut } from "lucide-react";
+import { useState } from "react";
+import { siGithub, siGoogle } from "simple-icons";
+import { Button } from "@/components/ui/button";
+import { authClient } from "@/lib/auth-client";
+
+type Provider = "google" | "github";
+type LinkedAccount = { providerId: string; accountId: string };
+
+const providers: ReadonlyArray<{
+  id: Provider;
+  name: string;
+  iconPath: string;
+}> = [
+  { id: "google", name: "Google", iconPath: siGoogle.path },
+  { id: "github", name: "GitHub", iconPath: siGithub.path },
+];
+
+function ProviderIcon({ path }: { path: string }) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="size-4">
+      <path d={path} fill="currentColor" />
+    </svg>
+  );
+}
+
+export function AuthButton() {
+  const { data: session, isPending } = authClient.useSession();
+  const [open, setOpen] = useState(false);
+  const [pendingProvider, setPendingProvider] = useState<Provider | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccount[] | null>(
+    null,
+  );
+  const [accountsError, setAccountsError] = useState(false);
+
+  async function loadLinkedAccounts() {
+    setAccountsError(false);
+    const result = await authClient.listAccounts();
+    if (result.error) {
+      setAccountsError(true);
+      return;
+    }
+    setLinkedAccounts(result.data ?? []);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen && session && linkedAccounts === null && !accountsError) {
+      void loadLinkedAccounts();
+    }
+  }
+
+  if (isPending) {
+    return (
+      <Button variant="outline" size="sm" disabled aria-label="Loading session">
+        <LoaderCircle className="animate-spin" />
+        <span className="hidden sm:inline">Sign in</span>
+      </Button>
+    );
+  }
+
+  if (session) {
+    return (
+      <PopoverPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+        <PopoverPrimitive.Trigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={`Account for ${session.user.name}`}
+            aria-expanded={open}
+          >
+            <span className="max-w-32 truncate">{session.user.name}</span>
+            <ChevronDown className="size-3.5 opacity-60" />
+          </Button>
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            align="end"
+            sideOffset={6}
+            className="bg-popover text-popover-foreground z-50 w-64 rounded-md border p-3 shadow-md outline-none"
+          >
+            <p className="text-sm font-medium">{session.user.name}</p>
+            <p className="truncate text-xs text-muted-foreground">
+              {session.user.email}
+            </p>
+
+            <div className="my-3 border-t" />
+            <p className="mb-2 text-xs font-medium text-muted-foreground">
+              Connected identities
+            </p>
+
+            {linkedAccounts === null && !accountsError && (
+              <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
+                <LoaderCircle className="animate-spin" />
+                Checking accounts…
+              </div>
+            )}
+
+            {linkedAccounts?.map((account) => {
+              const provider = providers.find(
+                (candidate) => candidate.id === account.providerId,
+              );
+              if (!provider) return null;
+              const accountSuffix = account.accountId.slice(-6);
+
+              return (
+                <div
+                  key={`${account.providerId}:${account.accountId}`}
+                  className="flex items-center gap-2 rounded-md bg-muted/50 px-2 py-2"
+                >
+                  <ProviderIcon path={provider.iconPath} />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">{provider.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Provider account ending {accountSuffix}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+
+            {accountsError && (
+              <p className="text-xs text-destructive">
+                Connected identities could not be loaded.
+              </p>
+            )}
+
+            <div className="my-3 border-t" />
+            <Button
+              variant="ghost"
+              className="w-full justify-start"
+              onClick={() =>
+                authClient.signOut({
+                  fetchOptions: { onSuccess: () => window.location.reload() },
+                })
+              }
+            >
+              <LogOut />
+              Sign out
+            </Button>
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
+    );
+  }
+
+  async function signIn(provider: Provider) {
+    setPendingProvider(provider);
+    setError(null);
+
+    const currentURL = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    try {
+      const result = await authClient.signIn.social({
+        provider,
+        callbackURL: currentURL,
+        errorCallbackURL: currentURL,
+      });
+      if (result.error) {
+        setError(result.error.message ?? "Sign-in could not be started.");
+      }
+    } catch {
+      setError("Sign-in could not be started. Please try again.");
+    } finally {
+      setPendingProvider(null);
+    }
+  }
+
+  return (
+    <PopoverPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+      <PopoverPrimitive.Trigger asChild>
+        <Button variant="outline" size="sm" aria-expanded={open}>
+          <LogIn />
+          <span className="hidden sm:inline">Sign in</span>
+          <ChevronDown className="size-3.5 opacity-60" />
+        </Button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="end"
+          sideOffset={6}
+          className="bg-popover text-popover-foreground z-50 w-56 rounded-md border p-2 shadow-md outline-none"
+        >
+          <p className="px-2 pb-2 text-xs font-medium text-muted-foreground">
+            Sign in to your recipes
+          </p>
+          <div className="flex flex-col gap-1">
+            {providers.map((provider) => (
+              <Button
+                key={provider.id}
+                variant="ghost"
+                className="w-full justify-start"
+                disabled={pendingProvider !== null}
+                onClick={() => signIn(provider.id)}
+              >
+                {pendingProvider === provider.id ? (
+                  <LoaderCircle className="animate-spin" />
+                ) : (
+                  <ProviderIcon path={provider.iconPath} />
+                )}
+                Continue with {provider.name}
+              </Button>
+            ))}
+          </div>
+          {error && (
+            <p role="alert" className="px-2 pt-2 text-xs text-destructive">
+              {error}
+            </p>
+          )}
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -54,6 +54,20 @@ export function AuthButton() {
     }
   }
 
+  async function signOut() {
+    setError(null);
+    try {
+      const result = await authClient.signOut({
+        fetchOptions: { onSuccess: () => window.location.reload() },
+      });
+      if (result?.error) {
+        setError(result.error.message ?? "Sign-out failed. Please try again.");
+      }
+    } catch {
+      setError("Sign-out failed. Please try again.");
+    }
+  }
+
   if (isPending) {
     return (
       <Button variant="outline" size="sm" disabled aria-label="Loading session">
@@ -129,15 +143,17 @@ export function AuthButton() {
               </p>
             )}
 
+            {error && (
+              <p role="alert" className="text-xs text-destructive">
+                {error}
+              </p>
+            )}
+
             <div className="my-3 border-t" />
             <Button
               variant="ghost"
               className="w-full justify-start"
-              onClick={() =>
-                authClient.signOut({
-                  fetchOptions: { onSuccess: () => window.location.reload() },
-                })
-              }
+              onClick={signOut}
             >
               <LogOut />
               Sign out

--- a/ui/lib/auth-client.ts
+++ b/ui/lib/auth-client.ts
@@ -1,0 +1,3 @@
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({ basePath: "/api/auth" });

--- a/ui/mise.toml
+++ b/ui/mise.toml
@@ -68,6 +68,7 @@ run = "pnpm typecheck"
 description = "Clean build artifacts and dependencies"
 run = """
 rm -rf .next
+rm -rf .next-dev
 rm -rf node_modules
 rm -rf out
 """

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { NextConfig } from "next";
+import { PHASE_DEVELOPMENT_SERVER } from "next/constants";
 
 type WebpackCompiler = {
   outputPath: string;
@@ -14,70 +15,87 @@ type WebpackCompiler = {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const nextConfig: NextConfig = {
-  output: "export",
-  images: {
-    unoptimized: true,
-  },
-  turbopack: {
-    root: path.join(__dirname, ".."),
-  },
-  // Prevent 'fs' and 'path' from being bundled into client-side chunks.
-  // Recipe .cook files are read server-side at build time only; these modules
-  // are never called in the browser, so replacing them with empty modules is safe.
-  webpack(config, { isServer }) {
-    config.experiments = {
-      ...config.experiments,
-      asyncWebAssembly: true,
-    };
-
-    if (isServer) {
-      config.plugins = config.plugins ?? [];
-      config.plugins.push({
-        apply(compiler: WebpackCompiler) {
-          compiler.hooks.afterEmit.tap("CooklangServerWasmPathPlugin", () => {
-            const outputPath = compiler.outputPath;
-            const sourceDir = path.join(outputPath, "chunks/static/wasm");
-            const targetDir = path.join(outputPath, "static/wasm");
-            const staticExportWasmDir = path.join(
-              outputPath,
-              "..",
-              "static/wasm",
-            );
-
-            if (!fs.existsSync(sourceDir)) {
-              return;
-            }
-
-            fs.mkdirSync(targetDir, { recursive: true });
-            fs.mkdirSync(staticExportWasmDir, { recursive: true });
-            for (const filename of fs.readdirSync(sourceDir)) {
-              if (filename.endsWith(".wasm")) {
-                const sourceFile = path.join(sourceDir, filename);
-                fs.copyFileSync(sourceFile, path.join(targetDir, filename));
-                fs.copyFileSync(
-                  sourceFile,
-                  path.join(staticExportWasmDir, filename),
-                );
-              }
-            }
-          });
+function createNextConfig(phase: string): NextConfig {
+  return {
+    // Keep Turbopack's development artifacts separate from production builds.
+    // Reusing .next after `next build` can leave dev looking for incompatible
+    // Pages Router manifests such as pages/_app/build-manifest.json.
+    distDir: phase === PHASE_DEVELOPMENT_SERVER ? ".next-dev" : ".next",
+    output: "export",
+    images: {
+      unoptimized: true,
+    },
+    // Dev-only: proxy auth requests to the local recipe-api Worker.
+    // In production the Cloudflare Pages Function (functions/api/auth/) handles this.
+    // Rewrites are ignored during `next build` with output: "export".
+    async rewrites() {
+      return [
+        {
+          source: "/api/auth/:path*",
+          destination: "http://localhost:8787/api/auth/:path*",
         },
-      });
-    }
-
-    if (!isServer) {
-      config.resolve = {
-        ...config.resolve,
-        fallback: {
-          ...config.resolve?.fallback,
-          fs: false,
-          path: false,
-        },
+      ];
+    },
+    turbopack: {
+      root: path.join(__dirname, ".."),
+    },
+    // Prevent 'fs' and 'path' from being bundled into client-side chunks.
+    // Recipe .cook files are read server-side at build time only; these modules
+    // are never called in the browser, so replacing them with empty modules is safe.
+    webpack(config, { isServer }) {
+      config.experiments = {
+        ...config.experiments,
+        asyncWebAssembly: true,
       };
-    }
-    return config;
-  },
-};
 
-export default nextConfig;
+      if (isServer) {
+        config.plugins = config.plugins ?? [];
+        config.plugins.push({
+          apply(compiler: WebpackCompiler) {
+            compiler.hooks.afterEmit.tap("CooklangServerWasmPathPlugin", () => {
+              const outputPath = compiler.outputPath;
+              const sourceDir = path.join(outputPath, "chunks/static/wasm");
+              const targetDir = path.join(outputPath, "static/wasm");
+              const staticExportWasmDir = path.join(
+                outputPath,
+                "..",
+                "static/wasm",
+              );
+
+              if (!fs.existsSync(sourceDir)) {
+                return;
+              }
+
+              fs.mkdirSync(targetDir, { recursive: true });
+              fs.mkdirSync(staticExportWasmDir, { recursive: true });
+              for (const filename of fs.readdirSync(sourceDir)) {
+                if (filename.endsWith(".wasm")) {
+                  const sourceFile = path.join(sourceDir, filename);
+                  fs.copyFileSync(sourceFile, path.join(targetDir, filename));
+                  fs.copyFileSync(
+                    sourceFile,
+                    path.join(staticExportWasmDir, filename),
+                  );
+                }
+              }
+            });
+          },
+        });
+      }
+
+      if (!isServer) {
+        config.resolve = {
+          ...config.resolve,
+          fallback: {
+            ...config.resolve?.fallback,
+            fs: false,
+            path: false,
+          },
+        };
+      }
+      return config;
+    },
+  };
+}
+
+export default createNextConfig;

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -27,15 +27,18 @@ function createNextConfig(phase: string): NextConfig {
     },
     // Dev-only: proxy auth requests to the local recipe-api Worker.
     // In production the Cloudflare Pages Function (functions/api/auth/) handles this.
-    // Rewrites are ignored during `next build` with output: "export".
-    async rewrites() {
-      return [
-        {
-          source: "/api/auth/:path*",
-          destination: "http://localhost:8787/api/auth/:path*",
-        },
-      ];
-    },
+    ...(phase === PHASE_DEVELOPMENT_SERVER
+      ? {
+          async rewrites() {
+            return [
+              {
+                source: "/api/auth/:path*",
+                destination: "http://localhost:8787/api/auth/:path*",
+              },
+            ];
+          },
+        }
+      : {}),
     turbopack: {
       root: path.join(__dirname, ".."),
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-sigma/core": "^5.0.6",
     "@tailwindcss/typography": "^0.5.19",
+    "better-auth": "^1.6.19",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  signInSocial: vi.fn(),
+  signOut: vi.fn(),
+  listAccounts: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: mocks.useSession,
+    signIn: { social: mocks.signInSocial },
+    signOut: mocks.signOut,
+    listAccounts: mocks.listAccounts,
+  },
+}));
+
+import { AuthButton } from "@/components/recipes/auth-button";
+
+describe("AuthButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useSession.mockReturnValue({ data: null, isPending: false });
+    mocks.signInSocial.mockResolvedValue({ data: null, error: null });
+    mocks.listAccounts.mockResolvedValue({ data: [], error: null });
+  });
+
+  it("lets the user choose Google or GitHub", async () => {
+    const user = userEvent.setup();
+    render(<AuthButton />);
+
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    ).toBeInTheDocument();
+  });
+
+  it("starts the selected provider flow and preserves the current page", async () => {
+    const user = userEvent.setup();
+    window.history.replaceState({}, "", "/recipes/pasta?servings=4#method");
+    render(<AuthButton />);
+
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+    await user.click(
+      screen.getByRole("button", { name: "Continue with GitHub" }),
+    );
+
+    expect(mocks.signInSocial).toHaveBeenCalledWith({
+      provider: "github",
+      callbackURL: "/recipes/pasta?servings=4#method",
+      errorCallbackURL: "/recipes/pasta?servings=4#method",
+    });
+  });
+
+  it("shows the signed-in user and supports sign out", async () => {
+    const user = userEvent.setup();
+    mocks.useSession.mockReturnValue({
+      data: { user: { name: "Robbie", email: "robbie@example.com" } },
+      isPending: false,
+    });
+    mocks.listAccounts.mockResolvedValue({
+      data: [
+        {
+          providerId: "github",
+          accountId: "123456789",
+        },
+      ],
+      error: null,
+    });
+    render(<AuthButton />);
+
+    expect(screen.getByText("Robbie")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Account for Robbie" }),
+    );
+
+    expect(await screen.findByText("Connected identities")).toBeInTheDocument();
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(
+      screen.getByText("Provider account ending 456789"),
+    ).toBeInTheDocument();
+    expect(mocks.listAccounts).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(mocks.signOut).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -25,6 +25,7 @@ describe("AuthButton", () => {
     vi.clearAllMocks();
     mocks.useSession.mockReturnValue({ data: null, isPending: false });
     mocks.signInSocial.mockResolvedValue({ data: null, error: null });
+    mocks.signOut.mockResolvedValue({ data: null, error: null });
     mocks.listAccounts.mockResolvedValue({ data: [], error: null });
   });
 
@@ -91,5 +92,27 @@ describe("AuthButton", () => {
     await user.click(screen.getByRole("button", { name: "Sign out" }));
 
     expect(mocks.signOut).toHaveBeenCalledOnce();
+  });
+
+  it("shows an error when sign out fails", async () => {
+    const user = userEvent.setup();
+    mocks.useSession.mockReturnValue({
+      data: { user: { name: "Robbie", email: "robbie@example.com" } },
+      isPending: false,
+    });
+    mocks.signOut.mockResolvedValue({
+      data: null,
+      error: { message: "Session could not be ended" },
+    });
+    render(<AuthButton />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Account for Robbie" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Session could not be ended",
+    );
   });
 });

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -26,6 +26,12 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "next-env.d.ts",
+    ".next-dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/workers/recipe-api/.dev.vars.example
+++ b/workers/recipe-api/.dev.vars.example
@@ -1,0 +1,14 @@
+# Public browser origin. OAuth providers redirect back through the frontend proxy.
+BETTER_AUTH_URL=http://localhost:3000
+
+# Use local OAuth credentials. GitHub requires a separate local OAuth app.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Generate with: openssl rand -base64 32
+BETTER_AUTH_SECRET=
+
+# Direct Neon connection used by Wrangler local development.
+DATABASE_URL=

--- a/workers/recipe-api/README.md
+++ b/workers/recipe-api/README.md
@@ -1,0 +1,54 @@
+# Recipe API Worker
+
+Cloudflare Worker for recipe data and Better Auth. Browser auth requests stay
+same-origin and are proxied to this Worker:
+
+- local: Next.js rewrites `/api/auth/*` to `http://localhost:8787`
+- production: the Pages Function at `functions/api/auth/[[path]].ts` proxies
+  `/api/auth/*` to the deployed Worker
+
+## Local OAuth setup
+
+Copy `.dev.vars.example` to `.dev.vars` and fill in the credentials. The file is
+ignored by git. Start both the frontend and Worker from the repository root:
+
+```bash
+mise run //:dev
+```
+
+The local public auth URL is set by the Worker `dev` script. Use these provider
+callback URLs:
+
+```text
+Google: http://localhost:3000/api/auth/callback/google
+GitHub: http://localhost:3000/api/auth/callback/github
+```
+
+Google permits both local and production redirect URIs on one OAuth client.
+GitHub OAuth apps permit only one callback URL, so use a separate development
+OAuth app and put its client ID and secret in `.dev.vars`.
+
+## Production OAuth setup
+
+The production public URL is configured as `BETTER_AUTH_URL` in
+`wrangler.toml`. Provider callbacks are:
+
+```text
+Google: https://robbiepalmer.me/api/auth/callback/google
+GitHub: https://robbiepalmer.me/api/auth/callback/github
+```
+
+Configure the production provider credentials and Better Auth secret as Worker
+secrets using the interactive command, once for each secret name:
+
+```bash
+pnpm --filter recipe-api exec wrangler secret put GOOGLE_CLIENT_ID
+pnpm --filter recipe-api exec wrangler secret put GOOGLE_CLIENT_SECRET
+pnpm --filter recipe-api exec wrangler secret put GITHUB_CLIENT_ID
+pnpm --filter recipe-api exec wrangler secret put GITHUB_CLIENT_SECRET
+pnpm --filter recipe-api exec wrangler secret put BETTER_AUTH_SECRET
+```
+
+Do not use the direct `workers.dev` URL as a provider callback. The supported
+browser origins are the local frontend and the production site, where the
+session cookie remains same-origin.

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --var BETTER_AUTH_URL:http://localhost:3000",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/workers/recipe-api/src/auth.ts
+++ b/workers/recipe-api/src/auth.ts
@@ -4,6 +4,7 @@ import type { createDb } from "./db";
 import * as schema from "./db/schema";
 
 type AuthEnv = {
+  BETTER_AUTH_URL: string;
   GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
   GITHUB_CLIENT_ID: string;
@@ -13,9 +14,9 @@ type AuthEnv = {
 
 export function createAuth(
   db: ReturnType<typeof createDb>["db"],
-  baseURL: string,
   env: AuthEnv,
 ) {
+  const baseURL = new URL(env.BETTER_AUTH_URL).origin;
   const isSecure = baseURL.startsWith("https://");
   return betterAuth({
     baseURL,

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -18,6 +18,15 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
+function isValidAuthURL(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 app.on(["POST", "GET"], "/api/auth/**", async (c) => {
   const connectionString =
     c.env.HYPERDRIVE?.connectionString ?? c.env.DATABASE_URL;
@@ -26,6 +35,9 @@ app.on(["POST", "GET"], "/api/auth/**", async (c) => {
   }
   if (!c.env.BETTER_AUTH_URL || !c.env.BETTER_AUTH_SECRET) {
     return c.json({ error: "Auth configuration is incomplete" }, 503);
+  }
+  if (!isValidAuthURL(c.env.BETTER_AUTH_URL)) {
+    return c.json({ error: "Auth configuration is invalid" }, 503);
   }
   const { db, client } = createDb(connectionString);
   try {

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -6,6 +6,7 @@ import { createAuth } from "./auth";
 type Bindings = {
   HYPERDRIVE?: Hyperdrive;
   DATABASE_URL?: string;
+  BETTER_AUTH_URL: string;
   GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
   GITHUB_CLIENT_ID: string;
@@ -17,48 +18,18 @@ const app = new Hono<{ Bindings: Bindings }>();
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
-// TODO: remove after verifying production OAuth works end-to-end
-app.get("/auth-test", (c) => {
-  return c.html(`<!DOCTYPE html>
-<html><head><title>Auth Test</title></head><body>
-<h2>OAuth Test</h2>
-<button onclick="signIn('google')">Sign in with Google</button>
-<button onclick="signIn('github')">Sign in with GitHub</button>
-<button onclick="getSession()">Get Session</button>
-<pre id="out"></pre>
-<script>
-async function signIn(provider) {
-  const res = await fetch('/api/auth/sign-in/social', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ provider, callbackURL: '/auth-test' }),
-  });
-  const data = await res.json();
-  if (data.url) window.location.href = data.url;
-  else document.getElementById('out').textContent = JSON.stringify(data, null, 2);
-}
-async function getSession() {
-  const res = await fetch('/api/auth/get-session');
-  const data = await res.json();
-  document.getElementById('out').textContent = JSON.stringify(data, null, 2);
-}
-</script>
-</body></html>`);
-});
-
 app.on(["POST", "GET"], "/api/auth/**", async (c) => {
   const connectionString =
     c.env.HYPERDRIVE?.connectionString ?? c.env.DATABASE_URL;
   if (!connectionString) {
     return c.json({ error: "No database connection configured" }, 503);
   }
-  if (!c.env.BETTER_AUTH_SECRET) {
-    return c.json({ error: "Auth secrets not configured" }, 503);
+  if (!c.env.BETTER_AUTH_URL || !c.env.BETTER_AUTH_SECRET) {
+    return c.json({ error: "Auth configuration is incomplete" }, 503);
   }
   const { db, client } = createDb(connectionString);
   try {
-    const baseURL = new URL(c.req.url).origin;
-    const auth = createAuth(db, baseURL, c.env);
+    const auth = createAuth(db, c.env);
     return await auth.handler(c.req.raw);
   } finally {
     try {

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -132,6 +132,23 @@ describe("POST /api/auth/sign-in/social", () => {
       error: "Auth configuration is incomplete",
     });
   });
+
+  it("returns 503 when the public auth URL is malformed", async () => {
+    const res = await app.request(
+      "/api/auth/sign-in/social",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provider: "google" }),
+      },
+      { ...env, BETTER_AUTH_URL: "not-a-valid-url" },
+    );
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: "Auth configuration is invalid",
+    });
+  });
 });
 
 describe("unknown routes", () => {

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -8,14 +8,21 @@ vi.mock("postgres", () => ({
     // client must expose those empty objects. Queries go through:
     //   client.unsafe(sql, params).values() — SELECT (drizzle maps array-of-arrays)
     //   client.unsafe(sql, params)          — DML
-    const emptyResult = Object.assign(Promise.resolve([]), {
-      values: () => Promise.resolve([]),
-    });
+    const queryResult = (rows: unknown[][] = []) =>
+      Object.assign(Promise.resolve(rows), {
+        values: () => Promise.resolve(rows),
+      });
+    const emptyResult = queryResult();
     return Object.assign(
       (_strings: TemplateStringsArray, ..._values: unknown[]) => emptyResult,
       {
         options: { parsers: {}, serializers: {} },
-        unsafe: (_query: string, _params?: unknown[]) => emptyResult,
+        unsafe: (query: string, params: unknown[] = []) => {
+          if (query.startsWith('insert into "verification"')) {
+            return queryResult([params]);
+          }
+          return emptyResult;
+        },
         end: (_options?: { timeout?: number }) => Promise.resolve(),
       },
     );
@@ -24,7 +31,15 @@ vi.mock("postgres", () => ({
 
 import app from "../src/index";
 
-const env = { DATABASE_URL: "postgresql://test:test@localhost/test" };
+const env = {
+  DATABASE_URL: "postgresql://test:test@localhost/test",
+  BETTER_AUTH_URL: "http://localhost:3000",
+  BETTER_AUTH_SECRET: "test-secret-that-is-at-least-thirty-two-characters",
+  GOOGLE_CLIENT_ID: "google-client-id",
+  GOOGLE_CLIENT_SECRET: "google-client-secret",
+  GITHUB_CLIENT_ID: "github-client-id",
+  GITHUB_CLIENT_SECRET: "github-client-secret",
+};
 
 describe("GET /health", () => {
   it("returns ok", async () => {
@@ -68,6 +83,54 @@ describe("GET /recipes", () => {
     expect(res.status).toBe(502);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Database query failed");
+  });
+});
+
+describe("POST /api/auth/sign-in/social", () => {
+  it.each(["google", "github"] as const)(
+    "uses the public frontend callback for %s",
+    async (provider) => {
+      const res = await app.request(
+        "/api/auth/sign-in/social",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            origin: "http://localhost:3000",
+          },
+          body: JSON.stringify({
+            provider,
+            callbackURL: "/recipes",
+            disableRedirect: true,
+          }),
+        },
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { url: string };
+      const providerURL = new URL(body.url);
+      expect(providerURL.searchParams.get("redirect_uri")).toBe(
+        `http://localhost:3000/api/auth/callback/${provider}`,
+      );
+    },
+  );
+
+  it("returns 503 when the public auth URL is missing", async () => {
+    const res = await app.request(
+      "/api/auth/sign-in/social",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ provider: "google" }),
+      },
+      { ...env, BETTER_AUTH_URL: "" },
+    );
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: "Auth configuration is incomplete",
+    });
   });
 });
 

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -3,6 +3,11 @@ main = "src/index.ts"
 compatibility_date = "2026-05-28"
 compatibility_flags = ["nodejs_compat"]
 
+[vars]
+# Browser-facing URL used to build OAuth callbacks in production.
+# The local dev script overrides this with http://localhost:3000.
+BETTER_AUTH_URL = "https://robbiepalmer.me"
+
 # Hyperdrive connection pooling to Neon.
 [[hyperdrive]]
 binding = "HYPERDRIVE"


### PR DESCRIPTION
## Summary

- add Google and GitHub OAuth selection, session/account details, and sign-out controls to the recipe UI
- proxy Better Auth through same-origin Next.js and Cloudflare Pages routes with deterministic local and production callback URLs
- improve combined local development startup/cleanup and isolate Next.js development build artifacts
- remove the Main Site links from the recipe navigation and footer

## Why

The OAuth flow worked when accessed directly through the Worker, but the recipe frontend had no complete same-origin sign-in flow. Callback origin inference and shared Next.js build artifacts also made local development unreliable.

## Impact

Recipe users can sign in with Google or GitHub, inspect the linked provider identity, and sign out. Local development uses the localhost frontend callback while production uses robbiepalmer.me.

## Validation

- `pnpm exec next build`
- `pnpm exec vitest run tests/components/recipes/auth-button.test.tsx`
- `pnpm test` in `workers/recipe-api`
- `pnpm typecheck` in `workers/recipe-api`
- `terraform fmt -check`
- live Google and GitHub OAuth sign-in verified locally
- pre-commit formatting and lint checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a recipes-page authentication control with sign-in/sign-out and connected identities.
  * Added OAuth login support for Google and GitHub, including a proxy for same-origin auth requests to the recipe API Worker.
  * Introduced a one-command local dev setup that runs both the UI and Worker together.

* **Bug Fixes**
  * Improved middleware routing so `/ingest` and `/api` requests are handled correctly.

* **Documentation**
  * Updated setup and OAuth configuration guides for local development and production.

* **Tests**
  * Added UI and Worker test coverage for auth flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->