### PR TITLE
[codex] Repair merged pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,7 +184,7 @@ importers:
         version: 0.5.20(tailwindcss@4.3.1)
       better-auth:
         specifier: ^1.6.19
-        version: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(gel@2.2.0)(kysely@0.29.2)(postgres@3.4.9))(next@15.5.19(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.19(@cloudflare/workers-types@4.20260615.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260615.1)(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.1)(@types/pg@8.11.6)(gel@2.2.0)(kysely@0.29.2)(postgres@3.4.9))(next@15.5.19(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## Summary

- align the UI Better Auth lockfile entry with the Vitest 4.1.9 peer snapshot already present after PR #574
- restore frozen pnpm installation for the Recipe API deployment workflow

## Root cause

PR #574 updated Vitest from 4.1.8 to 4.1.9 immediately before the OAuth PR was merged. Git merged the separate lockfile edits without a textual conflict, leaving the UI Better Auth importer on the removed Vitest 4.1.8 peer snapshot while the package snapshots contained only 4.1.9.

This caused [Recipe API CD run 27778693899](https://github.com/Robbie-Palmer/personal-site/actions/runs/27778693899) to fail during dependency installation before deployment.

## Impact

The deployment workflow can install dependencies again and proceed to the Worker deployment steps.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm test` in `workers/recipe-api` (9 tests passed)
- `pnpm typecheck` in `workers/recipe-api`
- repository pre-commit checks