### PR TITLE
Add navbar search trigger and global technology search to command palette

### DIFF
--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -3,6 +3,8 @@ import "./globals.css";
 import { CommandPaletteProvider } from "@/components/command-palette";
 import { ThemeProvider } from "@/components/theme-provider";
 import { siteConfig } from "@/lib/config/site-config";
+import { loadDomainRepository } from "@/lib/domain";
+import { getAllTechnologyBadgesSorted } from "@/lib/domain/technology";
 
 // Use Cloudflare Pages URL for preview deployments, fallback to production URL
 const baseUrl = process.env.CF_PAGES_URL || siteConfig.url;
@@ -53,6 +55,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const repository = loadDomainRepository();
+  const technologies = getAllTechnologyBadgesSorted(repository).map((tech) => ({
+    slug: tech.slug,
+    name: tech.name,
+    iconSlug: tech.iconSlug,
+    hasIcon: tech.hasIcon,
+  }));
+
   return (
     <html lang="en-GB" suppressHydrationWarning>
       <body>
@@ -62,7 +72,9 @@ export default function RootLayout({
           enableSystem={false}
           disableTransitionOnChange
         >
-          <CommandPaletteProvider>{children}</CommandPaletteProvider>
+          <CommandPaletteProvider technologies={technologies}>
+            {children}
+          </CommandPaletteProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/ui/components/command-palette.tsx
+++ b/ui/components/command-palette.tsx
@@ -25,6 +25,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { Button } from "@/components/ui/button";
 import { hasTechIcon, TechIcon } from "@/lib/api/tech-icons";
 import { siteConfig } from "@/lib/config/site-config";
 import { cn } from "@/lib/generic/styles";
@@ -35,6 +36,17 @@ interface FilterOption {
   icon?: ReactNode;
   group: string;
   paramName: string;
+}
+
+/**
+ * Minimal, serializable technology shape passed from server components into
+ * the (client) command palette so every technology is globally searchable.
+ */
+export interface PaletteTechnology {
+  slug: string;
+  name: string;
+  iconSlug?: string;
+  hasIcon: boolean;
 }
 
 interface NavigationItem {
@@ -103,10 +115,12 @@ const NAVIGATION_ITEMS: NavigationItem[] = [
 
 interface CommandPaletteProviderProps {
   children: ReactNode;
+  technologies?: PaletteTechnology[];
 }
 
 export function CommandPaletteProvider({
   children,
+  technologies = [],
 }: CommandPaletteProviderProps) {
   const [open, setOpen] = useState(false);
   const [pageFilters, setPageFilters] = useState<FilterOption[]>([]);
@@ -159,6 +173,7 @@ export function CommandPaletteProvider({
           open={open}
           onOpenChange={setOpen}
           pageFilters={pageFilters}
+          technologies={technologies}
         />
       </Suspense>
     </CommandPaletteContext.Provider>
@@ -169,12 +184,14 @@ interface CommandPaletteDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   pageFilters: FilterOption[];
+  technologies: PaletteTechnology[];
 }
 
 function CommandPaletteDialog({
   open,
   onOpenChange,
   pageFilters,
+  technologies,
 }: CommandPaletteDialogProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -343,6 +360,37 @@ function CommandPaletteDialog({
               ))}
             </Command.Group>
 
+            {/* Technologies — globally searchable; gated behind a query to
+                keep the default view compact given the large catalogue. */}
+            {search.trim().length > 0 && technologies.length > 0 && (
+              <Command.Group
+                heading="Technologies"
+                className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+              >
+                {technologies.map((tech) => (
+                  <Command.Item
+                    key={tech.slug}
+                    value={`technology ${tech.name}`}
+                    onSelect={() =>
+                      handleNavigation(`/technologies/${tech.slug}`)
+                    }
+                    className="flex items-center gap-2 px-2 py-1.5 text-sm rounded-sm cursor-pointer aria-selected:bg-accent aria-selected:text-accent-foreground"
+                  >
+                    {tech.hasIcon ? (
+                      <TechIcon
+                        name={tech.name}
+                        iconSlug={tech.iconSlug}
+                        className="size-4"
+                      />
+                    ) : (
+                      <Code2 className="size-4" />
+                    )}
+                    <span>{tech.name}</span>
+                  </Command.Item>
+                ))}
+              </Command.Group>
+            )}
+
             {/* Page-specific filters */}
             {Array.from(groupedFilters.entries()).map(([group, filters]) => (
               <Command.Group
@@ -428,6 +476,52 @@ function CommandPaletteDialog({
         </Command>
       </div>
     </div>
+  );
+}
+
+/**
+ * Navbar entry point for the command palette. Renders a compact icon button on
+ * mobile and a search-field-styled button (with a subtle ⌘K hint) on desktop.
+ */
+export function CommandPaletteTrigger({ className }: { className?: string }) {
+  const { setOpen } = useCommandPalette();
+
+  const handleOpen = useCallback(() => {
+    posthog.capture("command_palette_opened", { trigger: "navbar" });
+    setOpen(true);
+  }, [setOpen]);
+
+  return (
+    <>
+      {/* Mobile: icon-only */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={handleOpen}
+        aria-label="Search"
+        className={cn("md:hidden", className)}
+      >
+        <Search className="size-5" />
+      </Button>
+
+      {/* Desktop: search-field-styled button with hotkey hint */}
+      <button
+        type="button"
+        onClick={handleOpen}
+        aria-label="Search"
+        className={cn(
+          "hidden md:inline-flex items-center gap-2 h-9 w-44 rounded-md border bg-background px-3 text-sm text-muted-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+          className,
+        )}
+      >
+        <Search className="size-4 shrink-0" />
+        <span className="flex-1 text-left">Search</span>
+        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium">
+          <span className="text-xs">⌘</span>K
+        </kbd>
+      </button>
+    </>
   );
 }
 

--- a/ui/components/command-palette.tsx
+++ b/ui/components/command-palette.tsx
@@ -212,12 +212,14 @@ function CommandPaletteDialog({
   const [search, setSearch] = useState("");
 
   useEffect(() => {
-    if (open) {
-      setSearch("");
-      requestAnimationFrame(() => {
-        inputRef.current?.focus();
-      });
-    }
+    if (!open) return;
+    setSearch("");
+    // Skip auto-focus on touch devices so opening the palette doesn't force
+    // the on-screen keyboard up before the user chooses to type.
+    if (window.matchMedia("(pointer: coarse)").matches) return;
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
   }, [open]);
 
   // Prevent arrow keys from scrolling page when dialog is open
@@ -473,7 +475,7 @@ function CommandPaletteDialog({
             </Command.Group>
           </Command.List>
 
-          <div className="border-t px-3 py-2 text-xs text-muted-foreground flex items-center justify-between">
+          <div className="border-t px-3 py-2 text-xs text-muted-foreground hidden sm:flex items-center justify-between">
             <div className="flex items-center gap-2">
               <kbd className="px-1.5 py-0.5 rounded border bg-muted font-mono">
                 ↑↓

--- a/ui/components/command-palette.tsx
+++ b/ui/components/command-palette.tsx
@@ -26,6 +26,7 @@ import {
   useState,
 } from "react";
 import { Button } from "@/components/ui/button";
+import { useIsMac } from "@/hooks/use-is-mac";
 import { hasTechIcon, TechIcon } from "@/lib/api/tech-icons";
 import { siteConfig } from "@/lib/config/site-config";
 import { cn } from "@/lib/generic/styles";
@@ -84,6 +85,25 @@ export function useRegisterFilters(filters: FilterOption[]) {
     registerFilters(filters);
     return () => unregisterFilters();
   }, [filters, registerFilters, unregisterFilters]);
+}
+
+/**
+ * Renders the keyboard shortcut hint, using ⌘ on Mac and Ctrl elsewhere.
+ * Pass `className` to control display/spacing at each usage site.
+ */
+function HotkeyHint({ className }: { className?: string }) {
+  const isMac = useIsMac();
+  return (
+    <kbd
+      className={cn(
+        "pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium",
+        className,
+      )}
+    >
+      {isMac ? <span className="text-xs">⌘</span> : <span>Ctrl</span>}
+      <span>K</span>
+    </kbd>
+  );
 }
 
 const NAVIGATION_ITEMS: NavigationItem[] = [
@@ -323,9 +343,7 @@ function CommandPaletteDialog({
                 <X className="size-3" />
               </button>
             )}
-            <kbd className="hidden sm:inline-flex ml-2 pointer-events-none h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-              <span className="text-xs">⌘</span>K
-            </kbd>
+            <HotkeyHint className="hidden sm:inline-flex ml-2 text-muted-foreground" />
           </div>
 
           <Command.List className="max-h-80 overflow-y-auto p-2">
@@ -481,7 +499,8 @@ function CommandPaletteDialog({
 
 /**
  * Navbar entry point for the command palette. Renders a compact icon button on
- * mobile and a search-field-styled button (with a subtle ⌘K hint) on desktop.
+ * mobile and a search-field-styled button (with a subtle hotkey hint) on
+ * desktop, showing ⌘K on Mac and Ctrl K elsewhere.
  */
 export function CommandPaletteTrigger({ className }: { className?: string }) {
   const { setOpen } = useCommandPalette();
@@ -517,9 +536,7 @@ export function CommandPaletteTrigger({ className }: { className?: string }) {
       >
         <Search className="size-4 shrink-0" />
         <span className="flex-1 text-left">Search</span>
-        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium">
-          <span className="text-xs">⌘</span>K
-        </kbd>
+        <HotkeyHint />
       </button>
     </>
   );

--- a/ui/components/command-palette.tsx
+++ b/ui/components/command-palette.tsx
@@ -39,10 +39,6 @@ interface FilterOption {
   paramName: string;
 }
 
-/**
- * Minimal, serializable technology shape passed from server components into
- * the (client) command palette so every technology is globally searchable.
- */
 export interface PaletteTechnology {
   slug: string;
   name: string;
@@ -87,10 +83,6 @@ export function useRegisterFilters(filters: FilterOption[]) {
   }, [filters, registerFilters, unregisterFilters]);
 }
 
-/**
- * Renders the keyboard shortcut hint, using ⌘ on Mac and Ctrl elsewhere.
- * Pass `className` to control display/spacing at each usage site.
- */
 function HotkeyHint({ className }: { className?: string }) {
   const isMac = useIsMac();
   return (
@@ -307,8 +299,6 @@ function CommandPaletteDialog({
     return groups;
   }, [pageFilters]);
 
-  // Pre-filter and cap the technology list in React rather than rendering the
-  // whole catalogue and leaning on cmdk to filter it on every keystroke.
   const matchedTechnologies = useMemo(() => {
     const query = search.trim().toLowerCase();
     if (!query) return [];
@@ -392,8 +382,6 @@ function CommandPaletteDialog({
               ))}
             </Command.Group>
 
-            {/* Technologies — globally searchable; only shown once the user
-                types, with matches pre-filtered and capped above. */}
             {matchedTechnologies.length > 0 && (
               <Command.Group
                 heading="Technologies"
@@ -511,11 +499,6 @@ function CommandPaletteDialog({
   );
 }
 
-/**
- * Navbar entry point for the command palette. Renders a compact icon button on
- * mobile and a search-field-styled button (with a subtle hotkey hint) on
- * desktop, showing ⌘K on Mac and Ctrl K elsewhere.
- */
 export function CommandPaletteTrigger({ className }: { className?: string }) {
   const { setOpen } = useCommandPalette();
 

--- a/ui/components/command-palette.tsx
+++ b/ui/components/command-palette.tsx
@@ -307,6 +307,20 @@ function CommandPaletteDialog({
     return groups;
   }, [pageFilters]);
 
+  // Pre-filter and cap the technology list in React rather than rendering the
+  // whole catalogue and leaning on cmdk to filter it on every keystroke.
+  const matchedTechnologies = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return [];
+    return technologies
+      .filter(
+        (tech) =>
+          tech.name.toLowerCase().includes(query) ||
+          tech.slug.toLowerCase().includes(query),
+      )
+      .slice(0, 10);
+  }, [search, technologies]);
+
   if (!open) return null;
 
   return (
@@ -378,17 +392,17 @@ function CommandPaletteDialog({
               ))}
             </Command.Group>
 
-            {/* Technologies — globally searchable; gated behind a query to
-                keep the default view compact given the large catalogue. */}
-            {search.trim().length > 0 && technologies.length > 0 && (
+            {/* Technologies — globally searchable; only shown once the user
+                types, with matches pre-filtered and capped above. */}
+            {matchedTechnologies.length > 0 && (
               <Command.Group
                 heading="Technologies"
                 className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
               >
-                {technologies.map((tech) => (
+                {matchedTechnologies.map((tech) => (
                   <Command.Item
                     key={tech.slug}
-                    value={`technology ${tech.name}`}
+                    value={`${tech.name} ${tech.slug}`}
                     onSelect={() =>
                       handleNavigation(`/technologies/${tech.slug}`)
                     }

--- a/ui/components/scroll-navbar.tsx
+++ b/ui/components/scroll-navbar.tsx
@@ -2,6 +2,7 @@
 
 import { cva } from "class-variance-authority";
 import Link from "next/link";
+import { CommandPaletteTrigger } from "@/components/command-palette";
 import { Button } from "@/components/ui/button";
 import { useNavbarActions } from "@/contexts/navbar-actions-context";
 import { useNavbarVisibility } from "@/hooks/use-navbar-visibility";
@@ -38,6 +39,7 @@ export function ScrollNavbar() {
           </Link>
         </div>
         <div className="flex items-center gap-2">
+          <CommandPaletteTrigger />
           <Button variant="ghost" className="px-2 md:px-4" asChild>
             <Link href="/blog">Blog</Link>
           </Button>

--- a/ui/components/scroll-navbar.tsx
+++ b/ui/components/scroll-navbar.tsx
@@ -39,7 +39,6 @@ export function ScrollNavbar() {
           </Link>
         </div>
         <div className="flex items-center gap-2">
-          <CommandPaletteTrigger />
           <Button variant="ghost" className="px-2 md:px-4" asChild>
             <Link href="/blog">Blog</Link>
           </Button>
@@ -58,6 +57,7 @@ export function ScrollNavbar() {
               )}
             </Link>
           </Button>
+          <CommandPaletteTrigger />
           <AnimatedThemeToggler />
         </div>
       </nav>

--- a/ui/hooks/use-is-mac.ts
+++ b/ui/hooks/use-is-mac.ts
@@ -12,7 +12,9 @@ export function useIsMac() {
   const [isMac, setIsMac] = useState(false);
 
   useEffect(() => {
-    setIsMac(/Mac|iPhone|iPad|iPod/i.test(navigator.platform));
+    // `navigator.platform` is deprecated; `userAgent` is universally supported
+    // and reports "Macintosh"/"iPhone"/"iPad" for Apple platforms.
+    setIsMac(/Mac|iPhone|iPad|iPod/i.test(navigator.userAgent));
   }, []);
 
   return isMac;

--- a/ui/hooks/use-is-mac.ts
+++ b/ui/hooks/use-is-mac.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Detects whether the user is on a Mac so UI can show the right modifier key
+ * (⌘ vs Ctrl). Returns `false` until mounted to keep SSR and the first client
+ * render in agreement (avoiding hydration mismatches); it then resolves the
+ * real platform on the client.
+ */
+export function useIsMac() {
+  const [isMac, setIsMac] = useState(false);
+
+  useEffect(() => {
+    setIsMac(/Mac|iPhone|iPad|iPod/i.test(navigator.platform));
+  }, []);
+
+  return isMac;
+}

--- a/ui/hooks/use-is-mac.ts
+++ b/ui/hooks/use-is-mac.ts
@@ -3,8 +3,8 @@
 import { useEffect, useState } from "react";
 
 /**
- * Whether the user is on an Apple platform, for showing ⌘ vs Ctrl. Starts
- * `false` and resolves after mount so SSR and first client render agree.
+ * Whether the user is on an Apple platform. Starts `false` and resolves after
+ * mount so SSR and the first client render agree.
  */
 export function useIsMac() {
   const [isMac, setIsMac] = useState(false);

--- a/ui/hooks/use-is-mac.ts
+++ b/ui/hooks/use-is-mac.ts
@@ -3,17 +3,13 @@
 import { useEffect, useState } from "react";
 
 /**
- * Detects whether the user is on a Mac so UI can show the right modifier key
- * (⌘ vs Ctrl). Returns `false` until mounted to keep SSR and the first client
- * render in agreement (avoiding hydration mismatches); it then resolves the
- * real platform on the client.
+ * Whether the user is on an Apple platform, for showing ⌘ vs Ctrl. Starts
+ * `false` and resolves after mount so SSR and first client render agree.
  */
 export function useIsMac() {
   const [isMac, setIsMac] = useState(false);
 
   useEffect(() => {
-    // `navigator.platform` is deprecated; `userAgent` is universally supported
-    // and reports "Macintosh"/"iPhone"/"iPad" for Apple platforms.
     setIsMac(/Mac|iPhone|iPad|iPod/i.test(navigator.userAgent));
   }, []);
 


### PR DESCRIPTION
Make the command palette discoverable via a navbar search button and
expose technologies as a global search result, not just per-page filters.

- Add CommandPaletteTrigger to the navbar: an icon button on mobile and a
  search-field-styled button with a subtle Cmd+K hint on desktop.
- Surface all technologies in the palette (navigating to the tech detail
  page), gated behind a search query to keep the default view compact.
- Load the technology catalogue in the root layout and pass it to the
  CommandPaletteProvider.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WTDkiMawqDEBBFJ74EVMMG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The command palette now includes technology pages in search results, making it easier to find and open related content.
  * A new search trigger has been added to the navigation bar for quicker access on desktop and mobile.
  * Keyboard hints now adapt to the user’s device, showing the appropriate shortcut style.

* **Bug Fixes**
  * Improved the command palette so search results appear only when there is input, reducing clutter and making navigation more relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->