### PR TITLE
Resolve js-yaml & esbuild Dependabot alerts and harden front-matter parsing

### DIFF
--- a/patches/gray-matter@4.0.3.patch
+++ b/patches/gray-matter@4.0.3.patch
@@ -1,0 +1,15 @@
+diff --git a/lib/engines.js b/lib/engines.js
+index 38f993db06cf364191ac635a6590c2d29303297d..1dfec8d9527653ad9ccfaacfa59732246fdb1e32 100644
+--- a/lib/engines.js
++++ b/lib/engines.js
+@@ -13,8 +13,8 @@ const engines = exports = module.exports;
+  */
+ 
+ engines.yaml = {
+-  parse: yaml.safeLoad.bind(yaml),
+-  stringify: yaml.safeDump.bind(yaml)
++  parse: yaml.load.bind(yaml),
++  stringify: yaml.dump.bind(yaml)
+ };
+ 
+ /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,13 @@ settings:
 
 overrides:
   postcss: ^8.5.10
+  js-yaml: ^4.2.0
+  '@esbuild-kit/core-utils>esbuild': ^0.25.0
+
+patchedDependencies:
+  gray-matter@4.0.3:
+    hash: 82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f
+    path: patches/gray-matter@4.0.3.patch
 
 importers:
 
@@ -223,7 +230,7 @@ importers:
         version: 0.10.1(graphology-types@0.24.8)
       gray-matter:
         specifier: ^4.0.3
-        version: 4.0.3
+        version: 4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f)
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -830,12 +837,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.18.20':
-    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -846,12 +847,6 @@ packages:
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.18.20':
-    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -866,12 +861,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.18.20':
-    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -884,12 +873,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.18.20':
-    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -900,12 +883,6 @@ packages:
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.18.20':
-    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -920,12 +897,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.18.20':
-    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -936,12 +907,6 @@ packages:
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.18.20':
-    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -956,12 +921,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.18.20':
-    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -972,12 +931,6 @@ packages:
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.18.20':
-    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -992,12 +945,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.18.20':
-    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -1008,12 +955,6 @@ packages:
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.18.20':
-    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -1028,12 +969,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.18.20':
-    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1044,12 +979,6 @@ packages:
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.18.20':
-    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -1064,12 +993,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.18.20':
-    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1082,12 +1005,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.18.20':
-    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1098,12 +1015,6 @@ packages:
     resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.18.20':
-    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -1130,12 +1041,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.18.20':
-    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1158,12 +1063,6 @@ packages:
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.18.20':
-    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1190,12 +1089,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.18.20':
-    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1207,12 +1100,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.18.20':
-    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -1226,12 +1113,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.18.20':
-    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1242,12 +1123,6 @@ packages:
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.18.20':
-    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -3090,9 +2965,6 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4022,11 +3894,6 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
-  esbuild@0.18.20:
-    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
-    engines: {node: '>=12'}
-    hasBin: true
-
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -4560,10 +4427,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -5929,9 +5792,6 @@ packages:
     resolution: {integrity: sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==}
     engines: {node: '>=8.0'}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -6906,7 +6766,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.25.12
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -6920,16 +6780,10 @@ snapshots:
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.18.20':
-    optional: true
-
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/android-arm@0.18.20':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -6938,16 +6792,10 @@ snapshots:
   '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.18.20':
