### PR TITLE
Share coding agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Project Guide for Claude
+# Project Guide for Coding Agents
 
 ## Build System
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Personal website with blog and interactive resume.
 - **Dependency Management:** Renovate (automated PRs)
 - **Code Review:** [CodeRabbit](https://coderabbit.ai/) (AI-powered PR reviews)
 - **Project Management:** Shortcut (see [ADR 034](ui/content/projects/personal-site/adrs/034-shortcut.mdx))
-- **AI Pair Programming:** Claude (see [claude.md](claude.md) for agent guide)
+- **AI Pair Programming:** Claude (see [AGENTS.md](AGENTS.md) for agent guide)
 
 ## Setup
 
@@ -307,7 +307,7 @@ These require manual testing since preview generation happens on external platfo
 
 ## AI Coding Agent Guide
 
-If you're an AI coding agent (like Claude), read **[claude.md](claude.md)** for:
+If you're an AI coding agent (like Claude), read **[AGENTS.md](AGENTS.md)** for:
 
 - Build system details (mise usage)
 - Project structure and conventions

--- a/ui/content/blog/README.md
+++ b/ui/content/blog/README.md
@@ -541,4 +541,4 @@ A: Yes, MDX supports both Markdown and JSX/HTML syntax.
 **Internal:**
 
 - [Main README](../../../README.md) - Project overview and tech stack
-- [claude.md](../../../claude.md) - AI agent guide (includes build system details)
+- [AGENTS.md](../../../AGENTS.md) - AI agent guide (includes build system details)

--- a/ui/content/projects/personal-site/adrs/012-claude-code.mdx
+++ b/ui/content/projects/personal-site/adrs/012-claude-code.mdx
@@ -20,7 +20,7 @@ I will use **[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overvi
 This involves committing to its specific configuration infrastructure:
 
 * `.claude/` directory for tool-specific settings.
-* `claude.md` for providing high-level project context and architectural guidelines specifically formatted for this agent.
+* `CLAUDE.md` for Claude Code discovery, importing the shared project context and architectural guidelines from `AGENTS.md`.
 
 # Alternatives
 
@@ -35,10 +35,10 @@ This involves committing to its specific configuration infrastructure:
 * **Augment Code**: Optimizes for extreme speed and enterprise context.
 * **Reasoning**: While these are strong competitors, **Claude Code** provides the native, unmediated experience with the specific models (Claude 4.5 Sonnet, Opus) that I find most effective for complex reasoning tasks.
 
-## Standardized Config (`agents.md`)
+## Standardized Config (`AGENTS.md`)
 
 * **Pros**: Open standard for defining agent context, avoiding tool-specific files.
-* **Cons**: Claude Code reads `claude.md` natively and effectively. I am accepting the trade-off of using a tool-specific context file for better immediate results.
+* **Cons**: At the time of this decision, Claude Code relied on its tool-specific context file for native loading. The repository now preserves native discovery through `CLAUDE.md` while sharing the actual instructions through `AGENTS.md`.
 
 *Note: **Antigravity** is not considered in this ADR as it is a newer development than when this decision was originally made.*
 
@@ -47,7 +47,7 @@ This involves committing to its specific configuration infrastructure:
 ### Pros
 
 * **Velocity**: I can ship features significantly faster by delegating implementation details.
-* **Context Management**: Centralizing project knowledge in `claude.md` ensures the agent stays aligned with the project's evolving architecture.
+* **Context Management**: Centralizing project knowledge in `AGENTS.md` ensures coding agents stay aligned with the project's evolving architecture; `CLAUDE.md` imports it for Claude Code.
 * **Synergy**: Necessitates robust testing \[ADR 008] and review \[ADR 009] to verify the agent's output.
 
 ### Cons


### PR DESCRIPTION
## Summary

- rename the existing duplicated `claude.md` instructions to the agent-neutral `AGENTS.md`
- use an agent-neutral document heading
- add the canonical uppercase `CLAUDE.md` containing only `@AGENTS.md`

## Why

Claude Code supports importing instruction files with `@path/to/import` and specifically recommends importing `AGENTS.md` from `CLAUDE.md` when a repository supports multiple coding agents. This keeps one source of truth while preserving native discovery for both tools.

Documentation: https://code.claude.com/docs/en/memory#agents-md

The uppercase filename also matches Claude Code's documented convention and works correctly on case-sensitive filesystems.

## Impact

Codex and other `AGENTS.md`-aware tools read the shared instructions directly. Claude Code loads the same instructions through `CLAUDE.md` without duplicated content.

## Validation

- `mise //:lint:markdown:check AGENTS.md CLAUDE.md`
- repository pre-commit hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganised AI coding agent documentation to centralise guidance resources and improve discoverability.
  * Updated internal and external documentation references to reflect the restructured documentation architecture.
  * Consolidated shared project context and architectural guidelines into a unified, easily maintainable reference guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->