### PR TITLE
SC-253 Authorization middleware MVP policy matrix

### DIFF
--- a/workers/recipe-api/src/http/authorization.ts
+++ b/workers/recipe-api/src/http/authorization.ts
@@ -44,7 +44,7 @@ export type HouseholdResource = {
 };
 
 export type HouseholdReadContext = {
-  isHouseholdMemberOfOwner: boolean;
+  userSharesHouseholdWithOwner: boolean;
 };
 
 export type AuthSessionLoader = (
@@ -52,7 +52,7 @@ export type AuthSessionLoader = (
 ) => Promise<AuthenticatedSession | null>;
 
 const noHouseholdReadAccess: HouseholdReadContext = Object.freeze({
-  isHouseholdMemberOfOwner: false,
+  userSharesHouseholdWithOwner: false,
 });
 
 function hasSessionSignal(c: Context): boolean {
@@ -156,7 +156,7 @@ export function authorizeRecipeRead(
   if (recipe.userId === user.id) return allow();
   if (
     recipe.visibility === "household" &&
-    household.isHouseholdMemberOfOwner
+    household.userSharesHouseholdWithOwner
   ) {
     return allow();
   }

--- a/workers/recipe-api/src/http/authorization.ts
+++ b/workers/recipe-api/src/http/authorization.ts
@@ -1,0 +1,162 @@
+import type { Context, MiddlewareHandler } from "hono";
+import { createAuth, type Auth } from "../auth";
+import type { createDb } from "../db";
+
+type AuthorizationEnv = Parameters<typeof createAuth>[1];
+type Db = ReturnType<typeof createDb>["db"];
+
+export type AuthenticatedSession = NonNullable<
+  Awaited<ReturnType<Auth["api"]["getSession"]>>
+>;
+export type AuthenticatedUser = AuthenticatedSession["user"];
+
+export type AuthorizationVariables = {
+  authSession: AuthenticatedSession;
+  authUser: AuthenticatedUser;
+};
+
+export type AuthorizationDecision =
+  | { allowed: true }
+  | { allowed: false; status: 401 | 403; error: string };
+export type AuthorizationFailure = Extract<
+  AuthorizationDecision,
+  { allowed: false }
+>;
+
+export type RecipeVisibility = "public" | "private" | "household";
+
+export type OwnedResource = {
+  userId: string;
+};
+
+export type RecipeResource = OwnedResource & {
+  visibility: RecipeVisibility;
+};
+
+export type HouseholdResource = {
+  ownerId: string;
+};
+
+export type HouseholdReadContext = {
+  isHouseholdMemberOfOwner: boolean;
+};
+
+export type AuthSessionLoader = (
+  c: Context<{ Variables: Partial<AuthorizationVariables> }>,
+) => Promise<AuthenticatedSession | null>;
+
+const noHouseholdReadAccess: HouseholdReadContext = {
+  isHouseholdMemberOfOwner: false,
+};
+
+function hasSessionSignal(c: Context): boolean {
+  return Boolean(c.req.header("cookie") || c.req.header("authorization"));
+}
+
+export function allow(): AuthorizationDecision {
+  return { allowed: true };
+}
+
+export function unauthenticated(): AuthorizationFailure {
+  return {
+    allowed: false,
+    status: 401,
+    error: "Authentication required",
+  };
+}
+
+export function forbidden(): AuthorizationFailure {
+  return {
+    allowed: false,
+    status: 403,
+    error: "Authorization required",
+  };
+}
+
+export function authorizationResponse(
+  c: Context,
+  decision: AuthorizationFailure,
+): Response {
+  return c.json({ error: decision.error }, decision.status);
+}
+
+export async function loadBetterAuthSession(
+  c: Context<{
+    Bindings: AuthorizationEnv;
+    Variables: Partial<AuthorizationVariables>;
+  }>,
+  db: Db,
+): Promise<AuthenticatedSession | null> {
+  if (!hasSessionSignal(c)) return null;
+  const auth = createAuth(db, c.env);
+  return auth.api.getSession({
+    headers: c.req.raw.headers,
+    query: { disableCookieCache: true },
+  });
+}
+
+export function requireAuthenticatedUser(
+  loadSession: AuthSessionLoader,
+): MiddlewareHandler<{ Variables: Partial<AuthorizationVariables> }> {
+  return async (c, next) => {
+    const session = await loadSession(c);
+    if (!session) return authorizationResponse(c, unauthenticated());
+
+    c.set("authSession", session);
+    c.set("authUser", session.user);
+    await next();
+  };
+}
+
+export function requireAuthorization(
+  loadSession: AuthSessionLoader,
+  authorize: (
+    session: AuthenticatedSession | null,
+    c: Context<{ Variables: Partial<AuthorizationVariables> }>,
+  ) => AuthorizationDecision | Promise<AuthorizationDecision>,
+): MiddlewareHandler<{ Variables: Partial<AuthorizationVariables> }> {
+  return async (c, next) => {
+    const session = await loadSession(c);
+    if (session) {
+      c.set("authSession", session);
+      c.set("authUser", session.user);
+    }
+
+    const decision = await authorize(session, c);
+    if (!decision.allowed) return authorizationResponse(c, decision);
+    await next();
+  };
+}
+
+export function authorizeOwnerOnly(
+  user: AuthenticatedUser | null | undefined,
+  resource: OwnedResource,
+): AuthorizationDecision {
+  if (!user) return unauthenticated();
+  return resource.userId === user.id ? allow() : forbidden();
+}
+
+export function authorizeRecipeRead(
+  user: AuthenticatedUser | null | undefined,
+  recipe: RecipeResource,
+  household: HouseholdReadContext = noHouseholdReadAccess,
+): AuthorizationDecision {
+  if (recipe.visibility === "public") return allow();
+  if (!user) return unauthenticated();
+  if (recipe.userId === user.id) return allow();
+  if (
+    recipe.visibility === "household" &&
+    household.isHouseholdMemberOfOwner
+  ) {
+    return allow();
+  }
+  return forbidden();
+}
+
+export function authorizeHouseholdMembershipManagement(
+  user: AuthenticatedUser | null | undefined,
+  household: HouseholdResource,
+): AuthorizationDecision {
+  if (!user) return unauthenticated();
+  return household.ownerId === user.id ? allow() : forbidden();
+}

--- a/workers/recipe-api/src/http/authorization.ts
+++ b/workers/recipe-api/src/http/authorization.ts
@@ -14,7 +14,12 @@ export type AuthorizationVariables = {
   authSession: AuthenticatedSession;
   authUser: AuthenticatedUser;
 };
-export type AuthenticatedVariables = AuthorizationVariables;
+
+/** Narrowed variant used after `requireAuthenticatedUser` succeeds. */
+export type AuthenticatedVariables = {
+  authSession: AuthenticatedSession;
+  authUser: AuthenticatedUser;
+};
 
 export type AuthorizationDecision =
   | { allowed: true }

--- a/workers/recipe-api/src/http/authorization.ts
+++ b/workers/recipe-api/src/http/authorization.ts
@@ -14,6 +14,7 @@ export type AuthorizationVariables = {
   authSession: AuthenticatedSession;
   authUser: AuthenticatedUser;
 };
+export type AuthenticatedVariables = AuthorizationVariables;
 
 export type AuthorizationDecision =
   | { allowed: true }
@@ -45,12 +46,16 @@ export type AuthSessionLoader = (
   c: Context<{ Variables: Partial<AuthorizationVariables> }>,
 ) => Promise<AuthenticatedSession | null>;
 
-const noHouseholdReadAccess: HouseholdReadContext = {
+const noHouseholdReadAccess: HouseholdReadContext = Object.freeze({
   isHouseholdMemberOfOwner: false,
-};
+});
 
 function hasSessionSignal(c: Context): boolean {
-  return Boolean(c.req.header("cookie") || c.req.header("authorization"));
+  if (c.req.header("authorization")) return true;
+
+  const cookie = c.req.header("cookie");
+  if (!cookie) return false;
+  return /(?:^|;\s*)(?:__Secure-)?better-auth[.-]session_token=/.test(cookie);
 }
 
 export function allow(): AuthorizationDecision {

--- a/workers/recipe-api/src/http/authorization.ts
+++ b/workers/recipe-api/src/http/authorization.ts
@@ -43,7 +43,7 @@ export type HouseholdReadContext = {
 };
 
 export type AuthSessionLoader = (
-  c: Context<{ Variables: Partial<AuthorizationVariables> }>,
+  c: Context,
 ) => Promise<AuthenticatedSession | null>;
 
 const noHouseholdReadAccess: HouseholdReadContext = Object.freeze({
@@ -102,7 +102,7 @@ export async function loadBetterAuthSession(
 
 export function requireAuthenticatedUser(
   loadSession: AuthSessionLoader,
-): MiddlewareHandler<{ Variables: Partial<AuthorizationVariables> }> {
+): MiddlewareHandler<{ Variables: AuthenticatedVariables }> {
   return async (c, next) => {
     const session = await loadSession(c);
     if (!session) return authorizationResponse(c, unauthenticated());

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -34,6 +34,7 @@ type Bindings = {
 };
 
 type Recipe = typeof schema.recipe.$inferSelect;
+type DbClient = ReturnType<typeof createDb>["client"];
 type AuthSessionResult =
   | { success: true; session: AuthenticatedSession }
   | { success: false; response: Response };
@@ -75,6 +76,7 @@ const updateRecipeBodySchema = z
     body: z.string().trim().min(1).nullable().optional(),
     visibility: recipeVisibilitySchema.optional(),
   })
+  .strict()
   .refine((body) => Object.keys(body).length > 0, {
     message: "At least one recipe field must be provided",
   });
@@ -92,6 +94,15 @@ function isValidAuthURL(value: string): boolean {
 
 function databaseConnection(env: Bindings): string | undefined {
   return env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL;
+}
+
+async function closeDbClient(client: DbClient | undefined) {
+  if (!client) return;
+  try {
+    await client.end({ timeout: 5 });
+  } catch (e) {
+    console.error("client.end() cleanup failed", e);
+  }
 }
 
 function recipeResponse(recipe: Recipe) {
@@ -347,8 +358,11 @@ app.get("/recipes", async (c) => {
       503,
     );
   }
-  const { db, client } = createDb(connectionString);
+  let client: DbClient | undefined;
   try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
     const recipes = await db
       .select()
       .from(schema.recipe)
@@ -358,11 +372,7 @@ app.get("/recipes", async (c) => {
     console.error("GET /recipes query failed", e);
     return c.json({ error: "Database query failed" }, 502);
   } finally {
-    try {
-      await client.end({ timeout: 5 });
-    } catch (e) {
-      console.error("client.end() cleanup failed", e);
-    }
+    await closeDbClient(client);
   }
 });
 
@@ -378,8 +388,11 @@ app.get("/recipes/:slug", async (c) => {
     );
   }
 
-  const { db, client } = createDb(connectionString);
+  let client: DbClient | undefined;
   try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
     const session = await loadOptionalRecipeSession(c, db);
     const recipe = await findReadableRecipeBySlug(
       db,
@@ -393,11 +406,7 @@ app.get("/recipes/:slug", async (c) => {
     console.error("GET /recipes/:slug query failed", e);
     return c.json({ error: "Database query failed" }, 502);
   } finally {
-    try {
-      await client.end({ timeout: 5 });
-    } catch (e) {
-      console.error("client.end() cleanup failed", e);
-    }
+    await closeDbClient(client);
   }
 });
 
@@ -413,8 +422,11 @@ app.post("/recipes", async (c) => {
     );
   }
 
-  const { db, client } = createDb(connectionString);
+  let client: DbClient | undefined;
   try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
     const session = await requireRecipeSession(c, db);
     if (!session.success) return session.response;
 
@@ -439,11 +451,7 @@ app.post("/recipes", async (c) => {
     console.error("POST /recipes mutation failed", e);
     return c.json({ error: "Database mutation failed" }, 502);
   } finally {
-    try {
-      await client.end({ timeout: 5 });
-    } catch (e) {
-      console.error("client.end() cleanup failed", e);
-    }
+    await closeDbClient(client);
   }
 });
 
@@ -462,8 +470,11 @@ app.patch("/recipes/:slug", async (c) => {
     );
   }
 
-  const { db, client } = createDb(connectionString);
+  let client: DbClient | undefined;
   try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
     const session = await requireRecipeSession(c, db);
     if (!session.success) return session.response;
 
@@ -495,11 +506,7 @@ app.patch("/recipes/:slug", async (c) => {
     console.error("PATCH /recipes/:slug mutation failed", e);
     return c.json({ error: "Database mutation failed" }, 502);
   } finally {
-    try {
-      await client.end({ timeout: 5 });
-    } catch (e) {
-      console.error("client.end() cleanup failed", e);
-    }
+    await closeDbClient(client);
   }
 });
 
@@ -518,8 +525,11 @@ app.delete("/recipes/:slug", async (c) => {
     );
   }
 
-  const { db, client } = createDb(connectionString);
+  let client: DbClient | undefined;
   try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
     const session = await requireRecipeSession(c, db);
     if (!session.success) return session.response;
 
@@ -546,11 +556,7 @@ app.delete("/recipes/:slug", async (c) => {
     console.error("DELETE /recipes/:slug mutation failed", e);
     return c.json({ error: "Database mutation failed" }, 502);
   } finally {
-    try {
-      await client.end({ timeout: 5 });
-    } catch (e) {
-      console.error("client.end() cleanup failed", e);
-    }
+    await closeDbClient(client);
   }
 });
 

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -4,6 +4,14 @@ import { z } from "zod";
 import { createDb, schema } from "./db";
 import { createAuth } from "./auth";
 import { verifyCloudflareAccess } from "./cloudflare-access";
+import {
+  type AuthorizationVariables,
+  authorizationResponse,
+  authorizeOwnerOnly,
+  authorizeRecipeRead,
+  loadBetterAuthSession,
+  unauthenticated,
+} from "./http/authorization";
 import { validateCsrf } from "./http/security";
 import { parseJsonBody } from "./http/validation";
 import {
@@ -26,11 +34,37 @@ type Bindings = {
   CF_ACCESS_AUD?: string;
 };
 
-const app = new Hono<{ Bindings: Bindings }>();
+type Recipe = typeof schema.recipe.$inferSelect;
+
+const app = new Hono<{
+  Bindings: Bindings;
+  Variables: Partial<AuthorizationVariables>;
+}>();
 
 const previewSignInBodySchema = z.object({
   scenario: z.string().trim().min(1),
 });
+
+const recipeVisibilitySchema = z.enum(["public", "private", "household"]);
+
+const createRecipeBodySchema = z.object({
+  slug: z.string().trim().min(1),
+  title: z.string().trim().min(1),
+  description: z.string().trim().min(1).optional(),
+  body: z.string().trim().min(1).optional(),
+  visibility: recipeVisibilitySchema.default("private"),
+});
+
+const updateRecipeBodySchema = z
+  .object({
+    title: z.string().trim().min(1).optional(),
+    description: z.string().trim().min(1).nullable().optional(),
+    body: z.string().trim().min(1).nullable().optional(),
+    visibility: recipeVisibilitySchema.optional(),
+  })
+  .refine((body) => Object.keys(body).length > 0, {
+    message: "At least one recipe field must be provided",
+  });
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
@@ -62,6 +96,18 @@ function hasAuthConfiguration(env: Bindings): boolean {
       env.GITHUB_CLIENT_ID &&
       env.GITHUB_CLIENT_SECRET,
   );
+}
+
+async function findRecipeBySlug(
+  db: ReturnType<typeof createDb>["db"],
+  slug: string,
+): Promise<Recipe | undefined> {
+  const [recipe] = await db
+    .select()
+    .from(schema.recipe)
+    .where(eq(schema.recipe.slug, slug))
+    .limit(1);
+  return recipe;
 }
 
 async function hasPreviewAccess(request: Request, env: Bindings) {
@@ -188,6 +234,160 @@ app.get("/recipes", async (c) => {
   } catch (e) {
     console.error("GET /recipes query failed", e);
     return c.json({ error: "Database query failed" }, 502);
+  } finally {
+    try {
+      await client.end({ timeout: 5 });
+    } catch (e) {
+      console.error("client.end() cleanup failed", e);
+    }
+  }
+});
+
+app.get("/recipes/:slug", async (c) => {
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  const { db, client } = createDb(connectionString);
+  try {
+    const recipe = await findRecipeBySlug(db, c.req.param("slug"));
+    if (!recipe) return c.notFound();
+
+    const session = await loadBetterAuthSession(c, db);
+    const decision = authorizeRecipeRead(session?.user, recipe);
+    if (!decision.allowed) return authorizationResponse(c, decision);
+
+    return c.json(recipe);
+  } catch (e) {
+    console.error("GET /recipes/:slug query failed", e);
+    return c.json({ error: "Database query failed" }, 502);
+  } finally {
+    try {
+      await client.end({ timeout: 5 });
+    } catch (e) {
+      console.error("client.end() cleanup failed", e);
+    }
+  }
+});
+
+app.post("/recipes", async (c) => {
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  const { db, client } = createDb(connectionString);
+  try {
+    const session = await loadBetterAuthSession(c, db);
+    if (!session) return authorizationResponse(c, unauthenticated());
+
+    const csrfFailure = validateCsrf(c);
+    if (csrfFailure) return csrfFailure;
+
+    const body = await parseJsonBody(c, createRecipeBodySchema);
+    if (!body.success) return body.response;
+
+    const [recipe] = await db
+      .insert(schema.recipe)
+      .values({
+        ...body.data,
+        userId: session.user.id,
+      })
+      .returning();
+
+    return c.json(recipe, 201);
+  } catch (e) {
+    console.error("POST /recipes mutation failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    try {
+      await client.end({ timeout: 5 });
+    } catch (e) {
+      console.error("client.end() cleanup failed", e);
+    }
+  }
+});
+
+app.patch("/recipes/:slug", async (c) => {
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  const { db, client } = createDb(connectionString);
+  try {
+    const session = await loadBetterAuthSession(c, db);
+    if (!session) return authorizationResponse(c, unauthenticated());
+
+    const csrfFailure = validateCsrf(c);
+    if (csrfFailure) return csrfFailure;
+
+    const recipe = await findRecipeBySlug(db, c.req.param("slug"));
+    if (!recipe) return c.notFound();
+
+    const decision = authorizeOwnerOnly(session.user, recipe);
+    if (!decision.allowed) return authorizationResponse(c, decision);
+
+    const body = await parseJsonBody(c, updateRecipeBodySchema);
+    if (!body.success) return body.response;
+
+    const [updatedRecipe] = await db
+      .update(schema.recipe)
+      .set(body.data)
+      .where(eq(schema.recipe.id, recipe.id))
+      .returning();
+
+    return c.json(updatedRecipe);
+  } catch (e) {
+    console.error("PATCH /recipes/:slug mutation failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    try {
+      await client.end({ timeout: 5 });
+    } catch (e) {
+      console.error("client.end() cleanup failed", e);
+    }
+  }
+});
+
+app.delete("/recipes/:slug", async (c) => {
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  const { db, client } = createDb(connectionString);
+  try {
+    const session = await loadBetterAuthSession(c, db);
+    if (!session) return authorizationResponse(c, unauthenticated());
+
+    const csrfFailure = validateCsrf(c);
+    if (csrfFailure) return csrfFailure;
+
+    const recipe = await findRecipeBySlug(db, c.req.param("slug"));
+    if (!recipe) return c.notFound();
+
+    const decision = authorizeOwnerOnly(session.user, recipe);
+    if (!decision.allowed) return authorizationResponse(c, decision);
+
+    await db.delete(schema.recipe).where(eq(schema.recipe.id, recipe.id));
+    return c.body(null, 204);
+  } catch (e) {
+    console.error("DELETE /recipes/:slug mutation failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
   } finally {
     try {
       await client.end({ timeout: 5 });

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -1,5 +1,5 @@
-import { Hono } from "hono";
-import { eq } from "drizzle-orm";
+import { Hono, type Context } from "hono";
+import { and, eq, or } from "drizzle-orm";
 import { z } from "zod";
 import { createDb, schema } from "./db";
 import { createAuth } from "./auth";
@@ -7,8 +7,6 @@ import { verifyCloudflareAccess } from "./cloudflare-access";
 import {
   type AuthorizationVariables,
   authorizationResponse,
-  authorizeOwnerOnly,
-  authorizeRecipeRead,
   loadBetterAuthSession,
   unauthenticated,
 } from "./http/authorization";
@@ -35,20 +33,31 @@ type Bindings = {
 };
 
 type Recipe = typeof schema.recipe.$inferSelect;
-
-const app = new Hono<{
+type AppEnv = {
   Bindings: Bindings;
   Variables: Partial<AuthorizationVariables>;
-}>();
+};
+
+const app = new Hono<AppEnv>();
 
 const previewSignInBodySchema = z.object({
   scenario: z.string().trim().min(1),
 });
 
+const recipeSlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(120)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+    message:
+      "Slug must use lowercase letters, numbers, and single hyphens between words",
+  });
+
 const recipeVisibilitySchema = z.enum(["public", "private", "household"]);
 
 const createRecipeBodySchema = z.object({
-  slug: z.string().trim().min(1),
+  slug: recipeSlugSchema,
   title: z.string().trim().min(1),
   description: z.string().trim().min(1).optional(),
   body: z.string().trim().min(1).optional(),
@@ -81,6 +90,33 @@ function databaseConnection(env: Bindings): string | undefined {
   return env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL;
 }
 
+function invalidSlugResponse(c: Context<AppEnv>) {
+  return c.json(
+    {
+      error: "Invalid recipe slug",
+      details: [
+        {
+          path: ["slug"],
+          message:
+            "Slug must use lowercase letters, numbers, and single hyphens between words",
+        },
+      ],
+    },
+    400,
+  );
+}
+
+function parseRecipeSlug(c: Context<AppEnv>) {
+  const result = recipeSlugSchema.safeParse(c.req.param("slug"));
+  if (!result.success) {
+    return {
+      success: false,
+      response: invalidSlugResponse(c),
+    } as const;
+  }
+  return { success: true, slug: result.data } as const;
+}
+
 function hasAuthConfiguration(env: Bindings): boolean {
   if (!env.BETTER_AUTH_URL || !env.BETTER_AUTH_SECRET) return false;
   if (env.DEPLOYMENT_ENV === "preview") {
@@ -98,14 +134,31 @@ function hasAuthConfiguration(env: Bindings): boolean {
   );
 }
 
-async function findRecipeBySlug(
+async function findReadableRecipeBySlug(
   db: ReturnType<typeof createDb>["db"],
   slug: string,
+  userId: string | undefined,
+): Promise<Recipe | undefined> {
+  const visibilityFilter = userId
+    ? or(eq(schema.recipe.visibility, "public"), eq(schema.recipe.userId, userId))
+    : eq(schema.recipe.visibility, "public");
+  const [recipe] = await db
+    .select()
+    .from(schema.recipe)
+    .where(and(eq(schema.recipe.slug, slug), visibilityFilter))
+    .limit(1);
+  return recipe;
+}
+
+async function findOwnedRecipeBySlug(
+  db: ReturnType<typeof createDb>["db"],
+  slug: string,
+  userId: string,
 ): Promise<Recipe | undefined> {
   const [recipe] = await db
     .select()
     .from(schema.recipe)
-    .where(eq(schema.recipe.slug, slug))
+    .where(and(eq(schema.recipe.slug, slug), eq(schema.recipe.userId, userId)))
     .limit(1);
   return recipe;
 }
@@ -244,6 +297,9 @@ app.get("/recipes", async (c) => {
 });
 
 app.get("/recipes/:slug", async (c) => {
+  const slug = parseRecipeSlug(c);
+  if (!slug.success) return slug.response;
+
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
     return c.json(
@@ -254,12 +310,13 @@ app.get("/recipes/:slug", async (c) => {
 
   const { db, client } = createDb(connectionString);
   try {
-    const recipe = await findRecipeBySlug(db, c.req.param("slug"));
-    if (!recipe) return c.notFound();
-
     const session = await loadBetterAuthSession(c, db);
-    const decision = authorizeRecipeRead(session?.user, recipe);
-    if (!decision.allowed) return authorizationResponse(c, decision);
+    const recipe = await findReadableRecipeBySlug(
+      db,
+      slug.slug,
+      session?.user.id,
+    );
+    if (!recipe) return c.notFound();
 
     return c.json(recipe);
   } catch (e) {
@@ -302,6 +359,8 @@ app.post("/recipes", async (c) => {
       })
       .returning();
 
+    if (!recipe) return c.json({ error: "Database mutation failed" }, 502);
+
     return c.json(recipe, 201);
   } catch (e) {
     console.error("POST /recipes mutation failed", e);
@@ -316,6 +375,9 @@ app.post("/recipes", async (c) => {
 });
 
 app.patch("/recipes/:slug", async (c) => {
+  const slug = parseRecipeSlug(c);
+  if (!slug.success) return slug.response;
+
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
     return c.json(
@@ -332,11 +394,8 @@ app.patch("/recipes/:slug", async (c) => {
     const csrfFailure = validateCsrf(c);
     if (csrfFailure) return csrfFailure;
 
-    const recipe = await findRecipeBySlug(db, c.req.param("slug"));
+    const recipe = await findOwnedRecipeBySlug(db, slug.slug, session.user.id);
     if (!recipe) return c.notFound();
-
-    const decision = authorizeOwnerOnly(session.user, recipe);
-    if (!decision.allowed) return authorizationResponse(c, decision);
 
     const body = await parseJsonBody(c, updateRecipeBodySchema);
     if (!body.success) return body.response;
@@ -346,6 +405,8 @@ app.patch("/recipes/:slug", async (c) => {
       .set(body.data)
       .where(eq(schema.recipe.id, recipe.id))
       .returning();
+
+    if (!updatedRecipe) return c.notFound();
 
     return c.json(updatedRecipe);
   } catch (e) {
@@ -361,6 +422,9 @@ app.patch("/recipes/:slug", async (c) => {
 });
 
 app.delete("/recipes/:slug", async (c) => {
+  const slug = parseRecipeSlug(c);
+  if (!slug.success) return slug.response;
+
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
     return c.json(
@@ -377,13 +441,15 @@ app.delete("/recipes/:slug", async (c) => {
     const csrfFailure = validateCsrf(c);
     if (csrfFailure) return csrfFailure;
 
-    const recipe = await findRecipeBySlug(db, c.req.param("slug"));
+    const recipe = await findOwnedRecipeBySlug(db, slug.slug, session.user.id);
     if (!recipe) return c.notFound();
 
-    const decision = authorizeOwnerOnly(session.user, recipe);
-    if (!decision.allowed) return authorizationResponse(c, decision);
+    const [deletedRecipe] = await db
+      .delete(schema.recipe)
+      .where(eq(schema.recipe.id, recipe.id))
+      .returning({ id: schema.recipe.id });
+    if (!deletedRecipe) return c.notFound();
 
-    await db.delete(schema.recipe).where(eq(schema.recipe.id, recipe.id));
     return c.body(null, 204);
   } catch (e) {
     console.error("DELETE /recipes/:slug mutation failed", e);

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -5,6 +5,7 @@ import { createDb, schema } from "./db";
 import { createAuth } from "./auth";
 import { verifyCloudflareAccess } from "./cloudflare-access";
 import {
+  type AuthenticatedSession,
   type AuthorizationVariables,
   authorizationResponse,
   loadBetterAuthSession,
@@ -33,6 +34,9 @@ type Bindings = {
 };
 
 type Recipe = typeof schema.recipe.$inferSelect;
+type AuthSessionResult =
+  | { success: true; session: AuthenticatedSession }
+  | { success: false; response: Response };
 type AppEnv = {
   Bindings: Bindings;
   Variables: Partial<AuthorizationVariables>;
@@ -90,6 +94,11 @@ function databaseConnection(env: Bindings): string | undefined {
   return env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL;
 }
 
+function recipeResponse(recipe: Recipe) {
+  const { userId: _userId, ...response } = recipe;
+  return response;
+}
+
 function invalidSlugResponse(c: Context<AppEnv>) {
   return c.json(
     {
@@ -131,6 +140,67 @@ function hasAuthConfiguration(env: Bindings): boolean {
       env.GOOGLE_CLIENT_SECRET &&
       env.GITHUB_CLIENT_ID &&
       env.GITHUB_CLIENT_SECRET,
+  );
+}
+
+function hasLoadableAuthConfiguration(env: Bindings): boolean {
+  return hasAuthConfiguration(env) && isValidAuthURL(env.BETTER_AUTH_URL);
+}
+
+async function loadOptionalRecipeSession(
+  c: Context<AppEnv>,
+  db: ReturnType<typeof createDb>["db"],
+): Promise<AuthenticatedSession | null> {
+  if (!hasLoadableAuthConfiguration(c.env)) return null;
+  try {
+    return await loadBetterAuthSession(c, db);
+  } catch (error) {
+    console.error("Recipe session lookup failed", error);
+    return null;
+  }
+}
+
+async function requireRecipeSession(
+  c: Context<AppEnv>,
+  db: ReturnType<typeof createDb>["db"],
+): Promise<AuthSessionResult> {
+  if (!hasAuthConfiguration(c.env)) {
+    return {
+      success: false,
+      response: c.json({ error: "Auth configuration is incomplete" }, 503),
+    };
+  }
+  if (!isValidAuthURL(c.env.BETTER_AUTH_URL)) {
+    return {
+      success: false,
+      response: c.json({ error: "Auth configuration is invalid" }, 503),
+    };
+  }
+
+  try {
+    const session = await loadBetterAuthSession(c, db);
+    if (!session) {
+      return {
+        success: false,
+        response: authorizationResponse(c, unauthenticated()),
+      };
+    }
+    return { success: true, session };
+  } catch (error) {
+    console.error("Recipe session lookup failed", error);
+    return {
+      success: false,
+      response: c.json({ error: "Auth session lookup failed" }, 503),
+    };
+  }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "23505"
   );
 }
 
@@ -283,7 +353,7 @@ app.get("/recipes", async (c) => {
       .select()
       .from(schema.recipe)
       .where(eq(schema.recipe.visibility, "public"));
-    return c.json(recipes);
+    return c.json(recipes.map(recipeResponse));
   } catch (e) {
     console.error("GET /recipes query failed", e);
     return c.json({ error: "Database query failed" }, 502);
@@ -310,7 +380,7 @@ app.get("/recipes/:slug", async (c) => {
 
   const { db, client } = createDb(connectionString);
   try {
-    const session = await loadBetterAuthSession(c, db);
+    const session = await loadOptionalRecipeSession(c, db);
     const recipe = await findReadableRecipeBySlug(
       db,
       slug.slug,
@@ -318,7 +388,7 @@ app.get("/recipes/:slug", async (c) => {
     );
     if (!recipe) return c.notFound();
 
-    return c.json(recipe);
+    return c.json(recipeResponse(recipe));
   } catch (e) {
     console.error("GET /recipes/:slug query failed", e);
     return c.json({ error: "Database query failed" }, 502);
@@ -332,6 +402,9 @@ app.get("/recipes/:slug", async (c) => {
 });
 
 app.post("/recipes", async (c) => {
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
     return c.json(
@@ -342,11 +415,8 @@ app.post("/recipes", async (c) => {
 
   const { db, client } = createDb(connectionString);
   try {
-    const session = await loadBetterAuthSession(c, db);
-    if (!session) return authorizationResponse(c, unauthenticated());
-
-    const csrfFailure = validateCsrf(c);
-    if (csrfFailure) return csrfFailure;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
 
     const body = await parseJsonBody(c, createRecipeBodySchema);
     if (!body.success) return body.response;
@@ -355,14 +425,17 @@ app.post("/recipes", async (c) => {
       .insert(schema.recipe)
       .values({
         ...body.data,
-        userId: session.user.id,
+        userId: session.session.user.id,
       })
       .returning();
 
     if (!recipe) return c.json({ error: "Database mutation failed" }, 502);
 
-    return c.json(recipe, 201);
+    return c.json(recipeResponse(recipe), 201);
   } catch (e) {
+    if (isUniqueViolation(e)) {
+      return c.json({ error: "Recipe slug already exists" }, 409);
+    }
     console.error("POST /recipes mutation failed", e);
     return c.json({ error: "Database mutation failed" }, 502);
   } finally {
@@ -378,6 +451,9 @@ app.patch("/recipes/:slug", async (c) => {
   const slug = parseRecipeSlug(c);
   if (!slug.success) return slug.response;
 
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
     return c.json(
@@ -388,13 +464,14 @@ app.patch("/recipes/:slug", async (c) => {
 
   const { db, client } = createDb(connectionString);
   try {
-    const session = await loadBetterAuthSession(c, db);
-    if (!session) return authorizationResponse(c, unauthenticated());
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
 
-    const csrfFailure = validateCsrf(c);
-    if (csrfFailure) return csrfFailure;
-
-    const recipe = await findOwnedRecipeBySlug(db, slug.slug, session.user.id);
+    const recipe = await findOwnedRecipeBySlug(
+      db,
+      slug.slug,
+      session.session.user.id,
+    );
     if (!recipe) return c.notFound();
 
     const body = await parseJsonBody(c, updateRecipeBodySchema);
@@ -403,12 +480,17 @@ app.patch("/recipes/:slug", async (c) => {
     const [updatedRecipe] = await db
       .update(schema.recipe)
       .set(body.data)
-      .where(eq(schema.recipe.id, recipe.id))
+      .where(
+        and(
+          eq(schema.recipe.id, recipe.id),
+          eq(schema.recipe.userId, session.session.user.id),
+        ),
+      )
       .returning();
 
     if (!updatedRecipe) return c.notFound();
 
-    return c.json(updatedRecipe);
+    return c.json(recipeResponse(updatedRecipe));
   } catch (e) {
     console.error("PATCH /recipes/:slug mutation failed", e);
     return c.json({ error: "Database mutation failed" }, 502);
@@ -425,6 +507,9 @@ app.delete("/recipes/:slug", async (c) => {
   const slug = parseRecipeSlug(c);
   if (!slug.success) return slug.response;
 
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
     return c.json(
@@ -435,18 +520,24 @@ app.delete("/recipes/:slug", async (c) => {
 
   const { db, client } = createDb(connectionString);
   try {
-    const session = await loadBetterAuthSession(c, db);
-    if (!session) return authorizationResponse(c, unauthenticated());
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
 
-    const csrfFailure = validateCsrf(c);
-    if (csrfFailure) return csrfFailure;
-
-    const recipe = await findOwnedRecipeBySlug(db, slug.slug, session.user.id);
+    const recipe = await findOwnedRecipeBySlug(
+      db,
+      slug.slug,
+      session.session.user.id,
+    );
     if (!recipe) return c.notFound();
 
     const [deletedRecipe] = await db
       .delete(schema.recipe)
-      .where(eq(schema.recipe.id, recipe.id))
+      .where(
+        and(
+          eq(schema.recipe.id, recipe.id),
+          eq(schema.recipe.userId, session.session.user.id),
+        ),
+      )
       .returning({ id: schema.recipe.id });
     if (!deletedRecipe) return c.notFound();
 

--- a/workers/recipe-api/tests/authorization.test.ts
+++ b/workers/recipe-api/tests/authorization.test.ts
@@ -1,0 +1,140 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import {
+  type AuthenticatedSession,
+  authorizeHouseholdMembershipManagement,
+  authorizeOwnerOnly,
+  authorizeRecipeRead,
+  forbidden,
+  requireAuthorization,
+  requireAuthenticatedUser,
+} from "../src/http/authorization";
+
+const ownerSession = {
+  user: {
+    id: "user-owner",
+    email: "owner@example.test",
+    name: "Owner",
+    emailVerified: true,
+    banned: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  },
+  session: {
+    id: "session-owner",
+    token: "token-owner",
+    userId: "user-owner",
+    expiresAt: new Date("2026-01-02T00:00:00.000Z"),
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  },
+} satisfies AuthenticatedSession;
+
+describe("authorization policies", () => {
+  it("allows public recipe reads without a user", () => {
+    expect(
+      authorizeRecipeRead(undefined, {
+        userId: "recipe-owner",
+        visibility: "public",
+      }),
+    ).toEqual({ allowed: true });
+  });
+
+  it("requires authentication before private or household recipe reads", () => {
+    expect(
+      authorizeRecipeRead(undefined, {
+        userId: "recipe-owner",
+        visibility: "private",
+      }),
+    ).toEqual({
+      allowed: false,
+      status: 401,
+      error: "Authentication required",
+    });
+
+    expect(
+      authorizeRecipeRead(undefined, {
+        userId: "recipe-owner",
+        visibility: "household",
+      }),
+    ).toEqual({
+      allowed: false,
+      status: 401,
+      error: "Authentication required",
+    });
+  });
+
+  it("allows owner-only resource access only to the resource owner", () => {
+    expect(
+      authorizeOwnerOnly(ownerSession.user, { userId: "user-owner" }),
+    ).toEqual({ allowed: true });
+    expect(
+      authorizeOwnerOnly(ownerSession.user, { userId: "someone-else" }),
+    ).toEqual({
+      allowed: false,
+      status: 403,
+      error: "Authorization required",
+    });
+  });
+
+  it("allows household-shared recipe reads for household members", () => {
+    expect(
+      authorizeRecipeRead(
+        ownerSession.user,
+        {
+          userId: "someone-else",
+          visibility: "household",
+        },
+        { isHouseholdMemberOfOwner: true },
+      ),
+    ).toEqual({ allowed: true });
+  });
+
+  it("keeps household membership management owner-only", () => {
+    expect(
+      authorizeHouseholdMembershipManagement(ownerSession.user, {
+        ownerId: "user-owner",
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      authorizeHouseholdMembershipManagement(ownerSession.user, {
+        ownerId: "someone-else",
+      }),
+    ).toEqual({
+      allowed: false,
+      status: 403,
+      error: "Authorization required",
+    });
+  });
+});
+
+describe("authorization middleware", () => {
+  it("returns 401 when a privileged route has no authenticated session", async () => {
+    const app = new Hono();
+    app.use(
+      "/protected",
+      requireAuthenticatedUser(async () => null),
+    );
+    app.get("/protected", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/protected");
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+
+  it("returns 403 when an authenticated user is not authorized", async () => {
+    const app = new Hono();
+    app.use(
+      "/owner-only",
+      requireAuthorization(
+        async () => ownerSession,
+        () => forbidden(),
+      ),
+    );
+    app.get("/owner-only", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/owner-only");
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Authorization required" });
+  });
+});

--- a/workers/recipe-api/tests/authorization.test.ts
+++ b/workers/recipe-api/tests/authorization.test.ts
@@ -109,6 +109,32 @@ describe("authorization policies", () => {
 });
 
 describe("authorization middleware", () => {
+  it("continues to the route with auth context when a session exists", async () => {
+    const app = new Hono<{
+      Variables: {
+        authSession: AuthenticatedSession;
+        authUser: AuthenticatedSession["user"];
+      };
+    }>();
+    app.use(
+      "/protected",
+      requireAuthenticatedUser(async () => ownerSession),
+    );
+    app.get("/protected", (c) =>
+      c.json({
+        userId: c.var.authUser.id,
+        sessionUserId: c.var.authSession.session.userId,
+      }),
+    );
+
+    const res = await app.request("/protected");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      userId: "user-owner",
+      sessionUserId: "user-owner",
+    });
+  });
+
   it("returns 401 when a privileged route has no authenticated session", async () => {
     const app = new Hono();
     app.use(
@@ -136,5 +162,21 @@ describe("authorization middleware", () => {
     const res = await app.request("/owner-only");
     expect(res.status).toBe(403);
     expect(await res.json()).toEqual({ error: "Authorization required" });
+  });
+
+  it("continues to the route when authorization allows the session", async () => {
+    const app = new Hono();
+    app.use(
+      "/owner-only",
+      requireAuthorization(
+        async () => ownerSession,
+        () => ({ allowed: true }),
+      ),
+    );
+    app.get("/owner-only", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/owner-only");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
   });
 });

--- a/workers/recipe-api/tests/authorization.test.ts
+++ b/workers/recipe-api/tests/authorization.test.ts
@@ -85,7 +85,7 @@ describe("authorization policies", () => {
           userId: "someone-else",
           visibility: "household",
         },
-        { isHouseholdMemberOfOwner: true },
+        { userSharesHouseholdWithOwner: true },
       ),
     ).toEqual({ allowed: true });
   });

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -91,6 +91,29 @@ describe("GET /recipes", () => {
   });
 });
 
+describe("POST /recipes", () => {
+  it("requires authentication", async () => {
+    const res = await app.request(
+      "/recipes",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          slug: "private-draft",
+          title: "Private Draft",
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+});
+
 describe("POST /api/auth/sign-in/social", () => {
   it.each(["google", "github"] as const)(
     "uses the public frontend callback for %s",

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -91,6 +91,28 @@ describe("GET /recipes", () => {
   });
 });
 
+describe("GET /recipes/:slug", () => {
+  it("rejects malformed slugs before database access", async () => {
+    const res = await app.request(
+      "/recipes/Invalid%20Slug",
+      {},
+      { DATABASE_URL: "" },
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Invalid recipe slug",
+      details: [
+        {
+          path: ["slug"],
+          message:
+            "Slug must use lowercase letters, numbers, and single hyphens between words",
+        },
+      ],
+    });
+  });
+});
+
 describe("POST /recipes", () => {
   it("requires authentication", async () => {
     const res = await app.request(
@@ -111,6 +133,28 @@ describe("POST /recipes", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+});
+
+describe("PATCH /recipes/:slug", () => {
+  it("rejects malformed slugs before authentication or database access", async () => {
+    const res = await app.request(
+      "/recipes/-invalid",
+      { method: "PATCH" },
+      { DATABASE_URL: "" },
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Invalid recipe slug",
+      details: [
+        {
+          path: ["slug"],
+          message:
+            "Slug must use lowercase letters, numbers, and single hyphens between words",
+        },
+      ],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Add reusable recipe-api authorization helpers and middleware for Better Auth-backed session loading, 401/403 responses, owner-only access, household-shared read policy, and household-owner membership management checks.
- Enforce authorization on recipe detail and privileged recipe mutation routes while preserving the public `/recipes` read path.
- Add focused Worker tests for the ADR 034 policy matrix decisions, middleware status behavior, and unauthenticated recipe write enforcement.

## Notes

The current Worker schema has recipe ownership and `public` / `private` / `household` visibility, but no household membership table or Better Auth organization wiring yet. Household-shared read support is represented in the reusable policy helper and fail-closed in current routes until there is a server-side membership source of truth.

## Validation

- `CI=true mise //workers/recipe-api:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recipe access controls for public, private, and household recipes.
  * Introduced recipe actions by slug, including viewing, creating, updating, and deleting recipes.

* **Bug Fixes**
  * Invalid recipe slugs are now rejected early with clear validation errors.
  * Unauthorised requests now return consistent 401/403 responses.

* **Tests**
  * Added coverage for authorisation rules and recipe route validation/authentication checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->