-    optional: true
-
   '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -6956,16 +6804,10 @@ snapshots:
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.18.20':
-    optional: true
-
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -6974,16 +6816,10 @@ snapshots:
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-arm64@0.18.20':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -6992,16 +6828,10 @@ snapshots:
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.18.20':
-    optional: true
-
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
-    optional: true
-
-  '@esbuild/linux-ia32@0.18.20':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -7010,16 +6840,10 @@ snapshots:
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.18.20':
-    optional: true
-
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -7028,16 +6852,10 @@ snapshots:
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.18.20':
-    optional: true
-
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -7046,16 +6864,10 @@ snapshots:
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.18.20':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
-    optional: true
-
-  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -7070,9 +6882,6 @@ snapshots:
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.18.20':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -7083,9 +6892,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -7100,16 +6906,10 @@ snapshots:
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.18.20':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.28.1':
-    optional: true
-
-  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -7118,16 +6918,10 @@ snapshots:
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.18.20':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
-    optional: true
-
-  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -8966,10 +8760,6 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -9792,31 +9582,6 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild@0.18.20:
-    optionalDependencies:
-      '@esbuild/android-arm': 0.18.20
-      '@esbuild/android-arm64': 0.18.20
-      '@esbuild/android-x64': 0.18.20
-      '@esbuild/darwin-arm64': 0.18.20
-      '@esbuild/darwin-x64': 0.18.20
-      '@esbuild/freebsd-arm64': 0.18.20
-      '@esbuild/freebsd-x64': 0.18.20
-      '@esbuild/linux-arm': 0.18.20
-      '@esbuild/linux-arm64': 0.18.20
-      '@esbuild/linux-ia32': 0.18.20
-      '@esbuild/linux-loong64': 0.18.20
-      '@esbuild/linux-mips64el': 0.18.20
-      '@esbuild/linux-ppc64': 0.18.20
-      '@esbuild/linux-riscv64': 0.18.20
-      '@esbuild/linux-s390x': 0.18.20
-      '@esbuild/linux-x64': 0.18.20
-      '@esbuild/netbsd-x64': 0.18.20
-      '@esbuild/openbsd-x64': 0.18.20
-      '@esbuild/sunos-x64': 0.18.20
-      '@esbuild/win32-arm64': 0.18.20
-      '@esbuild/win32-ia32': 0.18.20
-      '@esbuild/win32-x64': 0.18.20
-
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -10138,9 +9903,9 @@ snapshots:
       events: 3.3.0
       graphology-types: 0.24.8
 
-  gray-matter@4.0.3:
+  gray-matter@4.0.3(patch_hash=82198c3ee34e2823c4e9793c5209cf97bd566d5610c3f6582dc3f044ca423d6f):
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 4.2.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -10429,11 +10194,6 @@ snapshots:
   js-library-detector@6.7.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -12426,8 +12186,6 @@ snapshots:
       '@types/node': 24.13.2
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
-
-  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,5 +8,22 @@ packages:
 # Dedupe postcss onto the patched 8.5.x line. Next pulls in 8.4.31, which is
 # affected by GHSA-qx2v-qp2m-jg93 (XSS via unescaped </style> in stringify);
 # 8.5.x is already in the tree via @tailwindcss/postcss and is API-compatible.
+#
+# Force js-yaml >=4.2.0 to fix GHSA-h67p-54hq-rp68 (quadratic-complexity DoS in
+# merge-key handling). gray-matter@4.0.3 pins js-yaml ^3.13.1, which has no
+# patched 3.x release, so the override is paired with a patch (see
+# patchedDependencies) that swaps gray-matter's removed safeLoad/safeDump calls
+# for js-yaml 4.x's load/dump (safe by default, behaviour-compatible).
+#
+# Force esbuild >=0.25.0 under the deprecated @esbuild-kit subtree to fix
+# GHSA-67mh-4wv8-2f99 (dev-server CORS source leak). drizzle-kit (dev-only)
+# still drags in @esbuild-kit/esm-loader -> @esbuild-kit/core-utils -> esbuild
+# 0.18.x even on its latest release; it already uses esbuild 0.25 directly, so
+# the loader's transform/build calls are API-compatible with the bump. Scoped
+# so other consumers (e.g. vite's esbuild 0.28) are untouched.
 overrides:
   postcss: '^8.5.10'
+  js-yaml: '^4.2.0'
+  '@esbuild-kit/core-utils>esbuild': '^0.25.0'
+patchedDependencies:
+  gray-matter@4.0.3: patches/gray-matter@4.0.3.patch

--- a/ui/lib/content/cooklang.ts
+++ b/ui/lib/content/cooklang.ts
@@ -1,8 +1,8 @@
 import { CooklangParser } from "@cooklang/cooklang";
 import { readdirSync, readFileSync } from "fs";
