### PR TITLE
Fix preview Neon branch creation on Free plan

### DIFF
--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -58,7 +58,8 @@ jobs:
           branch_type: schema-only
           database: recipes
           role: recipes_owner
-          suspend_timeout: 300
+          # Neon Free plan fixes scale-to-zero at 5 minutes and rejects any
+          # explicit suspend_timeout with HTTP 412, so it must be omitted.
           expires_at: ${{ steps.neon-expiry.outputs.expires_at }}
 
       # Provisioning above runs only trusted workflow/action code. Check out

--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -149,6 +149,19 @@ Add the scenario to
 to `workers/recipe-api/scripts/seed-preview.ts`. Seeds must be idempotent and
 must not erase QA changes on subsequent pushes.
 
+## Neon Free plan constraints
+
+The preview branch is a schema-only branch, which Neon implements as an
+independent **root branch**. The Free plan permits only **3 root branches per
+project**, and the project's `main` branch consumes one. Previews therefore
+support at most **two concurrent internal PRs**; a third preview branch fails
+with `ROOT_BRANCHES_LIMIT_EXCEEDED` until an open preview closes. Upgrading to a
+paid plan (Launch allows 5 root branches) raises this ceiling.
+
+Scale-to-zero is fixed at 5 minutes on the Free plan and cannot be configured.
+The Neon branch action must not pass `suspend_timeout`; any explicit value is
+rejected with `412 Precondition Failed`.
+
 ## Known follow-up: committed migrations
 
 The workflow currently uses `drizzle-kit push`, matching production. Before

--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -9,10 +9,12 @@ https://pr-<number>.<pages-host>
   -> preview-pr-<number> Neon branch
 ```
 
-The Neon branch is created as a schema-only child of the project's primary
-branch. Production rows, Better Auth sessions, OAuth tokens, and private
-recipes are therefore never copied into a preview. The workflow pushes the PR
-schema and adds deterministic QA fixtures.
+The Neon branch is created with a schema-only copy of the project's primary
+branch. It copies the structure but none of the rows, so it is technically an
+independent root branch rather than a child (see [Neon Free plan
+constraints](#neon-free-plan-constraints) below). Production rows, Better Auth
+sessions, OAuth tokens, and private recipes are therefore never copied into a
+preview. The workflow pushes the PR schema and adds deterministic QA fixtures.
 
 The branch and Worker survive updates to the PR so QA state is preserved. They
 are deleted when the PR closes. Neon also expires the branch after 30 days as a


### PR DESCRIPTION
The preview workflow passed `suspend_timeout: 300` to the Neon create-branch action. Neon's Free plan fixes scale-to-zero at 5 minutes and rejects any explicit `suspend_timeout` with **HTTP 412**, which blocked preview branch creation (root cause of the failed preview run on #604).

This drops the `suspend_timeout` input (schema-only branching and the 30-day `expires_at` are both verified working) and documents the Free-plan root-branch limit (max two concurrent previews).

After merge, the preview run on #604 can be re-triggered.