### PR TITLE
Add last-login-method plugin with "Last used" provider hint

### DIFF
--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -2,7 +2,7 @@
 
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { ChevronDown, LoaderCircle, LogIn, LogOut } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { siGithub, siGoogle } from "simple-icons";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
@@ -36,6 +36,17 @@ export function AuthButton() {
     null,
   );
   const [accountsError, setAccountsError] = useState(false);
+  const [lastUsedProvider, setLastUsedProvider] = useState<Provider | null>(
+    null,
+  );
+
+  // Read from the client-side cookie after mount to avoid a hydration mismatch.
+  useEffect(() => {
+    const method = authClient.getLastUsedLoginMethod();
+    if (method === "google" || method === "github") {
+      setLastUsedProvider(method);
+    }
+  }, []);
 
   async function loadLinkedAccounts() {
     setAccountsError(false);
@@ -225,6 +236,11 @@ export function AuthButton() {
                   <ProviderIcon path={provider.iconPath} />
                 )}
                 Continue with {provider.name}
+                {lastUsedProvider === provider.id && (
+                  <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
+                    Last used
+                  </span>
+                )}
               </Button>
             ))}
           </div>

--- a/ui/lib/auth-client.ts
+++ b/ui/lib/auth-client.ts
@@ -1,7 +1,7 @@
-import { adminClient } from "better-auth/client/plugins";
+import { adminClient, lastLoginMethodClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
   basePath: "/api/auth",
-  plugins: [adminClient()],
+  plugins: [adminClient(), lastLoginMethodClient()],
 });

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   signInSocial: vi.fn(),
   signOut: vi.fn(),
   listAccounts: vi.fn(),
+  getLastUsedLoginMethod: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -15,6 +16,7 @@ vi.mock("@/lib/auth-client", () => ({
     signIn: { social: mocks.signInSocial },
     signOut: mocks.signOut,
     listAccounts: mocks.listAccounts,
+    getLastUsedLoginMethod: mocks.getLastUsedLoginMethod,
   },
 }));
 
@@ -27,6 +29,7 @@ describe("AuthButton", () => {
     mocks.signInSocial.mockResolvedValue({ data: null, error: null });
     mocks.signOut.mockResolvedValue({ data: null, error: null });
     mocks.listAccounts.mockResolvedValue({ data: [], error: null });
+    mocks.getLastUsedLoginMethod.mockReturnValue(null);
   });
 
   it("lets the user choose Google or GitHub", async () => {
@@ -41,6 +44,21 @@ describe("AuthButton", () => {
     expect(
       screen.getByRole("button", { name: "Continue with GitHub" }),
     ).toBeInTheDocument();
+  });
+
+  it("marks the last used provider", async () => {
+    const user = userEvent.setup();
+    mocks.getLastUsedLoginMethod.mockReturnValue("google");
+    render(<AuthButton />);
+
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(
+      screen.getByRole("button", { name: /Continue with Google/ }),
+    ).toHaveTextContent("Last used");
+    expect(
+      screen.getByRole("button", { name: /Continue with GitHub/ }),
+    ).not.toHaveTextContent("Last used");
   });
 
   it("starts the selected provider flow and preserves the current page", async () => {

--- a/workers/recipe-api/src/auth.ts
+++ b/workers/recipe-api/src/auth.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth";
-import { admin } from "better-auth/plugins";
+import { admin, lastLoginMethod } from "better-auth/plugins";
 import { withCloudflare } from "better-auth-cloudflare";
 import type { createDb } from "./db";
 import * as schema from "./db/schema";
@@ -30,7 +30,7 @@ export function createAuth(
         geolocationTracking: false,
       },
       {
-        plugins: [admin()],
+        plugins: [admin(), lastLoginMethod()],
         emailAndPassword: { enabled: false },
         socialProviders: {
           google: {


### PR DESCRIPTION
## Summary

Adds the better-auth [last-login-method](https://better-auth.com/docs/plugins/last-login-method) plugin and surfaces which social provider was last used in the sign-in UI.

- **Server** (`workers/recipe-api/src/auth.ts`): registers the `lastLoginMethod()` plugin alongside `admin()`, so better-auth records the last-used provider in a cookie.
- **Client** (`ui/lib/auth-client.ts`): adds the matching `lastLoginMethodClient()` plugin, exposing `authClient.getLastUsedLoginMethod()`.
- **UI** (`ui/components/recipes/auth-button.tsx`): the sign-in menu reads the last-used method (in a `useEffect`, since it reads a cookie, to avoid a hydration mismatch) and renders a small **"Last used"** badge next to whichever button — Google or GitHub — was last used.
- **Tests**: adds the `getLastUsedLoginMethod` mock and a test asserting the badge appears on the correct provider.

## Approach note

This uses the plugin's cookie-based mode, which shows the hint on the **sign-in buttons** and needs no DB migration. The plugin also supports `storeInDatabase: true`, which adds a `lastLoginMethod` column to the `user` table (accessible via `session.user.lastLoginMethod`) — useful if the hint should instead appear in the signed-in account popover. Happy to switch if preferred.

## Verification

- `recipe-api` typecheck + tests: 9 passed
- `ui` typecheck: clean
- `ui` auth-button tests: 5 passed
- `ui` lint: no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSVTPjMtJNpXRA2FKuZ2LP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- The sign-in screen now displays a "Last used" indicator next to your previously selected authentication provider, making it quicker to sign back in. This enhancement applies to all supported providers, including Google and GitHub.

## Tests
- Added test coverage for the new "last used provider" tracking functionality to verify correct behaviour across all authentication methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->