### PR TITLE
Fix infra CD: add cf.colo.id to auth rate limit characteristics

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -172,7 +172,7 @@ resource "cloudflare_ruleset" "map_tiles_cache" {
 resource "cloudflare_ruleset" "auth_rate_limit" {
   zone_id     = data.cloudflare_zone.domain.id
   name        = "Auth endpoint rate limiting"
-  description = "Per-IP rate limiting for /api/auth/* — returns 429 on abuse"
+  description = "Per-IP rate limiting for /api/auth/* — returns 429 on abuse. Counting is per Cloudflare data center (cf.colo.id is a mandatory, always-on characteristic; Cloudflare has no global counter)."
   kind        = "zone"
   phase       = "http_ratelimit"
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -191,7 +191,7 @@ resource "cloudflare_ruleset" "auth_rate_limit" {
     action = "block"
 
     ratelimit {
-      characteristics     = ["ip.src"]
+      characteristics     = ["ip.src", "cf.colo.id"]
       period              = var.auth_rate_limit_period
       requests_per_period = var.auth_rate_limit_requests
       mitigation_timeout  = var.auth_rate_limit_mitigation_timeout


### PR DESCRIPTION
## Problem

The "infra CD" terraform apply job fails when creating `cloudflare_ruleset.auth_rate_limit`:

```
Error: error creating ruleset Auth endpoint rate limiting
'[ip.src]' is not a valid value for characteristics because characteristics
field is missing 'cf.colo.id', this is required as ratelimiting counting is
processed at colocation level only (20155)
```

## Fix

Cloudflare processes rate-limit counting at the colocation (data center) level, so any custom `characteristics` list must include `cf.colo.id`. Added it alongside `ip.src`.

Per-IP semantics are unchanged — `ip.src` still scopes counting per client IP; `cf.colo.id` is a required bookkeeping field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate-limiting behaviour for authentication requests, making limits apply more precisely across Cloudflare locations.
  * Reduced the chance of unrelated traffic being grouped together when 429 responses are triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->