### PR TITLE
[codex] Add Gemini Code Assist ADR

### DIFF
--- a/ui/content/projects/personal-site/adrs/041-gemini-code-assist.mdx
+++ b/ui/content/projects/personal-site/adrs/041-gemini-code-assist.mdx
@@ -1,0 +1,60 @@
+---
+title: "ADR 041: Gemini Code Assist"
+date: "2026-06-20"
+status: "Accepted"
+tech_stack: ["Google Gemini"]
+---
+
+# Context
+
+[ADR 009: CodeRabbit](/projects/personal-site/adrs/009-code-rabbit) records the decision to use automated AI review on Pull Requests and the broader reasons for keeping a review step in a solo-development workflow. This ADR does not repeat that rationale. It records why I added a second automated reviewer.
+
+Relying on one review provider creates two risks:
+
+1. **Review Blind Spots**: AI reviewers differ in the issues they notice and the recommendations they make. A single reviewer can repeatedly miss the same classes of problem.
+2. **Provider Dependency**: A pricing, product, or availability change from CodeRabbit could remove the review step or slow down delivery while I evaluate a replacement.
+
+Gemini Code Assist on GitHub has been available at no cost for public open-source repositories, making it possible to reduce these risks without adding a financial commitment.
+
+# Decision
+
+I will use **[Gemini Code Assist on GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code)** alongside CodeRabbit for automated code review on Pull Requests.
+
+Gemini Code Assist is a complementary reviewer, not a replacement for CodeRabbit. The value comes from receiving an independent review from a different provider and model family. Its feedback often diverges from CodeRabbit's, increasing the chance that one reviewer identifies an issue or alternative that the other misses.
+
+# Alternatives
+
+## CodeRabbit Only
+
+* **Pros**: Fewer review comments to process and only one service to configure.
+* **Cons**: Concentrates review coverage and workflow continuity in one provider. A CodeRabbit pricing or product change could interrupt the review workflow and reduce delivery velocity.
+* **Decision**: Rejected. Gemini Code Assist adds useful diversity at no cost for this public repository.
+
+## Replace CodeRabbit with Gemini Code Assist
+
+* **Pros**: Retains a single automated reviewer while avoiding dependence on CodeRabbit.
+* **Cons**: Loses CodeRabbit's accumulated learnings and removes the diversity of feedback that justifies adopting Gemini Code Assist.
+* **Decision**: Rejected. The services provide more value together than either provides alone.
+
+# Consequences
+
+## Positive
+
+* **Diverse Feedback**: Independent reviewers surface different concerns, interpretations, and implementation options.
+* **Reduced Provider Risk**: The review workflow is less exposed to pricing or availability changes from CodeRabbit.
+* **Maintained Velocity**: If one reviewer becomes unavailable or uneconomical, the other can continue reviewing PRs while a replacement is evaluated.
+* **No Additional Cost**: The consumer GitHub integration has been free for public open-source repositories.
+
+## Negative
+
+* **Additional Noise**: Two AI reviewers can produce duplicate, conflicting, or low-value comments that take time to assess.
+* **No Guaranteed Consensus**: Agreement between two AI reviewers does not prove that a change is correct, and disagreement still requires human judgement.
+* **Second Provider Dependency**: The approach reduces dependence on CodeRabbit but introduces dependence on Google's continued support for the integration.
+
+# Planned Deprecation
+
+Google has announced the **[sunset of the consumer version of Gemini Code Assist on GitHub](https://developers.google.com/gemini-code-assist/docs/deprecations/consumer-code-review)**. New consumer installations are blocked from June 18, 2026, and consumer code review activity will cease on July 17, 2026. The enterprise version is not affected.
+
+This ADR remains **Accepted** while the existing installation continues to review Pull Requests. Unless the enterprise version is adopted, its status should change to **Deprecated** when consumer review activity ceases on July 17, 2026.
+
+The enterprise GitHub integration is currently in Preview and requires Google Cloud billing, IAM configuration, and a Developer Connect connection in `us-east1`. Google does not publish product-specific pricing for it. Its uncertain post-preview cost and additional operational overhead make it unsuitable as a direct continuation of the original no-cost decision.

--- a/ui/content/projects/recipe-site/adrs/038-gemini-code-assist.mdx
+++ b/ui/content/projects/recipe-site/adrs/038-gemini-code-assist.mdx
@@ -1,0 +1,3 @@
+---
+inherits_from: "personal-site:041-gemini-code-assist"
+---


### PR DESCRIPTION
## Summary

- add ADR 041 documenting the use of Gemini Code Assist alongside CodeRabbit
- inherit the decision into the Recipe Site as ADR 038
- record reviewer diversity, provider resilience, and the no-cost open-source offering as decision drivers
- document the consumer sunset timeline and why the enterprise GitHub preview is not a direct continuation

## Impact

Provides both projects with the context behind adopting Gemini Code Assist and its planned deprecation after consumer reviews cease.

## Validation

- MDX lint passed for both ADR files
- `pnpm --dir ui exec vitest run tests/lib/domain/repository.test.ts` (21 tests passed)
- pre-commit checks passed