### PR TITLE
Export recipe-api Worker logs to PostHog

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -51,6 +51,10 @@ Secrets synced from Doppler:
 7. **`POSTHOG_HOST`**
    - PostHog ingestion host (`https://eu.posthog.com`).
    - Mapped to `NEXT_PUBLIC_POSTHOG_HOST` for the UI build.
+8. **`MISE_GITHUB_TOKEN`**
+   - GitHub token used by mise to download tools during Cloudflare Pages builds.
+   - Mapped to `TF_VAR_github_token`, which Terraform passes into the Pages
+     build configuration (`var.github_token`, required — no default).
 
 ### Required Environment
 
@@ -83,16 +87,20 @@ any rotation so it never drifts:
 ```bash
 #!/usr/bin/env bash
 # Pull values from Doppler into .env using the names Terraform expects
-# (TF_VAR_<variable>, lowercase suffix). All secrets are fetched and checked
-# before .env is written, so a failed or empty fetch aborts without leaving a
-# partial/broken .env behind (which would silently break Terraform).
+# (TF_VAR_<variable>, lowercase suffix). This covers the same secrets CI maps in
+# infra-ci.yml. All secrets are fetched and checked first, then written to a
+# temp file and moved into place, so a failed/empty fetch or interrupted write
+# never leaves a partial .env behind (which would silently break Terraform).
 set -euo pipefail
 
 require() {
   local value
-  value=$(doppler secrets get "$1" --plain)
+  value=$(doppler secrets get "$1" --plain) || {
+    echo "error: failed to read '$1' from Doppler" >&2
+    return 1
+  }
   if [ -z "$value" ]; then
-    echo "error: Doppler secret '$1' is missing or empty" >&2
+    echo "error: Doppler secret '$1' is empty" >&2
     return 1
   fi
   printf '%s' "$value"
@@ -103,14 +111,20 @@ tf_cloud_token=$(require TF_API_TOKEN)
 neon_api_key=$(require NEON_API_KEY)
 neon_org_id=$(require NEON_ORG_ID)
 posthog_key=$(require POSTHOG_KEY)
+cf_images_account_hash=$(require CF_IMAGES_ACCOUNT_HASH)
+github_token=$(require MISE_GITHUB_TOKEN)
 
-cat > .env <<EOF
+tmp=$(mktemp)
+cat > "$tmp" <<EOF
 CLOUDFLARE_API_TOKEN=$cloudflare_api_token
 TF_TOKEN_app_terraform_io=$tf_cloud_token
 NEON_API_KEY=$neon_api_key
 TF_VAR_neon_org_id=$neon_org_id
 TF_VAR_posthog_key=$posthog_key
+TF_VAR_cf_images_account_hash=$cf_images_account_hash
+TF_VAR_github_token=$github_token
 EOF
+mv "$tmp" .env
 ```
 
 Then run Terraform commands via mise:
@@ -177,6 +191,6 @@ stop arriving in PostHog, no error) if you forget it, so rotate in this order:
    and it is not a Worker secret or Pages var that Doppler's integrations sync.
 
 This destination is referenced by `workers/recipe-api/wrangler.toml`
-(`[observability.logs]`). In practice the public `phc_` project key rarely
+(`[observability.logs]`). In practice, the public `phc_` project key rarely
 rotates, which is why the manual step is an acceptable trade-off — but it is the
 one to remember.

--- a/infra/README.md
+++ b/infra/README.md
@@ -81,15 +81,36 @@ that `.env` from Doppler rather than hand-editing it, and regenerate it after
 any rotation so it never drifts:
 
 ```bash
-# Pull individual values from Doppler into .env using the names Terraform
-# expects (TF_VAR_<variable>); the variable suffix is lowercase.
-{
-  echo "CLOUDFLARE_API_TOKEN=$(doppler secrets get CLOUDFLARE_API_TOKEN --plain)"
-  echo "TF_TOKEN_app_terraform_io=$(doppler secrets get TF_API_TOKEN --plain)"
-  echo "NEON_API_KEY=$(doppler secrets get NEON_API_KEY --plain)"
-  echo "TF_VAR_neon_org_id=$(doppler secrets get NEON_ORG_ID --plain)"
-  echo "TF_VAR_posthog_key=$(doppler secrets get POSTHOG_KEY --plain)"
-} > .env
+#!/usr/bin/env bash
+# Pull values from Doppler into .env using the names Terraform expects
+# (TF_VAR_<variable>, lowercase suffix). All secrets are fetched and checked
+# before .env is written, so a failed or empty fetch aborts without leaving a
+# partial/broken .env behind (which would silently break Terraform).
+set -euo pipefail
+
+require() {
+  local value
+  value=$(doppler secrets get "$1" --plain)
+  if [ -z "$value" ]; then
+    echo "error: Doppler secret '$1' is missing or empty" >&2
+    return 1
+  fi
+  printf '%s' "$value"
+}
+
+cloudflare_api_token=$(require CLOUDFLARE_API_TOKEN)
+tf_cloud_token=$(require TF_API_TOKEN)
+neon_api_key=$(require NEON_API_KEY)
+neon_org_id=$(require NEON_ORG_ID)
+posthog_key=$(require POSTHOG_KEY)
+
+cat > .env <<EOF
+CLOUDFLARE_API_TOKEN=$cloudflare_api_token
+TF_TOKEN_app_terraform_io=$tf_cloud_token
+NEON_API_KEY=$neon_api_key
+TF_VAR_neon_org_id=$neon_org_id
+TF_VAR_posthog_key=$posthog_key
+EOF
 ```
 
 Then run Terraform commands via mise:

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,7 +6,17 @@ Terraform configuration for managing Cloudflare and Neon resources.
 
 ### Required Secrets
 
