### PR TITLE
[codex] Add Codex coding and review ADRs

### DIFF
--- a/ui/content/projects/personal-site/adrs/043-codex.mdx
+++ b/ui/content/projects/personal-site/adrs/043-codex.mdx
@@ -1,0 +1,60 @@
+---
+title: "ADR 043: Codex"
+date: "2026-06-21"
+status: "Accepted"
+tech_stack: ["Codex"]
+---
+
+# Context
+
+[ADR 012: Claude Code](/projects/personal-site/adrs/012-claude-code) records why this project uses an agentic coding assistant: deep reasoning, repository-wide changes, and autonomous iteration are central to maintaining velocity as a solo developer. This ADR accepts that basis without repeating it.
+
+Claude Code remains effective, but I regularly exhaust the usage included with the $20/month Claude Pro plan. When that happens, implementation work stops until the allowance resets or moves to usage-based billing. Anthropic's direct subscription solution is the **[Max 5x plan](https://support.claude.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan)** at $100/month.
+
+At the same time, experienced practitioners whose workflows I respect report that Codex and OpenAI's coding models can be at least as effective as Claude when used according to their different interaction model. That is not a claim that one model is universally better. It is sufficient evidence to evaluate Codex as a complementary tool rather than treating Claude Code as the only viable agent.
+
+# Decision
+
+I will use **[Codex](https://developers.openai.com/codex/)** alongside Claude Code as an agentic coding assistant.
+
+Codex is included with the **[$20/month ChatGPT Plus plan](https://developers.openai.com/codex/pricing)** across its app, CLI, IDE, and web surfaces. Current limits use a five-hour window for local messages and cloud tasks, with additional weekly limits possible. In my observed use, its allowance appears more generous than Claude Pro, and its reset cadence provides useful capacity when Claude Code is unavailable. This is an operational observation rather than a guaranteed entitlement; both providers can change their limits.
+
+This is a complementary adoption, not a replacement for Claude Code. Using both tools preserves access to their different models, interfaces, and workflows while reducing dependence on one provider's availability, pricing, and usage policy.
+
+# Alternatives
+
+## Upgrade Claude Pro to Max 5x
+
+* **Pros**: Increases Claude usage fivefold without introducing another coding tool or model family.
+* **Cons**: Raises the Claude subscription from $20 to $100 per month while retaining a single provider dependency.
+* **Decision**: Rejected. Keeping Claude Pro and adding ChatGPT Plus costs $40 per month in total, which is $60 less than Claude Max 5x, while also introducing provider and tooling diversity.
+
+## Continue with Claude Pro Only
+
+* **Pros**: No additional subscription or tool configuration.
+* **Cons**: Regularly reaching the usage limit interrupts delivery and leaves no equivalent agentic fallback.
+* **Decision**: Rejected. The existing limit is already constraining development velocity.
+
+## Claude Usage-Based Billing
+
+* **Pros**: Extends Claude Code usage without waiting for a reset or changing the base subscription.
+* **Cons**: Variable API expenditure is harder to budget and still concentrates the workflow on Anthropic.
+* **Decision**: Rejected as the default response to limits. It remains available for exceptional bursts of work.
+
+# Consequences
+
+## Positive
+
+* **Maintained Velocity**: Work can continue in Codex when the Claude allowance is exhausted.
+* **Lower Cost than Claude Max**: Claude Pro plus ChatGPT Plus costs $40 per month rather than $100 per month for Claude Max 5x.
+* **Provider Redundancy**: An outage, limit, or pricing change from one provider does not remove the agentic coding workflow entirely.
+* **Different Strengths**: OpenAI and Anthropic models reason and interact differently. Learning both creates opportunities to route work to the tool that handles it best.
+* **Broader Tooling**: The ChatGPT Plus plan includes Codex across local and cloud surfaces rather than only adding more of the same usage.
+
+## Negative
+
+* **Additional Subscription**: The decision adds $20 per month rather than remaining on Claude Pro alone.
+* **Workflow Adaptation**: Codex needs to be used differently from Claude Code. Applying the same prompting and supervision patterns mechanically may produce worse results.
+* **Configuration Duplication**: Both tools require installation, authentication, and occasional tool-specific configuration, even though `AGENTS.md` provides shared project guidance.
+* **Two Sets of Limits**: Redundancy reduces interruption risk but does not remove usage limits. Codex limits vary with task size, model, and execution surface, and additional weekly limits may apply.
+* **Verification Remains Required**: Practitioner recommendations and model reputation do not guarantee better results on this repository. Codex output requires the same testing and review discipline as Claude output.

--- a/ui/content/projects/personal-site/adrs/043-codex.mdx
+++ b/ui/content/projects/personal-site/adrs/043-codex.mdx
@@ -17,9 +17,11 @@ I also experienced severe Claude availability problems earlier in 2026. I have r
 
 At the same time, experienced practitioners whose workflows I respect report that Codex and OpenAI's coding models can be at least as effective as Claude when used according to their different interaction model. That is not a claim that one model is universally better. It is sufficient evidence to evaluate Codex as a complementary tool rather than treating Claude Code as the only viable agent.
 
-The tools also support complementary mobile-development workflows. I heavily use **[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)** from mobile. Each task runs in an isolated Anthropic-managed environment, which provides a useful security boundary but can require dependencies, tools, and project context to be prepared again for fresh sessions.
+I heavily use **[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)** from mobile. Each task runs in an isolated Anthropic-managed environment, which provides a useful security boundary but can require dependencies, tools, and project context to be prepared again for fresh sessions.
 
-**[Codex Remote Connections](https://developers.openai.com/codex/remote-connections)** instead allow the ChatGPT mobile app to control Codex on a connected host. The host supplies its existing projects, files, credentials, plugins, tools, and shell. I already operate an always-on Mac mini as a home server, so it can provide a persistent development environment for mobile Codex sessions. This avoids repeated environment bootstrapping and its associated command output and context consumption, although Codex must still inspect enough of the repository to perform each task.
+**[Codex Remote Connections](https://developers.openai.com/codex/remote-connections)** allow the ChatGPT mobile app to control Codex on a connected host. The host supplies its existing projects, files, credentials, plugins, tools, and shell. I already operate an always-on Mac mini as a home server, so it can provide a persistent development environment for mobile Codex sessions. This avoids repeated environment bootstrapping and its associated command output and context consumption, although Codex must still inspect enough of the repository to perform each task.
+
+This is not a unique Codex capability. **[Claude Remote Control](https://code.claude.com/docs/en/remote-control)** also runs Claude Code on my machine while exposing it through web and mobile interfaces. Claude Code added its public `remote-control` command before OpenAI announced Codex mobile connected-host access. I had not tried or accounted for it when initially evaluating Codex. The remote workflow therefore provides an alternative implementation and independent allowance, not meaningful feature breadth beyond Claude Code.
 
 # Decision
 
@@ -51,9 +53,9 @@ This is a complementary adoption, not a replacement for Claude Code. Using both 
 
 ## Claude Remote Control
 
-* **Pros**: Claude Code now supports running on my own machine while being controlled from its web or mobile interface. This can preserve the established local environment and reduce the same setup overhead as Codex Remote Connections.
+* **Pros**: Runs Claude Code on my own machine while being controlled from its web or mobile interface. It preserves the established local environment and provides substantially the same setup-efficiency benefit as Codex Remote Connections.
 * **Cons**: It still consumes Claude usage and depends on Claude availability, so it does not address the primary cost and provider-resilience drivers.
-* **Decision**: Not sufficient as the sole solution. It may complement Claude cloud sessions, but it does not replace the need for Codex.
+* **Decision**: Preferable when I specifically want Claude on the Mac mini, but not sufficient as the sole solution. Codex remains justified by independent usage and provider redundancy rather than this feature.
 
 # Consequences
 
@@ -63,14 +65,15 @@ This is a complementary adoption, not a replacement for Claude Code. Using both 
 * **Lower Cost than Claude Max**: Claude Pro plus ChatGPT Plus costs $40 per month rather than $100 per month for Claude Max 5x.
 * **Provider Redundancy**: An outage, limit, or pricing change from one provider does not remove the agentic coding workflow entirely.
 * **Different Strengths**: OpenAI and Anthropic models reason and interact differently. Learning both creates opportunities to route work to the tool that handles it best.
-* **Broader Tooling**: The ChatGPT Plus plan includes Codex across local and cloud surfaces rather than only adding more of the same usage.
 * **Complementary Mobile Capacity**: Mobile work can move between Claude's subscription allowance and Codex's independent allowance.
-* **Persistent Mobile Environment**: The Mac mini already has the repository, dependencies, tools, and credentials, reducing repeated setup work in fresh cloud environments.
+* **Alternative Remote Implementation**: Codex provides another route to the Mac mini even though Claude Remote Control offers equivalent core functionality.
+* **Persistent Mobile Environment**: Using either connected-host implementation, the Mac mini already has the repository, dependencies, tools, and credentials, reducing repeated setup work in fresh cloud environments.
 * **Existing Infrastructure**: An always-on home server gains another useful workload without buying a separate development host.
 
 ## Negative
 
 * **Additional Subscription**: The decision adds $20 per month rather than remaining on Claude Pro alone.
+* **Narrower Feature Set**: Codex duplicates several capabilities already available in Claude Code and may provide only a subset of the broader Claude workflow. This adoption is justified by capacity and resilience, not feature superiority.
 * **Workflow Adaptation**: Codex needs to be used differently from Claude Code. Applying the same prompting and supervision patterns mechanically may produce worse results.
 * **Configuration Duplication**: Both tools require installation, authentication, and occasional tool-specific configuration, even though `AGENTS.md` provides shared project guidance.
 * **Two Sets of Limits**: Redundancy reduces interruption risk but does not remove usage limits. Codex limits vary with task size, model, and execution surface, and additional weekly limits may apply.

--- a/ui/content/projects/personal-site/adrs/043-codex.mdx
+++ b/ui/content/projects/personal-site/adrs/043-codex.mdx
@@ -11,11 +11,19 @@ tech_stack: ["Codex"]
 
 Claude Code remains effective, but I regularly exhaust the usage included with the $20/month Claude Pro plan. When that happens, implementation work stops until the allowance resets or moves to usage-based billing. Anthropic's direct subscription solution is the **[Max 5x plan](https://support.claude.com/en/articles/11145838-using-claude-code-with-your-pro-or-max-plan)** at $100/month.
 
+Usage-based billing has not been a cost-effective fallback. In my experience, $20 of additional Claude usage can be consumed within a couple of working cycles. Reports that fully using a $200 subscription would correspond to thousands of dollars of API inference are difficult to verify precisely, but they are directionally consistent with my own experience: subscription allowances are heavily subsidized compared with marginal API usage.
+
+I also experienced severe Claude availability problems earlier in 2026. I have repeatedly perceived both availability and output quality declining around major model releases. The timing does not establish that releases cause the degradation, but the operational effect is the same: relying on Claude alone can reduce velocity when demand is highest.
+
 At the same time, experienced practitioners whose workflows I respect report that Codex and OpenAI's coding models can be at least as effective as Claude when used according to their different interaction model. That is not a claim that one model is universally better. It is sufficient evidence to evaluate Codex as a complementary tool rather than treating Claude Code as the only viable agent.
+
+The tools also support complementary mobile-development workflows. I heavily use **[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)** from mobile. Each task runs in an isolated Anthropic-managed environment, which provides a useful security boundary but can require dependencies, tools, and project context to be prepared again for fresh sessions.
+
+**[Codex Remote Connections](https://developers.openai.com/codex/remote-connections)** instead allow the ChatGPT mobile app to control Codex on a connected host. The host supplies its existing projects, files, credentials, plugins, tools, and shell. I already operate an always-on Mac mini as a home server, so it can provide a persistent development environment for mobile Codex sessions. This avoids repeated environment bootstrapping and its associated command output and context consumption, although Codex must still inspect enough of the repository to perform each task.
 
 # Decision
 
-I will use **[Codex](https://developers.openai.com/codex/)** alongside Claude Code as an agentic coding assistant.
+I will use **[Codex](https://developers.openai.com/codex/)** alongside Claude Code as an agentic coding assistant, including using the Mac mini as a connected host for mobile development.
 
 Codex is included with the **[$20/month ChatGPT Plus plan](https://developers.openai.com/codex/pricing)** across its app, CLI, IDE, and web surfaces. Current limits use a five-hour window for local messages and cloud tasks, with additional weekly limits possible. In my observed use, its allowance appears more generous than Claude Pro, and its reset cadence provides useful capacity when Claude Code is unavailable. This is an operational observation rather than a guaranteed entitlement; both providers can change their limits.
 
@@ -38,8 +46,14 @@ This is a complementary adoption, not a replacement for Claude Code. Using both 
 ## Claude Usage-Based Billing
 
 * **Pros**: Extends Claude Code usage without waiting for a reset or changing the base subscription.
-* **Cons**: Variable API expenditure is harder to budget and still concentrates the workflow on Anthropic.
+* **Cons**: Variable API expenditure is harder to budget, remains concentrated on Anthropic, and has already consumed $20 within a couple of working cycles.
 * **Decision**: Rejected as the default response to limits. It remains available for exceptional bursts of work.
+
+## Claude Remote Control
+
+* **Pros**: Claude Code now supports running on my own machine while being controlled from its web or mobile interface. This can preserve the established local environment and reduce the same setup overhead as Codex Remote Connections.
+* **Cons**: It still consumes Claude usage and depends on Claude availability, so it does not address the primary cost and provider-resilience drivers.
+* **Decision**: Not sufficient as the sole solution. It may complement Claude cloud sessions, but it does not replace the need for Codex.
 
 # Consequences
 
@@ -50,6 +64,9 @@ This is a complementary adoption, not a replacement for Claude Code. Using both 
 * **Provider Redundancy**: An outage, limit, or pricing change from one provider does not remove the agentic coding workflow entirely.
 * **Different Strengths**: OpenAI and Anthropic models reason and interact differently. Learning both creates opportunities to route work to the tool that handles it best.
 * **Broader Tooling**: The ChatGPT Plus plan includes Codex across local and cloud surfaces rather than only adding more of the same usage.
+* **Complementary Mobile Capacity**: Mobile work can move between Claude's subscription allowance and Codex's independent allowance.
+* **Persistent Mobile Environment**: The Mac mini already has the repository, dependencies, tools, and credentials, reducing repeated setup work in fresh cloud environments.
+* **Existing Infrastructure**: An always-on home server gains another useful workload without buying a separate development host.
 
 ## Negative
 
@@ -57,4 +74,7 @@ This is a complementary adoption, not a replacement for Claude Code. Using both 
 * **Workflow Adaptation**: Codex needs to be used differently from Claude Code. Applying the same prompting and supervision patterns mechanically may produce worse results.
 * **Configuration Duplication**: Both tools require installation, authentication, and occasional tool-specific configuration, even though `AGENTS.md` provides shared project guidance.
 * **Two Sets of Limits**: Redundancy reduces interruption risk but does not remove usage limits. Codex limits vary with task size, model, and execution surface, and additional weekly limits may apply.
+* **Larger Local Blast Radius**: Remote Codex sessions use the host's filesystem, credentials, plugins, browser state, and tools. The Mac mini also handles personal photos and an external backup drive, so an overly broad permission profile could expose unrelated personal data.
+* **Host Availability**: Mobile Codex work depends on the Mac mini remaining awake, online, signed in, and running the Codex app.
+* **Security Hardening**: The connected host needs least-privilege filesystem rules, sandboxing, action approvals, and ideally a dedicated development account or explicit denial of the photo library and backup drive. The secure relay avoids a public inbound service but does not remove local access risk.
 * **Verification Remains Required**: Practitioner recommendations and model reputation do not guarantee better results on this repository. Codex output requires the same testing and review discipline as Claude output.

--- a/ui/content/projects/personal-site/adrs/043-codex.mdx
+++ b/ui/content/projects/personal-site/adrs/043-codex.mdx
@@ -17,11 +17,13 @@ I also experienced severe Claude availability problems earlier in 2026. I have r
 
 At the same time, experienced practitioners whose workflows I respect report that Codex and OpenAI's coding models can be at least as effective as Claude when used according to their different interaction model. That is not a claim that one model is universally better. It is sufficient evidence to evaluate Codex as a complementary tool rather than treating Claude Code as the only viable agent.
 
-I heavily use **[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)** from mobile. Each task runs in an isolated Anthropic-managed environment, which provides a useful security boundary but can require dependencies, tools, and project context to be prepared again for fresh sessions.
+**[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)** supports mobile development in isolated Anthropic-managed environments. This provides a useful security boundary and does not require a personal computer to remain available, but fresh environments can require dependencies, tools, and project context to be prepared again.
 
-**[Codex Remote Connections](https://developers.openai.com/codex/remote-connections)** allow the ChatGPT mobile app to control Codex on a connected host. The host supplies its existing projects, files, credentials, plugins, tools, and shell. I already operate an always-on Mac mini as a home server, so it can provide a persistent development environment for mobile Codex sessions. This avoids repeated environment bootstrapping and its associated command output and context consumption, although Codex must still inspect enough of the repository to perform each task.
+**[Codex Remote Connections](https://developers.openai.com/codex/remote-connections)** allow the ChatGPT mobile app to control Codex on a connected host. The host supplies its existing projects, files, credentials, plugins, tools, and shell. The existing always-on Mac mini can provide that persistent development environment, avoiding repeated environment bootstrapping and its associated command output and context consumption. However, this workflow requires the Mac mini to remain available.
 
-This is not a unique Codex capability. **[Claude Remote Control](https://code.claude.com/docs/en/remote-control)** also runs Claude Code on my machine while exposing it through web and mobile interfaces. Claude Code added its public `remote-control` command before OpenAI announced Codex mobile connected-host access. I had not tried or accounted for it when initially evaluating Codex. The remote workflow therefore provides an alternative implementation and independent allowance, not meaningful feature breadth beyond Claude Code.
+This is not a unique Codex capability. **[Claude Remote Control](https://code.claude.com/docs/en/remote-control)** also runs Claude Code on a personal machine while exposing it through web and mobile interfaces. Its server mode can start new sessions remotely, run multiple sessions concurrently, and place sessions in separate worktrees. Claude therefore provides two mobile development options: hosted cloud environments that do not depend on a personal host and Remote Control for working in an established local environment.
+
+Both connected-host implementations are previews: Anthropic labels Remote Control a research preview, while OpenAI introduced Codex mobile remote access as a preview. Codex's documented mobile remote workflow requires a connected host, making its mobile development options a subset of Claude Code's. Codex is being adopted despite this limitation because its independent usage allowance, models, and provider improve capacity and resilience.
 
 # Decision
 
@@ -53,9 +55,9 @@ This is a complementary adoption, not a replacement for Claude Code. Using both 
 
 ## Claude Remote Control
 
-* **Pros**: Runs Claude Code on my own machine while being controlled from its web or mobile interface. It preserves the established local environment and provides substantially the same setup-efficiency benefit as Codex Remote Connections.
+* **Pros**: Runs Claude Code on a personal machine while being controlled from its web or mobile interface. Server mode can initiate multiple sessions and isolate them in worktrees, providing substantially the same core workflow and setup-efficiency benefit as Codex Remote Connections. Claude Code also offers hosted mobile sessions that do not require the personal machine to remain available.
 * **Cons**: It still consumes Claude usage and depends on Claude availability, so it does not address the primary cost and provider-resilience drivers.
-* **Decision**: Preferable when I specifically want Claude on the Mac mini, but not sufficient as the sole solution. Codex remains justified by independent usage and provider redundancy rather than this feature.
+* **Decision**: Rejected as the sole solution. Codex remains justified by independent usage and provider redundancy rather than exclusive or broader remote-control features.
 
 # Consequences
 
@@ -66,14 +68,13 @@ This is a complementary adoption, not a replacement for Claude Code. Using both 
 * **Provider Redundancy**: An outage, limit, or pricing change from one provider does not remove the agentic coding workflow entirely.
 * **Different Strengths**: OpenAI and Anthropic models reason and interact differently. Learning both creates opportunities to route work to the tool that handles it best.
 * **Complementary Mobile Capacity**: Mobile work can move between Claude's subscription allowance and Codex's independent allowance.
-* **Alternative Remote Implementation**: Codex provides another route to the Mac mini even though Claude Remote Control offers equivalent core functionality.
 * **Persistent Mobile Environment**: Using either connected-host implementation, the Mac mini already has the repository, dependencies, tools, and credentials, reducing repeated setup work in fresh cloud environments.
 * **Existing Infrastructure**: An always-on home server gains another useful workload without buying a separate development host.
 
 ## Negative
 
 * **Additional Subscription**: The decision adds $20 per month rather than remaining on Claude Pro alone.
-* **Narrower Feature Set**: Codex duplicates several capabilities already available in Claude Code and may provide only a subset of the broader Claude workflow. This adoption is justified by capacity and resilience, not feature superiority.
+* **Narrower Mobile Feature Set**: Codex's mobile remote workflow requires the Mac mini, while Claude Code supports both hosted cloud environments and connected-host sessions. This adoption is justified by capacity and resilience, not feature superiority.
 * **Workflow Adaptation**: Codex needs to be used differently from Claude Code. Applying the same prompting and supervision patterns mechanically may produce worse results.
 * **Configuration Duplication**: Both tools require installation, authentication, and occasional tool-specific configuration, even though `AGENTS.md` provides shared project guidance.
 * **Two Sets of Limits**: Redundancy reduces interruption risk but does not remove usage limits. Codex limits vary with task size, model, and execution surface, and additional weekly limits may apply.

--- a/ui/content/projects/personal-site/adrs/044-codex-code-review.mdx
+++ b/ui/content/projects/personal-site/adrs/044-codex-code-review.mdx
@@ -1,0 +1,56 @@
+---
+title: "ADR 044: Codex Code Review"
+date: "2026-06-21"
+status: "Accepted"
+tech_stack: ["Codex"]
+---
+
+# Context
+
+[ADR 009: CodeRabbit](/projects/personal-site/adrs/009-code-rabbit) records the core decision to use automated review. [ADR 041: Gemini Code Assist](/projects/personal-site/adrs/041-gemini-code-assist) and [ADR 042: Greptile](/projects/personal-site/adrs/042-greptile) record the value of independent reviewers, divergent feedback, and provider resilience. This ADR does not repeat that rationale.
+
+[ADR 043: Codex](/projects/personal-site/adrs/043-codex) introduces a ChatGPT Plus subscription for agentic coding. That plan also includes **Codex code review in GitHub**, including automatic Pull Request reviews, without another subscription.
+
+The current reviewers show why an additional implementation can be useful. Greptile has sometimes posted comments that are word-for-word identical to Gemini Code Assist, while also posting additional findings. CodeRabbit frequently produces a more divergent set of comments. This is strong operational evidence that the free Greptile review path may lean heavily on Gemini or a shared upstream review component, although Greptile does not publicly document enough about that path to establish the cause.
+
+Foundation model diversity is only one source of diversity. Different review harnesses can retrieve different context, run different prompts and tools, apply different severity thresholds, and aggregate findings differently even when they share a model. **[Greptile](https://www.greptile.com/independence)** and **[CodeRabbit](https://www.coderabbit.ai/blog/coderabbit-supports-nvidia-nemotron-3-ultra)** both describe multi-model approaches, so product-level independence should not be treated as proof of foundation-model independence.
+
+# Decision
+
+I will enable **[Codex code review in GitHub](https://developers.openai.com/codex/integrations/github)** for automatic review of Pull Requests.
+
+Codex code review follows repository guidance from `AGENTS.md`, posts a standard GitHub review, and focuses its default comments on P0 and P1 issues. This high-severity focus offers another review perspective without attempting to duplicate every summary, style suggestion, or lower-priority comment from the existing services.
+
+GitHub reviews are metered as **Code Review usage**. OpenAI documents this separately from the shared five-hour allowance for local messages and cloud tasks. The review service is therefore treated as a distinct decision from using Codex to generate code.
+
+# Alternatives
+
+## Existing Reviewers Only
+
+* **Pros**: Avoids another set of comments, configuration, and provider limits.
+* **Cons**: Leaves an included review capability unused and misses an opportunity for a further independent, high-severity review pass.
+* **Decision**: Rejected. Codex review is already included in the subscription adopted by ADR 043.
+
+## On-Demand Codex Reviews
+
+* **Pros**: Conserves the Code Review allowance and reduces comments on low-risk Pull Requests.
+* **Cons**: Relies on remembering to request `@codex review`, weakening the consistency of the review workflow.
+* **Decision**: Rejected as the default. On-demand review remains useful if automatic reviews consume the allowance too quickly.
+
+# Consequences
+
+## Positive
+
+* **No Additional Subscription Cost**: Automatic GitHub review is included with ChatGPT Plus, which is already adopted for Codex coding work.
+* **Independent Review Harness**: Codex adds another context, prompting, tooling, severity, and orchestration path to the existing reviewer mix, regardless of whether foundation models overlap.
+* **High-Severity Focus**: Default GitHub comments are limited to P0 and P1 issues, which should reduce low-value noise.
+* **Shared Repository Guidance**: Codex reads `AGENTS.md`, allowing the coding agent and reviewer to use the same project-specific expectations.
+* **Automatic Coverage**: Every eligible Pull Request receives the review without a manual trigger.
+
+## Negative
+
+* **Additional Noise**: A fourth automated reviewer can duplicate or conflict with existing comments, even with Codex's high-severity threshold.
+* **Finite Review Allowance**: Code Review usage has its own plan limit. Automatic review may exhaust it faster than selective `@codex review` requests.
+* **Future Quota Coupling**: Current documentation distinguishes GitHub Code Review usage from general Codex usage. If OpenAI changes that policy, reviews could reduce capacity available for code generation and this decision must be revisited.
+* **Correlated Findings**: Product diversity does not guarantee independent findings. Word-for-word overlap between Greptile and Gemini shows that some review paths can remain correlated, while Greptile and CodeRabbit's multi-model approaches can also overlap with Codex at the foundation-model level.
+* **Security and Access**: Codex cloud must be connected to the repository and given sufficient GitHub access to read changes and post reviews.

--- a/ui/content/projects/recipe-site/adrs/040-codex.mdx
+++ b/ui/content/projects/recipe-site/adrs/040-codex.mdx
@@ -1,0 +1,3 @@
+---
+inherits_from: "personal-site:043-codex"
+---

--- a/ui/content/projects/recipe-site/adrs/041-codex-code-review.mdx
+++ b/ui/content/projects/recipe-site/adrs/041-codex-code-review.mdx
@@ -1,0 +1,3 @@
+---
+inherits_from: "personal-site:044-codex-code-review"
+---

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -153,6 +153,13 @@ export const technologies: TechnologyContent[] = [
     type: "tool",
   },
   {
+    name: "Codex",
+    added: "2026-06-21",
+    description: "OpenAI agentic coding assistant",
+    website: "https://developers.openai.com/codex",
+    type: "tool",
+  },
+  {
     name: "Mise",
     added: "2026-01-04",
     description:


### PR DESCRIPTION
## Summary

- add ADR 043 adopting Codex alongside Claude Code as a complementary agentic coding assistant
- document regularly exhausted Claude Pro limits, expensive usage-based overflow, observed availability issues, and the rejected Claude Max upgrade
- record Codex as a narrower mobile feature set whose value comes from independent capacity, cost, stability, and provider redundancy rather than feature superiority
- compare Claude's hosted mobile environments and local Remote Control option with Codex's host-dependent mobile remote workflow
- record the Mac mini requirement and associated availability and personal-data security trade-offs as Codex limitations
- add ADR 044 separately adopting Codex code review in GitHub
- distinguish review-harness diversity from foundation-model diversity and record observed Greptile/Gemini overlap
- inherit both decisions into the Recipe Site and add Codex to the technology catalogue

## Impact

Documents why the project uses both Claude Code and Codex despite overlapping capabilities, and why Codex's independent allowance and provider path justify the additional subscription. It also records the rationale for enabling Codex's separately metered GitHub review capability alongside the existing automated reviewers.

## Validation

- pre-commit formatting and MDX checks passed
- focused repository tests passed before the final documentation-only correction; rerunning them was blocked by unavailable registry network access during dependency installation
