### PR TITLE
[codex] Fix Renovate lockfile release-age check

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,11 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "major"],
       "automerge": true
+    },
+    {
+      "description": "Disable release age for lockfile maintenance",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "minimumReleaseAge": null
     }
   ]
 }


### PR DESCRIPTION
## Summary

- disable `minimumReleaseAge` for lockfile-maintenance updates
- retain the existing release-age policy for normal dependency updates

## Root cause

Renovate cannot evaluate minimum release age for `lockFileMaintenance` updates because resolution is delegated to the package manager. The repository-wide seven-day setting therefore leaves `renovate/stability-days` pending indefinitely on lockfile-maintenance PRs.

## Impact

Weekly lockfile-maintenance PRs can become green and automerge normally. Dependency update PRs continue to observe their existing release-age requirements.

## Validation

- parsed `renovate.json` successfully with Node
- `git diff --check` passed
- pre-commit hook passed
- `mise //:lint` was attempted; repository Markdown/YAML/UI checks ran, but the aggregate task stopped at Terraform initialization because this environment has no HCP Terraform token. UI lint also reported existing warnings unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package maintenance configuration to improve the handling of dependency lock file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->