### PR TITLE
Split preview into independent frontend and backend jobs

### DIFF
--- a/.github/workflows/preview-environment-cleanup.yml
+++ b/.github/workflows/preview-environment-cleanup.yml
@@ -19,6 +19,8 @@ concurrency:
 
 jobs:
   cleanup:
+    # Always run on close (delete steps are continue-on-error and no-op when no
+    # preview resources exist)
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -205,25 +205,29 @@ jobs:
             const requested = process.env.BACKEND_REQUESTED === 'true';
             const ok = process.env.BACKEND_RESULT === 'success';
 
-            let backendSection;
+            let backendLines;
             if (requested && ok) {
-              backendSection = `**Worker:** \`${process.env.PREVIEW_WORKER_NAME}\`
-            **Database:** Neon branch \`${process.env.PREVIEW_BRANCH}\`
-
-            The site is protected by Cloudflare Access. Use the **Sign in** menu to choose a seeded QA scenario.`;
+              backendLines = [
+                `**Worker:** \`${process.env.PREVIEW_WORKER_NAME}\``,
+                `**Database:** Neon branch \`${process.env.PREVIEW_BRANCH}\``,
+                '',
+                'The site is protected by Cloudflare Access. Use the **Sign in** menu to choose a seeded QA scenario.',
+              ];
             } else if (requested && !ok) {
-              backendSection = `**Backend:** ⚠️ provisioning failed — the frontend is deployed, but sign-in is unavailable. Re-run the workflow to retry.`;
+              backendLines = ['**Backend:** ⚠️ provisioning failed — the frontend is deployed, but sign-in is unavailable. Re-run the workflow to retry.'];
             } else {
-              backendSection = `**Backend:** frontend-only preview — sign-in is disabled. Add the \`preview:backend\` label to provision an isolated Worker + database.`;
+              backendLines = ['**Backend:** frontend-only preview — sign-in is disabled. Add the `preview:backend` label to provision an isolated Worker + database.'];
             }
 
-            const body = `${marker}
-            ### Preview environment
+            const body = [
+              marker,
+              '### Preview environment',
+              '',
+              `**Site:** ${process.env.PREVIEW_SITE_URL}`,
+              ...backendLines,
+            ].join('\n');
 
-            **Site:** ${process.env.PREVIEW_SITE_URL}
-            ${backendSection}`;
-
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -16,11 +16,20 @@ concurrency:
 jobs:
   # Decide whether this PR needs a database-backed backend preview.
   detect:
+    # On label events, only react to the preview:* labels so unrelated label
+    # changes don't rebuild the preview.
     if: >
       github.event.pull_request.head.repo.full_name == github.repository
       && github.actor != 'renovate[bot]'
       && github.actor != 'dependabot[bot]'
+      && (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+        || startsWith(github.event.label.name, 'preview:')
+      )
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       backend: ${{ steps.decide.outputs.backend }}
     steps:

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -20,8 +20,8 @@ jobs:
     # changes don't rebuild the preview.
     if: >
       github.event.pull_request.head.repo.full_name == github.repository
-      && github.actor != 'renovate[bot]'
-      && github.actor != 'dependabot[bot]'
+      && github.event.pull_request.user.login != 'renovate[bot]'
+      && github.event.pull_request.user.login != 'dependabot[bot]'
       && (
         (github.event.action != 'labeled' && github.event.action != 'unlabeled')
         || startsWith(github.event.label.name, 'preview:')
@@ -39,8 +39,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          # contains() matches array elements exactly, avoiding substring
-          # surprises from label names that embed a marker label.
           FORCE_FRONTEND: ${{ contains(github.event.pull_request.labels.*.name, 'preview:frontend-only') }}
           FORCE_BACKEND: ${{ contains(github.event.pull_request.labels.*.name, 'preview:backend') }}
         run: |

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -2,7 +2,7 @@ name: Preview Environment
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -14,8 +14,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+  # Decide whether this PR needs a database-backed backend preview.
+  detect:
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'renovate[bot]'
+      && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.decide.outputs.backend }}
+    steps:
+      - name: Decide whether a backend preview is needed
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          labels=",${LABELS},"
+          if [[ "$labels" == *",preview:frontend-only,"* ]]; then
+            echo "Label preview:frontend-only forces frontend-only preview."
+            echo "backend=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$labels" == *",preview:backend,"* ]]; then
+            echo "Label preview:backend forces a backend preview."
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only)
+          if echo "$files" | grep -qE '^(workers/recipe-api/|functions/|packages/)'; then
+            echo "Backend-affecting paths changed; provisioning a backend preview."
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Frontend-only change; skipping backend provisioning."
+            echo "backend=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  backend:
+    needs: detect
+    if: needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     environment:
       name: cloudflare-preview