-Configure these in GitHub repository settings (Settings → Secrets and variables → Actions):
+**[Doppler](https://doppler.com) is the single source of truth for these
+values.** Doppler's GitHub Actions integration syncs them into GitHub
+repository secrets (Settings → Secrets and variables → Actions) — so don't edit
+the GitHub secrets by hand; change the value in Doppler and let it propagate.
+The workflows then map each synced secret onto the `TF_VAR_*` / build env vars
+that Terraform and the UI build expect (e.g. `secrets.POSTHOG_KEY` →
+`TF_VAR_posthog_key`, see `infra-ci.yml`). Because of this indirection, no
+workflow or Terraform changes are needed to source a value from Doppler — only
+the Doppler → GitHub sync.
+
+Secrets synced from Doppler:
 
 1. **`CLOUDFLARE_API_TOKEN`**
    - Create at: Cloudflare Dashboard → My Profile → API Tokens
@@ -29,6 +39,18 @@ Configure these in GitHub repository settings (Settings → Secrets and variable
 5. **`NEON_ORG_ID`**
    - Find at: [Neon Console](https://console.neon.tech) → Organization settings
    - Passed as `TF_VAR_neon_org_id`
+6. **`POSTHOG_KEY`**
+   - PostHog project API key (`phc_…`). This is a public, write-only ingestion
+     key — it already ships to browsers via `NEXT_PUBLIC_POSTHOG_KEY`, so it is
+     not secret in the usual sense, but it is sourced from Doppler for
+     single-source-of-truth config management.
+   - Mapped to `TF_VAR_posthog_key` (Terraform → Pages env var) and to
+     `NEXT_PUBLIC_POSTHOG_KEY` (UI build). It is **also** used — outside both
+     Terraform and Doppler's reach — as the auth header on the `posthog-logs`
+     Workers Observability destination. See [Rotating `POSTHOG_KEY`](#rotating-posthog_key).
+7. **`POSTHOG_HOST`**
+   - PostHog ingestion host (`https://eu.posthog.com`).
+   - Mapped to `NEXT_PUBLIC_POSTHOG_HOST` for the UI build.
 
 ### Required Environment
 
@@ -53,23 +75,31 @@ Create a workspace in Terraform Cloud for remote state:
 
 ## Local Development
 
-1. Create your local `.env` file:
+Credentials are sourced from Doppler (the same single source of truth CI uses).
+mise auto-loads a local `.env` (`_.file = ".env"` in `mise.toml`), so populate
+that `.env` from Doppler rather than hand-editing it, and regenerate it after
+any rotation so it never drifts:
 
-   ```bash
-   cp .env.example .env
-   ```
+```bash
+# Pull individual values from Doppler into .env using the names Terraform
+# expects (TF_VAR_<variable>); the variable suffix is lowercase.
+{
+  echo "CLOUDFLARE_API_TOKEN=$(doppler secrets get CLOUDFLARE_API_TOKEN --plain)"
+  echo "TF_TOKEN_app_terraform_io=$(doppler secrets get TF_API_TOKEN --plain)"
+  echo "NEON_API_KEY=$(doppler secrets get NEON_API_KEY --plain)"
+  echo "TF_VAR_neon_org_id=$(doppler secrets get NEON_ORG_ID --plain)"
+  echo "TF_VAR_posthog_key=$(doppler secrets get POSTHOG_KEY --plain)"
+} > .env
+```
 
-2. Fill in your credentials in `.env`:
-   - `CLOUDFLARE_API_TOKEN` - Your Cloudflare API token
-   - `TF_TOKEN_app_terraform_io` - Your Terraform Cloud token
-   - `NEON_API_KEY` - Your Neon API key
-   - `TF_VAR_neon_org_id` - Your Neon organization ID
+Then run Terraform commands via mise:
 
-3. Run Terraform commands via mise:
-   - `mise run //infra:plan` - Preview changes
-   - `mise run //infra:apply` - Apply changes
+- `mise run //infra:plan` - Preview changes
+- `mise run //infra:apply` - Apply changes
 
-The `.env` file is automatically loaded by mise when running tasks.
+The mapping from Doppler's uppercase secret names to Terraform's
+`TF_VAR_<variable>` names is the same one CI performs in the workflow `env:`
+blocks; doing it here keeps local and CI consistent.
 
 See `mise.toml` for all available tasks.
 
@@ -105,3 +135,27 @@ Terraform provider.
 - **Region:** `aws-us-east-1`
 - **Connection:** Use the pooled connection URI (`neon_connection_uri_pooler` output)
   for serverless/Workers environments
+
+## Rotating `POSTHOG_KEY`
+
+`POSTHOG_KEY` lives in Doppler, but it lands in **three** places — two are
+automated, one is **manual**. The manual one will break silently (logs just
+stop arriving in PostHog, no error) if you forget it, so rotate in this order:
+
+1. **Doppler** — update the value. This is the source of truth.
+2. **Pages / UI build** (automated) — Doppler syncs to the GitHub
+   `POSTHOG_KEY` secret; the next infra apply / UI build picks it up via
+   `TF_VAR_posthog_key` and `NEXT_PUBLIC_POSTHOG_KEY`. Nothing to do by hand.
+3. **`posthog-logs` Workers Observability destination** (⚠️ **manual**) —
+   Cloudflare Dashboard → Workers & Pages → Observability → Telemetry →
+   `posthog-logs` → update the `Authorization: Bearer <phc_…>` header. Neither
+   Terraform nor Doppler can reach this: there is a Cloudflare API for
+   observability destinations, but the Terraform resource
+   (`cloudflare_workers_observability_destination`) is currently
+   [unimplemented](https://github.com/cloudflare/terraform-provider-cloudflare/issues/7127),
+   and it is not a Worker secret or Pages var that Doppler's integrations sync.
+
+This destination is referenced by `workers/recipe-api/wrangler.toml`
+(`[observability.logs]`). In practice the public `phc_` project key rarely
+rotates, which is why the manual step is an acceptable trade-off — but it is the
+one to remember.

--- a/infra/README.md
+++ b/infra/README.md
@@ -114,16 +114,17 @@ posthog_key=$(require POSTHOG_KEY)
 cf_images_account_hash=$(require CF_IMAGES_ACCOUNT_HASH)
 github_token=$(require MISE_GITHUB_TOKEN)
 
-tmp=$(mktemp)
-cat > "$tmp" <<EOF
-CLOUDFLARE_API_TOKEN=$cloudflare_api_token
-TF_TOKEN_app_terraform_io=$tf_cloud_token
-NEON_API_KEY=$neon_api_key
-TF_VAR_neon_org_id=$neon_org_id
-TF_VAR_posthog_key=$posthog_key
-TF_VAR_cf_images_account_hash=$cf_images_account_hash
-TF_VAR_github_token=$github_token
-EOF
+tmp=$(mktemp)       # mktemp creates the file mode 0600
+chmod 600 "$tmp"    # make the owner-only intent explicit
+{
+  printf 'CLOUDFLARE_API_TOKEN=%s\n' "$cloudflare_api_token"
+  printf 'TF_TOKEN_app_terraform_io=%s\n' "$tf_cloud_token"
+  printf 'NEON_API_KEY=%s\n' "$neon_api_key"
+  printf 'TF_VAR_neon_org_id=%s\n' "$neon_org_id"
+  printf 'TF_VAR_posthog_key=%s\n' "$posthog_key"
+  printf 'TF_VAR_cf_images_account_hash=%s\n' "$cf_images_account_hash"
+  printf 'TF_VAR_github_token=%s\n' "$github_token"
+} > "$tmp"
 mv "$tmp" .env
 ```
 

--- a/ui/content/projects/recipe-site/adrs/047-posthog-logs.mdx
+++ b/ui/content/projects/recipe-site/adrs/047-posthog-logs.mdx
@@ -7,32 +7,31 @@ tech_stack: ["PostHog", "Cloudflare Workers", "OpenTelemetry"]
 
 # Summary
 
-Export `recipe-api` Worker logs to **PostHog Logs** via OpenTelemetry (OTLP), reusing
-the PostHog project that already powers product analytics
+Export `recipe-api` Worker logs to PostHog Logs via OpenTelemetry (OTLP), reusing the
+PostHog project that already powers product analytics
 ([ADR 028](/projects/recipe-site/adrs/028-posthog-analytics)).
 
-Backend logs land in the same place as frontend events, session replays, funnels, and
-retention — so operational signals (errors, latency) can be correlated with **product
-outcomes and KPIs**, not just inspected in isolation. The point is to make reliability and
-performance work *prioritisable against product impact* (is a buggy path actually driving
-churn? is latency actually hurting conversion?), not only to debug individual incidents.
-Neon log export is explicitly **not** adopted. The export *mechanism* — and the
-trade-offs of Cloudflare's beta observability pipeline — are a separate decision in
+Placing backend logs alongside frontend events, session replays, funnels, and retention
+lets operational signals such as errors and latency be correlated with product outcomes and
+KPIs. That supports prioritising reliability and performance work by product impact —
+whether a buggy path is driving churn, whether latency is hurting conversion — as well as
+debugging individual incidents. Neon log export is out of scope. The export mechanism, and
+the trade-offs of Cloudflare's beta observability pipeline, are covered in
 [ADR 048](/projects/recipe-site/adrs/048-cloudflare-observability-destinations).
 
 # Context
 
 The recipe site gained a server-side runtime
-([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)):
-a `recipe-api` Cloudflare Worker, two Cloudflare Pages Functions, and a Neon Postgres
-database behind Hyperdrive. That runtime needs observability — somewhere to answer "what
-happened when this request failed?" after the fact.
+([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)): a
+`recipe-api` Cloudflare Worker, two Cloudflare Pages Functions, and a Neon Postgres database
+behind Hyperdrive. That runtime needs observability — a way to answer "what happened when
+this request failed?" after the fact.
 
-PostHog is already in the stack for product analytics, session replay, and
-experimentation. The question is whether backend logs should also live in PostHog, or
-whether the existing Cloudflare-native tooling is sufficient on its own.
+PostHog already serves product analytics, session replay, and experimentation. The question
+is whether backend logs should also live in PostHog, or whether Cloudflare-native tooling is
+sufficient.
 
-Several options exist for Worker logs:
+Options for Worker logs:
 
 | Option                          | Retained / queryable | Correlated with PostHog | Effort                      |
 | ------------------------------- | -------------------- | ----------------------- | --------------------------- |
@@ -41,127 +40,120 @@ Several options exist for Worker logs:
 | Dedicated platform (Grafana / Axiom / Sentry / Better Stack) | Yes | No                      | New vendor + pipeline       |
 | **PostHog Logs**                | Yes                  | **Yes**                 | Low (native OTLP export)    |
 
-The honest framing: PostHog does **not** beat `wrangler tail` for live debugging, and it
-does **not** beat Cloudflare's built-in Workers Logs for cheap retention/query on its own.
-Retention is not the reason to adopt it.
+For live debugging, `wrangler tail` is better. For retained, queryable logs on their own,
+Cloudflare's built-in Workers Logs already suffice at little cost. Retention alone does not
+justify PostHog Logs; its value is the correlation described below.
 
 # Decision
 
-Use **PostHog Logs** as the destination for `recipe-api` Worker logs.
-
-The differentiator is **correlation with the product data we already have** — at two levels.
+Use PostHog Logs as the destination for `recipe-api` Worker logs. The value is correlation
+with product data PostHog already holds, at two levels.
 
 **Incident level.** A backend `500` can be tied to the same `distinct_id`, that person's
-product-analytics events, and their session replay: "user X failed to save a recipe → here
-is the request log → here is the replay of what they clicked." For this to work, the Worker
-must attach the PostHog `distinct_id` to logs.
+product-analytics events, and their session replay: a failed recipe save links to the
+request log and the replay of what the user did. This requires the Worker to attach the
+PostHog `distinct_id` to logs.
 
-**Aggregate / KPI level (the main reason).** Because logs share a home with funnels,
+**Aggregate / KPI level (the primary motivation).** Because logs sit with funnels,
 retention, and experiments, operational signals can be joined to product outcomes across
-cohorts rather than read in isolation:
+cohorts:
 
-- **Reliability vs. churn.** Do users who hit a buggy or error-prone path retain and convert
-  worse than those who don't? If a flaky experience is measurably driving churn, that reframes
-  it from "a bug" into a retention/revenue problem and raises its priority accordingly.
-- **Latency vs. value.** Is latency optimisation worth it versus shipping features? Compare
-  success metrics (conversion, task completion, retention) across cohorts with different
-  latency profiles. If the KPIs are indistinguishable, latency work is hard to justify over
-  new features; if the slow cohort converts worse, the optimisation pays for itself.
-- **Where to invest.** Prioritise reliability, performance, or features by their *measured*
-  impact on KPIs rather than by intuition.
+- **Reliability and churn.** Whether users who hit a buggy or error-prone path retain and
+  convert worse than those who do not. A flaky experience that measurably drives churn
+  becomes a retention and revenue issue with a priority to match.
+- **Latency and value.** Whether latency optimisation is worth doing before shipping
+  features. Comparing conversion, task completion, and retention across cohorts with
+  different latency profiles answers it: indistinguishable KPIs make latency work hard to
+  justify; a slower cohort that converts worse justifies the optimisation.
+- **Investment.** Choosing between reliability, performance, and features by their measured
+  impact on KPIs.
 
-This is the specific argument for *PostHog* as the destination: a standalone
-logging/observability tool (Grafana, Axiom, Sentry) has the operational signal but not the
-product/KPI side, and product analytics alone has the KPIs but not the per-request
-operational signal — PostHog has both. It is also something `wrangler tail` and Cloudflare's
-siloed Workers Logs cannot provide.
+This is the case for PostHog specifically. A standalone logging or observability tool
+(Grafana, Axiom, Sentry) holds the operational signal but lacks the product and KPI side;
+product analytics holds the KPIs but lacks the per-request operational signal. PostHog holds
+both. `wrangler tail` and Cloudflare's siloed Workers Logs hold neither connection.
 
 Supporting factors:
 
-- **Cost is a non-issue.** PostHog Logs is free for the first 50 GB/month, then $0.25/GB.
-  A personal recipe site will not approach the free tier.
-- **No proprietary SDK.** PostHog ingests standard OTLP, so the integration rides on the
-  OpenTelemetry ecosystem rather than a vendor lock-in client.
+- **Cost.** PostHog Logs includes the first 50 GB/month free, then $0.25/GB. A personal
+  recipe site stays well within the free tier.
+- **No proprietary SDK.** PostHog ingests standard OTLP, so the integration uses the
+  OpenTelemetry ecosystem and avoids a vendor-specific client.
 
 ## Scope
 
-- **Logs only, not traces.** Cloudflare's export supports logs but not trace export to
-  PostHog, so there are no distributed-trace waterfalls through this path. Acceptable for a
-  recipe site; logs cover the need.
-- **`recipe-api` Worker is the target.** Pages Functions observability export lags Workers
-  and is not assumed to be covered.
+- **Traces excluded.** Cloudflare exports logs but does not export traces to PostHog, so
+  there are no distributed-trace waterfalls on this path. Logs cover the recipe site's needs.
+- **`recipe-api` Worker only.** Pages Functions observability export lags Workers and is not
+  assumed to be covered.
 
 ## Neon logs are out of scope
 
 Neon log export was evaluated and rejected:
 
 - Neon's own logs are low-value for a small site, and queries already pass through
-  Hyperdrive, adding a layer between the app and the database.
-- The DB signal worth capturing — slow queries, query errors, connection churn — is far
-  more useful emitted **from inside the Worker**, where request context (route,
-  `distinct_id`, query name, duration) is available. That lands in the same PostHog log
-  stream with context Neon's logs could never provide.
+  Hyperdrive, which adds a layer between the app and the database.
+- The database signal worth capturing — slow queries, query errors, connection churn — is
+  more useful when emitted from inside the Worker, where request context (route,
+  `distinct_id`, query name, duration) is available. That context lands in the same PostHog
+  log stream and exceeds what Neon's logs could provide.
 
-So database visibility comes from a thin "log slow/failed query" wrapper in the Worker, not
-from Neon → OTel.
+Database visibility therefore comes from a thin "log slow/failed query" wrapper in the
+Worker. Neon → OTel is not used.
 
 # Alternatives Considered
 
 ## `wrangler tail` only
 
-Free and immediate, but ephemeral — it answers "what is happening right now," never "what
-happened on Tuesday." Kept as a complementary live-debugging tool, not a replacement.
+Free and immediate, but live-only: it shows what is happening now and keeps no history. It
+stays as a complementary live-debugging tool.
 
 ## Cloudflare Workers Logs (built-in)
 
-Cloudflare already persists and lets you query Worker logs in its dashboard for little to no
-cost. This is the real "do nothing extra" baseline. Rejected as the *primary* solution only
-because it is siloed from PostHog — no correlation to people, events, or replays — which is
-the entire reason to centralise. It remains available as a fallback if PostHog ingestion is
-ever unavailable.
+Cloudflare persists and lets you query Worker logs in its dashboard at little or no cost —
+the lowest-effort baseline. It was passed over as the primary solution because it is siloed
+from PostHog, with no link to people, events, or replays, which is the reason to centralise.
+It stays available as a fallback if PostHog ingestion is unavailable.
 
 ## Dedicated observability platform (Grafana Cloud / Axiom / Sentry / Better Stack)
 
-More powerful log/trace tooling than PostHog Logs, and Cloudflare supports OTLP export to
-all of them. Rejected because each adds a *new* vendor relationship and still leaves backend
-logs disconnected from the PostHog product-analytics data — the opposite of the
-consolidation goal. Sentry-style error tracking may be reconsidered if error triage
-outgrows what PostHog Logs offers.
+Stronger log and trace tooling than PostHog Logs, and Cloudflare exports OTLP to all of
+them. Each adds a new vendor relationship and leaves backend logs disconnected from
+PostHog's product-analytics data, which works against the consolidation goal. Sentry-style
+error tracking may be reconsidered if error triage outgrows PostHog Logs.
 
 ## Neon log export
 
-Rejected — see "Neon logs are out of scope" above.
+Rejected; see "Neon logs are out of scope" above.
 
 # Consequences
 
 ## Positive
 
-- **One pane of glass.** Backend logs, product analytics, and session replays share a home
-  and a person identity.
-- **Operational signals become prioritisable.** Errors and latency can be joined to KPIs and
-  cohorts, turning reliability/performance work into product-impact decisions rather than
-  guesses.
-- **Cheap.** Comfortably within PostHog's free log tier.
-- **Standards-based.** OTLP export, no proprietary logging SDK.
-- **Better DB signal than Neon logs would give**, captured with request context from the
-  Worker.
+- **Unified view.** Backend logs, product analytics, and session replays share a home and a
+  person identity.
+- **Prioritisation by impact.** Errors and latency can be joined to KPIs and cohorts, so
+  reliability and performance work can be judged by product impact.
+- **Within free tier.** Stays inside PostHog's free log allowance.
+- **Standards-based.** OTLP export with no proprietary logging SDK.
+- **Better database signal.** Stronger than Neon's own logs, captured with request context
+  from the Worker.
 
 ## Negative
 
-- **Correlation depends on discipline.** The payoff only materialises if logs carry the
-  right dimensions — `distinct_id` for incident correlation, plus route and latency for
-  cohort/KPI analysis. Without them, PostHog Logs is just another log bucket with no
-  advantage over Cloudflare's built-in logs.
-- **Logs only.** No distributed tracing via this path.
+- **Depends on log dimensions.** The payoff requires `distinct_id` for incident correlation,
+  and route plus latency for cohort and KPI analysis. Without them, PostHog Logs is another
+  log bucket with no advantage over Cloudflare's built-in logs.
+- **No tracing.** Distributed tracing is unavailable on this path.
 - **Pages Functions likely uncovered.** Observability export there lags Workers.
-- **A second consumer of `POSTHOG_KEY`.** The log pipeline authenticates with the public
-  PostHog project key, adding another place that key is used (see
+- **Second consumer of `POSTHOG_KEY`.** The log pipeline authenticates with the public
+  PostHog project key (see
   [ADR 048](/projects/recipe-site/adrs/048-cloudflare-observability-destinations) and the
   rotation runbook in `infra/README.md`).
 
 # When To Revisit
 
-- Error triage outgrows PostHog Logs and warrants dedicated error tracking (e.g. Sentry).
-- Distributed tracing becomes valuable enough to justify a trace-capable backend.
+- Error triage outgrows PostHog Logs and warrants dedicated error tracking such as Sentry.
+- Distributed tracing becomes worth a trace-capable backend.
 - Cloudflare adds trace export to PostHog, or Pages Functions gain first-class export.
-- Log volume unexpectedly approaches the PostHog free tier.
+- Log volume approaches the PostHog free tier.

--- a/ui/content/projects/recipe-site/adrs/047-posthog-logs.mdx
+++ b/ui/content/projects/recipe-site/adrs/047-posthog-logs.mdx
@@ -1,0 +1,140 @@
+---
+title: "ADR 047: PostHog Logs for Backend Observability"
+date: "2026-06-28"
+status: "Accepted"
+tech_stack: ["PostHog", "Cloudflare Workers", "OpenTelemetry"]
+---
+
+# Summary
+
+Export `recipe-api` Worker logs to **PostHog Logs** via OpenTelemetry (OTLP), reusing
+the PostHog project that already powers product analytics
+([ADR 028](/projects/recipe-site/adrs/028-posthog-analytics)).
+
+Backend logs land in the same place as frontend events and session replays, so a
+backend error can be correlated to the same person's product-analytics timeline and
+replay. Neon log export is explicitly **not** adopted. The export *mechanism* — and the
+trade-offs of Cloudflare's beta observability pipeline — are a separate decision in
+[ADR 048](/projects/recipe-site/adrs/048-cloudflare-observability-destinations).
+
+# Context
+
+The recipe site gained a server-side runtime
+([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)):
+a `recipe-api` Cloudflare Worker, two Cloudflare Pages Functions, and a Neon Postgres
+database behind Hyperdrive. That runtime needs observability — somewhere to answer "what
+happened when this request failed?" after the fact.
+
+PostHog is already in the stack for product analytics, session replay, and
+experimentation. The question is whether backend logs should also live in PostHog, or
+whether the existing Cloudflare-native tooling is sufficient on its own.
+
+Several options exist for Worker logs:
+
+| Option                          | Retained / queryable | Correlated with PostHog | Effort                      |
+| ------------------------------- | -------------------- | ----------------------- | --------------------------- |
+| `wrangler tail`                 | No (live only)       | No                      | Zero                        |
+| Cloudflare Workers Logs (built-in) | Yes (CF dashboard) | No                      | Zero (toggle)               |
+| Dedicated platform (Grafana / Axiom / Sentry / Better Stack) | Yes | No                      | New vendor + pipeline       |
+| **PostHog Logs**                | Yes                  | **Yes**                 | Low (native OTLP export)    |
+
+The honest framing: PostHog does **not** beat `wrangler tail` for live debugging, and it
+does **not** beat Cloudflare's built-in Workers Logs for cheap retention/query on its own.
+Retention is not the reason to adopt it.
+
+# Decision
+
+Use **PostHog Logs** as the destination for `recipe-api` Worker logs.
+
+The differentiator is **correlation with data we already have**. A backend `500` can be
+tied to the same `distinct_id`, that person's product-analytics events, and their session
+replay — "user X failed to save a recipe → here is the request log → here is the replay of
+what they clicked." That single-pane-of-glass is something `wrangler tail` and Cloudflare's
+siloed Workers Logs cannot provide. For that correlation to actually work, the Worker must
+attach the PostHog `distinct_id` to error logs.
+
+Supporting factors:
+
+- **Cost is a non-issue.** PostHog Logs is free for the first 50 GB/month, then $0.25/GB.
+  A personal recipe site will not approach the free tier.
+- **No proprietary SDK.** PostHog ingests standard OTLP, so the integration rides on the
+  OpenTelemetry ecosystem rather than a vendor lock-in client.
+
+## Scope
+
+- **Logs only, not traces.** Cloudflare's export supports logs but not trace export to
+  PostHog, so there are no distributed-trace waterfalls through this path. Acceptable for a
+  recipe site; logs cover the need.
+- **`recipe-api` Worker is the target.** Pages Functions observability export lags Workers
+  and is not assumed to be covered.
+
+## Neon logs are out of scope
+
+Neon log export was evaluated and rejected:
+
+- Neon's own logs are low-value for a small site, and queries already pass through
+  Hyperdrive, adding a layer between the app and the database.
+- The DB signal worth capturing — slow queries, query errors, connection churn — is far
+  more useful emitted **from inside the Worker**, where request context (route,
+  `distinct_id`, query name, duration) is available. That lands in the same PostHog log
+  stream with context Neon's logs could never provide.
+
+So database visibility comes from a thin "log slow/failed query" wrapper in the Worker, not
+from Neon → OTel.
+
+# Alternatives Considered
+
+## `wrangler tail` only
+
+Free and immediate, but ephemeral — it answers "what is happening right now," never "what
+happened on Tuesday." Kept as a complementary live-debugging tool, not a replacement.
+
+## Cloudflare Workers Logs (built-in)
+
+Cloudflare already persists and lets you query Worker logs in its dashboard for little to no
+cost. This is the real "do nothing extra" baseline. Rejected as the *primary* solution only
+because it is siloed from PostHog — no correlation to people, events, or replays — which is
+the entire reason to centralise. It remains available as a fallback if PostHog ingestion is
+ever unavailable.
+
+## Dedicated observability platform (Grafana Cloud / Axiom / Sentry / Better Stack)
+
+More powerful log/trace tooling than PostHog Logs, and Cloudflare supports OTLP export to
+all of them. Rejected because each adds a *new* vendor relationship and still leaves backend
+logs disconnected from the PostHog product-analytics data — the opposite of the
+consolidation goal. Sentry-style error tracking may be reconsidered if error triage
+outgrows what PostHog Logs offers.
+
+## Neon log export
+
+Rejected — see "Neon logs are out of scope" above.
+
+# Consequences
+
+## Positive
+
+- **One pane of glass.** Backend logs, product analytics, and session replays share a home
+  and a person identity.
+- **Cheap.** Comfortably within PostHog's free log tier.
+- **Standards-based.** OTLP export, no proprietary logging SDK.
+- **Better DB signal than Neon logs would give**, captured with request context from the
+  Worker.
+
+## Negative
+
+- **Correlation depends on discipline.** If the Worker does not attach `distinct_id` to
+  logs, PostHog Logs is just another log bucket with no advantage over Cloudflare's built-in
+  logs.
+- **Logs only.** No distributed tracing via this path.
+- **Pages Functions likely uncovered.** Observability export there lags Workers.
+- **A second consumer of `POSTHOG_KEY`.** The log pipeline authenticates with the public
+  PostHog project key, adding another place that key is used (see
+  [ADR 048](/projects/recipe-site/adrs/048-cloudflare-observability-destinations) and the
+  rotation runbook in `infra/README.md`).
+
+# When To Revisit
+
+- Error triage outgrows PostHog Logs and warrants dedicated error tracking (e.g. Sentry).
+- Distributed tracing becomes valuable enough to justify a trace-capable backend.
+- Cloudflare adds trace export to PostHog, or Pages Functions gain first-class export.
+- Log volume unexpectedly approaches the PostHog free tier.

--- a/ui/content/projects/recipe-site/adrs/047-posthog-logs.mdx
+++ b/ui/content/projects/recipe-site/adrs/047-posthog-logs.mdx
@@ -11,9 +11,12 @@ Export `recipe-api` Worker logs to **PostHog Logs** via OpenTelemetry (OTLP), re
 the PostHog project that already powers product analytics
 ([ADR 028](/projects/recipe-site/adrs/028-posthog-analytics)).
 
-Backend logs land in the same place as frontend events and session replays, so a
-backend error can be correlated to the same person's product-analytics timeline and
-replay. Neon log export is explicitly **not** adopted. The export *mechanism* — and the
+Backend logs land in the same place as frontend events, session replays, funnels, and
+retention — so operational signals (errors, latency) can be correlated with **product
+outcomes and KPIs**, not just inspected in isolation. The point is to make reliability and
+performance work *prioritisable against product impact* (is a buggy path actually driving
+churn? is latency actually hurting conversion?), not only to debug individual incidents.
+Neon log export is explicitly **not** adopted. The export *mechanism* — and the
 trade-offs of Cloudflare's beta observability pipeline — are a separate decision in
 [ADR 048](/projects/recipe-site/adrs/048-cloudflare-observability-destinations).
 
@@ -46,12 +49,32 @@ Retention is not the reason to adopt it.
 
 Use **PostHog Logs** as the destination for `recipe-api` Worker logs.
 
-The differentiator is **correlation with data we already have**. A backend `500` can be
-tied to the same `distinct_id`, that person's product-analytics events, and their session
-replay — "user X failed to save a recipe → here is the request log → here is the replay of
-what they clicked." That single-pane-of-glass is something `wrangler tail` and Cloudflare's
-siloed Workers Logs cannot provide. For that correlation to actually work, the Worker must
-attach the PostHog `distinct_id` to error logs.
+The differentiator is **correlation with the product data we already have** — at two levels.
+
+**Incident level.** A backend `500` can be tied to the same `distinct_id`, that person's
+product-analytics events, and their session replay: "user X failed to save a recipe → here
+is the request log → here is the replay of what they clicked." For this to work, the Worker
+must attach the PostHog `distinct_id` to logs.
+
+**Aggregate / KPI level (the main reason).** Because logs share a home with funnels,
+retention, and experiments, operational signals can be joined to product outcomes across
+cohorts rather than read in isolation:
+
+- **Reliability vs. churn.** Do users who hit a buggy or error-prone path retain and convert
+  worse than those who don't? If a flaky experience is measurably driving churn, that reframes
+  it from "a bug" into a retention/revenue problem and raises its priority accordingly.
+- **Latency vs. value.** Is latency optimisation worth it versus shipping features? Compare
+  success metrics (conversion, task completion, retention) across cohorts with different
+  latency profiles. If the KPIs are indistinguishable, latency work is hard to justify over
+  new features; if the slow cohort converts worse, the optimisation pays for itself.
+- **Where to invest.** Prioritise reliability, performance, or features by their *measured*
+  impact on KPIs rather than by intuition.
+
+This is the specific argument for *PostHog* as the destination: a standalone
+logging/observability tool (Grafana, Axiom, Sentry) has the operational signal but not the
+product/KPI side, and product analytics alone has the KPIs but not the per-request
+operational signal — PostHog has both. It is also something `wrangler tail` and Cloudflare's
+siloed Workers Logs cannot provide.
 
 Supporting factors:
 
@@ -115,6 +138,9 @@ Rejected — see "Neon logs are out of scope" above.
 
 - **One pane of glass.** Backend logs, product analytics, and session replays share a home
   and a person identity.
+- **Operational signals become prioritisable.** Errors and latency can be joined to KPIs and
+  cohorts, turning reliability/performance work into product-impact decisions rather than
+  guesses.
 - **Cheap.** Comfortably within PostHog's free log tier.
 - **Standards-based.** OTLP export, no proprietary logging SDK.
 - **Better DB signal than Neon logs would give**, captured with request context from the
@@ -122,9 +148,10 @@ Rejected — see "Neon logs are out of scope" above.
 
 ## Negative
 
-- **Correlation depends on discipline.** If the Worker does not attach `distinct_id` to
-  logs, PostHog Logs is just another log bucket with no advantage over Cloudflare's built-in
-  logs.
+- **Correlation depends on discipline.** The payoff only materialises if logs carry the
+  right dimensions — `distinct_id` for incident correlation, plus route and latency for
+  cohort/KPI analysis. Without them, PostHog Logs is just another log bucket with no
+  advantage over Cloudflare's built-in logs.
 - **Logs only.** No distributed tracing via this path.
 - **Pages Functions likely uncovered.** Observability export there lags Workers.
 - **A second consumer of `POSTHOG_KEY`.** The log pipeline authenticates with the public

--- a/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
+++ b/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
@@ -7,19 +7,19 @@ tech_stack: ["Cloudflare Workers", "OpenTelemetry", "Terraform", "PostHog"]
 
 # Summary
 
-Use Cloudflare's native **Workers Observability OTLP destinations** as the mechanism for
+Use Cloudflare's native Workers Observability OTLP destinations as the mechanism for
 exporting `recipe-api` logs to PostHog
 ([ADR 047](/projects/recipe-site/adrs/047-posthog-logs)).
 
-This feature is in **beta**, and its Terraform resource does not yet exist, so the
-destination is configured by hand in the Cloudflare dashboard while the toggle lives in
-`wrangler.toml`. This ADR records that choice and the trade-offs we are accepting —
-especially the gap against the project's code-owned-infrastructure principle and the
-silent-failure risk on key rotation.
+The feature is in beta, and its Terraform resource does not yet exist, so the destination is
+configured by hand in the Cloudflare dashboard while the toggle lives in `wrangler.toml`.
+This ADR records that choice and the trade-offs it carries, in particular the gap against the
+project's code-owned-infrastructure principle and the risk of a silent failure on key
+rotation.
 
 # Context
 
-[ADR 047](/projects/recipe-site/adrs/047-posthog-logs) decided *that* Worker logs go to
+[ADR 047](/projects/recipe-site/adrs/047-posthog-logs) decided that Worker logs go to
 PostHog. Something still has to ship the logs to PostHog's OTLP endpoint. The candidate
 mechanisms:
 
@@ -32,13 +32,13 @@ mechanisms:
 A relevant project principle
 ([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)):
 vendor control-plane configuration should be code-owned via Terraform or a stable API
-wherever a provider exists; dashboard-only configuration is a poor fit for an
+wherever a provider exists, since dashboard-only configuration is a poor fit for an
 agent-assisted, solo-maintained codebase.
 
 # Decision
 
-Use the **Cloudflare native observability destination**. It is the lowest-effort path, adds
-no application dependencies, and rides standard OTLP. Configuration is two parts:
+Use the Cloudflare native observability destination. It is the lowest-effort path, adds no
+application dependencies, and uses standard OTLP. Configuration is two parts:
 
 1. **Destination** (dashboard): create a `posthog-logs` destination under Workers
    Observability with the OTLP endpoint `https://eu.i.posthog.com/i/v1/logs` and an
@@ -53,16 +53,15 @@ no application dependencies, and rides standard OTLP. Configuration is two parts
    destinations = ["posthog-logs"]
    ```
 
-Keeping the key in the dashboard destination (rather than in `wrangler.toml`) also keeps it
-out of source control.
+Holding the key in the dashboard destination keeps it out of source control.
 
 ## Plan requirement and pricing
 
-OTel export is a **Workers Paid** feature — it is *not available* on Workers Free. This is
+OTel export requires the Workers Paid plan and is unavailable on Workers Free. This is
 already satisfied: the backend runs on Workers Paid for Hyperdrive and the 30s CPU limit
 ([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)), so
-no extra subscription is needed. (Note the distinction between a free Cloudflare *account*
-and the separate $5/month Workers Paid subscription — we have the latter.)
+no extra subscription is needed. A free Cloudflare account and the separate $5/month Workers
+Paid subscription are different things; this project has the latter.
 
 Cloudflare's pricing for the export itself (separate from PostHog's own log storage pricing
 in [ADR 047](/projects/recipe-site/adrs/047-posthog-logs)):
@@ -72,93 +71,96 @@ in [ADR 047](/projects/recipe-site/adrs/047-posthog-logs)):
 | Workers Free | Not available                 | Not available                 | —                   |
 | Workers Paid | 10M events/month included     | 10M events/month included     | $0.05 per 1M events |
 
-During the early-beta period export is free for Workers Paid; from **March 1, 2026** it is
-billed as above. A personal recipe site will not approach 10M log events/month, so the
-effective cost is zero. The two pricing models stack but neither bites: Cloudflare meters
-**export events** (10M/month free), PostHog meters **stored volume** (50 GB/month free).
+During the early-beta period export is free for Workers Paid; from March 1, 2026 it is
+billed as above. A personal recipe site stays well under 10M log events/month, so the
+effective cost is zero. The two pricing models stack and neither is reached: Cloudflare
+meters export events (10M/month free), PostHog meters stored volume (50 GB/month free).
 
 ## Accepting beta status
 
-The feature is in beta, which we accept because:
+The feature is in beta, which is acceptable here because:
 
-- The blast radius is observability only — if export breaks, the application is unaffected
+- The impact is limited to observability. If export breaks, the application is unaffected,
   and `wrangler tail` plus Cloudflare's built-in Workers Logs remain as fallbacks
   ([ADR 047](/projects/recipe-site/adrs/047-posthog-logs)).
-- It is standard OTLP, so if Cloudflare's beta disappoints, the same logs can be pointed at
-  another OTLP backend, or moved in-app via `otel-cf-workers`, without rewriting the app.
+- It uses standard OTLP. If Cloudflare's beta disappoints, the same logs can be pointed at
+  another OTLP backend, or moved in-app via `otel-cf-workers`, without rewriting the
+  application.
 
 ## Accepting the infrastructure-as-code gap
 
-This is the notable exception to the code-owned-infra principle. There **is** a Cloudflare
-API for observability destinations, but the Terraform resource
+This is the exception to the code-owned-infra principle. Cloudflare does expose an API for
+observability destinations, but the Terraform resource
 (`cloudflare_workers_observability_destination`) was announced in provider v5.19.0 and
 shipped unimplemented
 ([cloudflare/terraform-provider-cloudflare#7127](https://github.com/cloudflare/terraform-provider-cloudflare/issues/7127)).
-Nor is the destination a Worker secret or Pages variable, so Doppler's sync integrations
-cannot reach it either.
+The destination is also neither a Worker secret nor a Pages variable, so Doppler's sync
+integrations cannot reach it.
 
-The result: the destination's auth header is **manual** — neither Terraform nor Doppler
-manages it. This is the one place `POSTHOG_KEY` is not propagated automatically, so a key
-rotation will **silently** stop log ingestion (a `401` that drops logs, with no application
-error) if the destination header is not updated by hand.
+As a result the destination's auth header is managed by hand: neither Terraform nor Doppler
+owns it. `POSTHOG_KEY` is propagated automatically everywhere except here, so a key rotation
+that skips the destination header stops log ingestion silently — a `401` that drops logs
+with no application error.
 
 Mitigations:
 
-- A rotation runbook in `infra/README.md` ("Rotating `POSTHOG_KEY`") enumerates every
-  consumer and flags this destination as the manual step.
+- A rotation runbook in `infra/README.md` ("Rotating `POSTHOG_KEY`") lists every consumer
+  and marks this destination as the manual step.
 - A pointer comment in `workers/recipe-api/wrangler.toml` references that runbook.
-- In practice the public `phc_` project key rotates rarely, which makes the manual step an
-  acceptable trade-off rather than an ongoing burden.
+- The public `phc_` project key rotates rarely, which keeps the manual step a low-frequency
+  task.
 
-Managing the destination via a raw Cloudflare API call (e.g. a `null_resource`/`restapi`
-shim) was considered and rejected: it would store the value in Terraform state, lacks real
-drift detection, and is disproportionate machinery for a single public key.
+Managing the destination through a raw Cloudflare API call (for example a
+`null_resource`/`restapi` shim) was considered and rejected: it would store the value in
+Terraform state, lacks real drift detection, and is excessive machinery for a single public
+key.
 
 # Alternatives Considered
 
 ## `otel-cf-workers` (in-app OpenTelemetry)
 
-Instrument the Worker with an OpenTelemetry SDK and export OTLP directly from application
-code. Gives full control over spans/attributes and would be fully code-owned. Rejected for
-now as heavier than needed — it adds a runtime dependency and bundle weight for a log
-pipeline the native export already covers. It is the natural escape hatch if the native
-export proves limiting or if traces are wanted later.
+Instrument the Worker with an OpenTelemetry SDK and export OTLP from application code. This
+gives full control over spans and attributes and is fully code-owned. It was rejected for
+now because it adds a runtime dependency and bundle weight for a log pipeline that the native
+export already covers. It remains the escape hatch if the native export proves limiting or if
+traces are wanted later.
 
 ## Logpush
 
-Cloudflare Logpush is a different product aimed at bulk log delivery to object storage / SIEM
-sinks, not OTLP-native correlation into PostHog. Wrong shape for the
+Cloudflare Logpush targets bulk log delivery to object storage and SIEM sinks rather than
+OTLP-native correlation into PostHog, so it does not serve the
 [ADR 047](/projects/recipe-site/adrs/047-posthog-logs) correlation goal.
 
 ## Manual `fetch` to the OTLP endpoint
 
-Hand-rolling OTLP requests from the Worker is maximal control and zero platform dependency,
-but means owning batching, retries, and the OTLP wire format. Not worth it when the platform
-does it.
+Hand-rolling OTLP requests from the Worker gives full control and adds no platform
+dependency, but it means owning batching, retries, and the OTLP wire format — work the
+platform already does.
 
 # Consequences
 
 ## Positive
 
-- **Lowest effort**, no application dependencies, standard OTLP.
-- **Key stays out of git** — it lives in the dashboard destination.
-- **Reversible** — OTLP means the destination can be repointed or replaced with
-  `otel-cf-workers` without app changes.
+- **Lowest effort.** No application dependencies, standard OTLP.
+- **Key stays out of git.** It lives in the dashboard destination.
+- **Reversible.** OTLP lets the destination be repointed or replaced with `otel-cf-workers`
+  without application changes.
 
 ## Negative
 
-- **Beta risk** — API/behaviour may change, no stability guarantee, and trace export to
-  PostHog is unsupported.
-- **Not code-owned** — the destination is dashboard-managed, breaking the Terraform/Doppler
-  single-source-of-truth model for this one object.
-- **Silent-failure on rotation** — the manual auth header drops logs without erroring if a
-  rotation skips it; mitigated only by runbook discipline.
+- **Beta risk.** API and behaviour may change, there is no stability guarantee, and trace
+  export to PostHog is unsupported.
+- **Not code-owned.** The destination is dashboard-managed, which breaks the
+  Terraform/Doppler single-source-of-truth model for this one object.
+- **Silent failure on rotation.** The manual auth header drops logs without erroring if a
+  rotation skips it, guarded only by runbook discipline.
 
 # When To Revisit
 
-- The `cloudflare_workers_observability_destination` Terraform resource ships and works —
-  move the destination into `infra` and delete the manual step.
-- The feature leaves beta (revisit guarantees and trace support).
-- Traces or richer in-app instrumentation become worthwhile — adopt `otel-cf-workers`.
-- A silent ingestion outage actually occurs — add an active health check that logs are
-  arriving, rather than relying on the rotation runbook.
+- The `cloudflare_workers_observability_destination` Terraform resource ships and works, at
+  which point the destination moves into `infra` and the manual step is removed.
+- The feature leaves beta, prompting a review of guarantees and trace support.
+- Traces or richer in-app instrumentation become worthwhile, prompting adoption of
+  `otel-cf-workers`.
+- A silent ingestion outage occurs, prompting an active health check that logs are arriving
+  instead of relying on the rotation runbook.

--- a/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
+++ b/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
@@ -38,7 +38,7 @@ agent-assisted, solo-maintained codebase.
 # Decision
 
 Use the Cloudflare native observability destination. It is the lowest-effort path, adds no
-application dependencies, and uses standard OTLP. Configuration is two parts:
+application dependencies, and uses standard OTLP. Configuration is in two parts:
 
 1. **Destination** (dashboard): create a `posthog-logs` destination under Workers
    Observability with the OTLP endpoint `https://eu.i.posthog.com/i/v1/logs` and an
@@ -78,7 +78,7 @@ in [ADR 047](/projects/recipe-site/adrs/047-posthog-logs)):
 | Workers Free | Not available                 | Not available                 | —                   |
 | Workers Paid | 10M events/month included     | 10M events/month included     | $0.05 per 1M events |
 
-During the early-beta period export is free for Workers Paid; from March 1, 2026 it is
+During the early-beta period, export is free for Workers Paid; from March 1, 2026 it is
 billed as above. A personal recipe site stays well under 10M log events/month, so the
 effective cost is zero. The two pricing models stack and neither is reached: Cloudflare
 meters export events (10M/month free), PostHog meters stored volume (50 GB/month free).
@@ -104,7 +104,7 @@ shipped unimplemented
 The destination is also neither a Worker secret nor a Pages variable, so Doppler's sync
 integrations cannot reach it.
 
-As a result the destination's auth header is managed by hand: neither Terraform nor Doppler
+As a result, the destination's auth header is managed by hand: neither Terraform nor Doppler
 owns it. `POSTHOG_KEY` is propagated automatically everywhere except here, so a key rotation
 that skips the destination header stops log ingestion silently — a `401` that drops logs
 with no application error.

--- a/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
+++ b/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
@@ -56,6 +56,27 @@ no application dependencies, and rides standard OTLP. Configuration is two parts
 Keeping the key in the dashboard destination (rather than in `wrangler.toml`) also keeps it
 out of source control.
 
+## Plan requirement and pricing
+
+OTel export is a **Workers Paid** feature — it is *not available* on Workers Free. This is
+already satisfied: the backend runs on Workers Paid for Hyperdrive and the 30s CPU limit
+([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)), so
+no extra subscription is needed. (Note the distinction between a free Cloudflare *account*
+and the separate $5/month Workers Paid subscription — we have the latter.)
+
+Cloudflare's pricing for the export itself (separate from PostHog's own log storage pricing
+in [ADR 047](/projects/recipe-site/adrs/047-posthog-logs)):
+
+| Plan         | Logs                          | Traces                        | Overage             |
+| ------------ | ----------------------------- | ----------------------------- | ------------------- |
+| Workers Free | Not available                 | Not available                 | —                   |
+| Workers Paid | 10M events/month included     | 10M events/month included     | $0.05 per 1M events |
+
+During the early-beta period export is free for Workers Paid; from **March 1, 2026** it is
+billed as above. A personal recipe site will not approach 10M log events/month, so the
+effective cost is zero. The two pricing models stack but neither bites: Cloudflare meters
+**export events** (10M/month free), PostHog meters **stored volume** (50 GB/month free).
+
 ## Accepting beta status
 
 The feature is in beta, which we accept because:

--- a/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
+++ b/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
@@ -55,6 +55,13 @@ application dependencies, and uses standard OTLP. Configuration is two parts:
 
 Holding the key in the dashboard destination keeps it out of source control.
 
+Batching and delivery are platform-managed: there are no batch-size or flush-interval
+settings to tune. The only export-tuning knob is `head_sampling_rate` (0–1) under
+`[observability]`, applied head-based at request ingress and settable per signal (for
+example `[observability.logs] head_sampling_rate`). It defaults to `1` (export everything),
+which suits the recipe site's low volume. An account-wide 1% sample is forced only past 5
+billion logs/day, so it does not apply here.
+
 ## Plan requirement and pricing
 
 OTel export requires the Workers Paid plan and is unavailable on Workers Free. This is
@@ -119,11 +126,20 @@ key.
 
 ## `otel-cf-workers` (in-app OpenTelemetry)
 
-Instrument the Worker with an OpenTelemetry SDK and export OTLP from application code. This
-gives full control over spans and attributes and is fully code-owned. It was rejected for
-now because it adds a runtime dependency and bundle weight for a log pipeline that the native
-export already covers. It remains the escape hatch if the native export proves limiting or if
-traces are wanted later.
+Instrument the Worker with an OpenTelemetry SDK and export OTLP from application code. This is
+the most extensible option: it produces traces and spans (auto-instrumented `fetch` handlers,
+custom spans around Hyperdrive/Neon queries and auth flows) as well as logs, can fan out to
+several OTLP backends, gives full control over attribute enrichment, sampling, and batching,
+and keeps the whole pipeline code-owned in line with
+[ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features).
+
+The trace and span benefit does not apply to the current goal, however: PostHog ingests logs
+over OTLP but not general distributed traces, so it would only help once a separate trace
+backend (Grafana Tempo, Honeycomb, Axiom) is also adopted. Against a logs-only PostHog sink,
+`otel-cf-workers` delivers the same result as the native destination while adding a
+community-maintained runtime dependency, bundle weight, and self-built export-health
+visibility. Rejected for now, and kept as the step-up for when tracing, multiple backends, or
+full code ownership become real wants.
 
 ## Logpush
 
@@ -143,6 +159,10 @@ platform already does.
 
 - **Lowest effort.** No application dependencies, standard OTLP.
 - **Key stays out of git.** It lives in the dashboard destination.
+- **Managed delivery.** Cloudflare handles batching and transmission; the only knob is
+  `head_sampling_rate`.
+- **Built-in export visibility.** The Workers Observability dashboard shows per-destination
+  delivery status (last successful delivery, errors) with no extra setup.
 - **Reversible.** OTLP lets the destination be repointed or replaced with `otel-cf-workers`
   without application changes.
 
@@ -152,8 +172,11 @@ platform already does.
   export to PostHog is unsupported.
 - **Not code-owned.** The destination is dashboard-managed, which breaks the
   Terraform/Doppler single-source-of-truth model for this one object.
-- **Silent failure on rotation.** The manual auth header drops logs without erroring if a
-  rotation skips it, guarded only by runbook discipline.
+- **Failure is effectively silent on rotation.** If a rotation skips the manual auth header,
+  exports start failing with no application error, no deployment failure, and no push alert.
+  Cloudflare's destination dashboard does record the delivery errors, but only someone who
+  looks will notice, so the practical guard is runbook discipline (or a future active health
+  check; see When To Revisit).
 
 # When To Revisit
 

--- a/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
+++ b/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
@@ -48,10 +48,17 @@ application dependencies, and uses standard OTLP. Configuration is in two parts:
    destination by name.
 
    ```toml
+   [observability]
+   enabled = true  # persist built-in Workers Logs (the fallback below)
+
    [observability.logs]
    enabled = true
    destinations = ["posthog-logs"]
    ```
+
+   The parent `[observability] enabled = true` keeps Cloudflare's built-in Workers
+   Logs active, so the fallback that ADR 047 and this ADR rely on is genuinely
+   present rather than something that has to be turned on after an outage.
 
 Holding the key in the dashboard destination keeps it out of source control.
 

--- a/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
+++ b/ui/content/projects/recipe-site/adrs/048-cloudflare-observability-destinations.mdx
@@ -1,0 +1,143 @@
+---
+title: "ADR 048: Cloudflare Workers Observability Destinations (Beta)"
+date: "2026-06-28"
+status: "Accepted"
+tech_stack: ["Cloudflare Workers", "OpenTelemetry", "Terraform", "PostHog"]
+---
+
+# Summary
+
+Use Cloudflare's native **Workers Observability OTLP destinations** as the mechanism for
+exporting `recipe-api` logs to PostHog
+([ADR 047](/projects/recipe-site/adrs/047-posthog-logs)).
+
+This feature is in **beta**, and its Terraform resource does not yet exist, so the
+destination is configured by hand in the Cloudflare dashboard while the toggle lives in
+`wrangler.toml`. This ADR records that choice and the trade-offs we are accepting —
+especially the gap against the project's code-owned-infrastructure principle and the
+silent-failure risk on key rotation.
+
+# Context
+
+[ADR 047](/projects/recipe-site/adrs/047-posthog-logs) decided *that* Worker logs go to
+PostHog. Something still has to ship the logs to PostHog's OTLP endpoint. The candidate
+mechanisms:
+
+| Mechanism                                | Control      | Dependencies        | IaC story                  |
+| ---------------------------------------- | ------------ | ------------------- | -------------------------- |
+| **Cloudflare native OTLP destination**   | Low (config) | None in app code    | Dashboard + `wrangler.toml`|
+| `otel-cf-workers` library (in-app OTel)  | High         | Extra runtime dep   | Code-owned                 |
+| Manual `fetch` to OTLP endpoint          | Full         | Hand-rolled         | Code-owned                 |
+
+A relevant project principle
+([ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features)):
+vendor control-plane configuration should be code-owned via Terraform or a stable API
+wherever a provider exists; dashboard-only configuration is a poor fit for an
+agent-assisted, solo-maintained codebase.
+
+# Decision
+
+Use the **Cloudflare native observability destination**. It is the lowest-effort path, adds
+no application dependencies, and rides standard OTLP. Configuration is two parts:
+
+1. **Destination** (dashboard): create a `posthog-logs` destination under Workers
+   Observability with the OTLP endpoint `https://eu.i.posthog.com/i/v1/logs` and an
+   `Authorization: Bearer phc_…` header (the public PostHog project key — see
+   [ADR 047](/projects/recipe-site/adrs/047-posthog-logs)).
+2. **Toggle** (`workers/recipe-api/wrangler.toml`): enable export and reference the
+   destination by name.
+
+   ```toml
+   [observability.logs]
+   enabled = true
+   destinations = ["posthog-logs"]
+   ```
+
+Keeping the key in the dashboard destination (rather than in `wrangler.toml`) also keeps it
+out of source control.
+
+## Accepting beta status
+
+The feature is in beta, which we accept because:
+
+- The blast radius is observability only — if export breaks, the application is unaffected
+  and `wrangler tail` plus Cloudflare's built-in Workers Logs remain as fallbacks
+  ([ADR 047](/projects/recipe-site/adrs/047-posthog-logs)).
+- It is standard OTLP, so if Cloudflare's beta disappoints, the same logs can be pointed at
+  another OTLP backend, or moved in-app via `otel-cf-workers`, without rewriting the app.
+
+## Accepting the infrastructure-as-code gap
+
+This is the notable exception to the code-owned-infra principle. There **is** a Cloudflare
+API for observability destinations, but the Terraform resource
+(`cloudflare_workers_observability_destination`) was announced in provider v5.19.0 and
+shipped unimplemented
+([cloudflare/terraform-provider-cloudflare#7127](https://github.com/cloudflare/terraform-provider-cloudflare/issues/7127)).
+Nor is the destination a Worker secret or Pages variable, so Doppler's sync integrations
+cannot reach it either.
+
+The result: the destination's auth header is **manual** — neither Terraform nor Doppler
+manages it. This is the one place `POSTHOG_KEY` is not propagated automatically, so a key
+rotation will **silently** stop log ingestion (a `401` that drops logs, with no application
+error) if the destination header is not updated by hand.
+
+Mitigations:
+
+- A rotation runbook in `infra/README.md` ("Rotating `POSTHOG_KEY`") enumerates every
+  consumer and flags this destination as the manual step.
+- A pointer comment in `workers/recipe-api/wrangler.toml` references that runbook.
+- In practice the public `phc_` project key rotates rarely, which makes the manual step an
+  acceptable trade-off rather than an ongoing burden.
+
+Managing the destination via a raw Cloudflare API call (e.g. a `null_resource`/`restapi`
+shim) was considered and rejected: it would store the value in Terraform state, lacks real
+drift detection, and is disproportionate machinery for a single public key.
+
+# Alternatives Considered
+
+## `otel-cf-workers` (in-app OpenTelemetry)
+
+Instrument the Worker with an OpenTelemetry SDK and export OTLP directly from application
+code. Gives full control over spans/attributes and would be fully code-owned. Rejected for
+now as heavier than needed — it adds a runtime dependency and bundle weight for a log
+pipeline the native export already covers. It is the natural escape hatch if the native
+export proves limiting or if traces are wanted later.
+
+## Logpush
+
+Cloudflare Logpush is a different product aimed at bulk log delivery to object storage / SIEM
+sinks, not OTLP-native correlation into PostHog. Wrong shape for the
+[ADR 047](/projects/recipe-site/adrs/047-posthog-logs) correlation goal.
+
+## Manual `fetch` to the OTLP endpoint
+
+Hand-rolling OTLP requests from the Worker is maximal control and zero platform dependency,
+but means owning batching, retries, and the OTLP wire format. Not worth it when the platform
+does it.
+
+# Consequences
+
+## Positive
+
+- **Lowest effort**, no application dependencies, standard OTLP.
+- **Key stays out of git** — it lives in the dashboard destination.
+- **Reversible** — OTLP means the destination can be repointed or replaced with
+  `otel-cf-workers` without app changes.
+
+## Negative
+
+- **Beta risk** — API/behaviour may change, no stability guarantee, and trace export to
+  PostHog is unsupported.
+- **Not code-owned** — the destination is dashboard-managed, breaking the Terraform/Doppler
+  single-source-of-truth model for this one object.
+- **Silent-failure on rotation** — the manual auth header drops logs without erroring if a
+  rotation skips it; mitigated only by runbook discipline.
+
+# When To Revisit
+
+- The `cloudflare_workers_observability_destination` Terraform resource ships and works —
+  move the destination into `infra` and delete the manual step.
+- The feature leaves beta (revisit guarantees and trace support).
+- Traces or richer in-app instrumentation become worthwhile — adopt `otel-cf-workers`.
+- A silent ingestion outage actually occurs — add an active health check that logs are
+  arriving, rather than relying on the rotation runbook.

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -807,4 +807,12 @@ export const technologies: TechnologyContent[] = [
     website: "https://zizmor.sh",
     type: "tool",
   },
+  {
+    name: "OpenTelemetry",
+    added: "2026-06-28",
+    description:
+      "Vendor-neutral observability framework and protocol (OTLP) for emitting and exporting logs, metrics, and traces",
+    website: "https://opentelemetry.io",
+    type: "tool",
+  },
 ];

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -7,6 +7,9 @@ compatibility_flags = ["nodejs_compat"]
 # The "posthog-logs" destination (OTLP endpoint + PostHog API key auth header)
 # must be created in the Cloudflare dashboard under Workers Observability.
 # Keeping the key in the dashboard destination avoids committing it here.
+# NOTE: that auth header is the one place POSTHOG_KEY is NOT synced from Doppler
+# automatically — update it by hand on rotation. See infra/README.md
+# ("Rotating POSTHOG_KEY").
 [observability.logs]
 enabled = true
 destinations = ["posthog-logs"]

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -10,6 +10,11 @@ compatibility_flags = ["nodejs_compat"]
 # NOTE: this auth header is the one place POSTHOG_KEY is NOT synced from Doppler
 # automatically — update it by hand on rotation. See infra/README.md
 # ("Rotating POSTHOG_KEY").
+[observability]
+# Persist Cloudflare's built-in Workers Logs as well — the fallback referenced in
+# ADRs 047/048, so logs are retained even if PostHog ingestion is unavailable.
+enabled = true
+
 [observability.logs]
 enabled = true
 destinations = ["posthog-logs"]

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_flags = ["nodejs_compat"]
 # The "posthog-logs" destination (OTLP endpoint + PostHog API key auth header)
 # must be created in the Cloudflare dashboard under Workers Observability.
 # Keeping the key in the dashboard destination avoids committing it here.
-# NOTE: that auth header is the one place POSTHOG_KEY is NOT synced from Doppler
+# NOTE: this auth header is the one place POSTHOG_KEY is NOT synced from Doppler
 # automatically — update it by hand on rotation. See infra/README.md
 # ("Rotating POSTHOG_KEY").
 [observability.logs]

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -6,8 +6,6 @@ compatibility_flags = ["nodejs_compat"]
 # Export Worker logs to PostHog via OTLP. The "posthog-logs" destination
 # (endpoint + auth header) is configured in the Cloudflare dashboard, not here.
 [observability]
-# Persist Cloudflare's built-in Workers Logs as well — the fallback referenced in
-# ADRs 047/048, so logs are retained even if PostHog ingestion is unavailable.
 enabled = true
 
 [observability.logs]

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -3,13 +3,8 @@ main = "src/index.ts"
 compatibility_date = "2026-05-28"
 compatibility_flags = ["nodejs_compat"]
 
-# Export Worker logs to PostHog via OpenTelemetry (OTLP).
-# The "posthog-logs" destination (OTLP endpoint + PostHog API key auth header)
-# must be created in the Cloudflare dashboard under Workers Observability.
-# Keeping the key in the dashboard destination avoids committing it here.
-# NOTE: this auth header is the one place POSTHOG_KEY is NOT synced from Doppler
-# automatically — update it by hand on rotation. See infra/README.md
-# ("Rotating POSTHOG_KEY").
+# Export Worker logs to PostHog via OTLP. The "posthog-logs" destination
+# (endpoint + auth header) is configured in the Cloudflare dashboard, not here.
 [observability]
 # Persist Cloudflare's built-in Workers Logs as well — the fallback referenced in
 # ADRs 047/048, so logs are retained even if PostHog ingestion is unavailable.

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -3,6 +3,14 @@ main = "src/index.ts"
 compatibility_date = "2026-05-28"
 compatibility_flags = ["nodejs_compat"]
 
+# Export Worker logs to PostHog via OpenTelemetry (OTLP).
+# The "posthog-logs" destination (OTLP endpoint + PostHog API key auth header)
+# must be created in the Cloudflare dashboard under Workers Observability.
+# Keeping the key in the dashboard destination avoids committing it here.
+[observability.logs]
+enabled = true
+destinations = ["posthog-logs"]
+
 [vars]
 # Browser-facing URL used to build OAuth callbacks in production.
 # The local dev script overrides this with http://localhost:3000.


### PR DESCRIPTION
## What

Enable OpenTelemetry log export from the `recipe-api` Worker to PostHog, and document `POSTHOG_KEY` as a Doppler-sourced value with a rotation runbook.

## Why

The site already uses PostHog for product analytics. Exporting Worker logs there gives a single pane of glass — backend errors can be correlated with the same person's product-analytics events and session replays, which `wrangler tail` / Cloudflare's built-in logs can't do. The free tier (50 GB/mo) comfortably covers a personal site.

Scope is deliberately limited to the `recipe-api` Worker (logs only — Cloudflare doesn't support trace export to PostHog). Neon log export was evaluated and skipped: DB signal is more useful captured from the Worker, which has request context, and traffic goes through Hyperdrive anyway.

## Changes

- **`workers/recipe-api/wrangler.toml`** — add `[observability.logs]` pointing at a `posthog-logs` destination.
- **`infra/README.md`** — document `POSTHOG_KEY`/`POSTHOG_HOST` as Doppler-sourced (synced to GitHub secrets, mapped to `TF_VAR_posthog_key` / `NEXT_PUBLIC_POSTHOG_KEY`), update local dev to populate `.env` from Doppler, and add a **Rotating `POSTHOG_KEY`** runbook.

## ⚠️ Manual prerequisites before merge

This is a **draft** because it depends on out-of-band setup:

1. **Create the `posthog-logs` destination** in Cloudflare Dashboard → Workers Observability:
   - Endpoint: `https://eu.i.posthog.com/i/v1/logs`
   - Header: `Authorization: Bearer phc_…` (PostHog project key)
   - Name must match `posthog-logs` exactly.
2. **Set up the Doppler → GitHub Actions sync** so Doppler owns `POSTHOG_KEY`.

## Notes / trade-offs

- The observability destination's auth header is the one place that **can't** be synced by Terraform (`cloudflare_workers_observability_destination` is [unimplemented](https://github.com/cloudflare/terraform-provider-cloudflare/issues/7127)) or Doppler — it's a manual step on rotation. The runbook flags this; the key is a public `phc_` project key that rarely rotates.
- Pages Functions are not covered — their observability export lags Workers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FohpUAa3KxxdttxqajYewN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting `recipe-api` worker logs to PostHog for easier monitoring and incident analysis.
  * Introduced OpenTelemetry-based observability settings for log delivery.

* **Documentation**
  * Expanded setup guidance for secret management and local development using Doppler.
  * Added notes on rotating the PostHog key safely.
  * Published ADRs covering the new logging approach and observability destination setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->