### PR TITLE
[codex] Fix and validate AI review workflow

### DIFF
--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -49,7 +49,7 @@ noisy or not cost-effective.
 Scout responses allow up to 8,000 output tokens because reasoning tokens count
 against the same limit and thinking models can otherwise exhaust the budget
 before emitting their final structured response. The default Kimi K2.6 scout
-does not opt into reasoning because this workflow needs a small structured
+explicitly disables reasoning because this workflow needs a small structured
 response rather than long-horizon agentic thinking.
 
 ## Testing reviewer changes

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -47,7 +47,8 @@ noisy or not cost-effective.
 
 Scout responses allow up to 8,000 output tokens because reasoning tokens count
 against the same limit and thinking models can otherwise exhaust the budget
-before emitting their final structured response.
+before emitting their final structured response. Kimi scouts request low-effort
+reasoning and omit the unused reasoning text from the response.
 
 ## Testing reviewer changes
 

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -45,6 +45,10 @@ per-model cost, model failures, and incomplete-coverage warnings. These
 cumulative scorecard fields are intended to support removing scouts that are
 noisy or not cost-effective.
 
+Scout responses allow up to 8,000 output tokens because reasoning tokens count
+against the same limit and thinking models can otherwise exhaust the budget
+before emitting their final structured response.
+
 ## Testing reviewer changes
 
 `pull_request_target` deliberately runs the reviewer from the Pull Request's

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -45,6 +45,21 @@ per-model cost, model failures, and incomplete-coverage warnings. These
 cumulative scorecard fields are intended to support removing scouts that are
 noisy or not cost-effective.
 
+## Testing reviewer changes
+
+`pull_request_target` deliberately runs the reviewer from the Pull Request's
+trusted base commit, so it cannot validate reviewer changes in that Pull Request.
+To run a branch version end to end, a maintainer can manually dispatch the
+workflow against that branch and supply an open Pull Request number:
+
+```sh
+gh workflow run ai-review.yml --ref <branch> -f pr_number=<number>
+```
+
+The manual run checks out the selected branch commit. Do not add untrusted users
+as repository collaborators: collaborators can dispatch workflows with access to
+Actions secrets.
+
 The reviewer excludes lock files, generated/minified files, dependency/build
 directories, images, fonts, archives, documents, audio/video, compiled objects,
 databases, WebAssembly, model checkpoints, and binary data formats. GitHub also

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -58,7 +58,8 @@ gh workflow run ai-review.yml --ref <branch> -f pr_number=<number>
 
 The manual run checks out the selected branch commit. Do not add untrusted users
 as repository collaborators: collaborators can dispatch workflows with access to
-Actions secrets.
+Actions secrets. Every live review runs the reviewer unit tests and syntax check
+before making paid model calls.
 
 The reviewer excludes lock files, generated/minified files, dependency/build
 directories, images, fonts, archives, documents, audio/video, compiled objects,

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -19,7 +19,7 @@ Outside contributors cannot trigger a paid run themselves.
 Optional Actions repository variables:
 
 - `AI_REVIEW_MODELS`: comma-separated scout models. Defaults to
-  `moonshotai/kimi-k2.7-code,deepseek/deepseek-v4-pro,z-ai/glm-5.2,qwen/qwen3-coder`.
+  `moonshotai/kimi-k2.6,deepseek/deepseek-v4-pro,z-ai/glm-5.2,qwen/qwen3-coder`.
 - `AI_REVIEW_MERGER_MODEL`: defaults to `anthropic/claude-sonnet-4.6`.
 - `AI_REVIEW_IGNORED_AUTHORS`: comma-separated PR authors to skip. Defaults to
   `renovate[bot],dependabot[bot]`.
@@ -31,11 +31,12 @@ Optional Actions repository variables:
 The workflow needs the OpenRouter secret, but code in a pull request is
 untrusted. `pull_request_target` makes the secret available. Automatic reviews
 check out the PR's exact base commit. Manual comment and dispatch runs check out
