### PR TITLE
fix(recipes): scope scaled-recipe transform errors to their request

### DIFF
--- a/ui/hooks/use-scaled-recipe.ts
+++ b/ui/hooks/use-scaled-recipe.ts
@@ -161,12 +161,12 @@ export function useScaledRecipe(
     useState<TransformErrorRecord | null>(null);
 
   useEffect(() => {
+    setTransformError(null);
     if (isIdentity || !freshParsedRecipe || !freshParsedOriginal) return;
 
     let isActive = true;
     const targetCookBody = view.cookBody;
     const targetScale = scale;
-    setTransformError(null);
     loadTransformModule()
       .then(({ buildScaledRecipeParts }) => {
         if (!isActive) return;

--- a/ui/hooks/use-scaled-recipe.ts
+++ b/ui/hooks/use-scaled-recipe.ts
@@ -101,6 +101,12 @@ type ScaledPartsRecord = {
   parts: ScaledRecipeParts;
 };
 
+type TransformErrorRecord = {
+  cookBody: string;
+  scale: number;
+  error: Error;
+};
+
 export function useScaledRecipe(
   view: RecipeDetailView,
   scale: number,
@@ -151,7 +157,8 @@ export function useScaledRecipe(
   const [scaledParts, setScaledParts] = useState<ScaledPartsRecord | null>(
     null,
   );
-  const [transformError, setTransformError] = useState<Error | null>(null);
+  const [transformError, setTransformError] =
+    useState<TransformErrorRecord | null>(null);
 
   useEffect(() => {
     if (isIdentity || !freshParsedRecipe || !freshParsedOriginal) return;
@@ -159,6 +166,7 @@ export function useScaledRecipe(
     let isActive = true;
     const targetCookBody = view.cookBody;
     const targetScale = scale;
+    setTransformError(null);
     loadTransformModule()
       .then(({ buildScaledRecipeParts }) => {
         if (!isActive) return;
@@ -170,15 +178,17 @@ export function useScaledRecipe(
             scale: targetScale,
           }),
         });
-        setTransformError(null);
       })
       .catch((err: unknown) => {
         if (!isActive) return;
-        setTransformError(
-          err instanceof Error
-            ? err
-            : new Error("Failed to load cooklang transform"),
-        );
+        setTransformError({
+          cookBody: targetCookBody,
+          scale: targetScale,
+          error:
+            err instanceof Error
+              ? err
+              : new Error("Failed to load cooklang transform"),
+        });
       });
 
     return () => {
@@ -197,6 +207,11 @@ export function useScaledRecipe(
     scaledParts?.cookBody === view.cookBody && scaledParts?.scale === scale
       ? scaledParts.parts
       : null;
+  const freshTransformError =
+    transformError?.cookBody === view.cookBody &&
+    transformError?.scale === scale
+      ? transformError.error
+      : null;
 
   const scaledView = useMemo(
     () =>
@@ -213,7 +228,7 @@ export function useScaledRecipe(
       view: scaledView,
       scaleMultiplier: 1,
       isScaling: false,
-      error: error ?? originalError ?? transformError,
+      error: error ?? originalError ?? freshTransformError,
     };
   }
 
@@ -223,7 +238,7 @@ export function useScaledRecipe(
   return {
     view,
     scaleMultiplier: scale,
-    isScaling: !transformError,
-    error: error ?? originalError ?? transformError,
+    isScaling: !freshTransformError,
+    error: error ?? originalError ?? freshTransformError,
   };
 }

--- a/ui/tests/hooks/use-scaled-recipe.test.tsx
+++ b/ui/tests/hooks/use-scaled-recipe.test.tsx
@@ -19,6 +19,7 @@ const recipe: RecipeDetailView = {
   description: "A recipe used in tests.",
   date: "2026-05-23",
   cuisine: ["Test"],
+  tags: [],
   servings: 2,
   cookBody: "@flour{100%g}\n",
   cookware: ["bowl"],

--- a/ui/tests/hooks/use-scaled-recipe.test.tsx
+++ b/ui/tests/hooks/use-scaled-recipe.test.tsx
@@ -1,0 +1,134 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCooklangRecipe } from "@/hooks/use-cooklang-recipe";
+import { useScaledRecipe } from "@/hooks/use-scaled-recipe";
+import { buildScaledRecipeParts } from "@/lib/domain/recipe/cooklangTransform";
+import type { RecipeDetailView } from "@/lib/domain/recipe/recipeViews";
+
+vi.mock("@/hooks/use-cooklang-recipe", () => ({
+  useCooklangRecipe: vi.fn(),
+}));
+
+vi.mock("@/lib/domain/recipe/cooklangTransform", () => ({
+  buildScaledRecipeParts: vi.fn(),
+}));
+
+const recipe: RecipeDetailView = {
+  slug: "test-recipe",
+  title: "Test Recipe",
+  description: "A recipe used in tests.",
+  date: "2026-05-23",
+  cuisine: ["Test"],
+  servings: 2,
+  cookBody: "@flour{100%g}\n",
+  cookware: ["bowl"],
+  ingredientGroups: [
+    {
+      items: [{ ingredient: "flour", name: "Flour", amount: 100, unit: "g" }],
+    },
+  ],
+  instructions: ["Add flour to bowl."],
+};
+
+describe("useScaledRecipe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears a previous transform failure when a new scale request starts", async () => {
+    const transformFailure = new Error("Transient transform failure");
+    const parsedOriginal = { id: "original" };
+    const parsedScaledTwo = { id: "scaled-2" };
+    const parsedScaledThree = { id: "scaled-3" };
+    const scaledParts = {
+      cookware: ["bowl"],
+      ingredientGroups: [
+        { items: [{ ingredient: "flour", amount: 150, unit: "g" }] },
+      ],
+      instructions: ["Add 150g of flour to the bowl."],
+      instructionSdk: undefined,
+    };
+
+    let scaledPhase: "initial" | "retry-loading" | "retry-ready" = "initial";
+
+    vi.mocked(useCooklangRecipe).mockImplementation((cookBody, scale) => {
+      if (!cookBody) {
+        return { recipe: null, source: null, loading: false, error: null };
+      }
+
+      if (scale === undefined) {
+        return {
+          recipe: parsedOriginal as never,
+          source: { cookBody, scale: undefined },
+          loading: false,
+          error: null,
+        };
+      }
+
+      if (scale === 2) {
+        return {
+          recipe: parsedScaledTwo as never,
+          source: { cookBody, scale: 2 },
+          loading: false,
+          error: null,
+        };
+      }
+
+      if (scale === 3 && scaledPhase === "retry-loading") {
+        return {
+          recipe: parsedScaledTwo as never,
+          source: { cookBody, scale: 2 },
+          loading: true,
+          error: null,
+        };
+      }
+
+      if (scale === 3) {
+        return {
+          recipe: parsedScaledThree as never,
+          source: { cookBody, scale: 3 },
+          loading: false,
+          error: null,
+        };
+      }
+
+      throw new Error(`Unexpected scale ${scale}`);
+    });
+
+    vi.mocked(buildScaledRecipeParts)
+      .mockImplementationOnce(() => {
+        throw transformFailure;
+      })
+      .mockReturnValue(scaledParts as never);
+
+    const { result, rerender } = renderHook(
+      ({ scale }) => useScaledRecipe(recipe, scale),
+      {
+        initialProps: { scale: 2 },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isScaling).toBe(false);
+      expect(result.current.error).toBe(transformFailure);
+    });
+
+    scaledPhase = "retry-loading";
+    rerender({ scale: 3 });
+
+    expect(result.current.isScaling).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    scaledPhase = "retry-ready";
+    rerender({ scale: 3 });
+
+    await waitFor(() => {
+      expect(result.current.isScaling).toBe(false);
+      expect(result.current.error).toBeNull();
+      expect(result.current.scaleMultiplier).toBe(1);
+      expect(result.current.view.instructions).toEqual(
+        scaledParts.instructions,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

`useScaledRecipe` stored its transform error as a bare `Error` with no record of which recipe/scale produced it. A transient transform failure could therefore linger and surface against a *different* recipe (after soft navigation) or a *different* scale.

This wraps the error in a record keyed by `cookBody` + `scale` — mirroring the existing `scaledParts` freshness guard — and clears it at the start of each new request so a stale failure no longer leaks into an unrelated view.

## Changes

- `ui/hooks/use-scaled-recipe.ts` — `transformError` is now a `TransformErrorRecord { cookBody, scale, error }`, only surfaced when it matches the current view; reset moved to the start of the effect.
- `ui/tests/hooks/use-scaled-recipe.test.tsx` — regression test: a transform failure at one scale is cleared and recovers on a subsequent scale change.

## Testing

`vitest run tests/hooks/use-scaled-recipe.test.tsx` — passes.

## Notes

This had been sitting on a working tree for a while; the hook is live (used by `recipe-content.tsx`), so this is a real fix rather than dead code. A stray byte-identical duplicate of `vitest.config.ts` (`.mts`) was discarded and is not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scaling error handling so failed transformations are shown with the relevant recipe state, and loading no longer spins indefinitely after a known failure.
  * Added retry coverage to ensure scaling recovers correctly when the requested scale changes after an initial failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->