### PR TITLE
Accept ADR 045: SonarQube and inherit in personal-site

### DIFF
--- a/ui/content/projects/personal-site/adrs/048-sonarqube.mdx
+++ b/ui/content/projects/personal-site/adrs/048-sonarqube.mdx
@@ -1,0 +1,3 @@
+---
+inherits_from: "recipe-site:045-sonarqube"
+---

--- a/ui/content/projects/recipe-site/adrs/045-sonarqube.mdx
+++ b/ui/content/projects/recipe-site/adrs/045-sonarqube.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ADR 045: SonarQube"
 date: "2026-06-26"
-status: "Proposed"
+status: "Accepted"
 tech_stack: ["SonarQube"]
 ---
 
@@ -37,7 +37,7 @@ and login to maintain, back when the site was a static front-end with one human 
 revisits that decision because the reason no longer holds. What is proposed here is the free
 GitHub-native scan, not a separate platform.
 
-# Decision (Proposed)
+# Decision
 
 Adopt SonarQube Cloud's free GitHub App integration (free for public repositories) as a
 deterministic, trend-tracked code-health analysis that surfaces inside the GitHub pull request. It
@@ -143,7 +143,7 @@ platform?
 
 | Tool | GitHub-native? | Pros | Cons | Verdict |
 | --- | --- | --- | --- | --- |
-| **SonarQube Cloud + GitHub App** *(proposed)* | Yes (PR check + annotations) | Free for public repos; mature TS/JS engine, additive over Biome; large LLM corpus. | Security rules overlap CodeQL (redundant, not harmful); gate metrics invite Goodhart gaming. | **Proposed** |
+| **SonarQube Cloud + GitHub App** *(accepted)* | Yes (PR check + annotations) | Free for public repos; mature TS/JS engine, additive over Biome; large LLM corpus. | Security rules overlap CodeQL (redundant, not harmful); gate metrics invite Goodhart gaming. | **Accepted** |
 | **Qodana** (JetBrains) | Weaker PR annotations | Strong analysis; free for OSS. | Best inside the JetBrains IDEs we don't use; thinner community and LLM corpus. | Rejected: weaker fit, less established ([Goldilocks](/projects?tab=philosophy#the-goldilocks-zone)). |
 | **Codacy** | Yes (PR check) | Free OSS tier; one gate. | Mostly wraps linters we already run (Biome) plus Semgrep; little net-new signal. | Rejected: duplicates Biome without filling the health quadrant. |
 | **Qlty** (Code Climate successor) | Yes | Modern maintainability/duplication metrics. | 2024 relaunch mid-pivot from Code Climate; smaller corpus; churn risk. | Rejected: [Build Flywheels](/projects?tab=philosophy#build-flywheels) favours not betting learning on a product mid-transition. |


### PR DESCRIPTION
## Summary
Finalizes the decision to adopt SonarQube Cloud for the recipe-site project and establishes the same decision for the personal-site through inheritance.

## Key Changes
- **ADR 045 (recipe-site)**: Updated status from "Proposed" to "Accepted"
  - Changed section heading from "Decision (Proposed)" to "Decision"
  - Updated decision table to reflect "Accepted" verdict instead of "Proposed"
  - Updated tool description from "*(proposed)*" to "*(accepted)*"

- **ADR 048 (personal-site)**: Created new ADR that inherits from recipe-site's ADR 045
  - Establishes SonarQube as the code-health analysis tool for personal-site
  - Avoids duplication by referencing the detailed rationale in recipe-site's ADR

## Implementation Details
The personal-site ADR uses the `inherits_from` metadata field to reference the recipe-site decision, allowing both projects to adopt the same tooling decision without maintaining separate documentation of the analysis and rationale.

https://claude.ai/code/session_01PRPJuQwHJYb3echsqhhRex