### PR TITLE
[codex] Add focused preview auth tests

### DIFF
--- a/ui/tests/functions/auth-proxy.test.ts
+++ b/ui/tests/functions/auth-proxy.test.ts
@@ -31,4 +31,72 @@ describe("preview auth proxy routing", () => {
       previewApiBase(new URL("https://robbiepalmer.me/api/auth/session"), env),
     ).toBeUndefined();
   });
+
+  it.each([
+    [
+      "CF_PAGES_HOST",
+      {
+        RECIPE_API_PREVIEW_ORIGIN_TEMPLATE:
+          env.RECIPE_API_PREVIEW_ORIGIN_TEMPLATE,
+      },
+    ],
+    [
+      "RECIPE_API_PREVIEW_ORIGIN_TEMPLATE",
+      { CF_PAGES_HOST: env.CF_PAGES_HOST },
+    ],
+  ])("leaves routing unchanged when %s is missing", (_name, partialEnv) => {
+    expect(
+      previewApiBase(
+        new URL("https://pr-42.personal-site-bu5.pages.dev/api/auth/session"),
+        partialEnv,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("leaves the Pages root host on the production route", () => {
+    expect(
+      previewApiBase(
+        new URL("https://personal-site-bu5.pages.dev/api/auth/session"),
+        env,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("rejects preview origins that are not HTTPS", () => {
+    expect(
+      previewApiBase(
+        new URL("https://pr-42.personal-site-bu5.pages.dev/api/auth/session"),
+        {
+          ...env,
+          RECIPE_API_PREVIEW_ORIGIN_TEMPLATE:
+            "http://recipe-api-pr-{pr}.robbiepalmer95.workers.dev",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects preview origins that are not valid URLs", () => {
+    expect(
+      previewApiBase(
+        new URL("https://pr-42.personal-site-bu5.pages.dev/api/auth/session"),
+        {
+          ...env,
+          RECIPE_API_PREVIEW_ORIGIN_TEMPLATE: "not-a-valid-url-{pr}",
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("returns only the origin when the preview template includes a path", () => {
+    expect(
+      previewApiBase(
+        new URL("https://pr-42.personal-site-bu5.pages.dev/api/auth/session"),
+        {
+          ...env,
+          RECIPE_API_PREVIEW_ORIGIN_TEMPLATE:
+            "https://recipe-api-pr-{pr}.robbiepalmer95.workers.dev/api/auth",
+        },
+      ),
+    ).toBe("https://recipe-api-pr-42.robbiepalmer95.workers.dev");
+  });
 });

--- a/workers/recipe-api/tests/cloudflare-access.test.ts
+++ b/workers/recipe-api/tests/cloudflare-access.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const joseMocks = vi.hoisted(() => ({
+  jwks: vi.fn(),
+  createRemoteJWKSet: vi.fn(),
+  jwtVerify: vi.fn(),
+}));
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: joseMocks.createRemoteJWKSet,
+  jwtVerify: joseMocks.jwtVerify,
+}));
+
+import { verifyCloudflareAccess } from "../src/cloudflare-access";
+
+function request(assertion?: string): Request {
+  return new Request("https://recipe-api.example.test/api/auth/preview", {
+    headers: assertion ? { "cf-access-jwt-assertion": assertion } : undefined,
+  });
+}
+
+describe("verifyCloudflareAccess", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    joseMocks.createRemoteJWKSet.mockReturnValue(joseMocks.jwks);
+    joseMocks.jwtVerify.mockResolvedValue({ payload: { sub: "tester" } });
+  });
+
+  it.each([
+    [
+      "assertion",
+      request(),
+      {
+        CF_ACCESS_TEAM_DOMAIN: "missing-assertion.cloudflareaccess.com",
+        CF_ACCESS_AUD: "preview-audience",
+      },
+    ],
+    ["team domain", request("token"), { CF_ACCESS_AUD: "preview-audience" }],
+    [
+      "audience",
+      request("token"),
+      {
+        CF_ACCESS_TEAM_DOMAIN: "missing-audience.cloudflareaccess.com",
+      },
+    ],
+  ])("returns false when the %s is missing", async (_name, req, env) => {
+    await expect(verifyCloudflareAccess(req, env)).resolves.toBe(false);
+    expect(joseMocks.jwtVerify).not.toHaveBeenCalled();
+  });
+
+  it("verifies the assertion against the normalized issuer and configured audience", async () => {
+    await expect(
+      verifyCloudflareAccess(request("valid-token"), {
+        CF_ACCESS_TEAM_DOMAIN: "team-a.cloudflareaccess.com",
+        CF_ACCESS_AUD: "preview-audience",
+      }),
+    ).resolves.toBe(true);
+
+    expect(joseMocks.createRemoteJWKSet).toHaveBeenCalledWith(
+      new URL("https://team-a.cloudflareaccess.com/cdn-cgi/access/certs"),
+    );
+    expect(joseMocks.jwtVerify).toHaveBeenCalledWith(
+      "valid-token",
+      joseMocks.jwks,
+      {
+        issuer: "https://team-a.cloudflareaccess.com",
+        audience: "preview-audience",
+      },
+    );
+  });
+
+  it("accepts a team domain that already includes https", async () => {
+    await expect(
+      verifyCloudflareAccess(request("valid-token"), {
+        CF_ACCESS_TEAM_DOMAIN: "https://team-b.cloudflareaccess.com",
+        CF_ACCESS_AUD: "preview-audience",
+      }),
+    ).resolves.toBe(true);
+
+    expect(joseMocks.jwtVerify).toHaveBeenCalledWith(
+      "valid-token",
+      joseMocks.jwks,
+      expect.objectContaining({
+        issuer: "https://team-b.cloudflareaccess.com",
+      }),
+    );
+  });
+
+  it("returns false when the team domain is not HTTPS", async () => {
+    await expect(
+      verifyCloudflareAccess(request("token"), {
+        CF_ACCESS_TEAM_DOMAIN: "http://team-c.cloudflareaccess.com",
+        CF_ACCESS_AUD: "preview-audience",
+      }),
+    ).resolves.toBe(false);
+
+    expect(joseMocks.jwtVerify).not.toHaveBeenCalled();
+  });
+
+  it("returns false when JWT verification fails", async () => {
+    joseMocks.jwtVerify.mockRejectedValueOnce(new Error("expired"));
+
+    await expect(
+      verifyCloudflareAccess(request("expired-token"), {
+        CF_ACCESS_TEAM_DOMAIN: "team-d.cloudflareaccess.com",
+        CF_ACCESS_AUD: "preview-audience",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("reuses the JWKS for repeated checks against the same issuer", async () => {
+    const env = {
+      CF_ACCESS_TEAM_DOMAIN: "team-e.cloudflareaccess.com",
+      CF_ACCESS_AUD: "preview-audience",
+    };
+
+    await verifyCloudflareAccess(request("first-token"), env);
+    await verifyCloudflareAccess(request("second-token"), env);
+
+    expect(joseMocks.createRemoteJWKSet).toHaveBeenCalledOnce();
+    expect(joseMocks.jwtVerify).toHaveBeenCalledTimes(2);
+  });
+});

--- a/workers/recipe-api/tests/cloudflare-access.test.ts
+++ b/workers/recipe-api/tests/cloudflare-access.test.ts
@@ -11,7 +11,9 @@ vi.mock("jose", () => ({
   jwtVerify: joseMocks.jwtVerify,
 }));
 
-import { verifyCloudflareAccess } from "../src/cloudflare-access";
+let verifyCloudflareAccess: typeof import(
+  "../src/cloudflare-access"
+).verifyCloudflareAccess;
 
 function request(assertion?: string): Request {
   return new Request("https://recipe-api.example.test/api/auth/preview", {
@@ -20,10 +22,12 @@ function request(assertion?: string): Request {
 }
 
 describe("verifyCloudflareAccess", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
     joseMocks.createRemoteJWKSet.mockReturnValue(joseMocks.jwks);
     joseMocks.jwtVerify.mockResolvedValue({ payload: { sub: "tester" } });
+    ({ verifyCloudflareAccess } = await import("../src/cloudflare-access"));
   });
 
   it.each([

--- a/workers/recipe-api/tests/cloudflare-access.test.ts
+++ b/workers/recipe-api/tests/cloudflare-access.test.ts
@@ -118,8 +118,12 @@ describe("verifyCloudflareAccess", () => {
       CF_ACCESS_AUD: "preview-audience",
     };
 
-    await verifyCloudflareAccess(request("first-token"), env);
-    await verifyCloudflareAccess(request("second-token"), env);
+    await expect(
+      verifyCloudflareAccess(request("first-token"), env),
+    ).resolves.toBe(true);
+    await expect(
+      verifyCloudflareAccess(request("second-token"), env),
+    ).resolves.toBe(true);
 
     expect(joseMocks.createRemoteJWKSet).toHaveBeenCalledOnce();
     expect(joseMocks.jwtVerify).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

Adds a small follow-up test patch after closing the stale CodeRabbit-generated PR #603.

- expands preview auth proxy routing coverage for missing env, root-host routing, invalid/non-HTTPS preview origins, and path stripping
- adds focused Cloudflare Access verification tests for missing config, issuer/audience verification, HTTPS enforcement, JWT failures, and JWKS reuse

## Validation

- `mise exec -- pnpm --filter ui exec vitest run tests/functions/auth-proxy.test.ts`
- `mise exec -- pnpm --filter recipe-api exec vitest run tests/cloudflare-access.test.ts`
- `mise exec -- pnpm --filter ui exec biome check tests/functions/auth-proxy.test.ts ../workers/recipe-api/tests/cloudflare-access.test.ts`