-the protected default branch because those events do not contain a trusted PR
-base reference. The trusted reviewer then downloads the proposed changes through
-GitHub's API as text. It never checks out or executes code from the pull-request
-branch. Do not change the checkout to the PR head while the OpenRouter secret is
-present.
+the protected default branch for comments. Maintainer-only manual dispatches
+check out their explicitly selected ref so reviewer changes can be tested before
+merge. The trusted reviewer then downloads the proposed changes through GitHub's
+API as text. It never checks out or executes code from the reviewed Pull Request
+branch. Do not change automatic or comment-triggered checkout to the PR head
+while the OpenRouter secret is present.
 
 The reviewer is advisory: it creates one rolling comment, does not submit a
 formal review, and is not intended to be a required merge check initially. Its
@@ -47,8 +48,9 @@ noisy or not cost-effective.
 
 Scout responses allow up to 8,000 output tokens because reasoning tokens count
 against the same limit and thinking models can otherwise exhaust the budget
-before emitting their final structured response. Kimi scouts request low-effort
-reasoning and omit the unused reasoning text from the response.
+before emitting their final structured response. The default Kimi K2.6 scout
+does not opt into reasoning because this workflow needs a small structured
+response rather than long-horizon agentic thinking.
 
 ## Testing reviewer changes
 

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { completionContent, ignored, markdownText, renderComment, validateFindings } from "./ai-review.ts";
+import {
+  completionContent,
+  ignored,
+  markdownText,
+  parseModelPayload,
+  renderComment,
+  validateFindings,
+} from "./ai-review.ts";
 
 const finding = {
   severity: "high",
@@ -52,6 +59,11 @@ test("completion accepts a null finish reason but rejects truncation", () => {
     () => completionContent({ finish_reason: "length", message: { content: "{}" } }, "model"),
     /stopped with length/,
   );
+});
+
+test("model payload accepts a single JSON fence but rejects prose", () => {
+  assert.deepEqual(parseModelPayload('```json\n{"findings":[]}\n```'), { findings: [] });
+  assert.throws(() => parseModelPayload('Result: {"findings":[]}'), /Unexpected token|Unexpected character/);
 });
 
 test("model text cannot inject HTML, mentions, or markdown links", () => {

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -63,6 +63,8 @@ test("completion accepts a null finish reason but rejects truncation", () => {
 
 test("model payload accepts a single JSON fence but rejects prose", () => {
   assert.deepEqual(parseModelPayload('```json\n{"findings":[]}\n```'), { findings: [] });
+  assert.deepEqual(parseModelPayload('```json\n{"findings":[]}```'), { findings: [] });
+  assert.throws(() => parseModelPayload("```json\n```"));
   assert.throws(() => parseModelPayload('Result: {"findings":[]}'), /Unexpected token|Unexpected character/);
 });
 

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -41,6 +41,11 @@ test("finding validation rejects incomplete and out-of-diff findings", () => {
   );
 });
 
+test("finding validation enforces confidence bounds at runtime", () => {
+  assert.equal(validateFindings({ findings: [{ ...finding, confidence: -2 }] }, { merged: false })[0]?.confidence, 0);
+  assert.equal(validateFindings({ findings: [{ ...finding, confidence: 4 }] }, { merged: false })[0]?.confidence, 1);
+});
+
 test("model text cannot inject HTML, mentions, or markdown links", () => {
   const output = markdownText("<SCRIPT>@owner [click](https://example.com)</SCRIPT>");
   assert.doesNotMatch(output, /<script>|@owner|\[click\]\(/i);

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { ignored, markdownText, renderComment, validateFindings } from "./ai-review.ts";
+import { completionContent, ignored, markdownText, renderComment, validateFindings } from "./ai-review.ts";
 
 const finding = {
   severity: "high",
@@ -44,6 +44,14 @@ test("finding validation rejects incomplete and out-of-diff findings", () => {
 test("finding validation enforces confidence bounds at runtime", () => {
   assert.equal(validateFindings({ findings: [{ ...finding, confidence: -2 }] }, { merged: false })[0]?.confidence, 0);
   assert.equal(validateFindings({ findings: [{ ...finding, confidence: 4 }] }, { merged: false })[0]?.confidence, 1);
+});
+
+test("completion accepts a null finish reason but rejects truncation", () => {
+  assert.equal(completionContent({ finish_reason: null, message: { content: "{}" } }, "model"), "{}");
+  assert.throws(
+    () => completionContent({ finish_reason: "length", message: { content: "{}" } }, "model"),
+    /stopped with length/,
+  );
 });
 
 test("model text cannot inject HTML, mentions, or markdown links", () => {

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -64,6 +64,7 @@ test("completion accepts a null finish reason but rejects truncation", () => {
 test("model payload accepts a single JSON fence but rejects prose", () => {
   assert.deepEqual(parseModelPayload('```json\n{"findings":[]}\n```'), { findings: [] });
   assert.deepEqual(parseModelPayload('```json\n{"findings":[]}```'), { findings: [] });
+  assert.deepEqual(parseModelPayload('{"findings":[]}'), { findings: [] });
   assert.throws(() => parseModelPayload("```json\n```"));
   assert.throws(() => parseModelPayload('Result: {"findings":[]}'), /Unexpected token|Unexpected character/);
 });

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -145,6 +145,10 @@ const MAX_THREAD_CHARS = 40_000;
 const MAX_COMMENT_CHARS = 60_000;
 const SCOUT_FINDINGS_LIMIT = 25;
 const MERGED_FINDINGS_LIMIT = 100;
+// Reasoning tokens count against max_tokens. Kimi always thinks, and both Kimi
+// and DeepSeek have exhausted a 4,000-token budget before emitting final JSON.
+const SCOUT_MAX_TOKENS = 8_000;
+const MERGER_MAX_TOKENS = 6_000;
 const HTTP_TIMEOUT_MS = 300_000;
 const RETRIES = 3;
 
@@ -780,7 +784,14 @@ async function main(): Promise<void> {
   const settled = await Promise.allSettled(
     settings.scouts.map(async (model) => ({
       model,
-      result: await reviewer.callModel(model, scoutSystem, source, "code_review_findings", scoutSchema, 4_000),
+      result: await reviewer.callModel(
+        model,
+        scoutSystem,
+        source,
+        "code_review_findings",
+        scoutSchema,
+        SCOUT_MAX_TOKENS,
+      ),
     })),
   );
   const candidates: Record<string, Finding[]> = {};
@@ -820,7 +831,14 @@ async function main(): Promise<void> {
   const threads = await reviewer.reviewThreadContext();
   const mergerPrompt = `<DATA kind=scout-candidates>\n${JSON.stringify(candidates)}\n</DATA>
 <DATA kind=github-review-threads>\n${threads}\n</DATA>`;
-  const merged = await reviewer.callModel(settings.merger, mergerSystem, mergerPrompt, "merged_code_review", mergerSchema, 6_000);
+  const merged = await reviewer.callModel(
+    settings.merger,
+    mergerSystem,
+    mergerPrompt,
+    "merged_code_review",
+    mergerSchema,
+    MERGER_MAX_TOKENS,
+  );
   merged.payload.findings = (validateFindings(merged.payload, {
     merged: true,
     allowedFiles,

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -346,6 +346,16 @@ function finiteNumber(value: unknown): number {
   return Number.isFinite(number) ? number : 0;
 }
 
+export function completionContent(choice: JsonObject, model: string): string {
+  if (choice.finish_reason != null && choice.finish_reason !== "stop") {
+    throw new Error(`${model} stopped with ${String(choice.finish_reason)}`);
+  }
+  if (!isObject(choice.message) || typeof choice.message.content !== "string") {
+    throw new Error(`Invalid message from ${model}`);
+  }
+  return choice.message.content;
+}
+
 export function validateFindings(
   payload: unknown,
   options: { merged: boolean; allowedFiles?: Set<string> },
@@ -523,14 +533,8 @@ class Reviewer {
     const choices = response.choices;
     if (!Array.isArray(choices) || !isObject(choices[0])) throw new Error(`Invalid response from ${model}`);
     const choice = choices[0];
-    if (choice.finish_reason !== undefined && choice.finish_reason !== "stop") {
-      throw new Error(`${model} stopped with ${String(choice.finish_reason)}`);
-    }
-    if (!isObject(choice.message) || typeof choice.message.content !== "string") {
-      throw new Error(`Invalid message from ${model}`);
-    }
     const usage = isObject(response.usage) ? response.usage : {};
-    return { payload: JSON.parse(choice.message.content) as JsonObject, cost: Number(usage.cost ?? 0) };
+    return { payload: JSON.parse(completionContent(choice, model)) as JsonObject, cost: Number(usage.cost ?? 0) };
   }
 
   async existingComment(): Promise<{ id?: number; state: ReviewState }> {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -83,6 +83,7 @@ const DEFAULT_SCOUTS = [
   "z-ai/glm-5.2",
   "qwen/qwen3-coder",
 ];
+const REASONING_DISABLED_MODELS = new Set(["moonshotai/kimi-k2.6"]);
 const DEFAULT_MERGER = "anthropic/claude-sonnet-4.6";
 const DEFAULT_IGNORED_AUTHORS = ["renovate[bot]", "dependabot[bot]"];
 const IGNORED_FILENAMES = new Set([
@@ -812,7 +813,7 @@ async function main(): Promise<void> {
         "code_review_findings",
         scoutSchema,
         SCOUT_MAX_TOKENS,
-        model === "moonshotai/kimi-k2.6" ? { enabled: false, exclude: true } : undefined,
+        REASONING_DISABLED_MODELS.has(model) ? { enabled: false, exclude: true } : undefined,
       ),
     })),
   );

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -51,6 +51,13 @@ interface ModelResult {
   cost: number;
 }
 
+interface ReasoningSettings {
+  enabled: boolean;
+  // OpenRouter's unified reasoning API supports excluding reasoning text while
+  // still controlling whether the model reasons internally.
+  exclude: boolean;
+}
+
 interface ModelStats {
   runs: number;
   candidates: number;
@@ -358,8 +365,8 @@ export function completionContent(choice: JsonObject, model: string): string {
 
 export function parseModelPayload(content: string): JsonObject {
   const trimmed = content.trim();
-  const fenced = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/i);
-  const parsed = JSON.parse(fenced?.[1] ?? trimmed) as unknown;
+  const fenced = trimmed.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/i);
+  const parsed = JSON.parse(fenced?.[1].trim() ?? trimmed) as unknown;
   if (!isObject(parsed)) throw new Error("Model response is not a JSON object");
   return parsed;
 }
@@ -522,7 +529,7 @@ class Reviewer {
     schemaName: string,
     schema: JsonObject,
     maxTokens: number,
-    reasoning?: JsonObject,
+    reasoning?: ReasoningSettings,
   ): Promise<ModelResult> {
     const provider: JsonObject = { require_parameters: true };
     if (this.settings.requireZdr) Object.assign(provider, { zdr: true, data_collection: "deny" });

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -71,7 +71,7 @@ const MARKER = "<!-- ai-code-review -->";
 const COST_PATTERN = /<!-- ai-review-cost:(\{[^\n]*\}) -->/;
 const BOT_LOGINS = new Set(["github-actions[bot]"]);
 const DEFAULT_SCOUTS = [
-  "moonshotai/kimi-k2.7-code",
+  "moonshotai/kimi-k2.6",
   "deepseek/deepseek-v4-pro",
   "z-ai/glm-5.2",
   "qwen/qwen3-coder",
@@ -504,7 +504,6 @@ class Reviewer {
     schemaName: string,
     schema: JsonObject,
     maxTokens: number,
-    reasoning?: JsonObject,
   ): Promise<ModelResult> {
     const provider: JsonObject = { require_parameters: true };
     if (this.settings.requireZdr) Object.assign(provider, { zdr: true, data_collection: "deny" });
@@ -514,7 +513,6 @@ class Reviewer {
         temperature: 0,
         max_tokens: maxTokens,
         provider,
-        ...(reasoning ? { reasoning } : {}),
         response_format: { type: "json_schema", json_schema: { name: schemaName, strict: true, schema } },
         messages: [
           { role: "system", content: system },
@@ -793,7 +791,6 @@ async function main(): Promise<void> {
         "code_review_findings",
         scoutSchema,
         SCOUT_MAX_TOKENS,
-        model.startsWith("moonshotai/kimi-") ? { effort: "low", exclude: true } : undefined,
       ),
     })),
   );

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -155,7 +155,9 @@ const findingProperties = {
   title: { type: "string" },
   evidence: { type: "string" },
   recommendation: { type: "string" },
-  confidence: { type: "number", minimum: 0, maximum: 1 },
+  // Some OpenRouter providers only support a subset of JSON Schema and reject
+  // numeric bounds. Runtime validation below clamps confidence to this range.
+  confidence: { type: "number" },
 };
 
 const scoutSchema = {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -514,6 +514,7 @@ class Reviewer {
     schemaName: string,
     schema: JsonObject,
     maxTokens: number,
+    reasoning?: JsonObject,
   ): Promise<ModelResult> {
     const provider: JsonObject = { require_parameters: true };
     if (this.settings.requireZdr) Object.assign(provider, { zdr: true, data_collection: "deny" });
@@ -523,6 +524,7 @@ class Reviewer {
         temperature: 0,
         max_tokens: maxTokens,
         provider,
+        ...(reasoning ? { reasoning } : {}),
         response_format: { type: "json_schema", json_schema: { name: schemaName, strict: true, schema } },
         messages: [
           { role: "system", content: system },
@@ -795,6 +797,7 @@ async function main(): Promise<void> {
         "code_review_findings",
         scoutSchema,
         SCOUT_MAX_TOKENS,
+        model === "moonshotai/kimi-k2.6" ? { enabled: false, exclude: true } : undefined,
       ),
     })),
   );

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -504,6 +504,7 @@ class Reviewer {
     schemaName: string,
     schema: JsonObject,
     maxTokens: number,
+    reasoning?: JsonObject,
   ): Promise<ModelResult> {
     const provider: JsonObject = { require_parameters: true };
     if (this.settings.requireZdr) Object.assign(provider, { zdr: true, data_collection: "deny" });
@@ -513,6 +514,7 @@ class Reviewer {
         temperature: 0,
         max_tokens: maxTokens,
         provider,
+        ...(reasoning ? { reasoning } : {}),
         response_format: { type: "json_schema", json_schema: { name: schemaName, strict: true, schema } },
         messages: [
           { role: "system", content: system },
@@ -791,6 +793,7 @@ async function main(): Promise<void> {
         "code_review_findings",
         scoutSchema,
         SCOUT_MAX_TOKENS,
+        model.startsWith("moonshotai/kimi-") ? { effort: "low", exclude: true } : undefined,
       ),
     })),
   );

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -356,6 +356,14 @@ export function completionContent(choice: JsonObject, model: string): string {
   return choice.message.content;
 }
 
+export function parseModelPayload(content: string): JsonObject {
+  const trimmed = content.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*\n([\s\S]*?)\n```$/i);
+  const parsed = JSON.parse(fenced?.[1] ?? trimmed) as unknown;
+  if (!isObject(parsed)) throw new Error("Model response is not a JSON object");
+  return parsed;
+}
+
 export function validateFindings(
   payload: unknown,
   options: { merged: boolean; allowedFiles?: Set<string> },
@@ -536,7 +544,7 @@ class Reviewer {
     if (!Array.isArray(choices) || !isObject(choices[0])) throw new Error(`Invalid response from ${model}`);
     const choice = choices[0];
     const usage = isObject(response.usage) ? response.usage : {};
-    return { payload: JSON.parse(completionContent(choice, model)) as JsonObject, cost: Number(usage.cost ?? 0) };
+    return { payload: parseModelPayload(completionContent(choice, model)), cost: Number(usage.cost ?? 0) };
   }
 
   async existingComment(): Promise<{ id?: number; state: ReviewState }> {

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -43,13 +43,13 @@ jobs:
       # github.sha is the immutable commit selected by that dispatch, which avoids
       # a branch moving between workflow dispatch and checkout.
       - name: Check out trusted reviewer
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.base.sha || github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -40,7 +40,8 @@ jobs:
       # pull_request_target has access to secrets. Always execute reviewer code from
       # the trusted base commit, never from the pull request head. A manual dispatch
       # can execute a selected ref because only maintainers can start that event;
-      # this is the safe path for validating reviewer changes before they are merged.
+      # github.sha is the immutable commit selected by that dispatch, which avoids
+      # a branch moving between workflow dispatch and checkout.
       - name: Check out trusted reviewer
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Test trusted reviewer
+        run: |
+          node --test .github/scripts/ai-review/ai-review.test.ts
+          node --check .github/scripts/ai-review/ai-review.ts
+
       - name: Review pull request
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -38,11 +38,13 @@ jobs:
 
     steps:
       # pull_request_target has access to secrets. Always execute reviewer code from
-      # the trusted base commit, never from the pull request head.
+      # the trusted base commit, never from the pull request head. A manual dispatch
+      # can execute a selected ref because only maintainers can start that event;
+      # this is the safe path for validating reviewer changes before they are merged.
       - name: Check out trusted reviewer
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.pull_request.base.sha || github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Set up Node.js


### PR DESCRIPTION
## What changed

- allow maintainer-triggered manual dispatches to execute the selected branch ref
- run reviewer tests and syntax checking before paid model calls
- remove provider-incompatible numeric JSON Schema bounds while retaining runtime validation
- tolerate nullable finish reasons and narrowly unwrap fenced structured JSON
- increase the scout output budget and replace always-thinking K2.7 Code with K2.6 in explicit non-reasoning mode
- pin secret-bearing workflow actions to immutable commit SHAs
- document the safe pre-merge end-to-end test path

## Root causes

The merger providers rejected `minimum` and `maximum` on JSON Schema number fields. Reviewer changes could not be validated before merge because manual dispatches checked out the default branch. Reasoning scouts also exhausted the original 4,000-token output budget, and Kimi returned provider-specific nullable finish reasons and fenced JSON.

## Validation

- Node 24 test suite: 8 passed
- Node 24 syntax check
- YAML lint
- Markdown lint
- `git diff --check`
- all-scout end-to-end run: [successful run](https://github.com/Robbie-Palmer/personal-site/actions/runs/27912729960)
- final reviewed head: [successful run](https://github.com/Robbie-Palmer/personal-site/actions/runs/27913136205)

The final run checked out exact PR-head commit `7c60c16`, passed the preflight tests, tolerated two independent scout failures, merged the successful scout results, and updated the rolling Pull Request comment. An earlier run completed all four scouts without warnings.

The automatic AI-review check on this Pull Request is expected to fail because `pull_request_target` securely executes the broken reviewer currently on `main`. It cannot exercise this Pull Request's fix; the maintainer-dispatched branch runs above provide that pre-merge proof. The AI-review check is advisory and not required by branch protection.
