### PR TITLE
[codex] fix recipe sign-in routing on Pages

### DIFF
--- a/ui/scripts/generate-agent-markdown.ts
+++ b/ui/scripts/generate-agent-markdown.ts
@@ -532,6 +532,7 @@ function buildRoutesJson(): string {
     {
       version: 1,
       include: [
+        "/api/auth/*",
         "/ingest/*",
         "/",
         "/experience",

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -76,6 +76,7 @@ describe("agent markdown generation", () => {
 
   it("scopes the middleware to page routes in _routes.json", () => {
     const routes = JSON.parse(read("_routes.json"));
+    expect(routes.include).toContain("/api/auth/*");
     expect(routes.include).toContain("/ingest/*");
     expect(routes.include).toContain("/projects/*");
     expect(routes.exclude).toContain("/_next/*");


### PR DESCRIPTION
## What changed
- Added `/api/auth/*` to the generated Cloudflare Pages `_routes.json` include list.
- Added an integration test to lock that route into the generated manifest.

## Why
The production Pages deployment was serving `/api/auth/*` as static content instead of invoking the Pages Function proxy. That produced the `404` and `405` errors when the sign-in flow tried to call Better Auth endpoints.

## Impact
Auth sign-in should start working again on the deployed recipe site without changing the recipe API worker itself.

## Validation
- `node --import tsx scripts/generate-agent-markdown.ts`
- `pnpm --filter ui exec vitest run --no-file-parallelism tests/integration/agent-markdown.test.ts`
- Verified the generated `ui/out/_routes.json` now includes `/api/auth/*`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated authentication API route configuration in the build system to ensure secure request handling and proper middleware enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->