@@ -111,6 +151,28 @@ jobs:
           CF_ACCESS_TEAM_DOMAIN: ${{ vars.CF_ACCESS_TEAM_DOMAIN }}
           CF_ACCESS_AUD: ${{ vars.CF_ACCESS_AUD }}
 
+  # Always deploy the static frontend for non-bot PRs, independent of the
+  # backend job. NEXT_PUBLIC_PREVIEW_BACKEND tells the build whether sign-in is
+  # backed by a per-PR Worker so the UI can present the right state.
+  frontend:
+    needs: detect
+    if: needs.detect.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: cloudflare-preview
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d
+        with:
+          experimental: true
+
+      - name: Install dependencies
+        run: mise run //:install
+
       - name: Build and deploy canonical PR Pages preview
         # //ui:deploy depends on //ui:build, so this single step both builds
         # and deploys the UI; a separate build step would only rebuild.
@@ -122,24 +184,44 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DEPLOY_BRANCH: pr-${{ github.event.pull_request.number }}
           NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ secrets.CF_IMAGES_ACCOUNT_HASH }}
+          NEXT_PUBLIC_PREVIEW_BACKEND: ${{ needs.detect.outputs.backend }}
 
+  comment:
+    needs: [detect, backend, frontend]
+    if: always() && needs.frontend.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
       - name: Comment preview URL on PR
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           PREVIEW_SITE_URL: https://pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
           PREVIEW_WORKER_NAME: recipe-api-pr-${{ github.event.pull_request.number }}
           PREVIEW_BRANCH: preview-pr-${{ github.event.pull_request.number }}
+          BACKEND_REQUESTED: ${{ needs.detect.outputs.backend }}
+          BACKEND_RESULT: ${{ needs.backend.result }}
         with:
           script: |
             const marker = '<!-- preview-environment -->';
