### PR TITLE
Add ADR 036 for Google OIDC login

### DIFF
--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -77,8 +77,8 @@ split:
 | **OAuth consent screen (brand)**                | **Not** manageable as a normal web-app brand; the only Terraform resource (`google_iap_brand`) is Identity-Aware Proxy only. |
 | **OAuth 2.0 Client ID (type "Web application")** | **No Terraform resource exists.** This is the credential the sign-in flow depends on.                                       |
 
-The gap is specific and confirmed, not unknown: the HashiCorp Google provider has no resource for a
-standard (non-IAP) web-application OAuth 2.0 Client ID. The long-running feature request
+The HashiCorp Google provider has no resource for a standard (non-IAP) web-application OAuth 2.0
+Client ID. The long-running feature request
 ([terraform-provider-google#16452](https://github.com/hashicorp/terraform-provider-google/issues/16452))
 is still open and unresolved. The existing `google_iap_client` resource is for Identity-Aware Proxy
 and cannot manage these credentials, and `google_iam_oauth_client` is for Workforce Identity

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -149,11 +149,13 @@ fee, not a technical advantage.
 | -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Email + password** | Out of scope | The highest-friction sign-up for this audience and the one that drags in password storage, resets, recovery, and breach response — the exact complexity this decision exists to avoid. Not planned.                                |
 | **Magic links**      | Deferred     | Passwordless like Google, but adds an email-delivery dependency and link-consumption edge cases (expiry, reuse, multi-device) that a federated provider sidesteps. A reasonable *fallback* for users without a Google account.     |
-| **Passkeys**         | Deferred     | The strongest long-term direction: phishing-resistant and passwordless. Less universally ready for non-technical users today, and best added as an *enhancement* on top of an existing account rather than the first-run path.     |
+| **Passkeys**         | Deferred     | Phishing-resistant and passwordless, and the strongest long-term direction. The catch: passkeys only deliver that security if they are the sole or required way in. While Google sign-in stays enabled beside them, the account is only as phishing-resistant as Google's flow, because an attacker falls back to it — so bolting passkeys on as an optional extra is mostly convenience until they gate or replace the weaker method, which works against the Google-first, low-friction goal. Also less universally ready for non-technical users today. |
 
-Magic links and passkeys are future layers rather than competitors: magic links as a
-no-account-required fallback, passkeys as a step-up once a user exists. Neither needs to displace
-Google to be worth adding.
+Magic links and passkeys are future layers rather than competitors. Magic links would be a
+no-account-required fallback for users without Google. Passkeys are the harder call: their
+phishing-resistance only counts if they become the sole or required factor, so adding them while
+Google stays enabled raises convenience more than security. They are worth the headline benefit only
+if they eventually gate the account rather than sit beside Google as one option among several.
 
 # Consequences
 

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -12,7 +12,7 @@ site's primary sign-in method.
 
 [ADR 032](/projects/recipe-site/adrs/032-better-auth) chose Better Auth as the authentication
 library and named Google as the expected default sign-in path. This ADR formalises *why* Google
-OIDC is that default, with explicit pros and cons, so the trade-off is recorded rather than implied.
+OIDC is that default, with explicit pros and cons.
 
 This is a decision about the **identity provider used for sign-in**. It does not decide the auth
 library ([Better Auth, ADR 032](/projects/recipe-site/adrs/032-better-auth)), the backend runtime
@@ -36,8 +36,7 @@ Two goals dominate the choice:
    removes a whole category of code, support burden, and security risk.
 
 Better Auth ([ADR 032](/projects/recipe-site/adrs/032-better-auth)) already states the social-first
-position: email/password is out of scope, and Google is the default path. This ADR is the dedicated
-record of the Google OIDC decision itself.
+position: email/password is out of scope, and Google is the default path.
 
 # Decision
 
@@ -87,14 +86,13 @@ Federation, not Sign in with Google.
 The consequence for this decision: the project and its APIs can be Terraformed, but **creating the
 OAuth consent screen and the web OAuth client is a manual Google Cloud Console step**. The resulting
 client ID and secret are then fed into the secret-management layer, which *is* code-owned. This is
-the one piece of console-owned configuration this decision introduces, and it is bounded — it
-happens once per environment and produces values that the rest of the pipeline can consume as code.
+the one piece of console-owned configuration this decision introduces: it happens once per
+environment and produces values the rest of the pipeline consumes as code.
 
 ## Same-Origin Proxy
 
 Google OIDC with Better Auth needs the auth/API backend and the frontend to share a **site**, and
-the cleanest way to guarantee that is to serve both on the **same origin**. The reason is worth
-recording so it is not treated as folklore.
+the cleanest way to guarantee that is to serve both on the **same origin**.
 
 The site's frontend is a static export on Cloudflare Pages; the auth/API layer is a separate
 Cloudflare Worker ([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)).
@@ -114,14 +112,12 @@ Serving the Worker on the **same origin** as the site — for example routing `/
 domain to the Worker via a proxy — sidesteps both cases: the session cookie is first-party with no
 special `Domain`/`SameSite` handling, there is no CORS preflight, and Google has a single stable
 callback URL on that one origin. This is the
-[backend-for-frontend](https://github.com/better-auth/better-auth/issues/7657) pattern, not a quirk
-of one deployment.
+[backend-for-frontend](https://github.com/better-auth/better-auth/issues/7657) pattern.
 
-The decision here is therefore explicit: **the deployment will front the auth Worker on the site's
-own origin** rather than expose it on a separate host. The exact mechanism (a Pages route/proxy, a
-Cloudflare route binding, or equivalent) is an implementation detail left to the backend work, but
-keeping the two halves same-origin is worth committing to up front — especially since Cloudflare's
-default `*.pages.dev` / `*.workers.dev` hosts are cross-site and would otherwise force the fragile
+So **the deployment will front the auth Worker on the site's own origin** rather than expose it on a
+separate host. The exact mechanism (a Pages route/proxy, a Cloudflare route binding, or equivalent)
+is left to the backend work, but the two halves must stay same-origin: Cloudflare's default
+`*.pages.dev` / `*.workers.dev` hosts are cross-site and would otherwise force the fragile
 `SameSite=None` path.
 
 # This Is A Default, Not An Exclusive Choice
@@ -129,12 +125,10 @@ default `*.pages.dev` / `*.workers.dev` hosts are cross-site and would otherwise
 Choosing Google as the primary sign-in method does **not** preclude any other method. Better Auth
 ([ADR 032](/projects/recipe-site/adrs/032-better-auth)) treats sign-in methods as additive
 configuration: each social provider is a few lines, and magic links and passkeys are plugins. Adding
-a second provider or method later does not require revisiting this ADR — it is expected headroom, not
-a reversal.
+a second provider or method later does not require revisiting this ADR — it is expected headroom.
 
 What this ADR fixes is the **default**: the path the sign-in screen leads with, and the one onboarding
-is optimised for. The comparison below is therefore about *what to lead with*, not about ruling the
-others out.
+is optimised for. The comparison below is about *what to lead with*, not about ruling the others out.
 
 # How Google Compares To The Alternatives
 
@@ -157,8 +151,8 @@ fee, not a technical advantage.
 | **Magic links**      | Deferred     | Passwordless like Google, but adds an email-delivery dependency and link-consumption edge cases (expiry, reuse, multi-device) that a federated provider sidesteps. A reasonable *fallback* for users without a Google account.     |
 | **Passkeys**         | Deferred     | The strongest long-term direction: phishing-resistant and passwordless. Less universally ready for non-technical users today, and best added as an *enhancement* on top of an existing account rather than the first-run path.     |
 
-Magic links and passkeys are not competitors to Google here so much as future layers: magic links as
-a no-account-required fallback, passkeys as a step-up once a user exists. Neither needs to displace
+Magic links and passkeys are future layers rather than competitors: magic links as a
+no-account-required fallback, passkeys as a step-up once a user exists. Neither needs to displace
 Google to be worth adding.
 
 # Consequences
@@ -184,7 +178,7 @@ Google to be worth adding.
 * **A same-origin proxy is needed.** The auth Worker must be fronted on the site's own origin so the
   session cookie stays first-party; running it cross-site (e.g. on the default `*.pages.dev` /
   `*.workers.dev` hosts) forces the fragile `SameSite=None` path. This is extra routing
-  infrastructure to operate, justified by the cookie/OAuth flow rather than incidental.
+  infrastructure to operate.
 * **No preview-environment story.** OAuth requires pre-registered, static redirect URIs, so
   ephemeral per-PR preview URLs cannot complete a Google sign-in out of the box. This conflicts with
   the short-feedback-loop / preview-environment goals in ADR 033, and there is no obvious solution

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -2,7 +2,7 @@
 title: "ADR 036: Google OIDC Login"
 date: "2026-06-19"
 status: "Accepted"
-tech_stack: ["Google Identity Platform", "Better Auth"]
+tech_stack: ["Google Identity Platform"]
 ---
 
 # Summary

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -2,7 +2,7 @@
 title: "ADR 036: Google OIDC Login"
 date: "2026-06-19"
 status: "Accepted"
-tech_stack: ["Google Identity Platform"]
+tech_stack: ["Google OAuth"]
 ---
 
 # Summary
@@ -15,9 +15,10 @@ library and named Google as the expected default sign-in path. This ADR formalis
 OIDC is that default, with explicit pros and cons, so the trade-off is recorded rather than implied.
 
 This is a decision about the **identity provider used for sign-in**. It does not decide the auth
-library (Better Auth, ADR 032), the backend runtime (ADR 033), the authorization model
-([ADR 034](/projects/recipe-site/adrs/034-authorization-model)), or the security baseline
-([ADR 035](/projects/recipe-site/adrs/035-application-security-baseline)).
+library ([Better Auth, ADR 032](/projects/recipe-site/adrs/032-better-auth)), the backend runtime
+([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)), the
+authorization model ([ADR 034](/projects/recipe-site/adrs/034-authorization-model)), or the security
+baseline ([ADR 035](/projects/recipe-site/adrs/035-application-security-baseline)).
 
 # Context
 
@@ -91,30 +92,37 @@ happens once per environment and produces values that the rest of the pipeline c
 
 ## Same-Origin Proxy
 
-Google OIDC with Better Auth needs the auth/API backend to be reachable on the **same origin** as the
-static frontend. That has a concrete cause worth recording so it is not treated as folklore.
+Google OIDC with Better Auth needs the auth/API backend and the frontend to share a **site**, and
+the cleanest way to guarantee that is to serve both on the **same origin**. The reason is worth
+recording so it is not treated as folklore.
 
 The site's frontend is a static export on Cloudflare Pages; the auth/API layer is a separate
 Cloudflare Worker ([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)).
-If those sit on different origins (for example `recipes.example.com` and `api.example.com`), the
-sign-in flow breaks on cookies:
+Better Auth sets the session cookie during the OAuth callback, and whether the browser returns that
+cookie on later requests depends on how the two halves are hosted:
 
-* Better Auth sets the session cookie during the OAuth callback on the **Worker's** origin.
-* A cookie set on `api.example.com` is not sent on requests to `recipes.example.com`, so the user
-  appears unauthenticated even though the OAuth exchange succeeded.
-* The cross-site workaround (`SameSite=None`) is increasingly blocked by browsers' third-party-cookie
-  restrictions, so it is not a durable fix.
+* **Subdomains of one registrable domain** (for example `recipes.example.com` and
+  `api.example.com`) are *same-site*. The session cookie can be shared by scoping it to
+  `Domain=example.com` with `SameSite=Lax`; it is not affected by third-party-cookie restrictions.
+  This works, but it needs explicit cookie-domain configuration and still triggers CORS preflight on
+  cross-subdomain API calls.
+* **Genuinely cross-site origins** (different registrable domains — notably Cloudflare's defaults
+  `*.pages.dev` and `*.workers.dev`) require `SameSite=None`, which is subject to browsers'
+  third-party-cookie phase-out. That is not a durable setup.
 
-The remedy is to put the Worker behind the **same origin** as the site — for example routing
-`/api/*` on the site's domain to the Worker via a proxy. Then the session cookie is first-party and
-is sent on every request, and Google has a single stable callback URL on that one origin. This is the
+Serving the Worker on the **same origin** as the site — for example routing `/api/*` on the site's
+domain to the Worker via a proxy — sidesteps both cases: the session cookie is first-party with no
+special `Domain`/`SameSite` handling, there is no CORS preflight, and Google has a single stable
+callback URL on that one origin. This is the
 [backend-for-frontend](https://github.com/better-auth/better-auth/issues/7657) pattern, not a quirk
 of one deployment.
 
 The decision here is therefore explicit: **the deployment will front the auth Worker on the site's
 own origin** rather than expose it on a separate host. The exact mechanism (a Pages route/proxy, a
 Cloudflare route binding, or equivalent) is an implementation detail left to the backend work, but
-the same-origin requirement itself is a property of the cookie/OAuth flow and is not optional.
+keeping the two halves same-origin is worth committing to up front — especially since Cloudflare's
+default `*.pages.dev` / `*.workers.dev` hosts are cross-site and would otherwise force the fragile
+`SameSite=None` path.
 
 # This Is A Default, Not An Exclusive Choice
 
@@ -174,8 +182,9 @@ Google to be worth adding.
   console step. This is one bounded piece of console-owned configuration, mitigated by storing the
   resulting credentials in the code-owned secret layer.
 * **A same-origin proxy is needed.** The auth Worker must be fronted on the site's own origin so the
-  session cookie stays first-party; running it on a separate host breaks sign-in. This is extra
-  routing infrastructure to operate, justified by the cookie/OAuth flow rather than incidental.
+  session cookie stays first-party; running it cross-site (e.g. on the default `*.pages.dev` /
+  `*.workers.dev` hosts) forces the fragile `SameSite=None` path. This is extra routing
+  infrastructure to operate, justified by the cookie/OAuth flow rather than incidental.
 * **No preview-environment story.** OAuth requires pre-registered, static redirect URIs, so
   ephemeral per-PR preview URLs cannot complete a Google sign-in out of the box. This conflicts with
   the short-feedback-loop / preview-environment goals in ADR 033, and there is no obvious solution

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -1,0 +1,152 @@
+---
+title: "ADR 036: Google OIDC Login"
+date: "2026-06-19"
+status: "Accepted"
+tech_stack: ["Google Identity Platform", "Better Auth"]
+---
+
+# Summary
+
+Use **Sign in with Google** (Google's OAuth 2.0 / OpenID Connect implementation) as the recipe
+site's primary sign-in method.
+
+[ADR 032](/projects/recipe-site/adrs/032-better-auth) chose Better Auth as the authentication
+library and named Google as the expected default sign-in path. This ADR formalises *why* Google
+OIDC is that default, with explicit pros and cons, so the trade-off is recorded rather than implied.
+
+This is a decision about the **identity provider used for sign-in**. It does not decide the auth
+library (Better Auth, ADR 032), the backend runtime (ADR 033), the authorization model
+([ADR 034](/projects/recipe-site/adrs/034-authorization-model)), or the security baseline
+([ADR 035](/projects/recipe-site/adrs/035-application-security-baseline)).
+
+# Context
+
+The recipe site is moving from a shared public collection toward authenticated, user-specific state
+and household sharing. That needs a sign-in method.
+
+Two goals dominate the choice:
+
+1. **Sign-up should be as frictionless as possible.** The intended users — household members and a
+   small inner circle of friends — already have Google accounts. The ideal sign-up is a couple of
+   clicks with no form to fill in: no username to invent, no password to choose, no email to verify.
+2. **Password handling should sit with someone else.** Storing passwords drags in a long tail of
+   complexity: secure hashing, breach response, password reset flows, account recovery, and the UX
+   for all of it. None of that is differentiating work for a recipe site. Deferring it to Google
+   removes a whole category of code, support burden, and security risk.
+
+Better Auth ([ADR 032](/projects/recipe-site/adrs/032-better-auth)) already states the social-first
+position: email/password is out of scope, Google is the default path, and GitHub is a useful
+secondary provider for technical friends. This ADR is the dedicated record of the Google OIDC
+decision itself.
+
+# Decision
+
+Use **Google OIDC** as the primary sign-in method, wired through Better Auth's `google` social
+provider:
+
+```ts
+socialProviders: {
+  google: {
+    clientId: env.GOOGLE_CLIENT_ID,
+    clientSecret: env.GOOGLE_CLIENT_SECRET,
+  },
+}
+```
+
+The supporting setup is:
+
+* A **Google Cloud project** holds the OAuth consent screen and OAuth 2.0 client credentials.
+* The client ID and secret live in the project's secret-management layer, not in the repo.
+* Authorized redirect URIs point at the backend's OAuth callback route.
+* GitHub OAuth remains the documented secondary provider; this ADR does not remove it.
+
+Sign-up and sign-in are the same gesture: a returning user who authenticates with Google lands on
+their existing account; a new user gets one created on first sign-in. There is no separate
+registration step.
+
+# Why Google OIDC
+
+| Need                              | Google OIDC fit                                                                                                       |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Frictionless sign-up**          | Target users already have Google accounts. Sign-up is a consent click — no form, no password, no email verification. |
+| **No password ownership**         | Hashing, storage, reset, and recovery flows all sit with Google rather than this codebase.                           |
+| **Lower security surface**        | No password database to breach, and no credential-stuffing target. Account-takeover risk shifts to Google's controls. |
+| **MFA handled upstream**          | Multi-factor enforcement lives at the identity provider, consistent with the deferral stance in ADR 032.             |
+| **Verified email for free**       | Google returns a verified email and basic profile, removing a verification round-trip from onboarding.               |
+| **No auth-provider cost**         | Google OAuth is $0 for normal use, consistent with the cost model in ADR 032 and ADR 033.                            |
+
+Two points matter most: the sign-up experience is about as low-friction as it gets for this
+audience, and an entire problem domain — passwords and everything around them — never enters the
+system.
+
+# Alternatives Considered
+
+## Email + password
+
+Rejected. It is the highest-friction sign-up for this audience and pulls in password storage, reset
+flows, recovery, and breach response — exactly the complexity this decision exists to avoid.
+
+## Magic links
+
+Deferred. Lower friction than passwords, but adds an email-delivery dependency and link-consumption
+edge cases (expiry, reuse, multi-device) that Google OIDC sidesteps.
+
+## GitHub OAuth as the primary provider
+
+Kept as a secondary provider, not the primary one. Most household members do not have GitHub
+accounts, so it is a worse default than Google for the intended audience, while remaining useful for
+technical friends.
+
+## Passkeys
+
+Deferred, per ADR 032. Worth revisiting later, but not necessary for MVP and not as universally
+ready for non-technical users as Google sign-in today.
+
+# Consequences
+
+## Positive
+
+* **Sign-up is a couple of clicks.** No forms, no password, no email verification step.
+* **No password complexity.** Storage, resets, recovery, and breach response are Google's
+  responsibility, not ours.
+* **Smaller security surface.** There is no password store to leak and no credential-stuffing
+  target.
+* **Cheap.** No auth-provider cost at MVP scale.
+
+## Negative
+
+* **A Google Cloud project is required.** Sign-in depends on an external GCP project with an OAuth
+  consent screen and client credentials — a setup step and an ongoing dependency that would not
+  exist with self-contained auth.
+* **Setup is currently manual.** The Google Cloud OAuth client is configured by hand in the console.
+  Whether it can be managed via Terraform/IaC is unconfirmed; until that is resolved, this is
+  console-owned configuration, which sits awkwardly with the code-first, agent-friendly principle in
+  ADR 032 and ADR 033.
+* **No preview-environment story.** OAuth requires pre-registered, static redirect URIs, so
+  ephemeral per-PR preview URLs cannot complete a Google sign-in out of the box. This conflicts with
+  the short-feedback-loop / preview-environment goals in ADR 033, and there is currently no adopted
+  solution (options to explore: a shared fixed callback host, a wildcard-tolerant proxy, or a
+  dedicated long-lived staging client).
+* **A proxy currently sits between frontend and backend.** Making the flow work in practice required
+  an additional proxy in front of the static frontend (Cloudflare Pages) and the API Worker so the
+  OAuth callback and session cookies share an origin. This is extra moving infrastructure that is
+  annoying to operate, and the reason it is needed should be understood and ideally removed rather
+  than left as folklore.
+* **Hard dependency on Google.** Users without a Google account cannot sign in via this path; GitHub
+  OAuth is the mitigation. A Google outage or account-level lockout blocks sign-in entirely.
+
+# When To Revisit
+
+Revisit this ADR if any of the following become true:
+
+* a meaningful number of intended users do not have, or do not want to use, a Google account
+* the manual Google Cloud setup becomes painful enough to justify investing in IaC for it (or Google
+  ships a workable Terraform path)
+* preview environments need real sign-in and the missing callback-URL story starts to hurt
+* the frontend/backend proxy proves removable, or conversely becomes a recurring source of bugs
+* Google changes OAuth terms, pricing, or verification requirements in a way that affects this use
+* product needs change such that owning identity directly (passwords, passkeys, magic links) becomes
+  worthwhile
+
+If Google OIDC stops being the right default, this ADR can be marked **Deprecated** in favour of a
+successor, while Better Auth (ADR 032) keeps the underlying auth layer stable through the change.

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -35,9 +35,8 @@ Two goals dominate the choice:
    removes a whole category of code, support burden, and security risk.
 
 Better Auth ([ADR 032](/projects/recipe-site/adrs/032-better-auth)) already states the social-first
-position: email/password is out of scope, Google is the default path, and GitHub is a useful
-secondary provider for technical friends. This ADR is the dedicated record of the Google OIDC
-decision itself.
+position: email/password is out of scope, and Google is the default path. This ADR is the dedicated
+record of the Google OIDC decision itself.
 
 # Decision
 
@@ -58,26 +57,64 @@ The supporting setup is:
 * A **Google Cloud project** holds the OAuth consent screen and OAuth 2.0 client credentials.
 * The client ID and secret live in the project's secret-management layer, not in the repo.
 * Authorized redirect URIs point at the backend's OAuth callback route.
-* GitHub OAuth remains the documented secondary provider; this ADR does not remove it.
 
 Sign-up and sign-in are the same gesture: a returning user who authenticates with Google lands on
 their existing account; a new user gets one created on first sign-in. There is no separate
 registration step.
 
-# Why Google OIDC
+## Infrastructure as Code
 
-| Need                              | Google OIDC fit                                                                                                       |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| **Frictionless sign-up**          | Target users already have Google accounts. Sign-up is a consent click — no form, no password, no email verification. |
-| **No password ownership**         | Hashing, storage, reset, and recovery flows all sit with Google rather than this codebase.                           |
-| **Lower security surface**        | No password database to breach, and no credential-stuffing target. Account-takeover risk shifts to Google's controls. |
-| **MFA handled upstream**          | Multi-factor enforcement lives at the identity provider, consistent with the deferral stance in ADR 032.             |
-| **Verified email for free**       | Google returns a verified email and basic profile, removing a verification round-trip from onboarding.               |
-| **No auth-provider cost**         | Google OAuth is $0 for normal use, consistent with the cost model in ADR 032 and ADR 033.                            |
+The project's standing principle (ADR 032, ADR 033) is that vendor configuration should live in code
+wherever a Terraform provider or stable API exists. Google OIDC only partly satisfies that, and the
+split is worth recording because it is a real constraint rather than an open question:
 
-Two points matter most: the sign-up experience is about as low-friction as it gets for this
-audience, and an entire problem domain — passwords and everything around them — never enters the
-system.
+| Element                                        | IaC status                                                                                                                 |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Google Cloud project                           | Terraformable (`google_project`).                                                                                          |
+| Enabling required APIs                          | Terraformable (`google_project_service`).                                                                                  |
+| Client ID / secret stored as app secrets        | Terraformable via the project's secret-management layer.                                                                   |
+| **OAuth consent screen (brand)**                | **Not** manageable as a normal web-app brand; the only Terraform resource (`google_iap_brand`) is Identity-Aware Proxy only. |
+| **OAuth 2.0 Client ID (type "Web application")** | **No Terraform resource exists.** This is the credential Sign in with Google actually uses.                                 |
+
+The gap is specific and confirmed, not unknown: the HashiCorp Google provider has no resource for a
+standard (non-IAP) web-application OAuth 2.0 Client ID. The long-running feature request
+([terraform-provider-google#16452](https://github.com/hashicorp/terraform-provider-google/issues/16452))
+is still open and unresolved. The existing `google_iap_client` resource is for Identity-Aware Proxy
+and cannot manage these credentials, and `google_iam_oauth_client` is for Workforce Identity
+Federation, not Sign in with Google.
+
+The consequence for this decision: the project and its APIs can be Terraformed, but **creating the
+OAuth consent screen and the web OAuth client is a manual Google Cloud Console step**. The resulting
+client ID and secret are then fed into the secret-management layer, which *is* code-owned. This is
+the one piece of console-owned configuration this decision introduces, and it is bounded — it
+happens once per environment and produces values that the rest of the pipeline can consume as code.
+
+## Same-Origin Proxy
+
+Google OIDC with Better Auth needs the auth/API backend to be reachable on the **same origin** as the
+static frontend. That has a concrete cause worth recording so it is not treated as folklore.
+
+The site's frontend is a static export on Cloudflare Pages; the auth/API layer is a separate
+Cloudflare Worker ([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)).
+If those sit on different origins (for example `recipes.example.com` and `api.example.com`), the
+sign-in flow breaks on cookies:
+
+* Better Auth sets the session cookie during the OAuth callback on the **Worker's** origin.
+* A cookie set on `api.example.com` is not sent on requests to `recipes.example.com`, so the user
+  appears unauthenticated even though the OAuth exchange succeeded.
+* The cross-site workaround (`SameSite=None`) is increasingly blocked by browsers' third-party-cookie
+  restrictions, so it is not a durable fix.
+
+The remedy is to put the Worker behind the **same origin** as the site — for example routing
+`/api/*` on the site's domain to the Worker via a proxy. Then the session cookie is first-party and
+is sent on every request, and Google has a single stable callback URL on that one origin. This is the
+[backend-for-frontend](https://github.com/better-auth/better-auth/issues/7657) pattern, not a quirk
+of one deployment.
+
+The decision here is therefore explicit: **the deployment will front the auth Worker on the site's
+own origin** rather than expose it on a separate host. The exact mechanism (a Pages route/proxy, a
+Cloudflare route binding, or equivalent) is an implementation detail left to the backend work, but
+the same-origin requirement itself is a property of the cookie/OAuth flow and is not optional.
 
 # This Is A Default, Not An Exclusive Choice
 
@@ -95,23 +132,22 @@ others out.
 
 ## Other OIDC providers
 
-| Provider   | Status for this site         | How it compares to Google                                                                                                                                                            |
-| ---------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Google** | **Primary (this ADR)**       | Near-universal account ownership in the target audience, lowest-friction consent, verified email, no provider cost.                                                                   |
-| **GitHub** | Secondary, already supported | Same OAuth shape and effort as Google, but most household members do not have GitHub accounts — a worse *default*, a good *complement* for technical friends. Already wired in 032.   |
-| **Apple**  | Deferred                     | Strong fit for iOS users and sometimes required by App Store policy, but adds the recurring **client-secret rotation** burden called out in ADR 032. Worth adding on a real iOS need. |
+| Provider   | Status for this site   | How it compares to Google                                                                                                                                                                                        |
+| ---------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Google** | **Primary (this ADR)** | Near-universal account ownership in the target audience, lowest-friction consent, verified email, no provider cost.                                                                                               |
+| **Apple**  | Deferred               | Strong fit for iOS users and sometimes required by App Store policy, but **requires a paid Apple Developer Program membership ($99/year)** and carries the recurring client-secret rotation burden noted in ADR 032. Worth adding on a real iOS need. |
 
-GitHub and Apple are the same kind of decision as Google — federated OIDC, no passwords held here —
-so they stack cleanly alongside it. The only reason Google leads is audience fit, not a technical
-advantage.
+Apple is the same *kind* of decision as Google — federated OIDC, no passwords held here — so it
+stacks cleanly alongside it. The reasons Google leads are audience fit and that it has no membership
+fee, not a technical advantage.
 
 ## Non-OIDC methods
 
-| Method               | Status       | How it compares to Google                                                                                                                                                                                |
-| -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Email + password** | Out of scope | The highest-friction sign-up for this audience and the one that drags in password storage, resets, recovery, and breach response — the exact complexity this decision exists to avoid. Not planned.       |
-| **Magic links**      | Deferred     | Passwordless like Google, but adds an email-delivery dependency and link-consumption edge cases (expiry, reuse, multi-device) that a federated provider sidesteps. A reasonable *fallback* for non-Google users. |
-| **Passkeys**         | Deferred     | The strongest long-term direction: phishing-resistant and passwordless. Less universally ready for non-technical users today, and best added as an *enhancement* on top of an existing account rather than the first-run path. |
+| Method               | Status       | How it compares to Google                                                                                                                                                                                                          |
+| -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Email + password** | Out of scope | The highest-friction sign-up for this audience and the one that drags in password storage, resets, recovery, and breach response — the exact complexity this decision exists to avoid. Not planned.                                |
+| **Magic links**      | Deferred     | Passwordless like Google, but adds an email-delivery dependency and link-consumption edge cases (expiry, reuse, multi-device) that a federated provider sidesteps. A reasonable *fallback* for users without a Google account.     |
+| **Passkeys**         | Deferred     | The strongest long-term direction: phishing-resistant and passwordless. Less universally ready for non-technical users today, and best added as an *enhancement* on top of an existing account rather than the first-run path.     |
 
 Magic links and passkeys are not competitors to Google here so much as future layers: magic links as
 a no-account-required fallback, passkeys as a step-up once a user exists. Neither needs to displace
@@ -126,39 +162,40 @@ Google to be worth adding.
   responsibility, not ours.
 * **Smaller security surface.** There is no password store to leak and no credential-stuffing
   target.
-* **Cheap.** No auth-provider cost at MVP scale.
+* **Cheap.** No auth-provider cost and no membership fee at MVP scale.
 
 ## Negative
 
 * **A Google Cloud project is required.** Sign-in depends on an external GCP project with an OAuth
   consent screen and client credentials — a setup step and an ongoing dependency that would not
   exist with self-contained auth.
-* **Setup is currently manual.** The Google Cloud OAuth client is configured by hand in the console.
-  Whether it can be managed via Terraform/IaC is unconfirmed; until that is resolved, this is
-  console-owned configuration, which sits awkwardly with the code-first, agent-friendly principle in
-  ADR 032 and ADR 033.
+* **The OAuth client cannot be created via IaC.** As detailed above, the project and APIs are
+  Terraformable but the OAuth consent screen and web OAuth 2.0 Client ID are not — they are a manual
+  console step. This is one bounded piece of console-owned configuration, mitigated by storing the
+  resulting credentials in the code-owned secret layer.
+* **A same-origin proxy is needed.** The auth Worker must be fronted on the site's own origin so the
+  session cookie stays first-party; running it on a separate host breaks sign-in. This is extra
+  routing infrastructure to operate, justified by the cookie/OAuth flow rather than incidental.
 * **No preview-environment story.** OAuth requires pre-registered, static redirect URIs, so
   ephemeral per-PR preview URLs cannot complete a Google sign-in out of the box. This conflicts with
-  the short-feedback-loop / preview-environment goals in ADR 033, and there is currently no adopted
-  solution (options to explore: a shared fixed callback host, a wildcard-tolerant proxy, or a
-  dedicated long-lived staging client).
-* **A proxy currently sits between frontend and backend.** Making the flow work in practice required
-  an additional proxy in front of the static frontend (Cloudflare Pages) and the API Worker so the
-  OAuth callback and session cookies share an origin. This is extra moving infrastructure that is
-  annoying to operate, and the reason it is needed should be understood and ideally removed rather
-  than left as folklore.
-* **Hard dependency on Google.** Users without a Google account cannot sign in via this path; GitHub
-  OAuth is the mitigation. A Google outage or account-level lockout blocks sign-in entirely.
+  the short-feedback-loop / preview-environment goals in ADR 033, and there is no obvious solution
+  yet (options to explore: a shared fixed callback host, a wildcard-tolerant proxy, or a dedicated
+  long-lived staging client).
+* **Hard dependency on Google.** Users without a Google account cannot sign in via this path; a
+  deferred fallback such as magic links would be the mitigation. A Google outage or account-level
+  lockout blocks sign-in entirely.
 
 # When To Revisit
 
 Revisit this ADR if any of the following become true:
 
 * a meaningful number of intended users do not have, or do not want to use, a Google account
-* the manual Google Cloud setup becomes painful enough to justify investing in IaC for it (or Google
-  ships a workable Terraform path)
+* the manual Google Cloud setup becomes painful enough to justify scripting it (or Google ships a
+  Terraform-supported OAuth client resource — track
+  [terraform-provider-google#16452](https://github.com/hashicorp/terraform-provider-google/issues/16452))
 * preview environments need real sign-in and the missing callback-URL story starts to hurt
-* the frontend/backend proxy proves removable, or conversely becomes a recurring source of bugs
+* the same-origin proxy becomes a recurring source of bugs, or a simpler topology removes the need
+  for it
 * Google changes OAuth terms, pricing, or verification requirements in a way that affects this use
 * another method (passkeys, magic links, or another provider) becomes a better *default* than Google
   for first-run sign-up — note that merely *adding* one of these alongside Google does not need this

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -79,28 +79,43 @@ Two points matter most: the sign-up experience is about as low-friction as it ge
 audience, and an entire problem domain — passwords and everything around them — never enters the
 system.
 
-# Alternatives Considered
+# This Is A Default, Not An Exclusive Choice
 
-## Email + password
+Choosing Google as the primary sign-in method does **not** preclude any other method. Better Auth
+([ADR 032](/projects/recipe-site/adrs/032-better-auth)) treats sign-in methods as additive
+configuration: each social provider is a few lines, and magic links and passkeys are plugins. Adding
+a second provider or method later does not require revisiting this ADR — it is expected headroom, not
+a reversal.
 
-Rejected. It is the highest-friction sign-up for this audience and pulls in password storage, reset
-flows, recovery, and breach response — exactly the complexity this decision exists to avoid.
+What this ADR fixes is the **default**: the path the sign-in screen leads with, and the one onboarding
+is optimised for. The comparison below is therefore about *what to lead with*, not about ruling the
+others out.
 
-## Magic links
+# How Google Compares To The Alternatives
 
-Deferred. Lower friction than passwords, but adds an email-delivery dependency and link-consumption
-edge cases (expiry, reuse, multi-device) that Google OIDC sidesteps.
+## Other OIDC providers
 
-## GitHub OAuth as the primary provider
+| Provider   | Status for this site         | How it compares to Google                                                                                                                                                            |
+| ---------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Google** | **Primary (this ADR)**       | Near-universal account ownership in the target audience, lowest-friction consent, verified email, no provider cost.                                                                   |
+| **GitHub** | Secondary, already supported | Same OAuth shape and effort as Google, but most household members do not have GitHub accounts — a worse *default*, a good *complement* for technical friends. Already wired in 032.   |
+| **Apple**  | Deferred                     | Strong fit for iOS users and sometimes required by App Store policy, but adds the recurring **client-secret rotation** burden called out in ADR 032. Worth adding on a real iOS need. |
 
-Kept as a secondary provider, not the primary one. Most household members do not have GitHub
-accounts, so it is a worse default than Google for the intended audience, while remaining useful for
-technical friends.
+GitHub and Apple are the same kind of decision as Google — federated OIDC, no passwords held here —
+so they stack cleanly alongside it. The only reason Google leads is audience fit, not a technical
+advantage.
 
-## Passkeys
+## Non-OIDC methods
 
-Deferred, per ADR 032. Worth revisiting later, but not necessary for MVP and not as universally
-ready for non-technical users as Google sign-in today.
+| Method               | Status       | How it compares to Google                                                                                                                                                                                |
+| -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Email + password** | Out of scope | The highest-friction sign-up for this audience and the one that drags in password storage, resets, recovery, and breach response — the exact complexity this decision exists to avoid. Not planned.       |
+| **Magic links**      | Deferred     | Passwordless like Google, but adds an email-delivery dependency and link-consumption edge cases (expiry, reuse, multi-device) that a federated provider sidesteps. A reasonable *fallback* for non-Google users. |
+| **Passkeys**         | Deferred     | The strongest long-term direction: phishing-resistant and passwordless. Less universally ready for non-technical users today, and best added as an *enhancement* on top of an existing account rather than the first-run path. |
+
+Magic links and passkeys are not competitors to Google here so much as future layers: magic links as
+a no-account-required fallback, passkeys as a step-up once a user exists. Neither needs to displace
+Google to be worth adding.
 
 # Consequences
 
@@ -145,8 +160,9 @@ Revisit this ADR if any of the following become true:
 * preview environments need real sign-in and the missing callback-URL story starts to hurt
 * the frontend/backend proxy proves removable, or conversely becomes a recurring source of bugs
 * Google changes OAuth terms, pricing, or verification requirements in a way that affects this use
-* product needs change such that owning identity directly (passwords, passkeys, magic links) becomes
-  worthwhile
+* another method (passkeys, magic links, or another provider) becomes a better *default* than Google
+  for first-run sign-up — note that merely *adding* one of these alongside Google does not need this
+  ADR revisited
 
 If Google OIDC stops being the right default, this ADR can be marked **Deprecated** in favour of a
 successor, while Better Auth (ADR 032) keeps the underlying auth layer stable through the change.

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -75,7 +75,7 @@ split:
 | Enabling required APIs                          | Terraformable (`google_project_service`).                                                                                  |
 | Client ID / secret stored as app secrets        | Terraformable via the project's secret-management layer.                                                                   |
 | **OAuth consent screen (brand)**                | **Not** manageable as a normal web-app brand; the only Terraform resource (`google_iap_brand`) is Identity-Aware Proxy only. |
-| **OAuth 2.0 Client ID (type "Web application")** | **No Terraform resource exists.** This is the credential Sign in with Google actually uses.                                 |
+| **OAuth 2.0 Client ID (type "Web application")** | **No Terraform resource exists.** This is the credential the sign-in flow depends on.                                       |
 
 The gap is specific and confirmed, not unknown: the HashiCorp Google provider has no resource for a
 standard (non-IAP) web-application OAuth 2.0 Client ID. The long-running feature request

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -149,13 +149,14 @@ fee, not a technical advantage.
 | -------------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Email + password** | Out of scope | The highest-friction sign-up for this audience and the one that drags in password storage, resets, recovery, and breach response — the exact complexity this decision exists to avoid. Not planned.                                |
 | **Magic links**      | Deferred     | Passwordless like Google, but adds an email-delivery dependency and link-consumption edge cases (expiry, reuse, multi-device) that a federated provider sidesteps. A reasonable *fallback* for users without a Google account.     |
-| **Passkeys**         | Deferred     | Phishing-resistant and passwordless, and the strongest long-term direction. The catch: passkeys only deliver that security if they are the sole or required way in. While Google sign-in stays enabled beside them, the account is only as phishing-resistant as Google's flow, because an attacker falls back to it — so bolting passkeys on as an optional extra is mostly convenience until they gate or replace the weaker method, which works against the Google-first, low-friction goal. Also less universally ready for non-technical users today. |
+| **Passkeys**         | Deferred     | Phishing-resistant and passwordless, and the strongest long-term direction. The security ceiling is **per account**: a user who registers only a passkey gets the full guarantee, and is unaffected by which methods other users or the system offer. It is only diluted for a user who links *both* a passkey and a weaker method (e.g. Google) to the *same* account, since an attacker can then fall back to the weaker one. So passkeys deliver real value as soon as any individual wants stronger protection — they do not require replacing Google system-wide. Still less universally ready for non-technical users today. |
 
 Magic links and passkeys are future layers rather than competitors. Magic links would be a
-no-account-required fallback for users without Google. Passkeys are the harder call: their
-phishing-resistance only counts if they become the sole or required factor, so adding them while
-Google stays enabled raises convenience more than security. They are worth the headline benefit only
-if they eventually gate the account rather than sit beside Google as one option among several.
+no-account-required fallback for users without Google. Passkeys give individual users full
+phishing-resistance: a passkey-only account is unaffected by the methods other people use, and the
+guarantee is only diluted if a single account links a passkey alongside a weaker method like Google.
+So passkeys are worth adding whenever a user wants stronger protection, with no need to drop Google
+for everyone else.
 
 # Consequences
 
@@ -206,5 +207,7 @@ Revisit this ADR if any of the following become true:
   for first-run sign-up — note that merely *adding* one of these alongside Google does not need this
   ADR revisited
 
-If Google OIDC stops being the right default, this ADR can be marked **Deprecated** in favour of a
-successor, while Better Auth (ADR 032) keeps the underlying auth layer stable through the change.
+This ADR stays **Accepted** for as long as Google is offered as a sign-in option, even if it stops
+being the default. Losing default status is a reason to update this ADR, not to deprecate it. It
+would only move to **Deprecated** if Google sign-in were removed entirely, and Better Auth (ADR 032)
+keeps the underlying auth layer stable through any such change.

--- a/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
+++ b/ui/content/projects/recipe-site/adrs/036-google-oidc-login.mdx
@@ -66,8 +66,8 @@ registration step.
 ## Infrastructure as Code
 
 The project's standing principle (ADR 032, ADR 033) is that vendor configuration should live in code
-wherever a Terraform provider or stable API exists. Google OIDC only partly satisfies that, and the
-split is worth recording because it is a real constraint rather than an open question:
+wherever a Terraform provider or stable API exists. Google OIDC only partly satisfies that. The
+split:
 
 | Element                                        | IaC status                                                                                                                 |
 | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -735,4 +735,13 @@ export const technologies: TechnologyContent[] = [
     website: "https://neon.com",
     type: "database",
   },
+  {
+    name: "Google Identity Platform",
+    added: "2026-06-19",
+    description:
+      "Sign in with Google via OAuth 2.0 / OpenID Connect, configured through a Google Cloud project",
+    website: "https://developers.google.com/identity",
+    iconSlug: "google",
+    type: "platform",
+  },
 ];

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -736,7 +736,7 @@ export const technologies: TechnologyContent[] = [
     type: "database",
   },
   {
-    name: "Google Identity Platform",
+    name: "Google OAuth",
     added: "2026-06-19",
     description:
       "Sign in with Google via OAuth 2.0 / OpenID Connect, configured through a Google Cloud project",


### PR DESCRIPTION
Formalize the Google OIDC sign-in decision referenced in ADR 032, with
explicit pros and cons and an Accepted status that can be deprecated later.

Add a Google Identity Platform technology entry to back the ADR tech_stack.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ERK5Tk2nfBggSgipki7gyC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Added a new architecture decision record documenting Google OIDC as the recipe site’s default sign-in method, including key configuration, deployment, and operational constraints
- Captured the rationale by comparing Google with alternative authentication options and trade-offs
- Updated authentication and environment considerations for the sign-in workflow
- Extended the technology stack documentation to include **Google OAuth**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->