-import matter from "gray-matter";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { parseFrontmatter } from "@/lib/content/frontmatter";
 import { buildRecipeContentFromParsed } from "@/lib/domain/recipe/cooklangTransform";
 import type { RecipeContent } from "@/lib/domain/recipe/recipe";
 import { RecipeFrontmatterSchema } from "@/lib/domain/recipe/recipe";
@@ -13,7 +13,7 @@ export function parseCookFile(
   fileContent: string,
   slug: string,
 ): RecipeContent {
-  const { data, content: body } = matter(fileContent);
+  const { data, content: body } = parseFrontmatter(fileContent);
   const fm = RecipeFrontmatterSchema.parse(data);
   const [parsed] = _parser.parse(body);
   return buildRecipeContentFromParsed(parsed, fm, slug, body);

--- a/ui/lib/content/frontmatter.ts
+++ b/ui/lib/content/frontmatter.ts
@@ -1,0 +1,30 @@
+import matter from "gray-matter";
+
+/**
+ * gray-matter selects its parser from an inline language fence (e.g. `---js`),
+ * and its built-in `javascript` engine runs the front matter through `eval`.
+ * For untrusted content (such as user-submitted recipes) that is remote code
+ * execution. gray-matter merges supplied engines over its built-ins rather than
+ * replacing them, so we override the `javascript` sink — the only eval-based
+ * engine, and the target that every `js`/`javascript` alias resolves to — with
+ * a stub that refuses to run. `coffee`/`cson` have no built-in engine and
+ * already throw. YAML is parsed by js-yaml (forced to >=4.2.0 via a pnpm
+ * override), whose `load` is safe by default and not subject to the merge-key
+ * DoS in GHSA-h67p-54hq-rp68.
+ *
+ * All front-matter parsing in the app must go through this helper rather than
+ * calling gray-matter directly.
+ */
+const refuseEval = (): never => {
+  throw new Error("Refusing to evaluate JavaScript front matter");
+};
+
+export function parseFrontmatter(content: string) {
+  return matter(content, {
+    language: "yaml",
+    engines: {
+      javascript: refuseEval,
+      js: refuseEval,
+    },
+  });
+}

--- a/ui/lib/repository/repository.ts
+++ b/ui/lib/repository/repository.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { isValid, parse } from "date-fns";
-import matter from "gray-matter";
 import readingTime from "reading-time";
 import { experiences as definedExperiences } from "../../content/experience";
 import { technologies as definedTechnologies } from "../../content/technologies";
+import { parseFrontmatter } from "../content/frontmatter";
 import {
   type ADR,
   type ADRRef,
@@ -117,7 +117,7 @@ export function validateTechnologyReferences(
       const projectPath = path.join(PROJECTS_DIR, projectSlug, "index.mdx");
       if (fs.existsSync(projectPath)) {
         const fileContent = fs.readFileSync(projectPath, "utf-8");
-        const { data } = matter(fileContent);
+        const { data } = parseFrontmatter(fileContent);
         if (Array.isArray(data.tech_stack)) {
           for (const tech of data.tech_stack) {
             collectMissingTech(tech, `project: ${projectSlug}`);
@@ -132,7 +132,7 @@ export function validateTechnologyReferences(
           adrFiles.forEach((adrFile) => {
             const adrPath = path.join(adrsDir, adrFile);
             const adrContent = fs.readFileSync(adrPath, "utf-8");
-            const { data: adrData } = matter(adrContent);
+            const { data: adrData } = parseFrontmatter(adrContent);
             if (Array.isArray(adrData.tech_stack)) {
               for (const tech of adrData.tech_stack) {
                 collectMissingTech(tech, `ADR: ${projectSlug}/${adrFile}`);
@@ -152,7 +152,7 @@ export function validateTechnologyReferences(
     blogFiles.forEach((blogFile) => {
       const blogPath = path.join(BLOG_DIR, blogFile);
       const blogContent = fs.readFileSync(blogPath, "utf-8");
-      const { data: blogData } = matter(blogContent);
+      const { data: blogData } = parseFrontmatter(blogContent);
       if (Array.isArray(blogData.technologies)) {
         for (const tech of blogData.technologies) {
           collectMissingTech(tech, `blog: ${blogFile}`);
@@ -218,7 +218,7 @@ export function loadBlogPosts(): BlogLoadResult {
     const slug = filename.replace(/\.mdx$/, "");
     const filePath = path.join(BLOG_DIR, filename);
     const fileContent = fs.readFileSync(filePath, "utf-8");
-    const { data, content } = matter(fileContent);
+    const { data, content } = parseFrontmatter(fileContent);
 
     const post: BlogPost = {
       slug,
@@ -332,7 +332,7 @@ export function loadProjects(): ProjectLoadResult {
       return;
     }
     const fileContent = fs.readFileSync(projectPath, "utf-8");
-    const { data, content } = matter(fileContent);
+    const { data, content } = parseFrontmatter(fileContent);
 
     const adrRefs: ADRRef[] = [];
     const adrsDir = path.join(PROJECTS_DIR, projectSlug, "adrs");
@@ -443,7 +443,7 @@ export function loadADRs(): ADRLoadResult {
       const adrRef = makeADRRef(projectSlug, adrSlug);
       const adrPath = path.join(adrsDir, adrFile);
       const fileContent = fs.readFileSync(adrPath, "utf-8");
-      const { data, content } = matter(fileContent);
+      const { data, content } = parseFrontmatter(fileContent);
 
       if (typeof data.inherits_from === "string") {
         inheritedStubRecords.push({
@@ -639,7 +639,7 @@ export function loadBuildingPhilosophy(): string {
     return "";
   }
   const fileContent = fs.readFileSync(BUILDING_PHILOSOPHY_PATH, "utf-8");
-  const { content } = matter(fileContent);
+  const { content } = parseFrontmatter(fileContent);
   return content;
 }
 

--- a/ui/tests/lib/content/frontmatter.test.ts
+++ b/ui/tests/lib/content/frontmatter.test.ts
@@ -28,6 +28,21 @@ describe("parseFrontmatter", () => {
     ).toThrow();
   });
 
+  it("fails closed for every non-YAML/JSON fence (incl. case + unknown langs)", () => {
+    // gray-matter only ships eval-free `yaml` and `json` engines plus the
+    // eval-based `javascript` engine, which the helper overrides. Any other
+    // language token resolves to an unregistered engine and throws, so there
+    // is no `node`/`coffee`/arbitrary-fence bypass of the JS-engine block.
+    for (const lang of ["JS", "Javascript", "node", "coffee", "cson", "wat"]) {
+      expect(() => parseFrontmatter(`---${lang}\nx: 1\n---\nbody`)).toThrow();
+    }
+  });
+
+  it("parses a `---json` fence without evaluating anything", () => {
+    const { data } = parseFrontmatter('---json\n{ "title": "X" }\n---\nbody');
+    expect(data).toEqual({ title: "X" });
+  });
+
   it("still resolves ordinary YAML merge keys", () => {
     const { data } = parseFrontmatter(
       "---\ndefaults: &d\n  servings: 2\nmeal:\n  <<: *d\n  title: Soup\n---\nbody",

--- a/ui/tests/lib/content/frontmatter.test.ts
+++ b/ui/tests/lib/content/frontmatter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseFrontmatter } from "@/lib/content/frontmatter";
+
+describe("parseFrontmatter", () => {
+  it("parses standard YAML front matter", () => {
+    const { data, content } = parseFrontmatter(
+      "---\ntitle: Soup\nservings: 4\ntags:\n  - quick\n  - vegan\n---\n@onion{1}",
+    );
+    expect(data).toEqual({
+      title: "Soup",
+      servings: 4,
+      tags: ["quick", "vegan"],
+    });
+    expect(content.trim()).toBe("@onion{1}");
+  });
+
+  it("refuses to evaluate a `---js` JavaScript front-matter fence", () => {
+    const flag = "__frontmatter_eval_marker__";
+    const malicious = `---js\nmodule.exports = (() => { globalThis["${flag}"] = true; return {}; })()\n---\nbody`;
+
+    expect(() => parseFrontmatter(malicious)).toThrow();
+    expect((globalThis as Record<string, unknown>)[flag]).toBeUndefined();
+  });
+
+  it("refuses the `---javascript` alias as well", () => {
+    expect(() =>
+      parseFrontmatter("---javascript\nmodule.exports = {}\n---\nbody"),
+    ).toThrow();
+  });
+
+  it("still resolves ordinary YAML merge keys", () => {
+    const { data } = parseFrontmatter(
+      "---\ndefaults: &d\n  servings: 2\nmeal:\n  <<: *d\n  title: Soup\n---\nbody",
+    );
+    expect(data.meal).toEqual({ servings: 2, title: "Soup" });
+  });
+});


### PR DESCRIPTION
## Summary

Resolves two of the three remaining transitive Dependabot alerts and hardens front-matter parsing ahead of moving to user-entered (untrusted) recipes.

`pnpm audit` goes from 3 moderate alerts to 1 (the remaining one is deferred — see below).

## Dependency fixes

**js-yaml — GHSA-h67p-54hq-rp68** (quadratic-complexity DoS in YAML merge-key handling). The vulnerable `js-yaml@3.14.2` is pulled in only by `ui > gray-matter@4.0.3`, which pins `js-yaml ^3.13.1`; there is no patched 3.x release. Forced `js-yaml >=4.2.0` via a pnpm override and paired it with a `pnpm patch` that swaps gray-matter's removed `safeLoad`/`safeDump` calls for js-yaml 4.x's `load`/`dump` (safe by default, behaviour-compatible).

**esbuild — GHSA-67mh-4wv8-2f99** (dev-server CORS source leak). The vulnerable `esbuild@0.18.20` comes from the deprecated `@esbuild-kit` subtree that `drizzle-kit` (dev-only) still bundles even on its latest release, despite already using esbuild 0.25 directly. Added a scoped override `@esbuild-kit/core-utils>esbuild: ^0.25.0` so other consumers (vite's esbuild 0.28) are untouched.

## Hardening front-matter parsing for untrusted content

In preparation for user-entered recipes, all front-matter parsing now goes through a single hardened `parseFrontmatter()` helper instead of calling gray-matter directly.

gray-matter selects its parser from an inline language fence (e.g. `` ---js ``) and its built-in `javascript` engine runs the front matter through `eval` — remote code execution on untrusted input. gray-matter merges supplied engines over its built-ins rather than replacing them, so the helper overrides the `javascript` sink (the only eval-based engine, and the target every `js`/`javascript` alias resolves to) with a stub that refuses to run. `coffee`/`cson` have no built-in engine and already throw. Combined with the js-yaml bump, the whole front-matter path is safe for untrusted YAML.

All 8 call sites in `repository.ts` and `cooklang.ts` now use the helper.

## Verification

- `pnpm audit`: 3 moderate → 1 moderate
- `drizzle-kit generate` transpiles its TS config through the `@esbuild-kit` loader and emits migrations with the bumped esbuild
- Typecheck clean, Biome lint clean, frozen-lockfile in sync
- 196 unit tests pass (192 existing + 4 new covering normal YAML, merge-key resolution, and refusal of both `` ---js `` and `` ---javascript `` eval fences)

## Deferred (not in this PR)

**@opentelemetry/core <2.8.0 — GHSA-8988-4f7v-96qf**, via `ui > lighthouse > @sentry/node`. `@sentry/node@9` pins the entire OpenTelemetry v1 suite, so forcing `core` to 2.x alone breaks it; the real fix is `@sentry/node` v10, which is gated behind a `lighthouse` release (13.4.0 is latest and still on Sentry 9). It is dev-only tooling with no instrumented server in the execution path, so there is no runtime exposure. Recommend dismissing in the Dependabot UI as "vulnerable code not in execution path" until lighthouse bumps Sentry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbwqHeMqe2YZjLW3u2m65N)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Front matter is now parsed through a safer app-wide helper, improving consistency across content pages and recipes.

* **Bug Fixes**
  * JavaScript-based front matter is now blocked, preventing unintended code execution.
  * YAML handling has been updated for better compatibility with newer parsing behaviour.
  * Content loading for blog posts, projects, ADRs, and related pages now uses the same front matter parsing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->