### PR TITLE
Reframe preview setup doc as operational runbook

### DIFF
--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -26,11 +26,17 @@ default branch, then explicitly checks out the internal PR commit. Only
 preview-scoped credentials should be stored in the preview environment because
 the deployed application code is still the PR's code.
 
-## One-time manual setup
+## Operational setup & runbook
 
-### 1. Apply the Terraform change
+This environment is already provisioned. The steps below are retained as a
+recovery and rotation runbook — how to recreate the GitHub environment, rotate
+the scoped credentials, or rebuild the Cloudflare Access app and Terraform
+variables. None of these live in the repository.
 
-After this change reaches `main`, apply the infrastructure workspace:
+### 1. Apply the Terraform variables
+
+A push to `main` that touches `infra/**` applies these automatically via the
+`infra-cd` workflow. To apply by hand (the fallback):
 
 ```bash
 mise run //infra:plan
@@ -78,10 +84,17 @@ Do not store that service token in this repository.
 
 ### 3. Create a least-privilege Cloudflare token
 
-Create a token intended only for previews. It needs the account permissions
-required to deploy/delete Workers and deploy Pages projects. Scope it to this
-Cloudflare account and, where Cloudflare permits, the `personal-site` Pages
-project. Do not reuse a global or DNS-capable production token.
+Create a token intended only for previews, with exactly these account-scoped
+permissions:
+
+- **Account -> Workers Scripts -> Edit** (deploy/delete the preview Worker and
+  upload its secrets)
+- **Account -> Cloudflare Pages -> Edit** (deploy the canonical PR Pages alias)
+
+Scope it to this Cloudflare account. Cloudflare's Pages permission is
+account-level only and cannot be narrowed to the `personal-site` project, so
+account scope is the tightest available. Do not reuse a global or DNS-capable
+production token.
 
 ### 4. Create the GitHub environment
 
@@ -114,12 +127,20 @@ Add these environment variables:
 | `CF_ACCESS_TEAM_DOMAIN` | `https://your-team.cloudflareaccess.com` |
 | `CF_ACCESS_AUD` | Audience tag from the Pages preview Access application |
 
-The Neon key currently operates at project or organization scope. Keep it in
-the controller action only and rotate it if GitHub reports any exposure.
+`NEON_API_KEY` is a **project-scoped** key for the `recipes` project (Neon
+Console -> organization -> Settings -> API keys -> Create API key ->
+Project-scoped), so it can manage branches in that project and nothing else.
+Keep it in the `cloudflare-preview` environment only and rotate it if GitHub
+reports any exposure.
 
-### 5. Verify the first preview
+`POSTHOG_KEY` and `POSTHOG_HOST` are currently omitted, so previews run without
+analytics. The UI build only requires `CF_IMAGES_ACCOUNT_HASH`; the PostHog
+client no-ops when its key is unset.
 
-Open or update an internal PR after the workflow has landed on `main`. Confirm:
+### 5. Smoke-test a preview
+
+To validate the pipeline (after recreating any of the above, or when debugging),
+open or update an internal PR — the workflow runs from `main`. Confirm:
 
 1. The PR receives one `Preview environment` comment.
 2. Neon contains `preview-pr-<number>` and it has no production rows.

--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -30,13 +30,14 @@ the deployed application code is still the PR's code.
 
 This environment is already provisioned. The steps below are retained as a
 recovery and rotation runbook — how to recreate the GitHub environment, rotate
-the scoped credentials, or rebuild the Cloudflare Access app and Terraform
-variables. None of these live in the repository.
+the scoped credentials, and rebuild the Cloudflare Access application. These
+pieces are configured out of band; their sensitive values are not stored in the
+repository (the Terraform configuration itself is, under `infra/`).
 
-### 1. Apply the Terraform variables
+### 1. Apply the Terraform configuration
 
-A push to `main` that touches `infra/**` applies these automatically via the
-`infra-cd` workflow. To apply by hand (the fallback):
+A push to `main` that touches `infra/**` applies the configuration
+automatically via the `infra-cd` workflow. To apply by hand (the fallback):
 
 ```bash
 mise run //infra:plan


### PR DESCRIPTION
Now that the preview environment is fully provisioned and verified, the "One-time manual setup" section read as stale pending work. This reframes it as a recovery/rotation runbook and folds in what the rollout established:

- **Retitled** to "Operational setup & runbook" with an 'already provisioned' note.
- **§1**: Terraform applies automatically via `infra-cd` on `main`; manual commands are the fallback.
- **§3**: the preview CF token's exact least-privilege scope (Workers Scripts: Edit + Cloudflare Pages: Edit; Pages can't be project-scoped).
- **§4**: `NEON_API_KEY` is project-scoped (how to recreate); PostHog is omitted so previews run without analytics.
- **§5**: reframed as a reusable smoke-test checklist.

Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified preview environment setup documentation with improved guidance on credentials, permissions, and security best practices.
  * Enhanced operational runbook for the preview pipeline with explicit procedures for manual configuration and security validation.
  * Expanded guidance on API key scoping requirements, Cloudflare token creation, and secure credential rotation practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->