### PR TITLE
Fix preview Pages deploy missing build env var

### DIFF
--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -117,8 +117,6 @@ jobs:
           mise run //ui:build
         env:
           NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
-          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
-          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
       - name: Deploy canonical PR Pages preview
         run: mise run //ui:deploy
@@ -127,10 +125,8 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOY_BRANCH: pr-${{ github.event.pull_request.number }}
           # //ui:deploy depends on //ui:build, which rebuilds and needs the
-          # same public build vars as the Build UI step above.
+          # same public build var as the Build UI step above.
           NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
-          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
-          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
       - name: Comment preview URL on PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -126,6 +126,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOY_BRANCH: pr-${{ github.event.pull_request.number }}
+          # //ui:deploy depends on //ui:build, which rebuilds and needs the
+          # same public build vars as the Build UI step above.
+          NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
       - name: Comment preview URL on PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -111,21 +111,16 @@ jobs:
           CF_ACCESS_TEAM_DOMAIN: ${{ vars.CF_ACCESS_TEAM_DOMAIN }}
           CF_ACCESS_AUD: ${{ vars.CF_ACCESS_AUD }}
 
-      - name: Build UI
+      - name: Build and deploy canonical PR Pages preview
+        # //ui:deploy depends on //ui:build, so this single step both builds
+        # and deploys the UI; a separate build step would only rebuild.
         run: |
           : "${NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH:?NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH is required}"
-          mise run //ui:build
-        env:
-          NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
-
-      - name: Deploy canonical PR Pages preview
-        run: mise run //ui:deploy
+          mise run //ui:deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOY_BRANCH: pr-${{ github.event.pull_request.number }}
-          # //ui:deploy depends on //ui:build, which rebuilds and needs the
-          # same public build var as the Build UI step above.
           NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
 
       - name: Comment preview URL on PR


### PR DESCRIPTION
The preview run's final step (`Deploy canonical PR Pages preview`) runs `mise run //ui:deploy`, which depends on `//ui:build` and rebuilds the UI. That step didn't pass `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH`, so the rebuild failed:

```
Error: NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH environment variable is required.
```

Production `ui-cd.yml` avoids this by setting the public build vars at job level (available to its rebuilding deploy step). This mirrors that by passing them to the preview deploy step.

Backend is already verified working on #604: Neon branch `preview-pr-604` created (schema-only, isolated — 3 seeded `@preview.invalid` users, 0 prod rows), Worker `recipe-api-pr-604` deployed with no Hyperdrive binding. Only the Pages deploy remained.