### PR TITLE
[codex] Add Greptile ADR

### DIFF
--- a/ui/content/projects/personal-site/adrs/042-greptile.mdx
+++ b/ui/content/projects/personal-site/adrs/042-greptile.mdx
@@ -1,0 +1,56 @@
+---
+title: "ADR 042: Greptile"
+date: "2026-06-20"
+status: "Accepted"
+tech_stack: ["Greptile"]
+---
+
+# Context
+
+[ADR 009: CodeRabbit](/projects/personal-site/adrs/009-code-rabbit) records the decision to use automated AI review on Pull Requests. [ADR 041: Gemini Code Assist](/projects/personal-site/adrs/041-gemini-code-assist) records why a second, independent reviewer adds value without repeating that general rationale.
+
+This ADR records an existing decision retrospectively. Greptile was added while both CodeRabbit and Gemini Code Assist were already reviewing the project. The goal was to add a third, materially different review approach rather than depend on two reviewers that could share similar blind spots.
+
+The additional reviewer also reduces dependence on either existing provider. This matters if pricing, product direction, or availability changes, but was a general resilience concern rather than a response to a known deprecation.
+
+# Decision
+
+I will use **[Greptile](https://www.greptile.com/)** alongside CodeRabbit and Gemini Code Assist for automated code review on Pull Requests.
+
+Greptile builds a graph of the whole codebase, including relationships between functions, files, and dependencies. It uses that graph to reason about the effect of a diff beyond the changed lines. This gives it a useful emphasis on cross-file behaviour, coupling, and architectural consistency that complements CodeRabbit's broader PR summaries, walkthroughs, and first-pass workflow coverage.
+
+Greptile also learns from reactions to its comments and supports related pattern repositories as additional review context. These mechanisms provide another source of contextual feedback without depending on CodeRabbit's accumulated learnings.
+
+Greptile's **[Open Source Program](https://www.greptile.com/open-source)** provides eligible non-commercial open-source projects with a 100% discount. This allowed the project to add a third reviewer without a financial commitment.
+
+# Alternatives
+
+## CodeRabbit and Gemini Code Assist Only
+
+* **Pros**: Fewer comments and one less external review service to configure.
+* **Cons**: Misses Greptile's graph-based whole-codebase analysis and leaves review coverage dependent on two providers.
+* **Decision**: Rejected. Greptile adds a distinct review approach at no cost to qualifying open-source projects.
+
+## Replace CodeRabbit with Greptile
+
+* **Pros**: Greptile's graph-based context is designed to find cross-file and dependency-related issues while reducing the number of review providers.
+* **Cons**: Removes CodeRabbit's PR summaries, workflow coverage, and accumulated project learnings. It also gives up the diversity of feedback that motivates this decision.
+* **Decision**: Rejected. Greptile is intended to complement CodeRabbit, not replace it.
+
+# Consequences
+
+## Positive
+
+* **Whole-Codebase Context**: A code graph helps Greptile identify effects outside the immediate diff, including affected callers, dependencies, and similar patterns.
+* **Different Review Emphasis**: Greptile focuses on structural and cross-file issues, providing feedback that can diverge from CodeRabbit's broader first-pass review.
+* **Greater Reviewer Diversity**: A third provider increases the chance that one reviewer catches an issue or alternative missed by the others.
+* **Provider Resilience**: The later Gemini consumer sunset demonstrates the value of adopting Greptile before a provider change was announced. Greptile preserves a second external opinion when Gemini reviews cease.
+* **Feedback Learning**: Reactions to comments allow reviews to adapt to which findings are useful.
+* **No Additional Cost**: The Open Source Program provides qualifying non-commercial projects with a 100% discount.
+
+## Negative
+
+* **Additional Noise**: Greptile and CodeRabbit can produce duplicate or conflicting findings that require human judgement.
+* **Repository Indexing**: Whole-codebase context requires Greptile to index and maintain a representation of the repository.
+* **Programme Dependency**: The zero-cost decision depends on continued eligibility for Greptile's Open Source Program. A change to its terms or approval would require reassessment.
+* **Vendor Claims Require Validation**: Claims about review depth and signal-to-noise come from Greptile. Its practical value must be assessed from reviews on this repository.

--- a/ui/content/projects/recipe-site/adrs/039-greptile.mdx
+++ b/ui/content/projects/recipe-site/adrs/039-greptile.mdx
@@ -1,0 +1,3 @@
+---
+inherits_from: "personal-site:042-greptile"
+---

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -218,6 +218,13 @@ export const technologies: TechnologyContent[] = [
     type: "tool",
   },
   {
+    name: "Greptile",
+    added: "2026-06-20",
+    description: "AI code reviewer with whole-codebase context",
+    website: "https://www.greptile.com",
+    type: "tool",
+  },
+  {
     name: "CLA Assistant",
     added: "2026-01-11",
     description: "Contributor License Agreement automation for GitHub",


### PR DESCRIPTION
## Summary

- add Personal Site ADR 042 documenting the existing decision to use Greptile alongside CodeRabbit and Gemini Code Assist
- record Greptile's whole-codebase graph, cross-file review emphasis, feedback learning, and Open Source Program as decision drivers
- inherit the decision into the Recipe Site as ADR 039
- add Greptile to the technology catalogue

## Impact

Provides historical context for the project's third independent AI reviewer and explains how Greptile preserves reviewer diversity when Gemini's consumer integration shuts down.

## Validation

- pre-commit formatting and MDX checks passed
- `vitest run tests/lib/domain/repository.test.ts` (21 tests passed)