### PR TITLE
Fix duplicate technologies in project tech stack

### DIFF
--- a/ui/lib/domain/project/projectQueries.ts
+++ b/ui/lib/domain/project/projectQueries.ts
@@ -165,12 +165,19 @@ export function getProjectWithADRs(
     .filter((adr) => adr.status === "Accepted")
     .flatMap((adr) => adr.technologies);
 
+  // Dedupe by slug across both project and ADR technologies. A technology can
+  // legitimately appear in multiple accepted ADRs (e.g. Better Auth in both the
+  // auth ADR and the security baseline ADR), so deduping only ADR-vs-project is
+  // not enough — it must also collapse repeats within the ADR set itself.
+  const seenSlugs = new Set<string>();
   const mergedTechnologies = [
     ...projectTechnologies,
-    ...adrTechnologies.filter(
-      (adrTech) => !projectTechnologies.some((t) => t.slug === adrTech.slug),
-    ),
-  ];
+    ...adrTechnologies,
+  ].filter((tech) => {
+    if (seenSlugs.has(tech.slug)) return false;
+    seenSlugs.add(tech.slug);
+    return true;
+  });
 
   const adrSlugs = getADRSlugsForProject(repository.graph, slug);
   const role = getRoleView(repository, slug);

--- a/ui/lib/domain/project/projectQueries.ts
+++ b/ui/lib/domain/project/projectQueries.ts
@@ -165,10 +165,6 @@ export function getProjectWithADRs(
     .filter((adr) => adr.status === "Accepted")
     .flatMap((adr) => adr.technologies);
 
-  // Dedupe by slug across both project and ADR technologies. A technology can
-  // legitimately appear in multiple accepted ADRs (e.g. Better Auth in both the
-  // auth ADR and the security baseline ADR), so deduping only ADR-vs-project is
-  // not enough — it must also collapse repeats within the ADR set itself.
   const seenSlugs = new Set<string>();
   const mergedTechnologies = [
     ...projectTechnologies,

--- a/ui/tests/lib/projects.test.ts
+++ b/ui/tests/lib/projects.test.ts
@@ -94,6 +94,24 @@ describe("Projects functions", () => {
       }
     });
 
+    it("should not include duplicate technologies", () => {
+      const projects = getAllProjects();
+      for (const project of projects) {
+        const slugs = project.technologies.map((t) => t.slug);
+        const uniqueSlugs = new Set(slugs);
+        expect(slugs.length).toBe(uniqueSlugs.size);
+      }
+    });
+
+    it("should dedupe technologies shared across multiple accepted ADRs", () => {
+      // Better Auth and Cloudflare Workers are each referenced by more than one
+      // accepted recipe-site ADR; they must still appear only once.
+      const project = getProject("recipe-site");
+      const names = project.technologies.map((t) => t.name);
+      expect(names.filter((n) => n === "Better Auth")).toHaveLength(1);
+      expect(names.filter((n) => n === "Cloudflare Workers")).toHaveLength(1);
+    });
+
     it("should include technologies from accepted ADRs", () => {
       const project = getProject("personal-site");
       const acceptedADRs = project.adrs.filter(

--- a/ui/tests/lib/projects.test.ts
+++ b/ui/tests/lib/projects.test.ts
@@ -104,8 +104,6 @@ describe("Projects functions", () => {
     });
 
     it("should dedupe technologies shared across multiple accepted ADRs", () => {
-      // Better Auth and Cloudflare Workers are each referenced by more than one
-      // accepted recipe-site ADR; they must still appear only once.
       const project = getProject("recipe-site");
       const names = project.technologies.map((t) => t.name);
       expect(names.filter((n) => n === "Better Auth")).toHaveLength(1);

--- a/ui/tests/lib/projects.test.ts
+++ b/ui/tests/lib/projects.test.ts
@@ -82,27 +82,6 @@ describe("Projects functions", () => {
       }
     });
 
-    it("should include project technologies", () => {
-      const projects = getAllProjects();
-      const projectWithTech = projects.find((p) => p.technologies.length > 0);
-      expect(projectWithTech).toBeDefined();
-      if (!projectWithTech) return;
-      expect(projectWithTech.technologies.length).toBeGreaterThan(0);
-      for (const tech of projectWithTech.technologies) {
-        expect(typeof tech.name).toBe("string");
-        expect(tech.name.length).toBeGreaterThan(0);
-      }
-    });
-
-    it("should not include duplicate technologies", () => {
-      const projects = getAllProjects();
-      for (const project of projects) {
-        const slugs = project.technologies.map((t) => t.slug);
-        const uniqueSlugs = new Set(slugs);
-        expect(slugs.length).toBe(uniqueSlugs.size);
-      }
-    });
-
     it("should dedupe technologies shared across multiple accepted ADRs", () => {
       const project = getProject("recipe-site");
       const names = project.technologies.map((t) => t.name);
@@ -157,6 +136,27 @@ describe("Projects functions", () => {
       const projectSlugs = projects.map((p) => p.slug);
       for (const slug of slugs) {
         expect(projectSlugs).toContain(slug);
+      }
+    });
+
+    it("should include project technologies", () => {
+      const projects = getAllProjects();
+      const projectWithTech = projects.find((p) => p.technologies.length > 0);
+      expect(projectWithTech).toBeDefined();
+      if (!projectWithTech) return;
+      expect(projectWithTech.technologies.length).toBeGreaterThan(0);
+      for (const tech of projectWithTech.technologies) {
+        expect(typeof tech.name).toBe("string");
+        expect(tech.name.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("should not include duplicate technologies", () => {
+      const projects = getAllProjects();
+      for (const project of projects) {
+        const slugs = project.technologies.map((t) => t.slug);
+        const uniqueSlugs = new Set(slugs);
+        expect(slugs.length).toBe(uniqueSlugs.size);
       }
     });
   });


### PR DESCRIPTION
A technology referenced by multiple accepted ADRs (e.g. Better Auth in
both the auth and security-baseline ADRs, Cloudflare Workers in both the
backend-platform and security-baseline ADRs) appeared multiple times in
a project's tech stack. The merge in getProjectWithADRs only deduped ADR
technologies against project technologies, not against each other.

The duplicate slugs were also used as React keys in ProjectTechStack,
causing reconciliation glitches that rendered stray icon-only badges.

Dedupe the merged technologies by slug while preserving order, and add
regression tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QiZjWb9W9skkAThwNVDkyo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where technologies referenced across multiple architectural decisions were appearing as duplicates in project technology lists, ensuring each technology displays exactly once.

* **Tests**
  * Strengthened test coverage to verify technology deduplication functionality and prevent duplicate entries in project collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->