+            const requested = process.env.BACKEND_REQUESTED === 'true';
+            const ok = process.env.BACKEND_RESULT === 'success';
+
+            let backendSection;
+            if (requested && ok) {
+              backendSection = `**Worker:** \`${process.env.PREVIEW_WORKER_NAME}\`
+            **Database:** Neon branch \`${process.env.PREVIEW_BRANCH}\`
+
+            The site is protected by Cloudflare Access. Use the **Sign in** menu to choose a seeded QA scenario.`;
+            } else if (requested && !ok) {
+              backendSection = `**Backend:** ⚠️ provisioning failed — the frontend is deployed, but sign-in is unavailable. Re-run the workflow to retry.`;
+            } else {
+              backendSection = `**Backend:** frontend-only preview — sign-in is disabled. Add the \`preview:backend\` label to provision an isolated Worker + database.`;
+            }
+
             const body = `${marker}
             ### Preview environment
 
             **Site:** ${process.env.PREVIEW_SITE_URL}
-            **Worker:** \`${process.env.PREVIEW_WORKER_NAME}\`
-            **Database:** Neon branch \`${process.env.PREVIEW_BRANCH}\`
-
-            The site is protected by Cloudflare Access. Use the **Sign in** menu to choose a seeded QA scenario.`;
+            ${backendSection}`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -30,16 +30,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          # contains() matches array elements exactly, avoiding substring
+          # surprises from label names that embed a marker label.
+          FORCE_FRONTEND: ${{ contains(github.event.pull_request.labels.*.name, 'preview:frontend-only') }}
+          FORCE_BACKEND: ${{ contains(github.event.pull_request.labels.*.name, 'preview:backend') }}
         run: |
           set -euo pipefail
-          labels=",${LABELS},"
-          if [[ "$labels" == *",preview:frontend-only,"* ]]; then
+          if [[ "$FORCE_FRONTEND" == "true" ]]; then
             echo "Label preview:frontend-only forces frontend-only preview."
             echo "backend=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ "$labels" == *",preview:backend,"* ]]; then
+          if [[ "$FORCE_BACKEND" == "true" ]]; then
             echo "Label preview:backend forces a backend preview."
             echo "backend=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -231,6 +233,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
             const existing = comments.find(comment =>
               comment.user.type === 'Bot' && comment.body?.includes(marker)

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -69,6 +69,11 @@ export function AuthButton() {
     setIsPreview(preview);
     if (!preview) return;
 
+    if (process.env.NEXT_PUBLIC_PREVIEW_BACKEND === "false") {
+      setError("Sign-in is disabled on this frontend-only preview.");
+      return;
+    }
+
     void fetch("/api/auth/preview/scenarios")
       .then(async (response) => {
         if (!response.ok) throw new Error("Preview scenarios unavailable");

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -40,6 +40,8 @@ function ProviderIcon({ path }: { path: string }) {
 }
 
 export function AuthButton() {
+  const previewBackendDisabled =
+    process.env.NEXT_PUBLIC_PREVIEW_BACKEND === "false";
   const { data: session, isPending } = authClient.useSession();
   const [open, setOpen] = useState(false);
   const [pendingSignIn, setPendingSignIn] = useState<string | null>(null);
@@ -279,7 +281,9 @@ export function AuthButton() {
         >
           <p className="px-2 pb-2 text-xs font-medium text-muted-foreground">
             {isPreview
-              ? "Choose a preview scenario"
+              ? previewBackendDisabled
+                ? "Sign-in unavailable"
+                : "Choose a preview scenario"
               : "Sign in to your recipes"}
           </p>
           <div className="flex flex-col gap-1">

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -71,7 +71,7 @@ export function AuthButton() {
     setIsPreview(preview);
     if (!preview) return;
 
-    if (process.env.NEXT_PUBLIC_PREVIEW_BACKEND === "false") {
+    if (previewBackendDisabled) {
       setError("Sign-in is disabled on this frontend-only preview.");
       return;
     }
@@ -83,7 +83,7 @@ export function AuthButton() {
       })
       .then(setPreviewScenarios)
       .catch(() => setError("Preview sign-in is not configured."));
-  }, []);
+  }, [previewBackendDisabled]);
 
   async function loadLinkedAccounts() {
     setAccountsError(false);

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -37,6 +37,7 @@ describe("AuthButton", () => {
     mocks.getLastUsedLoginMethod.mockReturnValue(null);
     mocks.isPreviewDeployment.mockReturnValue(false);
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   it("lets the user choose Google or GitHub", async () => {
@@ -130,6 +131,22 @@ describe("AuthButton", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Preview sign-in failed",
     );
+  });
+
+  it("disables sign-in on a frontend-only preview", async () => {
+    const user = userEvent.setup();
+    mocks.isPreviewDeployment.mockReturnValue(true);
+    vi.stubEnv("NEXT_PUBLIC_PREVIEW_BACKEND", "false");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    render(<AuthButton />);
+
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Sign-in is disabled on this frontend-only preview.",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("shows the signed-in user and supports sign out", async () => {

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -146,6 +146,10 @@ describe("AuthButton", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Sign-in is disabled on this frontend-only preview.",
     );
+    expect(screen.getByText("Sign-in unavailable")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a preview scenario"),
+    ).not.toBeInTheDocument();
     expect(fetchMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Problem

The preview workflow created a **schema-only Neon branch per PR**. Schema-only branches are **root branches**, and the Neon **Free plan caps root branches at 3** (`main` + 2). Concurrent open PRs — especially Renovate's — exhausted the quota, so new previews failed branch creation with **HTTP 422**. Separately, backend provisioning blocked the frontend deploy even for frontend-only changes.

## Changes

Restructured `preview-environment.yml` into independent jobs:

- **`detect`** — provisions a backend only when the PR touches `workers/recipe-api/**`, `functions/**`, or `packages/**`, or carries a `preview:backend` label (`preview:frontend-only` forces it off).
- **`backend`** (conditional) — Neon branch + Worker, as before.
- **`frontend`** (always, non-bot) — deploys Pages in **parallel** with the backend job and is **never blocked** by it, even on backend failure.
- Skips previews entirely for `renovate[bot]` / `dependabot[bot]` PRs (they don't need a DB preview and were eating both slots).
- Frontend-only builds set `NEXT_PUBLIC_PREVIEW_BACKEND=false`; the sign-in menu shows a disabled state instead of calling a missing Worker.
- Cleanup now runs on **every** closed PR (delete steps are `continue-on-error`), so branches are never orphaned.

## New labels

- `preview:backend` — force a full backend preview.
- `preview:frontend-only` — force a frontend-only preview.

## Verification

- 274 UI tests pass (incl. new frontend-only sign-in test); typecheck + lint clean; workflows validate.
- Confirmed the root cause against the live Neon branch list and Neon's documented Free-plan root-branch limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview deployments can now be frontend-only or include backend support based on label selection and changed files.
  * The sign-in button now clearly reflects when preview sign-in is unavailable versus when a preview scenario can be chosen.

* **Bug Fixes**
  * Prevents sign-in attempts from loading preview scenarios when backend support is disabled.
  * Improves preview comment updates so the latest deployment status is shown more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->