### PR TITLE
Exclude vendored design exports from SonarQube analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+# Vendored design prototypes exported from Claude Design — not production code.
+# They are not part of the app's quality/security surface (also excluded from
+# Biome in ui/biome.json) and are re-exported wholesale, so local fixes would be
+# clobbered on the next export. The flagged postMessage(..., '*') host protocol
+# is editor tooling that is stripped from the served build
+# (ui/public/recipe-site-design/standalone.html) and never runs in production.
+sonar.exclusions=ui/content/projects/*/designs/**


### PR DESCRIPTION
## What

Adds a root `sonar-project.properties` excluding `ui/content/projects/*/designs/**` from SonarQube analysis.

## Why

SonarQube flags S2819 (`postMessage(..., '*')` without a target origin) in `ui/content/projects/recipe-site/designs/tweaks-panel.jsx`. Triaging it:

- **Not in the production bundle.** The only thing served is the compiled `ui/public/recipe-site-design/standalone.html`, which contains zero `postMessage`/edit-mode code — the host protocol is editor tooling stripped from the served build.
- **Trusted peer where it does run.** The flagged code only executes when opening the local `Recipe Site Mid-fi.html`, where `window.parent` is the Claude Design editor host.
- **Non-sensitive payload.** Messages carry design tweak values (colors, font sizes, booleans), no secrets/PII.
- **Re-exported source.** These are vendored Claude Design exports, re-exported wholesale — hand-fixing would be clobbered and drift from the source of truth.

This mirrors the existing Biome exclusion (`!content/projects/*/designs` in `ui/biome.json`), keeping the design prototypes consistently outside the app's quality/security surface.