### PR TITLE
Household membership flows

### DIFF
--- a/workers/recipe-api/src/db/schema.ts
+++ b/workers/recipe-api/src/db/schema.ts
@@ -5,6 +5,7 @@ import {
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 
@@ -88,6 +89,62 @@ export const visibilityEnum = pgEnum("visibility", [
   "private",
   "household",
 ]);
+
+export const organization = pgTable("organization", {
+  id: text().primaryKey(),
+  name: text().notNull(),
+  slug: text().notNull().unique(),
+  logo: text(),
+  metadata: text(),
+  createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp({ withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export const member = pgTable(
+  "member",
+  {
+    id: text().primaryKey(),
+    organizationId: text()
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    userId: text()
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    role: text().notNull().default("member"),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("member_organization_id_idx").on(table.organizationId),
+    index("member_user_id_idx").on(table.userId),
+    uniqueIndex("member_user_unique").on(table.userId),
+  ],
+);
+
+export const invitation = pgTable(
+  "invitation",
+  {
+    id: text().primaryKey(),
+    organizationId: text()
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    email: text().notNull(),
+    role: text().notNull().default("member"),
+    status: text().notNull().default("pending"),
+    expiresAt: timestamp({ withTimezone: true }).notNull(),
+    inviterId: text()
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("invitation_organization_id_idx").on(table.organizationId),
+    index("invitation_email_idx").on(table.email),
+    index("invitation_status_idx").on(table.status),
+  ],
+);
 
 export const recipe = pgTable(
   "recipe",

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -1,5 +1,5 @@
 import { Hono, type Context } from "hono";
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, inArray, or } from "drizzle-orm";
 import { z } from "zod";
 import { createDb, schema } from "./db";
 import { createAuth } from "./auth";
@@ -8,6 +8,10 @@ import {
   type AuthenticatedSession,
   type AuthorizationVariables,
   authorizationResponse,
+  authorizeHouseholdMembershipManagement,
+  authorizeOwnerOnly,
+  authorizeRecipeRead,
+  forbidden,
   loadBetterAuthSession,
   unauthenticated,
 } from "./http/authorization";
@@ -34,6 +38,9 @@ type Bindings = {
 };
 
 type Recipe = typeof schema.recipe.$inferSelect;
+type Household = typeof schema.organization.$inferSelect;
+type HouseholdMember = typeof schema.member.$inferSelect;
+type HouseholdInvitation = typeof schema.invitation.$inferSelect;
 type DbClient = ReturnType<typeof createDb>["client"];
 type AuthSessionResult =
   | { success: true; session: AuthenticatedSession }
@@ -61,6 +68,9 @@ const recipeSlugSchema = z
 
 const recipeVisibilitySchema = z.enum(["public", "private", "household"]);
 
+// Household invitations stay valid for 48 hours after they are created.
+const INVITATION_EXPIRY_MS = 48 * 60 * 60 * 1000;
+
 const createRecipeBodySchema = z.object({
   slug: recipeSlugSchema,
   title: z.string().trim().min(1),
@@ -80,6 +90,18 @@ const updateRecipeBodySchema = z
   .refine((body) => Object.keys(body).length > 0, {
     message: "At least one recipe field must be provided",
   });
+
+const createHouseholdBodySchema = z
+  .object({
+    name: z.string().trim().min(1).max(120).optional(),
+  })
+  .strict();
+
+const inviteHouseholdMemberBodySchema = z
+  .object({
+    email: z.string().trim().email(),
+  })
+  .strict();
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 
@@ -108,6 +130,44 @@ async function closeDbClient(client: DbClient | undefined) {
 function recipeResponse(recipe: Recipe) {
   const { userId: _userId, ...response } = recipe;
   return response;
+}
+
+function householdResponse(household: Household) {
+  const { metadata: _metadata, ...response } = household;
+  return response;
+}
+
+function memberResponse(
+  member: HouseholdMember & {
+    user: Pick<typeof schema.user.$inferSelect, "id" | "email" | "name" | "image">;
+  },
+) {
+  return {
+    id: member.id,
+    role: member.role,
+    createdAt: member.createdAt,
+    user: member.user,
+  };
+}
+
+function invitationResponse(invitation: HouseholdInvitation) {
+  return {
+    id: invitation.id,
+    householdId: invitation.organizationId,
+    email: invitation.email,
+    role: invitation.role,
+    status: invitation.status,
+    expiresAt: invitation.expiresAt,
+    createdAt: invitation.createdAt,
+  };
+}
+
+function createId() {
+  return crypto.randomUUID();
+}
+
+function householdSlug() {
+  return `household-${createId()}`;
 }
 
 function invalidSlugResponse(c: Context<AppEnv>) {
@@ -215,20 +275,57 @@ function isUniqueViolation(error: unknown): boolean {
   );
 }
 
-async function findReadableRecipeBySlug(
+async function findRecipeBySlug(
   db: ReturnType<typeof createDb>["db"],
   slug: string,
-  userId: string | undefined,
 ): Promise<Recipe | undefined> {
-  const visibilityFilter = userId
-    ? or(eq(schema.recipe.visibility, "public"), eq(schema.recipe.userId, userId))
-    : eq(schema.recipe.visibility, "public");
   const [recipe] = await db
     .select()
     .from(schema.recipe)
-    .where(and(eq(schema.recipe.slug, slug), visibilityFilter))
+    .where(eq(schema.recipe.slug, slug))
     .limit(1);
   return recipe;
+}
+
+async function findReadableRecipes(
+  db: ReturnType<typeof createDb>["db"],
+  userId: string | undefined,
+): Promise<Recipe[]> {
+  if (!userId) {
+    return db
+      .select()
+      .from(schema.recipe)
+      .where(eq(schema.recipe.visibility, "public"));
+  }
+
+  const householdMembership = await findUserHouseholdMembership(db, userId);
+  const householdMemberIds = householdMembership
+    ? await findHouseholdMemberUserIds(
+        db,
+        householdMembership.organizationId,
+      )
+    : [];
+
+  const householdFilter =
+    householdMemberIds.length > 0
+      ? and(
+          eq(schema.recipe.visibility, "household"),
+          inArray(schema.recipe.userId, householdMemberIds),
+        )
+      : undefined;
+
+  return db
+    .select()
+    .from(schema.recipe)
+    .where(
+      householdFilter
+        ? or(
+            eq(schema.recipe.visibility, "public"),
+            eq(schema.recipe.userId, userId),
+            householdFilter,
+          )
+        : or(eq(schema.recipe.visibility, "public"), eq(schema.recipe.userId, userId)),
+    );
 }
 
 async function findOwnedRecipeBySlug(
@@ -242,6 +339,131 @@ async function findOwnedRecipeBySlug(
     .where(and(eq(schema.recipe.slug, slug), eq(schema.recipe.userId, userId)))
     .limit(1);
   return recipe;
+}
+
+async function usersShareHousehold(
+  db: ReturnType<typeof createDb>["db"],
+  firstUserId: string,
+  secondUserId: string,
+): Promise<boolean> {
+  if (firstUserId === secondUserId) return true;
+
+  const [firstMember, secondMember] = await Promise.all([
+    findUserHouseholdMembership(db, firstUserId),
+    findUserHouseholdMembership(db, secondUserId),
+  ]);
+  return Boolean(
+    firstMember &&
+      secondMember &&
+      firstMember.organizationId === secondMember.organizationId,
+  );
+}
+
+async function findUserHouseholdMembership(
+  db: ReturnType<typeof createDb>["db"],
+  userId: string,
+): Promise<HouseholdMember | undefined> {
+  const [member] = await db
+    .select()
+    .from(schema.member)
+    .where(eq(schema.member.userId, userId))
+    .limit(1);
+  return member;
+}
+
+async function findHouseholdMemberUserIds(
+  db: ReturnType<typeof createDb>["db"],
+  householdId: string,
+): Promise<string[]> {
+  const members = await db
+    .select({ userId: schema.member.userId })
+    .from(schema.member)
+    .where(eq(schema.member.organizationId, householdId));
+  return members.map((member) => member.userId);
+}
+
+async function findHouseholdById(
+  db: ReturnType<typeof createDb>["db"],
+  householdId: string,
+): Promise<Household | undefined> {
+  const [household] = await db
+    .select()
+    .from(schema.organization)
+    .where(eq(schema.organization.id, householdId))
+    .limit(1);
+  return household;
+}
+
+async function findHouseholdOwner(
+  db: ReturnType<typeof createDb>["db"],
+  householdId: string,
+): Promise<HouseholdMember | undefined> {
+  const [owner] = await db
+    .select()
+    .from(schema.member)
+    .where(
+      and(
+        eq(schema.member.organizationId, householdId),
+        eq(schema.member.role, "owner"),
+      ),
+    )
+    .limit(1);
+  return owner;
+}
+
+async function findHouseholdMembership(
+  db: ReturnType<typeof createDb>["db"],
+  householdId: string,
+  userId: string,
+): Promise<HouseholdMember | undefined> {
+  const [member] = await db
+    .select()
+    .from(schema.member)
+    .where(
+      and(
+        eq(schema.member.organizationId, householdId),
+        eq(schema.member.userId, userId),
+      ),
+    )
+    .limit(1);
+  return member;
+}
+
+async function authorizeHouseholdOwnerResponse(
+  c: Context<AppEnv>,
+  db: ReturnType<typeof createDb>["db"],
+  householdId: string,
+  session: AuthenticatedSession,
+): Promise<Response | undefined> {
+  const household = await findHouseholdById(db, householdId);
+  if (!household) return c.notFound();
+
+  const owner = await findHouseholdOwner(db, householdId);
+  const decision = owner
+    ? authorizeHouseholdMembershipManagement(session.user, {
+        ownerId: owner.userId,
+      })
+    : forbidden();
+  if (!decision.allowed) return authorizationResponse(c, decision);
+  return undefined;
+}
+
+async function requireHouseholdMemberResponse(
+  c: Context<AppEnv>,
+  db: ReturnType<typeof createDb>["db"],
+  householdId: string,
+  session: AuthenticatedSession,
+): Promise<Response | undefined> {
+  const household = await findHouseholdById(db, householdId);
+  if (!household) return c.notFound();
+
+  const membership = await findHouseholdMembership(
+    db,
+    householdId,
+    session.user.id,
+  );
+  if (!membership) return authorizationResponse(c, forbidden());
+  return undefined;
 }
 
 async function hasPreviewAccess(request: Request, env: Bindings) {
@@ -322,6 +544,13 @@ app.on(["POST", "GET"], "/api/auth/*", async (c) => {
   if (blockedPasswordRoute.test(c.req.path)) {
     return c.notFound();
   }
+  // Households reuse Better Auth's organization tables but are managed entirely
+  // through our own authorization-checked endpoints. Better Auth's organization
+  // plugin is intentionally not registered; block these paths defensively so the
+  // raw organization API can never be exposed.
+  if (/^\/api\/auth\/organization(?:\/|$)/.test(c.req.path)) {
+    return c.notFound();
+  }
 
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
@@ -350,6 +579,592 @@ app.on(["POST", "GET"], "/api/auth/*", async (c) => {
   }
 });
 
+app.get("/households", async (c) => {
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const households = await db
+      .select({
+        id: schema.organization.id,
+        name: schema.organization.name,
+        slug: schema.organization.slug,
+        logo: schema.organization.logo,
+        createdAt: schema.organization.createdAt,
+        updatedAt: schema.organization.updatedAt,
+        memberId: schema.member.id,
+        role: schema.member.role,
+      })
+      .from(schema.member)
+      .innerJoin(
+        schema.organization,
+        eq(schema.member.organizationId, schema.organization.id),
+      )
+      .where(eq(schema.member.userId, session.session.user.id));
+
+    return c.json(
+      households.map(({ memberId, role, ...household }) => ({
+        ...household,
+        membership: { id: memberId, role },
+      })),
+    );
+  } catch (e) {
+    console.error("GET /households query failed", e);
+    return c.json({ error: "Database query failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.post("/households", async (c) => {
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const existingMembership = await findUserHouseholdMembership(
+      db,
+      session.session.user.id,
+    );
+    if (existingMembership) {
+      return c.json({ error: "User already belongs to a household" }, 409);
+    }
+
+    const body = await parseJsonBody(c, createHouseholdBodySchema);
+    if (!body.success) return body.response;
+
+    const householdId = createId();
+    const household = await db.transaction(async (tx) => {
+      const [createdHousehold] = await tx
+        .insert(schema.organization)
+        .values({
+          id: householdId,
+          name: body.data.name ?? `${session.session.user.name}'s household`,
+          slug: householdSlug(),
+        })
+        .returning();
+      if (!createdHousehold) throw new Error("Household insert failed");
+
+      await tx.insert(schema.member).values({
+        id: createId(),
+        organizationId: householdId,
+        userId: session.session.user.id,
+        role: "owner",
+      });
+
+      return createdHousehold;
+    });
+
+    return c.json(householdResponse(household), 201);
+  } catch (e) {
+    if (isUniqueViolation(e)) {
+      return c.json({ error: "User already belongs to a household" }, 409);
+    }
+    console.error("POST /households mutation failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.get("/households/:householdId/members", async (c) => {
+  const householdId = c.req.param("householdId");
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const memberFailure = await requireHouseholdMemberResponse(
+      c,
+      db,
+      householdId,
+      session.session,
+    );
+    if (memberFailure) return memberFailure;
+
+    const members = await db
+      .select({
+        id: schema.member.id,
+        organizationId: schema.member.organizationId,
+        userId: schema.member.userId,
+        role: schema.member.role,
+        createdAt: schema.member.createdAt,
+        user: {
+          id: schema.user.id,
+          email: schema.user.email,
+          name: schema.user.name,
+          image: schema.user.image,
+        },
+      })
+      .from(schema.member)
+      .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
+      .where(eq(schema.member.organizationId, householdId));
+
+    return c.json(members.map(memberResponse));
+  } catch (e) {
+    console.error("GET /households/:householdId/members query failed", e);
+    return c.json({ error: "Database query failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.post("/households/:householdId/invitations", async (c) => {
+  const householdId = c.req.param("householdId");
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const ownerFailure = await authorizeHouseholdOwnerResponse(
+      c,
+      db,
+      householdId,
+      session.session,
+    );
+    if (ownerFailure) return ownerFailure;
+
+    const body = await parseJsonBody(c, inviteHouseholdMemberBodySchema);
+    if (!body.success) return body.response;
+
+    const email = body.data.email.toLowerCase();
+
+    const [existingInvitation] = await db
+      .select()
+      .from(schema.invitation)
+      .where(
+        and(
+          eq(schema.invitation.organizationId, householdId),
+          eq(schema.invitation.email, email),
+          eq(schema.invitation.status, "pending"),
+        ),
+      )
+      .limit(1);
+    if (existingInvitation) {
+      return c.json(
+        { error: "A pending invitation already exists for this email" },
+        409,
+      );
+    }
+
+    const [invitation] = await db
+      .insert(schema.invitation)
+      .values({
+        id: createId(),
+        organizationId: householdId,
+        email,
+        role: "member",
+        status: "pending",
+        expiresAt: new Date(Date.now() + INVITATION_EXPIRY_MS),
+        inviterId: session.session.user.id,
+      })
+      .returning();
+
+    if (!invitation) return c.json({ error: "Database mutation failed" }, 502);
+    return c.json(invitationResponse(invitation), 201);
+  } catch (e) {
+    console.error("POST /households/:householdId/invitations failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.post("/households/invitations/:invitationId/accept", async (c) => {
+  const invitationId = c.req.param("invitationId");
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const [invitation] = await db
+      .select()
+      .from(schema.invitation)
+      .where(eq(schema.invitation.id, invitationId))
+      .limit(1);
+    if (!invitation) return c.notFound();
+    if (invitation.status !== "pending") {
+      return c.json({ error: "Invitation is not pending" }, 409);
+    }
+    if (invitation.expiresAt.getTime() < Date.now()) {
+      return c.json({ error: "Invitation has expired" }, 410);
+    }
+    if (invitation.email.toLowerCase() !== session.session.user.email.toLowerCase()) {
+      return authorizationResponse(c, forbidden());
+    }
+
+    const existingMembership = await findUserHouseholdMembership(
+      db,
+      session.session.user.id,
+    );
+    if (existingMembership) {
+      return c.json({ error: "User already belongs to a household" }, 409);
+    }
+
+    const member = await db.transaction(async (tx) => {
+      const [accepted] = await tx
+        .update(schema.invitation)
+        .set({ status: "accepted" })
+        .where(
+          and(
+            eq(schema.invitation.id, invitationId),
+            eq(schema.invitation.status, "pending"),
+          ),
+        )
+        .returning();
+      if (!accepted) throw new Error("Invitation is not pending");
+
+      const [createdMember] = await tx
+        .insert(schema.member)
+        .values({
+          id: createId(),
+          organizationId: invitation.organizationId,
+          userId: session.session.user.id,
+          role: "member",
+        })
+        .returning();
+      if (!createdMember) throw new Error("Member insert failed");
+      return createdMember;
+    });
+
+    return c.json({
+      invitation: { ...invitationResponse(invitation), status: "accepted" },
+      membershipCreated: Boolean(member),
+    });
+  } catch (e) {
+    if (isUniqueViolation(e)) {
+      return c.json({ error: "User already belongs to a household" }, 409);
+    }
+    if (e instanceof Error && e.message === "Invitation is not pending") {
+      return c.json({ error: "Invitation is not pending" }, 409);
+    }
+    console.error("POST /households/invitations/:invitationId/accept failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.post("/households/invitations/:invitationId/decline", async (c) => {
+  const invitationId = c.req.param("invitationId");
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const [invitation] = await db
+      .select()
+      .from(schema.invitation)
+      .where(eq(schema.invitation.id, invitationId))
+      .limit(1);
+    if (!invitation) return c.notFound();
+    if (invitation.status !== "pending") {
+      return c.json({ error: "Invitation is not pending" }, 409);
+    }
+    if (invitation.expiresAt.getTime() < Date.now()) {
+      return c.json({ error: "Invitation has expired" }, 410);
+    }
+    if (invitation.email.toLowerCase() !== session.session.user.email.toLowerCase()) {
+      return authorizationResponse(c, forbidden());
+    }
+
+    const [declined] = await db
+      .update(schema.invitation)
+      .set({ status: "rejected" })
+      .where(
+        and(
+          eq(schema.invitation.id, invitationId),
+          eq(schema.invitation.status, "pending"),
+        ),
+      )
+      .returning();
+
+    if (!declined) {
+      return c.json({ error: "Invitation is not pending" }, 409);
+    }
+    return c.json(invitationResponse(declined));
+  } catch (e) {
+    console.error("POST /households/invitations/:invitationId/decline failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.delete(
+  "/households/:householdId/invitations/:invitationId",
+  async (c) => {
+    const householdId = c.req.param("householdId");
+    const invitationId = c.req.param("invitationId");
+    const csrfFailure = validateCsrf(c);
+    if (csrfFailure) return csrfFailure;
+
+    const connectionString = databaseConnection(c.env);
+    if (!connectionString) {
+      return c.json(
+        { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+        503,
+      );
+    }
+
+    let client: DbClient | undefined;
+    try {
+      const connection = createDb(connectionString);
+      client = connection.client;
+      const { db } = connection;
+      const session = await requireRecipeSession(c, db);
+      if (!session.success) return session.response;
+
+      const ownerFailure = await authorizeHouseholdOwnerResponse(
+        c,
+        db,
+        householdId,
+        session.session,
+      );
+      if (ownerFailure) return ownerFailure;
+
+      const [invitation] = await db
+        .select()
+        .from(schema.invitation)
+        .where(
+          and(
+            eq(schema.invitation.id, invitationId),
+            eq(schema.invitation.organizationId, householdId),
+          ),
+        )
+        .limit(1);
+      if (!invitation) return c.notFound();
+      if (invitation.status !== "pending") {
+        return c.json({ error: "Invitation is not pending" }, 409);
+      }
+
+      const [revoked] = await db
+        .update(schema.invitation)
+        .set({ status: "canceled" })
+        .where(
+          and(
+            eq(schema.invitation.id, invitationId),
+            eq(schema.invitation.organizationId, householdId),
+            eq(schema.invitation.status, "pending"),
+          ),
+        )
+        .returning();
+      if (!revoked) {
+        return c.json({ error: "Invitation is not pending" }, 409);
+      }
+      return c.json(invitationResponse(revoked));
+    } catch (e) {
+      console.error(
+        "DELETE /households/:householdId/invitations/:invitationId failed",
+        e,
+      );
+      return c.json({ error: "Database mutation failed" }, 502);
+    } finally {
+      await closeDbClient(client);
+    }
+  },
+);
+
+app.delete("/households/:householdId/members/:memberId", async (c) => {
+  const householdId = c.req.param("householdId");
+  const memberId = c.req.param("memberId");
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const ownerFailure = await authorizeHouseholdOwnerResponse(
+      c,
+      db,
+      householdId,
+      session.session,
+    );
+    if (ownerFailure) return ownerFailure;
+
+    const [member] = await db
+      .select()
+      .from(schema.member)
+      .where(
+        and(
+          eq(schema.member.id, memberId),
+          eq(schema.member.organizationId, householdId),
+        ),
+      )
+      .limit(1);
+    if (!member) return c.notFound();
+    if (member.role === "owner") {
+      return c.json({ error: "Household owner cannot be revoked" }, 400);
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.recipe)
+        .set({ visibility: "private" })
+        .where(
+          and(
+            eq(schema.recipe.visibility, "household"),
+            eq(schema.recipe.userId, member.userId),
+          ),
+        );
+      await tx.delete(schema.member).where(eq(schema.member.id, memberId));
+    });
+    return c.body(null, 204);
+  } catch (e) {
+    console.error("DELETE /households/:householdId/members/:memberId failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.post("/households/:householdId/leave", async (c) => {
+  const householdId = c.req.param("householdId");
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const household = await findHouseholdById(db, householdId);
+    if (!household) return c.notFound();
+
+    const member = await findHouseholdMembership(
+      db,
+      householdId,
+      session.session.user.id,
+    );
+    if (!member) return authorizationResponse(c, forbidden());
+    if (member.role === "owner") {
+      return c.json({ error: "Household owner cannot leave" }, 400);
+    }
+
+    await db.transaction(async (tx) => {
+      await tx
+        .update(schema.recipe)
+        .set({ visibility: "private" })
+        .where(
+          and(
+            eq(schema.recipe.visibility, "household"),
+            eq(schema.recipe.userId, session.session.user.id),
+          ),
+        );
+      await tx.delete(schema.member).where(eq(schema.member.id, member.id));
+    });
+    return c.body(null, 204);
+  } catch (e) {
+    console.error("POST /households/:householdId/leave failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
 app.get("/recipes", async (c) => {
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
@@ -363,10 +1178,8 @@ app.get("/recipes", async (c) => {
     const connection = createDb(connectionString);
     client = connection.client;
     const { db } = connection;
-    const recipes = await db
-      .select()
-      .from(schema.recipe)
-      .where(eq(schema.recipe.visibility, "public"));
+    const session = await loadOptionalRecipeSession(c, db);
+    const recipes = await findReadableRecipes(db, session?.user.id);
     return c.json(recipes.map(recipeResponse));
   } catch (e) {
     console.error("GET /recipes query failed", e);
@@ -394,12 +1207,21 @@ app.get("/recipes/:slug", async (c) => {
     client = connection.client;
     const { db } = connection;
     const session = await loadOptionalRecipeSession(c, db);
-    const recipe = await findReadableRecipeBySlug(
-      db,
-      slug.slug,
-      session?.user.id,
-    );
+    const recipe = await findRecipeBySlug(db, slug.slug);
     if (!recipe) return c.notFound();
+
+    if (recipe.visibility !== "public") {
+      if (!session) return c.notFound();
+      const household = {
+        userSharesHouseholdWithOwner: await usersShareHousehold(
+          db,
+          recipe.userId,
+          session.user.id,
+        ),
+      };
+      const decision = authorizeRecipeRead(session.user, recipe, household);
+      if (!decision.allowed) return c.notFound();
+    }
 
     return c.json(recipeResponse(recipe));
   } catch (e) {
@@ -432,6 +1254,14 @@ app.post("/recipes", async (c) => {
 
     const body = await parseJsonBody(c, createRecipeBodySchema);
     if (!body.success) return body.response;
+
+    if (body.data.visibility === "household") {
+      const membership = await findUserHouseholdMembership(
+        db,
+        session.session.user.id,
+      );
+      if (!membership) return authorizationResponse(c, forbidden());
+    }
 
     const [recipe] = await db
       .insert(schema.recipe)
@@ -488,9 +1318,24 @@ app.patch("/recipes/:slug", async (c) => {
     const body = await parseJsonBody(c, updateRecipeBodySchema);
     if (!body.success) return body.response;
 
+    const ownerDecision = authorizeOwnerOnly(session.session.user, recipe);
+    if (!ownerDecision.allowed) return authorizationResponse(c, ownerDecision);
+
+    if (body.data.visibility === "household") {
+      const membership = await findUserHouseholdMembership(
+        db,
+        session.session.user.id,
+      );
+      if (!membership) return authorizationResponse(c, forbidden());
+    }
+
+    const updates = {
+      ...body.data,
+    };
+
     const [updatedRecipe] = await db
       .update(schema.recipe)
-      .set(body.data)
+      .set(updates)
       .where(
         and(
           eq(schema.recipe.id, recipe.id),
@@ -504,6 +1349,131 @@ app.patch("/recipes/:slug", async (c) => {
     return c.json(recipeResponse(updatedRecipe));
   } catch (e) {
     console.error("PATCH /recipes/:slug mutation failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.post("/recipes/:slug/household-share", async (c) => {
+  const slug = parseRecipeSlug(c);
+  if (!slug.success) return slug.response;
+
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const recipe = await findOwnedRecipeBySlug(
+      db,
+      slug.slug,
+      session.session.user.id,
+    );
+    if (!recipe) return c.notFound();
+
+    const membership = await findUserHouseholdMembership(
+      db,
+      session.session.user.id,
+    );
+    if (!membership) return authorizationResponse(c, forbidden());
+
+    const memberFailure = await requireHouseholdMemberResponse(
+      c,
+      db,
+      membership.organizationId,
+      session.session,
+    );
+    if (memberFailure) return memberFailure;
+
+    const [updatedRecipe] = await db
+      .update(schema.recipe)
+      .set({
+        visibility: "household",
+      })
+      .where(
+        and(
+          eq(schema.recipe.id, recipe.id),
+          eq(schema.recipe.userId, session.session.user.id),
+        ),
+      )
+      .returning();
+
+    if (!updatedRecipe) return c.notFound();
+    return c.json(recipeResponse(updatedRecipe));
+  } catch (e) {
+    console.error("POST /recipes/:slug/household-share failed", e);
+    return c.json({ error: "Database mutation failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.delete("/recipes/:slug/household-share", async (c) => {
+  const slug = parseRecipeSlug(c);
+  if (!slug.success) return slug.response;
+
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+    const session = await requireRecipeSession(c, db);
+    if (!session.success) return session.response;
+
+    const recipe = await findOwnedRecipeBySlug(
+      db,
+      slug.slug,
+      session.session.user.id,
+    );
+    if (!recipe) return c.notFound();
+
+    const ownerDecision = authorizeOwnerOnly(session.session.user, recipe);
+    if (!ownerDecision.allowed) {
+      return authorizationResponse(c, ownerDecision);
+    }
+
+    const [updatedRecipe] = await db
+      .update(schema.recipe)
+      .set({
+        visibility: "private",
+      })
+      .where(
+        and(
+          eq(schema.recipe.id, recipe.id),
+          eq(schema.recipe.userId, session.session.user.id),
+        ),
+      )
+      .returning();
+
+    if (!updatedRecipe) return c.notFound();
+    return c.json(recipeResponse(updatedRecipe));
+  } catch (e) {
+    console.error("DELETE /recipes/:slug/household-share failed", e);
     return c.json({ error: "Database mutation failed" }, 502);
   } finally {
     await closeDbClient(client);

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -1,5 +1,419 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import postgres from "postgres";
+
+const authzMock = vi.hoisted(() => ({
+  session: null as unknown,
+}));
+
+const dbMock = vi.hoisted(() => {
+  const date = new Date("2026-01-01T00:00:00.000Z");
+  type UserRow = {
+    id: string;
+    name: string;
+    email: string;
+    emailVerified: boolean;
+    image: string | null;
+    role: string | null;
+    banned: boolean | null;
+    banReason: string | null;
+    banExpires: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  type OrganizationRow = {
+    id: string;
+    name: string;
+    slug: string;
+    logo: string | null;
+    metadata: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  type MemberRow = {
+    id: string;
+    organizationId: string;
+    userId: string;
+    role: string;
+    createdAt: Date;
+  };
+  type InvitationRow = {
+    id: string;
+    organizationId: string;
+    email: string;
+    role: string;
+    status: string;
+    expiresAt: Date;
+    inviterId: string;
+    createdAt: Date;
+  };
+  type RecipeRow = {
+    id: string;
+    slug: string;
+    title: string;
+    description: string | null;
+    body: string | null;
+    userId: string;
+    visibility: "public" | "private" | "household";
+    createdAt: Date;
+    updatedAt: Date;
+  };
+
+  const state = {
+    users: [] as UserRow[],
+    organizations: [] as OrganizationRow[],
+    members: [] as MemberRow[],
+    invitations: [] as InvitationRow[],
+    recipes: [] as RecipeRow[],
+  };
+
+  const organizationRow = (organization: OrganizationRow) => [
+    organization.id,
+    organization.name,
+    organization.slug,
+    organization.logo,
+    organization.metadata,
+    organization.createdAt,
+    organization.updatedAt,
+  ];
+  const memberRow = (member: MemberRow) => [
+    member.id,
+    member.organizationId,
+    member.userId,
+    member.role,
+    member.createdAt,
+  ];
+  const invitationRow = (invitation: InvitationRow) => [
+    invitation.id,
+    invitation.organizationId,
+    invitation.email,
+    invitation.role,
+    invitation.status,
+    invitation.expiresAt,
+    invitation.inviterId,
+    invitation.createdAt,
+  ];
+  const recipeRow = (recipe: RecipeRow) => [
+    recipe.id,
+    recipe.slug,
+    recipe.title,
+    recipe.description,
+    recipe.body,
+    recipe.userId,
+    recipe.visibility,
+    recipe.createdAt,
+    recipe.updatedAt,
+  ];
+
+  function reset() {
+    state.users = [];
+    state.organizations = [];
+    state.members = [];
+    state.invitations = [];
+    state.recipes = [];
+  }
+
+  function queryRows(query: string, params: unknown[] = []) {
+    if (query.startsWith('insert into "organization"')) {
+      const organization: OrganizationRow = {
+        id: params[0] as string,
+        name: params[1] as string,
+        slug: params[2] as string,
+        logo: null,
+        metadata: null,
+        createdAt: date,
+        updatedAt: date,
+      };
+      state.organizations.push(organization);
+      return [organizationRow(organization)];
+    }
+
+    if (query.startsWith('insert into "member"')) {
+      const member: MemberRow = {
+        id: params[0] as string,
+        organizationId: params[1] as string,
+        userId: params[2] as string,
+        role: (params[3] as string | undefined) ?? "member",
+        createdAt: date,
+      };
+      const exists = state.members.some(
+        (existing) => existing.userId === member.userId,
+      );
+      if (exists) return [];
+      state.members.push(member);
+      return [memberRow(member)];
+    }
+
+    if (query.startsWith('insert into "invitation"')) {
+      const invitation: InvitationRow = {
+        id: params[0] as string,
+        organizationId: params[1] as string,
+        email: params[2] as string,
+        role: params[3] as string,
+        status: params[4] as string,
+        expiresAt: params[5] as Date,
+        inviterId: params[6] as string,
+        createdAt: date,
+      };
+      state.invitations.push(invitation);
+      return [invitationRow(invitation)];
+    }
+
+    if (query.startsWith('update "invitation" set "status"')) {
+      const status = params[0] as string;
+      const invitationId = params[1] as string;
+      const hasHouseholdFilter = query.includes(
+        '"invitation"."organization_id"',
+      );
+      const householdId = hasHouseholdFilter
+        ? (params[2] as string)
+        : undefined;
+      const pendingStatus = hasHouseholdFilter
+        ? (params[3] as string | undefined)
+        : (params[2] as string | undefined);
+      const invitation = state.invitations.find(
+        (candidate) =>
+          candidate.id === invitationId &&
+          (!householdId || candidate.organizationId === householdId) &&
+          (!pendingStatus || candidate.status === pendingStatus),
+      );
+      if (!invitation) return [];
+      invitation.status = status;
+      return query.includes("returning") ? [invitationRow(invitation)] : [];
+    }
+
+    if (query.startsWith('delete from "member"')) {
+      const memberId = params[0] as string;
+      state.members = state.members.filter((member) => member.id !== memberId);
+      return [];
+    }
+
+    if (query.startsWith('update "recipe"')) {
+      if (
+        query.includes('"recipe"."user_id"') &&
+        query.includes('"recipe"."visibility"') &&
+        !query.includes('"recipe"."id"')
+      ) {
+        const visibility = params[0] as RecipeRow["visibility"];
+        const userId = params.at(-1) as string;
+        for (const recipe of state.recipes) {
+          if (recipe.visibility === "household" && recipe.userId === userId) {
+            recipe.visibility = visibility;
+            recipe.updatedAt = date;
+          }
+        }
+        return [];
+      }
+
+      const recipeId = params.at(-2) as string;
+      const userId = params.at(-1) as string;
+      const recipe = state.recipes.find(
+        (candidate) => candidate.id === recipeId && candidate.userId === userId,
+      );
+      if (!recipe) return [];
+      recipe.visibility = params[0] as RecipeRow["visibility"];
+      recipe.updatedAt = date;
+      return [recipeRow(recipe)];
+    }
+
+    if (query.includes('from "organization"') && query.includes('"organization"."id"')) {
+      const householdId = params[0] as string;
+      return state.organizations
+        .filter((organization) => organization.id === householdId)
+        .map(organizationRow);
+    }
+
+    if (
+      query.includes('from "member"') &&
+      query.includes('inner join "organization"')
+    ) {
+      const userId = params[0] as string;
+      return state.members
+        .filter((member) => member.userId === userId)
+        .map((member) => {
+          const organization = state.organizations.find(
+            (candidate) => candidate.id === member.organizationId,
+          )!;
+          return [
+            organization.id,
+            organization.name,
+            organization.slug,
+            organization.logo,
+            organization.createdAt,
+            organization.updatedAt,
+            member.id,
+            member.role,
+          ];
+        });
+    }
+
+    if (query.includes('from "member"') && query.includes('inner join "user"')) {
+      const householdId = params[0] as string;
+      return state.members
+        .filter((member) => member.organizationId === householdId)
+        .map((member) => {
+          const user = state.users.find((candidate) => candidate.id === member.userId)!;
+          return [
+            member.id,
+            member.organizationId,
+            member.userId,
+            member.role,
+            member.createdAt,
+            user.id,
+            user.email,
+            user.name,
+            user.image,
+          ];
+        });
+    }
+
+    if (
+      query.includes('from "member"') &&
+      query.includes('"member"."organization_id"') &&
+      query.includes('"member"."role"')
+    ) {
+      const householdId = params[0] as string;
+      const role = params[1] as string;
+      return state.members
+        .filter(
+          (member) =>
+            member.organizationId === householdId && member.role === role,
+        )
+        .map(memberRow);
+    }
+
+    if (
+      query.includes('from "member"') &&
+      query.includes('"member"."id"') &&
+      query.includes('"member"."organization_id"')
+    ) {
+      const memberId = params[0] as string;
+      const householdId = params[1] as string;
+      return state.members
+        .filter(
+          (member) =>
+            member.id === memberId && member.organizationId === householdId,
+        )
+        .map(memberRow);
+    }
+
+    if (
+      query.includes('from "member"') &&
+      query.includes('"member"."organization_id"') &&
+      query.includes('"member"."user_id"') &&
+      params.length > 1
+    ) {
+      const householdId = params[0] as string;
+      const userId = params[1] as string;
+      return state.members
+        .filter(
+          (member) =>
+            member.organizationId === householdId && member.userId === userId,
+        )
+        .map((member) => (query.includes('"member"."id"') ? [member.id] : memberRow(member)));
+    }
+
+    if (
+      query.includes('from "member"') &&
+      query.includes('"member"."organization_id"') &&
+      params.length === 1
+    ) {
+      const householdId = params[0] as string;
+      return state.members
+        .filter((member) => member.organizationId === householdId)
+        .map((member) => [member.userId]);
+    }
+
+    if (
+      query.includes('from "member"') &&
+      query.includes('"member"."user_id"')
+    ) {
+      const userId = params[0] as string;
+      return state.members
+        .filter((member) => member.userId === userId)
+        .map(memberRow);
+    }
+
+    if (query.includes('from "invitation"') && query.includes('"invitation"."id"')) {
+      const invitationId = params[0] as string;
+      return state.invitations
+        .filter((invitation) => invitation.id === invitationId)
+        .map(invitationRow);
+    }
+
+    if (
+      query.includes('from "invitation"') &&
+      query.includes('"invitation"."email"')
+    ) {
+      const organizationId = params[0] as string;
+      const email = params[1] as string;
+      const status = params[2] as string;
+      return state.invitations
+        .filter(
+          (invitation) =>
+            invitation.organizationId === organizationId &&
+            invitation.email === email &&
+            invitation.status === status,
+        )
+        .map(invitationRow);
+    }
+
+    if (
+      query.includes('from "recipe"') &&
+      query.includes('"recipe"."slug"') &&
+      query.includes('"recipe"."user_id"')
+    ) {
+      const slug = params[0] as string;
+      const userId = params[1] as string;
+      return state.recipes
+        .filter((recipe) => recipe.slug === slug && recipe.userId === userId)
+        .map(recipeRow);
+    }
+
+    if (query.includes('from "recipe"') && query.includes('"recipe"."slug"')) {
+      const slug = params[0] as string;
+      return state.recipes
+        .filter((recipe) => recipe.slug === slug)
+        .map(recipeRow);
+    }
+
+    if (query.includes('from "recipe"')) {
+      const publicVisibility = params[0] as string | undefined;
+      const ownerUserId = params[1] as string | undefined;
+      const householdVisibilityIndex = params.indexOf("household");
+      const householdUserIds =
+        householdVisibilityIndex >= 0
+          ? new Set(params.slice(householdVisibilityIndex + 1))
+          : new Set();
+
+      return state.recipes
+        .filter(
+          (recipe) =>
+            recipe.visibility === publicVisibility ||
+            recipe.userId === ownerUserId ||
+            (recipe.visibility === "household" &&
+              householdUserIds.has(recipe.userId)),
+        )
+        .map(recipeRow);
+    }
+
+    if (query.startsWith('insert into "verification"')) {
+      return [params];
+    }
+
+    return [];
+  }
+
+  return { date, state, reset, queryRows };
+});
+
+vi.mock("../src/http/authorization", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/http/authorization")>();
+  return {
+    ...actual,
+    loadBetterAuthSession: vi.fn(() => Promise.resolve(authzMock.session)),
+  };
+});
 
 vi.mock("postgres", () => ({
   default: vi.fn(() => {
@@ -13,19 +427,20 @@ vi.mock("postgres", () => ({
         values: () => Promise.resolve(rows),
       });
     const emptyResult = queryResult();
-    return Object.assign(
+    const client = Object.assign(
       (_strings: TemplateStringsArray, ..._values: unknown[]) => emptyResult,
       {
         options: { parsers: {}, serializers: {} },
         unsafe: (query: string, params: unknown[] = []) => {
-          if (query.startsWith('insert into "verification"')) {
-            return queryResult([params]);
-          }
-          return emptyResult;
+          const rows = dbMock.queryRows(query, params);
+          return rows.length > 0 ? queryResult(rows) : emptyResult;
         },
+        begin: <T>(transaction: (sql: unknown) => Promise<T>) =>
+          transaction(client),
         end: (_options?: { timeout?: number }) => Promise.resolve(),
       },
     );
+    return client;
   }),
 }));
 
@@ -35,6 +450,101 @@ vi.mock("jose", () => ({
 }));
 
 import app from "../src/index";
+
+function sessionFor(user: { id: string; email: string; name: string }) {
+  return {
+    user: {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      emailVerified: true,
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    },
+    session: {
+      id: `session-${user.id}`,
+      token: `token-${user.id}`,
+      userId: user.id,
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    },
+  };
+}
+
+function seedHousehold() {
+  dbMock.state.users.push(
+    {
+      id: "owner-user",
+      name: "Owner",
+      email: "owner@example.test",
+      emailVerified: true,
+      image: null,
+      role: "user",
+      banned: null,
+      banReason: null,
+      banExpires: null,
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    },
+    {
+      id: "member-user",
+      name: "Member",
+      email: "member@example.test",
+      emailVerified: true,
+      image: null,
+      role: "user",
+      banned: null,
+      banReason: null,
+      banExpires: null,
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    },
+    {
+      id: "outsider-user",
+      name: "Outsider",
+      email: "outsider@example.test",
+      emailVerified: true,
+      image: null,
+      role: "user",
+      banned: null,
+      banReason: null,
+      banExpires: null,
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    },
+  );
+  dbMock.state.organizations.push({
+    id: "household-1",
+    name: "Owner household",
+    slug: "owner-household",
+    logo: null,
+    metadata: null,
+    createdAt: dbMock.date,
+    updatedAt: dbMock.date,
+  });
+  dbMock.state.members.push(
+    {
+      id: "owner-member",
+      organizationId: "household-1",
+      userId: "owner-user",
+      role: "owner",
+      createdAt: dbMock.date,
+    },
+    {
+      id: "member-member",
+      organizationId: "household-1",
+      userId: "member-user",
+      role: "member",
+      createdAt: dbMock.date,
+    },
+  );
+}
+
+beforeEach(() => {
+  authzMock.session = null;
+  dbMock.reset();
+});
 
 const env = {
   DATABASE_URL: "postgresql://test:test@localhost/test",
@@ -111,6 +621,102 @@ describe("GET /recipes/:slug", () => {
       ],
     });
   });
+
+  it("allows household members to read household-shared recipes", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "shared-soup",
+      title: "Shared Soup",
+      description: null,
+      body: null,
+      userId: "owner-user",
+      visibility: "household",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request("/recipes/shared-soup", {}, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      slug: "shared-soup",
+      title: "Shared Soup",
+      visibility: "household",
+    });
+  });
+
+  it("returns 404 for anonymous household-shared recipe reads", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "shared-soup",
+      title: "Shared Soup",
+      description: null,
+      body: null,
+      userId: "owner-user",
+      visibility: "household",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+
+    const res = await app.request("/recipes/shared-soup", {}, env);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for non-member household-shared recipe reads", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "shared-soup",
+      title: "Shared Soup",
+      description: null,
+      body: null,
+      userId: "owner-user",
+      visibility: "household",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "outsider-user",
+      email: "outsider@example.test",
+      name: "Outsider",
+    });
+
+    const res = await app.request("/recipes/shared-soup", {}, env);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when a stale household share points at a non-member owner", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "stale-soup",
+      title: "Stale Soup",
+      description: null,
+      body: null,
+      userId: "outsider-user",
+      visibility: "household",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request("/recipes/stale-soup", {}, env);
+
+    expect(res.status).toBe(404);
+  });
 });
 
 describe("POST /recipes", () => {
@@ -133,6 +739,689 @@ describe("POST /recipes", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+});
+
+describe("household membership flows", () => {
+  it("requires authentication before creating a household", async () => {
+    const res = await app.request(
+      "/households",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ name: "Dinner Club" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+
+  it("creates a household with the creator as owner", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/households",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ name: "Dinner Club" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({ name: "Dinner Club" });
+    expect(dbMock.state.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ userId: "owner-user", role: "owner" }),
+      ]),
+    );
+  });
+
+  it("prevents a user from creating a second household", async () => {
+    seedHousehold();
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/households",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ name: "Second Household" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "User already belongs to a household",
+    });
+  });
+
+  it("lists household members for existing members", async () => {
+    seedHousehold();
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request("/households/household-1/members", {}, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "owner-member",
+          role: "owner",
+          user: expect.objectContaining({ email: "owner@example.test" }),
+        }),
+        expect.objectContaining({
+          id: "member-member",
+          role: "member",
+          user: expect.objectContaining({ email: "member@example.test" }),
+        }),
+      ]),
+    );
+  });
+
+  it("returns 403 when non-members list household members", async () => {
+    seedHousehold();
+    authzMock.session = sessionFor({
+      id: "outsider-user",
+      email: "outsider@example.test",
+      name: "Outsider",
+    });
+
+    const res = await app.request("/households/household-1/members", {}, env);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Authorization required" });
+  });
+
+  it("allows owners to invite household members", async () => {
+    seedHousehold();
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/households/household-1/invitations",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ email: "NewMember@Example.test" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({
+      householdId: "household-1",
+      email: "newmember@example.test",
+      role: "member",
+      status: "pending",
+    });
+  });
+
+  it("returns 409 when a pending invitation already exists for the email", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "household-1",
+      email: "newmember@example.test",
+      role: "member",
+      status: "pending",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/households/household-1/invitations",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ email: "NewMember@Example.test" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "A pending invitation already exists for this email",
+    });
+    expect(dbMock.state.invitations).toHaveLength(1);
+  });
+
+  it("returns 403 when non-owners invite household members", async () => {
+    seedHousehold();
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/households/household-1/invitations",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ email: "newmember@example.test" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Authorization required" });
+  });
+
+  it("allows invited users to accept invitations", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "household-1",
+      email: "outsider@example.test",
+      role: "member",
+      status: "pending",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "outsider-user",
+      email: "outsider@example.test",
+      name: "Outsider",
+    });
+
+    const res = await app.request(
+      "/households/invitations/invitation-1/accept",
+      {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      invitation: { id: "invitation-1", status: "accepted" },
+      membershipCreated: true,
+    });
+    expect(dbMock.state.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          organizationId: "household-1",
+          userId: "outsider-user",
+          role: "member",
+        }),
+      ]),
+    );
+  });
+
+  it("returns 403 when a different user accepts an invitation", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "household-1",
+      email: "member@example.test",
+      role: "member",
+      status: "pending",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "outsider-user",
+      email: "outsider@example.test",
+      name: "Outsider",
+    });
+
+    const res = await app.request(
+      "/households/invitations/invitation-1/accept",
+      {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Authorization required" });
+  });
+
+  it("prevents a user from accepting an invite while already in a household", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "other-household",
+      email: "member@example.test",
+      role: "member",
+      status: "pending",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/households/invitations/invitation-1/accept",
+      {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "User already belongs to a household",
+    });
+  });
+
+  it("allows invited users to decline invitations", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "household-1",
+      email: "member@example.test",
+      role: "member",
+      status: "pending",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/households/invitations/invitation-1/decline",
+      {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      id: "invitation-1",
+      status: "rejected",
+    });
+  });
+
+  it("prevents declining finalized invitations", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "household-1",
+      email: "member@example.test",
+      role: "member",
+      status: "accepted",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/households/invitations/invitation-1/decline",
+      {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "Invitation is not pending",
+    });
+  });
+
+  it("allows owners to revoke pending invitations", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "household-1",
+      email: "outsider@example.test",
+      role: "member",
+      status: "pending",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/households/household-1/invitations/invitation-1",
+      {
+        method: "DELETE",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      id: "invitation-1",
+      status: "canceled",
+    });
+  });
+
+  it("prevents owners from revoking finalized invitations", async () => {
+    seedHousehold();
+    dbMock.state.invitations.push({
+      id: "invitation-1",
+      organizationId: "household-1",
+      email: "outsider@example.test",
+      role: "member",
+      status: "accepted",
+      expiresAt: new Date("2027-01-02T00:00:00.000Z"),
+      inviterId: "owner-user",
+      createdAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/households/household-1/invitations/invitation-1",
+      {
+        method: "DELETE",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: "Invitation is not pending",
+    });
+  });
+
+  it("allows owners to revoke members", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "member-soup",
+      title: "Member Soup",
+      description: null,
+      body: null,
+      userId: "member-user",
+      visibility: "household",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/households/household-1/members/member-member",
+      {
+        method: "DELETE",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(204);
+    expect(dbMock.state.members).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "member-member" })]),
+    );
+    expect(dbMock.state.recipes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: "member-soup",
+          visibility: "private",
+        }),
+      ]),
+    );
+  });
+
+  it("allows members to leave voluntarily", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "member-soup",
+      title: "Member Soup",
+      description: null,
+      body: null,
+      userId: "member-user",
+      visibility: "household",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/households/household-1/leave",
+      {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(204);
+    expect(dbMock.state.members).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "member-member" })]),
+    );
+    expect(dbMock.state.recipes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: "member-soup",
+          visibility: "private",
+        }),
+      ]),
+    );
+  });
+
+  it("returns 404 when leaving a missing household", async () => {
+    seedHousehold();
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/households/missing-household/leave",
+      {
+        method: "POST",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("household recipe sharing", () => {
+  it("allows recipe owners to share and unshare with their household", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "private-soup",
+      title: "Private Soup",
+      description: null,
+      body: null,
+      userId: "owner-user",
+      visibility: "private",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const shareRes = await app.request(
+      "/recipes/private-soup/household-share",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+      },
+      env,
+    );
+
+    expect(shareRes.status).toBe(200);
+    expect(await shareRes.json()).toMatchObject({
+      slug: "private-soup",
+      visibility: "household",
+    });
+
+    const unshareRes = await app.request(
+      "/recipes/private-soup/household-share",
+      {
+        method: "DELETE",
+        headers: { origin: "http://localhost:3000" },
+      },
+      env,
+    );
+
+    expect(unshareRes.status).toBe(200);
+    expect(await unshareRes.json()).toMatchObject({
+      slug: "private-soup",
+      visibility: "private",
+    });
+  });
+
+  it("allows household members to share their own recipes", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "member-soup",
+      title: "Member Soup",
+      description: null,
+      body: null,
+      userId: "member-user",
+      visibility: "private",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "member-user",
+      email: "member@example.test",
+      name: "Member",
+    });
+
+    const res = await app.request(
+      "/recipes/member-soup/household-share",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      slug: "member-soup",
+      visibility: "household",
+    });
+  });
+
+  it("returns 403 when a non-member shares to a household", async () => {
+    seedHousehold();
+    dbMock.state.recipes.push({
+      id: "recipe-1",
+      slug: "outsider-soup",
+      title: "Outsider Soup",
+      description: null,
+      body: null,
+      userId: "outsider-user",
+      visibility: "private",
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    authzMock.session = sessionFor({
+      id: "outsider-user",
+      email: "outsider@example.test",
+      name: "Outsider",
+    });
+
+    const res = await app.request(
+      "/recipes/outsider-soup/household-share",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+      },
+      env,
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Authorization required" });
   });
 });
 
@@ -295,6 +1584,23 @@ describe("POST /api/auth/sign-in/social", () => {
         },
       ],
     });
+  });
+
+  it("does not expose raw Better Auth organization endpoints", async () => {
+    const res = await app.request(
+      "/api/auth/organization/create",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ name: "Bypass", slug: "bypass" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(404);
   });
 });
 


### PR DESCRIPTION
## Summary
- add Better Auth organization support and household membership tables to the recipe API schema
- add household create/list/invite/accept/decline/revoke/leave endpoints with server-side owner/member authorization
- add household share/unshare flows and read-only access for household-shared recipes
- cover success paths and 401/403 boundaries in worker tests

## Validation
- CI=true mise //workers/recipe-api:check

## Notes
- Shortcut ticket #254 was not marked Done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added household support for recipes, including sharing and unsharing, plus household-based recipe visibility.
  * Introduced household management actions such as creating households, inviting members, accepting or declining invitations, leaving households, and removing members.
  * Expanded recipe access rules so household recipes appear for eligible members and access is protected when sharing changes.  
* **Bug Fixes**
  * Prevented access to Better Auth organisation endpoints under the public auth route surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->