### PR TITLE
[codex] Push recipe schema before Worker deployment

### DIFF
--- a/.github/workflows/recipe-api-cd.yml
+++ b/.github/workflows/recipe-api-cd.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Push database schema
+        run: pnpm db:push:ci
+        env:
+          DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }}
+
       - name: Deploy worker
         run: npx wrangler deploy
         env:

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -12,7 +12,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "db:push:ci": "drizzle-kit push --force",
+    "db:push:ci": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -12,6 +12,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
+    "db:push:ci": "drizzle-kit push --force",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- add a non-interactive `db:push:ci` command for the recipe API
- push the Drizzle schema before deploying the Cloudflare Worker
- keep the current schema-push workflow while the project is still pre-migrations

## Root cause

The Better Auth admin plugin added fields to the Drizzle schema, but the production Worker was deployed without applying those schema changes to Neon. OAuth callbacks then failed when Better Auth queried the missing user and session columns. The later last-login-method change made the timing look related but did not require a database migration itself.

## Impact

Future recipe API deployments apply schema changes before new Worker code begins serving requests, preventing code/schema drift during the current prototyping phase.

The missing production columns were pushed separately while diagnosing the incident, restoring the database schema immediately.

## Validation

- `pnpm --filter recipe-api test` (9 tests passed)
- `pnpm --filter recipe-api typecheck`
- `pnpm exec yamllint .github/workflows/recipe-api-cd.yml`
- ran `pnpm db:push:ci` twice against Neon; the second run reported no changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment processes to include database schema synchronisation before worker deployment, improving deployment reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->