### PR TITLE
[codex] Fix asset tracker mobile cards and add flow Sankey

### DIFF
--- a/ui/components/assettracker/asset-tracker-dashboard.tsx
+++ b/ui/components/assettracker/asset-tracker-dashboard.tsx
@@ -14,6 +14,7 @@ import { AddAccountDrawer } from "./add-account-drawer";
 import { AssetAllocationChart } from "./asset-allocation-chart";
 import { useAssetTracker } from "./asset-tracker-provider";
 import { DataControls } from "./data-controls";
+import { FlowSankeyChart } from "./flow-sankey-chart";
 import { LogBalanceDrawer } from "./log-balance-drawer";
 import { NetWorthChart } from "./net-worth-chart";
 import { PortfolioGoal } from "./portfolio-goal";
@@ -87,6 +88,7 @@ export function AssetTrackerDashboard() {
         <PortfolioGoal />
         <UpcomingFlows />
       </div>
+      <FlowSankeyChart />
       <div className="grid gap-8 lg:grid-cols-2">
         <AssetAllocationChart data={assetAllocation} />
         <AccountBalanceChart accounts={accountDetails} />

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -35,6 +35,7 @@ const MIN_SYNTHETIC_FLOW = 1;
 
 type FlowSankeyAccount = AccountSummaryView & {
   expectedReturnChanges?: ExpectedReturnChange[];
+  linkedAccountId?: string;
 };
 
 type FlowSankeyNode = {
@@ -148,6 +149,19 @@ export function buildFlowSankeyData(
     });
   }
 
+  function monthlyIncoming(accountId: string): number {
+    return flows.reduce((total, flow) => {
+      if (flow.toAccountId !== accountId) return total;
+      const liabilityBalance = liabilityBalances[accountId];
+      return (
+        total +
+        (flow.formula
+          ? monthlyAmount(flow, liabilityBalance)
+          : monthlyAmount(flow))
+      );
+    }, 0);
+  }
+
   for (const flow of flows) {
     const sourceId = flow.fromAccountId ?? EXTERNAL_INCOME_NODE;
     const targetId = flow.toAccountId ?? EXTERNAL_SPENDING_NODE;
@@ -177,7 +191,18 @@ export function buildFlowSankeyData(
     if (change > 0) {
       addLink(EXPECTED_RETURNS_NODE, account.id, value, "Expected return");
     } else if (balance < 0) {
-      addLink(INTEREST_CHARGED_NODE, account.id, value, "Interest charged");
+      addLink(account.id, INTEREST_CHARGED_NODE, value, "Interest charged");
+      if (account.linkedAccountId != null) {
+        const principal = monthlyIncoming(account.id) - value;
+        if (principal >= MIN_SYNTHETIC_FLOW) {
+          addLink(
+            account.id,
+            account.linkedAccountId,
+            principal,
+            "Principal repayment",
+          );
+        }
+      }
     }
   }
 

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { type ReactElement, type SVGProps, useMemo } from "react";
+import {
+  ResponsiveContainer,
+  Sankey,
+  type SankeyLinkProps,
+  type SankeyNodeProps,
+  Tooltip,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ACCOUNT_COLORS,
+  type AccountSummaryView,
+  formatCurrency,
+  monthlyAmount,
+  type RecurringFlow,
+} from "@/lib/domain/assettracker";
+import { useAssetTracker } from "./asset-tracker-provider";
+
+const EXTERNAL_INCOME_NODE = "__external_income";
+const EXTERNAL_SPENDING_NODE = "__external_spending";
+
+type FlowSankeyNode = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+type FlowSankeyLink = {
+  source: number;
+  target: number;
+  value: number;
+  label: string;
+};
+
+export type FlowSankeyData = {
+  nodes: FlowSankeyNode[];
+  links: FlowSankeyLink[];
+};
+
+function accountColor(index: number): string {
+  return ACCOUNT_COLORS[index % ACCOUNT_COLORS.length] ?? ACCOUNT_COLORS[0];
+}
+
+export function buildFlowSankeyData(
+  accounts: AccountSummaryView[],
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+): FlowSankeyData {
+  const accountById = new Map(accounts.map((account) => [account.id, account]));
+  const nodeIndexes = new Map<string, number>();
+  const nodes: FlowSankeyNode[] = [];
+  const linkTotals = new Map<string, FlowSankeyLink>();
+
+  function addNode(id: string): number {
+    const existing = nodeIndexes.get(id);
+    if (existing != null) return existing;
+    const account = accountById.get(id);
+    const index = nodes.length;
+    nodes.push({
+      id,
+      name:
+        id === EXTERNAL_INCOME_NODE
+          ? "External income"
+          : id === EXTERNAL_SPENDING_NODE
+            ? "External spending"
+            : (account?.name ?? id),
+      color:
+        id === EXTERNAL_INCOME_NODE || id === EXTERNAL_SPENDING_NODE
+          ? "hsl(220, 10%, 60%)"
+          : accountColor(index),
+    });
+    nodeIndexes.set(id, index);
+    return index;
+  }
+
+  for (const flow of flows) {
+    const sourceId = flow.fromAccountId ?? EXTERNAL_INCOME_NODE;
+    const targetId = flow.toAccountId ?? EXTERNAL_SPENDING_NODE;
+    const liabilityBalance =
+      flow.toAccountId != null
+        ? liabilityBalances[flow.toAccountId]
+        : undefined;
+    const value = flow.formula
+      ? monthlyAmount(flow, liabilityBalance)
+      : monthlyAmount(flow);
+
+    if (value <= 0) continue;
+
+    const source = addNode(sourceId);
+    const target = addNode(targetId);
+    const key = `${source}->${target}`;
+    const existing = linkTotals.get(key);
+    if (existing) {
+      existing.value += value;
+      existing.label = `${existing.label}, ${flow.name}`;
+    } else {
+      linkTotals.set(key, {
+        source,
+        target,
+        value,
+        label: flow.name,
+      });
+    }
+  }
+
+  return {
+    nodes,
+    links: Array.from(linkTotals.values()).map((link) => ({
+      ...link,
+      value: Math.round(link.value * 100) / 100,
+    })),
+  };
+}
+
+function SankeyNode({
+  x,
+  y,
+  width,
+  height,
+  payload,
+}: SankeyNodeProps): ReactElement<SVGProps<SVGRectElement>> {
+  const node = payload as unknown as FlowSankeyNode & { value?: number };
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx={4}
+        fill={node.color}
+        fillOpacity={0.85}
+      />
+      <text
+        x={x + width + 6}
+        y={y + Math.max(height / 2, 10)}
+        fill="currentColor"
+        fontSize={11}
+        dominantBaseline="middle"
+      >
+        {node.name}
+      </text>
+    </g>
+  );
+}
+
+function SankeyLink({
+  sourceX,
+  targetX,
+  sourceY,
+  targetY,
+  sourceControlX,
+  targetControlX,
+  sourceRelativeY,
+  targetRelativeY,
+  linkWidth,
+}: SankeyLinkProps): ReactElement<SVGProps<SVGPathElement>> {
+  const source = sourceY + sourceRelativeY + linkWidth / 2;
+  const target = targetY + targetRelativeY + linkWidth / 2;
+  return (
+    <path
+      d={`M${sourceX},${source} C${sourceControlX},${source} ${targetControlX},${target} ${targetX},${target}`}
+      fill="none"
+      stroke="hsl(220, 70%, 50%)"
+      strokeOpacity={0.25}
+      strokeWidth={Math.max(1, linkWidth)}
+    />
+  );
+}
+
+function SankeyTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ payload?: FlowSankeyLink }>;
+}) {
+  const link = payload?.[0]?.payload;
+  if (!active || !link) return null;
+  return (
+    <div className="rounded-lg border bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      <p className="font-medium">{link.label}</p>
+      <p className="font-mono">{formatCurrency(link.value)}/mo</p>
+    </div>
+  );
+}
+
+export function FlowSankeyChart() {
+  const { accounts, accountDetails, recurringFlows } = useAssetTracker();
+  const liabilityBalances = useMemo(
+    () =>
+      Object.fromEntries(
+        accountDetails.map((detail) => [detail.id, detail.latestBalance ?? 0]),
+      ),
+    [accountDetails],
+  );
+  const data = useMemo(
+    () => buildFlowSankeyData(accounts, recurringFlows, liabilityBalances),
+    [accounts, recurringFlows, liabilityBalances],
+  );
+
+  return (
+    <Card className="min-w-0">
+      <CardHeader>
+        <CardTitle>Regular Flow Map</CardTitle>
+        <CardDescription>
+          Monthly-equivalent expected flows between income, accounts, savings,
+          and liabilities.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-2 sm:px-6">
+        {data.links.length === 0 ? (
+          <p className="px-2 text-sm text-muted-foreground">
+            No regular flows yet. Add income, contributions, or repayments from
+            an account's detail view.
+          </p>
+        ) : (
+          <div className="h-[320px] min-w-0">
+            <ResponsiveContainer width="100%" height="100%">
+              <Sankey
+                data={data}
+                dataKey="value"
+                nameKey="name"
+                node={SankeyNode}
+                link={SankeyLink}
+                nodePadding={18}
+                nodeWidth={12}
+                margin={{ top: 8, right: 140, bottom: 8, left: 8 }}
+                iterations={64}
+              >
+                <Tooltip content={<SankeyTooltip />} />
+              </Sankey>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -329,6 +329,7 @@ export function FlowSankeyChart() {
                   nodePadding={isCompact ? 14 : 18}
                   nodeWidth={12}
                   margin={chartMargin}
+                  align="left"
                   iterations={64}
                 >
                   <Tooltip content={<SankeyTooltip />} />

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { type ReactElement, type SVGProps, useMemo } from "react";
+import { useMediaQuery } from "react-responsive";
 import {
   ResponsiveContainer,
   Sankey,
-  type SankeyLinkProps,
   type SankeyNodeProps,
   Tooltip,
 } from "recharts";
@@ -38,6 +38,8 @@ type FlowSankeyLink = {
   target: number;
   value: number;
   label: string;
+  sourceName: string;
+  targetName: string;
 };
 
 export type FlowSankeyData = {
@@ -102,11 +104,15 @@ export function buildFlowSankeyData(
       existing.value += value;
       existing.label = `${existing.label}, ${flow.name}`;
     } else {
+      const sourceNode = nodes[source];
+      const targetNode = nodes[target];
       linkTotals.set(key, {
         source,
         target,
         value,
         label: flow.name,
+        sourceName: sourceNode?.name ?? sourceId,
+        targetName: targetNode?.name ?? targetId,
       });
     }
   }
@@ -120,14 +126,20 @@ export function buildFlowSankeyData(
   };
 }
 
-function SankeyNode({
+function FlowSankeyNodeShape({
   x,
   y,
   width,
   height,
   payload,
-}: SankeyNodeProps): ReactElement<SVGProps<SVGRectElement>> {
+  showLabel,
+}: SankeyNodeProps & {
+  showLabel: boolean;
+}): ReactElement<SVGProps<SVGRectElement>> {
   const node = payload as unknown as FlowSankeyNode & { value?: number };
+  const depth = "depth" in payload ? Number(payload.depth) : 0;
+  const labelOnLeft = depth === 0;
+  const labelX = labelOnLeft ? x - 8 : x + width + 8;
   return (
     <g>
       <rect
@@ -139,40 +151,19 @@ function SankeyNode({
         fill={node.color}
         fillOpacity={0.85}
       />
-      <text
-        x={x + width + 6}
-        y={y + Math.max(height / 2, 10)}
-        fill="currentColor"
-        fontSize={11}
-        dominantBaseline="middle"
-      >
-        {node.name}
-      </text>
+      {showLabel && (
+        <text
+          x={labelX}
+          y={y + Math.max(height / 2, 10)}
+          fill="currentColor"
+          fontSize={11}
+          textAnchor={labelOnLeft ? "end" : "start"}
+          dominantBaseline="middle"
+        >
+          {node.name}
+        </text>
+      )}
     </g>
-  );
-}
-
-function SankeyLink({
-  sourceX,
-  targetX,
-  sourceY,
-  targetY,
-  sourceControlX,
-  targetControlX,
-  sourceRelativeY,
-  targetRelativeY,
-  linkWidth,
-}: SankeyLinkProps): ReactElement<SVGProps<SVGPathElement>> {
-  const source = sourceY + sourceRelativeY + linkWidth / 2;
-  const target = targetY + targetRelativeY + linkWidth / 2;
-  return (
-    <path
-      d={`M${sourceX},${source} C${sourceControlX},${source} ${targetControlX},${target} ${targetX},${target}`}
-      fill="none"
-      stroke="hsl(220, 70%, 50%)"
-      strokeOpacity={0.25}
-      strokeWidth={Math.max(1, linkWidth)}
-    />
   );
 }
 
@@ -188,6 +179,11 @@ function SankeyTooltip({
   return (
     <div className="rounded-lg border bg-background px-2.5 py-1.5 text-xs shadow-xl">
       <p className="font-medium">{link.label}</p>
+      <p className="text-muted-foreground">
+        {link.sourceName}
+        {" -> "}
+        {link.targetName}
+      </p>
       <p className="font-mono">{formatCurrency(link.value)}/mo</p>
     </div>
   );
@@ -195,6 +191,7 @@ function SankeyTooltip({
 
 export function FlowSankeyChart() {
   const { accounts, accountDetails, recurringFlows } = useAssetTracker();
+  const isCompact = useMediaQuery({ maxWidth: 639 });
   const liabilityBalances = useMemo(
     () =>
       Object.fromEntries(
@@ -206,6 +203,9 @@ export function FlowSankeyChart() {
     () => buildFlowSankeyData(accounts, recurringFlows, liabilityBalances),
     [accounts, recurringFlows, liabilityBalances],
   );
+  const chartMargin = isCompact
+    ? { top: 8, right: 12, bottom: 8, left: 12 }
+    : { top: 8, right: 140, bottom: 8, left: 120 };
 
   return (
     <Card className="min-w-0">
@@ -223,23 +223,47 @@ export function FlowSankeyChart() {
             an account's detail view.
           </p>
         ) : (
-          <div className="h-[320px] min-w-0">
-            <ResponsiveContainer width="100%" height="100%">
-              <Sankey
-                data={data}
-                dataKey="value"
-                nameKey="name"
-                node={SankeyNode}
-                link={SankeyLink}
-                nodePadding={18}
-                nodeWidth={12}
-                margin={{ top: 8, right: 140, bottom: 8, left: 8 }}
-                iterations={64}
-              >
-                <Tooltip content={<SankeyTooltip />} />
-              </Sankey>
-            </ResponsiveContainer>
-          </div>
+          <>
+            <div className="h-[280px] min-w-0 sm:h-[320px]">
+              <ResponsiveContainer width="100%" height="100%">
+                <Sankey
+                  data={data}
+                  dataKey="value"
+                  nameKey="name"
+                  node={(props) => (
+                    <FlowSankeyNodeShape {...props} showLabel={!isCompact} />
+                  )}
+                  link={{
+                    stroke: "hsl(220, 70%, 50%)",
+                    strokeOpacity: 0.25,
+                  }}
+                  nodePadding={isCompact ? 14 : 18}
+                  nodeWidth={12}
+                  margin={chartMargin}
+                  iterations={64}
+                >
+                  <Tooltip content={<SankeyTooltip />} />
+                </Sankey>
+              </ResponsiveContainer>
+            </div>
+            <ul className="mt-3 grid gap-1.5 text-xs sm:hidden">
+              {data.links.map((link) => (
+                <li
+                  key={`${link.source}-${link.target}-${link.label}`}
+                  className="flex min-w-0 items-center justify-between gap-2 rounded-md border px-2 py-1.5"
+                >
+                  <span className="min-w-0 truncate">
+                    {link.sourceName}
+                    {" -> "}
+                    {link.targetName}
+                  </span>
+                  <span className="shrink-0 font-mono">
+                    {formatCurrency(link.value)}/mo
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </>
         )}
       </CardContent>
     </Card>

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -40,7 +40,9 @@ function FlowSankeyNodeShape({
   showLabel: boolean;
 }): ReactElement<SVGProps<SVGGElement>> {
   const node = payload as unknown as FlowSankeyNode & { value?: number };
-  const depth = "depth" in payload ? Number(payload.depth) : 0;
+  const rawDepth = "depth" in payload ? payload.depth : 0;
+  const depth =
+    typeof rawDepth === "number" && Number.isFinite(rawDepth) ? rawDepth : 0;
   const labelOnLeft = depth === 0;
   const labelX = labelOnLeft ? x - 8 : x + width + 8;
   return (

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -246,20 +246,21 @@ export function FlowSankeyChart() {
                 </Sankey>
               </ResponsiveContainer>
             </div>
-            <ul className="mt-3 grid gap-1.5 text-xs sm:hidden">
-              {data.links.map((link) => (
+            <ul
+              aria-label="Flow map legend"
+              className="mt-3 flex flex-wrap gap-2 text-xs sm:hidden"
+            >
+              {data.nodes.map((node) => (
                 <li
-                  key={`${link.source}-${link.target}-${link.label}`}
-                  className="flex min-w-0 items-center justify-between gap-2 rounded-md border px-2 py-1.5"
+                  key={node.id}
+                  className="inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2 py-1"
                 >
-                  <span className="min-w-0 truncate">
-                    {link.sourceName}
-                    {" -> "}
-                    {link.targetName}
-                  </span>
-                  <span className="shrink-0 font-mono">
-                    {formatCurrency(link.value)}/mo
-                  </span>
+                  <span
+                    aria-hidden="true"
+                    className="size-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: node.color }}
+                  />
+                  <span className="min-w-0 truncate">{node.name}</span>
                 </li>
               ))}
             </ul>

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -72,19 +72,19 @@ function FlowSankeyNodeShape({
 
 type SankeyTooltipItem = Partial<FlowSankeyLink & FlowSankeyNode> & {
   value?: number;
-  source?: { name?: string };
-  target?: { name?: string };
+  source?: Readonly<{ name?: string }>;
+  target?: Readonly<{ name?: string }>;
 };
 
 function SankeyTooltip({
   active,
   payload,
-}: {
+}: Readonly<{
   active?: boolean;
-  payload?: Array<{ payload?: SankeyTooltipItem }>;
-}) {
+  payload?: ReadonlyArray<Readonly<{ payload?: SankeyTooltipItem }>>;
+}>) {
   const item = payload?.[0]?.payload;
-  if (!active || !item || item.value == null) return null;
+  if (!active || item?.value == null) return null;
 
   const sourceName = item.sourceName ?? item.source?.name;
   const targetName = item.targetName ?? item.target?.name;
@@ -101,6 +101,14 @@ function SankeyTooltip({
       <p className="font-mono">{formatCurrency(item.value)}/mo</p>
     </div>
   );
+}
+
+function LabeledFlowSankeyNodeShape(props: SankeyNodeProps) {
+  return <FlowSankeyNodeShape {...props} showLabel />;
+}
+
+function CompactFlowSankeyNodeShape(props: SankeyNodeProps) {
+  return <FlowSankeyNodeShape {...props} showLabel={false} />;
 }
 
 export function FlowSankeyChart() {
@@ -127,6 +135,9 @@ export function FlowSankeyChart() {
   const chartMargin = isCompact
     ? { top: 8, right: 12, bottom: 8, left: 12 }
     : { top: 8, right: 140, bottom: 8, left: 120 };
+  const nodeRenderer = isCompact
+    ? CompactFlowSankeyNodeShape
+    : LabeledFlowSankeyNodeShape;
 
   return (
     <Card className="min-w-0">
@@ -151,9 +162,7 @@ export function FlowSankeyChart() {
                     data={data}
                     dataKey="value"
                     nameKey="name"
-                    node={(props) => (
-                      <FlowSankeyNodeShape {...props} showLabel={!isCompact} />
-                    )}
+                    node={nodeRenderer}
                     link={{
                       stroke: "hsl(220, 70%, 50%)",
                       strokeOpacity: 0.25,

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -18,14 +18,24 @@ import {
 import {
   ACCOUNT_COLORS,
   type AccountSummaryView,
+  type ExpectedReturnChange,
+  effectiveExpectedReturn,
   formatCurrency,
   monthlyAmount,
   type RecurringFlow,
+  todayIsoDate,
 } from "@/lib/domain/assettracker";
 import { useAssetTracker } from "./asset-tracker-provider";
 
 const EXTERNAL_INCOME_NODE = "__external_income";
 const EXTERNAL_SPENDING_NODE = "__external_spending";
+const EXPECTED_RETURNS_NODE = "__expected_returns";
+const INTEREST_CHARGED_NODE = "__interest_charged";
+const MIN_SYNTHETIC_FLOW = 1;
+
+type FlowSankeyAccount = AccountSummaryView & {
+  expectedReturnChanges?: ExpectedReturnChange[];
+};
 
 type FlowSankeyNode = {
   id: string;
@@ -51,8 +61,41 @@ function accountColor(index: number): string {
   return ACCOUNT_COLORS[index % ACCOUNT_COLORS.length] ?? ACCOUNT_COLORS[0];
 }
 
+function nodeName(id: string, account?: FlowSankeyAccount): string {
+  switch (id) {
+    case EXTERNAL_INCOME_NODE:
+      return "External income";
+    case EXTERNAL_SPENDING_NODE:
+      return "External spending";
+    case EXPECTED_RETURNS_NODE:
+      return "Expected returns";
+    case INTEREST_CHARGED_NODE:
+      return "Interest charged";
+    default:
+      return account?.name ?? id;
+  }
+}
+
+function nodeColor(id: string, index: number): string {
+  switch (id) {
+    case EXTERNAL_INCOME_NODE:
+    case EXTERNAL_SPENDING_NODE:
+      return "hsl(220, 10%, 60%)";
+    case EXPECTED_RETURNS_NODE:
+      return "hsl(145, 55%, 45%)";
+    case INTEREST_CHARGED_NODE:
+      return "hsl(350, 65%, 55%)";
+    default:
+      return accountColor(index);
+  }
+}
+
+function monthlyExpectedChange(balance: number, annualRate: number): number {
+  return balance * ((1 + annualRate) ** (1 / 12) - 1);
+}
+
 export function buildFlowSankeyData(
-  accounts: AccountSummaryView[],
+  accounts: FlowSankeyAccount[],
   flows: RecurringFlow[],
   liabilityBalances: Record<string, number>,
 ): FlowSankeyData {
@@ -68,19 +111,41 @@ export function buildFlowSankeyData(
     const index = nodes.length;
     nodes.push({
       id,
-      name:
-        id === EXTERNAL_INCOME_NODE
-          ? "External income"
-          : id === EXTERNAL_SPENDING_NODE
-            ? "External spending"
-            : (account?.name ?? id),
-      color:
-        id === EXTERNAL_INCOME_NODE || id === EXTERNAL_SPENDING_NODE
-          ? "hsl(220, 10%, 60%)"
-          : accountColor(index),
+      name: nodeName(id, account),
+      color: nodeColor(id, index),
     });
     nodeIndexes.set(id, index);
     return index;
+  }
+
+  function addLink(
+    sourceId: string,
+    targetId: string,
+    value: number,
+    label: string,
+  ) {
+    if (value <= 0) return;
+
+    const source = addNode(sourceId);
+    const target = addNode(targetId);
+    const key = `${source}->${target}`;
+    const existing = linkTotals.get(key);
+    if (existing) {
+      existing.value += value;
+      existing.label = `${existing.label}, ${label}`;
+      return;
+    }
+
+    const sourceNode = nodes[source];
+    const targetNode = nodes[target];
+    linkTotals.set(key, {
+      source,
+      target,
+      value,
+      label,
+      sourceName: sourceNode?.name ?? sourceId,
+      targetName: targetNode?.name ?? targetId,
+    });
   }
 
   for (const flow of flows) {
@@ -94,26 +159,25 @@ export function buildFlowSankeyData(
       ? monthlyAmount(flow, liabilityBalance)
       : monthlyAmount(flow);
 
-    if (value <= 0) continue;
+    addLink(sourceId, targetId, value, flow.name);
+  }
 
-    const source = addNode(sourceId);
-    const target = addNode(targetId);
-    const key = `${source}->${target}`;
-    const existing = linkTotals.get(key);
-    if (existing) {
-      existing.value += value;
-      existing.label = `${existing.label}, ${flow.name}`;
-    } else {
-      const sourceNode = nodes[source];
-      const targetNode = nodes[target];
-      linkTotals.set(key, {
-        source,
-        target,
-        value,
-        label: flow.name,
-        sourceName: sourceNode?.name ?? sourceId,
-        targetName: targetNode?.name ?? targetId,
-      });
+  const today = todayIsoDate();
+  for (const account of accounts) {
+    const balance = account.latestBalance ?? 0;
+    if (balance === 0) continue;
+
+    const rate = effectiveExpectedReturn(account, today);
+    if (rate === 0) continue;
+
+    const change = monthlyExpectedChange(balance, rate);
+    const value = Math.abs(change);
+    if (value < MIN_SYNTHETIC_FLOW) continue;
+
+    if (change > 0) {
+      addLink(EXPECTED_RETURNS_NODE, account.id, value, "Expected return");
+    } else if (balance < 0) {
+      addLink(INTEREST_CHARGED_NODE, account.id, value, "Interest charged");
     }
   }
 
@@ -190,7 +254,7 @@ function SankeyTooltip({
 }
 
 export function FlowSankeyChart() {
-  const { accounts, accountDetails, recurringFlows } = useAssetTracker();
+  const { accountDetails, recurringFlows } = useAssetTracker();
   const isCompact = useMediaQuery({ maxWidth: 639 });
   const liabilityBalances = useMemo(
     () =>
@@ -200,8 +264,9 @@ export function FlowSankeyChart() {
     [accountDetails],
   );
   const data = useMemo(
-    () => buildFlowSankeyData(accounts, recurringFlows, liabilityBalances),
-    [accounts, recurringFlows, liabilityBalances],
+    () =>
+      buildFlowSankeyData(accountDetails, recurringFlows, liabilityBalances),
+    [accountDetails, recurringFlows, liabilityBalances],
   );
   const chartMargin = isCompact
     ? { top: 8, right: 12, bottom: 8, left: 12 }
@@ -212,8 +277,7 @@ export function FlowSankeyChart() {
       <CardHeader>
         <CardTitle>Regular Flow Map</CardTitle>
         <CardDescription>
-          Monthly-equivalent expected flows between income, accounts, savings,
-          and liabilities.
+          Monthly-equivalent cash flows, expected returns, and interest charges.
         </CardDescription>
       </CardHeader>
       <CardContent className="px-2 sm:px-6">

--- a/ui/components/assettracker/flow-sankey-chart.tsx
+++ b/ui/components/assettracker/flow-sankey-chart.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { type ReactElement, type SVGProps, useMemo } from "react";
+import {
+  type ReactElement,
+  type SVGProps,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useMediaQuery } from "react-responsive";
 import {
   ResponsiveContainer,
@@ -16,204 +22,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import {
-  ACCOUNT_COLORS,
-  type AccountSummaryView,
-  type ExpectedReturnChange,
-  effectiveExpectedReturn,
+  buildFlowSankeyData,
+  type FlowSankeyLink,
+  type FlowSankeyNode,
   formatCurrency,
-  monthlyAmount,
-  type RecurringFlow,
-  todayIsoDate,
 } from "@/lib/domain/assettracker";
 import { useAssetTracker } from "./asset-tracker-provider";
-
-const EXTERNAL_INCOME_NODE = "__external_income";
-const EXTERNAL_SPENDING_NODE = "__external_spending";
-const EXPECTED_RETURNS_NODE = "__expected_returns";
-const INTEREST_CHARGED_NODE = "__interest_charged";
-const MIN_SYNTHETIC_FLOW = 1;
-
-type FlowSankeyAccount = AccountSummaryView & {
-  expectedReturnChanges?: ExpectedReturnChange[];
-  linkedAccountId?: string;
-};
-
-type FlowSankeyNode = {
-  id: string;
-  name: string;
-  color: string;
-};
-
-type FlowSankeyLink = {
-  source: number;
-  target: number;
-  value: number;
-  label: string;
-  sourceName: string;
-  targetName: string;
-};
-
-export type FlowSankeyData = {
-  nodes: FlowSankeyNode[];
-  links: FlowSankeyLink[];
-};
-
-function accountColor(index: number): string {
-  return ACCOUNT_COLORS[index % ACCOUNT_COLORS.length] ?? ACCOUNT_COLORS[0];
-}
-
-function nodeName(id: string, account?: FlowSankeyAccount): string {
-  switch (id) {
-    case EXTERNAL_INCOME_NODE:
-      return "External income";
-    case EXTERNAL_SPENDING_NODE:
-      return "External spending";
-    case EXPECTED_RETURNS_NODE:
-      return "Expected returns";
-    case INTEREST_CHARGED_NODE:
-      return "Interest charged";
-    default:
-      return account?.name ?? id;
-  }
-}
-
-function nodeColor(id: string, index: number): string {
-  switch (id) {
-    case EXTERNAL_INCOME_NODE:
-    case EXTERNAL_SPENDING_NODE:
-      return "hsl(220, 10%, 60%)";
-    case EXPECTED_RETURNS_NODE:
-      return "hsl(145, 55%, 45%)";
-    case INTEREST_CHARGED_NODE:
-      return "hsl(350, 65%, 55%)";
-    default:
-      return accountColor(index);
-  }
-}
-
-function monthlyExpectedChange(balance: number, annualRate: number): number {
-  return balance * ((1 + annualRate) ** (1 / 12) - 1);
-}
-
-export function buildFlowSankeyData(
-  accounts: FlowSankeyAccount[],
-  flows: RecurringFlow[],
-  liabilityBalances: Record<string, number>,
-): FlowSankeyData {
-  const accountById = new Map(accounts.map((account) => [account.id, account]));
-  const nodeIndexes = new Map<string, number>();
-  const nodes: FlowSankeyNode[] = [];
-  const linkTotals = new Map<string, FlowSankeyLink>();
-
-  function addNode(id: string): number {
-    const existing = nodeIndexes.get(id);
-    if (existing != null) return existing;
-    const account = accountById.get(id);
-    const index = nodes.length;
-    nodes.push({
-      id,
-      name: nodeName(id, account),
-      color: nodeColor(id, index),
-    });
-    nodeIndexes.set(id, index);
-    return index;
-  }
-
-  function addLink(
-    sourceId: string,
-    targetId: string,
-    value: number,
-    label: string,
-  ) {
-    if (value <= 0) return;
-
-    const source = addNode(sourceId);
-    const target = addNode(targetId);
-    const key = `${source}->${target}`;
-    const existing = linkTotals.get(key);
-    if (existing) {
-      existing.value += value;
-      existing.label = `${existing.label}, ${label}`;
-      return;
-    }
-
-    const sourceNode = nodes[source];
-    const targetNode = nodes[target];
-    linkTotals.set(key, {
-      source,
-      target,
-      value,
-      label,
-      sourceName: sourceNode?.name ?? sourceId,
-      targetName: targetNode?.name ?? targetId,
-    });
-  }
-
-  function monthlyIncoming(accountId: string): number {
-    return flows.reduce((total, flow) => {
-      if (flow.toAccountId !== accountId) return total;
-      const liabilityBalance = liabilityBalances[accountId];
-      return (
-        total +
-        (flow.formula
-          ? monthlyAmount(flow, liabilityBalance)
-          : monthlyAmount(flow))
-      );
-    }, 0);
-  }
-
-  for (const flow of flows) {
-    const sourceId = flow.fromAccountId ?? EXTERNAL_INCOME_NODE;
-    const targetId = flow.toAccountId ?? EXTERNAL_SPENDING_NODE;
-    const liabilityBalance =
-      flow.toAccountId != null
-        ? liabilityBalances[flow.toAccountId]
-        : undefined;
-    const value = flow.formula
-      ? monthlyAmount(flow, liabilityBalance)
-      : monthlyAmount(flow);
-
-    addLink(sourceId, targetId, value, flow.name);
-  }
-
-  const today = todayIsoDate();
-  for (const account of accounts) {
-    const balance = account.latestBalance ?? 0;
-    if (balance === 0) continue;
-
-    const rate = effectiveExpectedReturn(account, today);
-    if (rate === 0) continue;
-
-    const change = monthlyExpectedChange(balance, rate);
-    const value = Math.abs(change);
-    if (value < MIN_SYNTHETIC_FLOW) continue;
-
-    if (change > 0) {
-      addLink(EXPECTED_RETURNS_NODE, account.id, value, "Expected return");
-    } else if (balance < 0) {
-      addLink(account.id, INTEREST_CHARGED_NODE, value, "Interest charged");
-      if (account.linkedAccountId != null) {
-        const principal = monthlyIncoming(account.id) - value;
-        if (principal >= MIN_SYNTHETIC_FLOW) {
-          addLink(
-            account.id,
-            account.linkedAccountId,
-            principal,
-            "Principal repayment",
-          );
-        }
-      }
-    }
-  }
-
-  return {
-    nodes,
-    links: Array.from(linkTotals.values()).map((link) => ({
-      ...link,
-      value: Math.round(link.value * 100) / 100,
-    })),
-  };
-}
 
 function FlowSankeyNodeShape({
   x,
@@ -224,7 +38,7 @@ function FlowSankeyNodeShape({
   showLabel,
 }: SankeyNodeProps & {
   showLabel: boolean;
-}): ReactElement<SVGProps<SVGRectElement>> {
+}): ReactElement<SVGProps<SVGGElement>> {
   const node = payload as unknown as FlowSankeyNode & { value?: number };
   const depth = "depth" in payload ? Number(payload.depth) : 0;
   const labelOnLeft = depth === 0;
@@ -256,31 +70,44 @@ function FlowSankeyNodeShape({
   );
 }
 
+type SankeyTooltipItem = Partial<FlowSankeyLink & FlowSankeyNode> & {
+  value?: number;
+  source?: { name?: string };
+  target?: { name?: string };
+};
+
 function SankeyTooltip({
   active,
   payload,
 }: {
   active?: boolean;
-  payload?: Array<{ payload?: FlowSankeyLink }>;
+  payload?: Array<{ payload?: SankeyTooltipItem }>;
 }) {
-  const link = payload?.[0]?.payload;
-  if (!active || !link) return null;
+  const item = payload?.[0]?.payload;
+  if (!active || !item || item.value == null) return null;
+
+  const sourceName = item.sourceName ?? item.source?.name;
+  const targetName = item.targetName ?? item.target?.name;
   return (
     <div className="rounded-lg border bg-background px-2.5 py-1.5 text-xs shadow-xl">
-      <p className="font-medium">{link.label}</p>
-      <p className="text-muted-foreground">
-        {link.sourceName}
-        {" -> "}
-        {link.targetName}
-      </p>
-      <p className="font-mono">{formatCurrency(link.value)}/mo</p>
+      <p className="font-medium">{item.label ?? item.name}</p>
+      {sourceName && targetName && (
+        <p className="text-muted-foreground">
+          {sourceName}
+          {" -> "}
+          {targetName}
+        </p>
+      )}
+      <p className="font-mono">{formatCurrency(item.value)}/mo</p>
     </div>
   );
 }
 
 export function FlowSankeyChart() {
   const { accountDetails, recurringFlows } = useAssetTracker();
-  const isCompact = useMediaQuery({ maxWidth: 639 });
+  const [mounted, setMounted] = useState(false);
+  const compactQuery = useMediaQuery({ maxWidth: 639 });
+  const isCompact = mounted && compactQuery;
   const liabilityBalances = useMemo(
     () =>
       Object.fromEntries(
@@ -293,6 +120,10 @@ export function FlowSankeyChart() {
       buildFlowSankeyData(accountDetails, recurringFlows, liabilityBalances),
     [accountDetails, recurringFlows, liabilityBalances],
   );
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const chartMargin = isCompact
     ? { top: 8, right: 12, bottom: 8, left: 12 }
     : { top: 8, right: 140, bottom: 8, left: 120 };
@@ -313,29 +144,33 @@ export function FlowSankeyChart() {
           </p>
         ) : (
           <>
-            <div className="h-[280px] min-w-0 sm:h-[320px]">
-              <ResponsiveContainer width="100%" height="100%">
-                <Sankey
-                  data={data}
-                  dataKey="value"
-                  nameKey="name"
-                  node={(props) => (
-                    <FlowSankeyNodeShape {...props} showLabel={!isCompact} />
-                  )}
-                  link={{
-                    stroke: "hsl(220, 70%, 50%)",
-                    strokeOpacity: 0.25,
-                  }}
-                  nodePadding={isCompact ? 14 : 18}
-                  nodeWidth={12}
-                  margin={chartMargin}
-                  align="left"
-                  iterations={64}
-                >
-                  <Tooltip content={<SankeyTooltip />} />
-                </Sankey>
-              </ResponsiveContainer>
-            </div>
+            {mounted ? (
+              <div className="h-[280px] min-w-0 sm:h-[320px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <Sankey
+                    data={data}
+                    dataKey="value"
+                    nameKey="name"
+                    node={(props) => (
+                      <FlowSankeyNodeShape {...props} showLabel={!isCompact} />
+                    )}
+                    link={{
+                      stroke: "hsl(220, 70%, 50%)",
+                      strokeOpacity: 0.25,
+                    }}
+                    nodePadding={isCompact ? 14 : 18}
+                    nodeWidth={12}
+                    margin={chartMargin}
+                    align="left"
+                    iterations={64}
+                  >
+                    <Tooltip content={<SankeyTooltip />} />
+                  </Sankey>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <div className="h-[280px] min-w-0 sm:h-[320px]" />
+            )}
             <ul
               aria-label="Flow map legend"
               className="mt-3 flex flex-wrap gap-2 text-xs sm:hidden"

--- a/ui/components/assettracker/portfolio-goal.tsx
+++ b/ui/components/assettracker/portfolio-goal.tsx
@@ -120,7 +120,7 @@ export function PortfolioGoal() {
   }
 
   return (
-    <Card>
+    <Card className="min-w-0">
       <CardHeader>
         <CardTitle>Net Worth Goal</CardTitle>
         <CardDescription>
@@ -128,14 +128,14 @@ export function PortfolioGoal() {
           deposit, or your FI number.
         </CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-col gap-3">
+      <CardContent className="flex min-w-0 flex-col gap-3 px-4 sm:px-6">
         {netWorthTarget != null && goal ? (
           <>
-            <div className="flex items-baseline justify-between gap-2">
+            <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-2">
               <p className="text-2xl font-bold">
                 {formatCurrency(currentNetWorth)}
               </p>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm text-muted-foreground sm:text-right">
                 of {formatCurrency(netWorthTarget)} {moneyLabel} (
                 {Math.round(goal.progress * 100)}%)
               </p>
@@ -164,7 +164,7 @@ export function PortfolioGoal() {
           </>
         ) : (
           <form onSubmit={handleSetTarget} className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <label htmlFor="net-worth-target" className="sr-only">
                 Target net worth
               </label>
@@ -173,14 +173,18 @@ export function PortfolioGoal() {
                 type="number"
                 inputMode="decimal"
                 min="1"
-                step="1000"
+                step="any"
                 required
                 placeholder="e.g. 500000"
-                className="max-w-44"
+                className="w-full sm:max-w-44"
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
               />
-              <Button type="submit" variant="outline">
+              <Button
+                type="submit"
+                variant="outline"
+                className="w-full sm:w-auto"
+              >
                 Set goal
               </Button>
             </div>

--- a/ui/components/assettracker/upcoming-flows.tsx
+++ b/ui/components/assettracker/upcoming-flows.tsx
@@ -48,7 +48,7 @@ export function UpcomingFlows() {
   const overflow = occurrences.length - shown.length;
 
   return (
-    <Card>
+    <Card className="min-w-0">
       <CardHeader>
         <CardTitle>Upcoming</CardTitle>
         <CardDescription>
@@ -56,20 +56,20 @@ export function UpcomingFlows() {
           an account's flows to turn them into real transfers as they land.
         </CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="px-4 sm:px-6">
         {shown.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             No expected flows in the next {UPCOMING_DAYS} days — add regular
             income or contributions from an account's detail view.
           </p>
         ) : (
-          <ul className="divide-y rounded-lg border">
+          <ul className="min-w-0 divide-y rounded-lg border">
             {shown.map((occurrence) => (
               <li
                 key={`${occurrence.flow.id}-${occurrence.date}`}
-                className="flex items-center gap-2 px-3 py-2 text-sm"
+                className="grid min-w-0 grid-cols-[auto_1fr] gap-x-2 gap-y-1 px-3 py-2 text-sm sm:flex sm:items-center"
               >
-                <span className="w-24 shrink-0 text-muted-foreground">
+                <span className="shrink-0 text-muted-foreground sm:w-24">
                   {occurrence.date}
                 </span>
                 <div className="min-w-0">
@@ -79,7 +79,7 @@ export function UpcomingFlows() {
                     {accountName(occurrence.flow.toAccountId)}
                   </p>
                 </div>
-                <span className="ml-auto shrink-0 font-mono">
+                <span className="col-span-2 font-mono sm:col-span-1 sm:ml-auto sm:shrink-0">
                   {formatCurrency(Math.round(occurrence.amount * 100) / 100)}
                 </span>
               </li>

--- a/ui/lib/domain/assettracker/flowSankeyData.ts
+++ b/ui/lib/domain/assettracker/flowSankeyData.ts
@@ -1,0 +1,275 @@
+import { type ExpectedReturnChange, effectiveExpectedReturn } from "./account";
+import { todayIsoDate } from "./assetTrackerCommands";
+import type { AccountSummaryView } from "./assetTrackerViews";
+import { ACCOUNT_COLORS } from "./constants";
+import { monthlyAmount, type RecurringFlow } from "./recurringFlow";
+
+const EXTERNAL_INCOME_NODE = "__external_income";
+const EXTERNAL_SPENDING_NODE = "__external_spending";
+const EXPECTED_RETURNS_NODE = "__expected_returns";
+const EXPECTED_LOSSES_NODE = "__expected_losses";
+const INTEREST_CHARGED_NODE = "__interest_charged";
+const MIN_SYNTHETIC_FLOW = 1;
+
+type FlowSankeyAccount = AccountSummaryView & {
+  expectedReturnChanges?: ExpectedReturnChange[];
+  linkedAccountId?: string;
+};
+
+export type FlowSankeyNode = {
+  id: string;
+  name: string;
+  color: string;
+};
+
+export type FlowSankeyLink = {
+  source: number;
+  target: number;
+  value: number;
+  label: string;
+  sourceName: string;
+  targetName: string;
+};
+
+export type FlowSankeyData = {
+  nodes: FlowSankeyNode[];
+  links: FlowSankeyLink[];
+};
+
+type FlowSankeyBuilder = {
+  addLink: (
+    sourceId: string,
+    targetId: string,
+    value: number,
+    label: string,
+  ) => void;
+};
+
+function accountColor(index: number): string {
+  return ACCOUNT_COLORS[index % ACCOUNT_COLORS.length] ?? ACCOUNT_COLORS[0];
+}
+
+function nodeName(id: string, account?: FlowSankeyAccount): string {
+  switch (id) {
+    case EXTERNAL_INCOME_NODE:
+      return "External income";
+    case EXTERNAL_SPENDING_NODE:
+      return "External spending";
+    case EXPECTED_RETURNS_NODE:
+      return "Expected returns";
+    case EXPECTED_LOSSES_NODE:
+      return "Expected losses";
+    case INTEREST_CHARGED_NODE:
+      return "Interest charged";
+    default:
+      return account?.name ?? id;
+  }
+}
+
+function nodeColor(id: string, index: number): string {
+  switch (id) {
+    case EXTERNAL_INCOME_NODE:
+    case EXTERNAL_SPENDING_NODE:
+      return "hsl(220, 10%, 60%)";
+    case EXPECTED_RETURNS_NODE:
+      return "hsl(145, 55%, 45%)";
+    case EXPECTED_LOSSES_NODE:
+      return "hsl(20, 75%, 55%)";
+    case INTEREST_CHARGED_NODE:
+      return "hsl(350, 65%, 55%)";
+    default:
+      return accountColor(index);
+  }
+}
+
+function monthlyExpectedChange(balance: number, annualRate: number): number {
+  return balance * ((1 + annualRate) ** (1 / 12) - 1);
+}
+
+function recurringFlowValue(
+  flow: RecurringFlow,
+  liabilityBalances: Record<string, number>,
+): number {
+  const liabilityBalance =
+    flow.toAccountId != null ? liabilityBalances[flow.toAccountId] : undefined;
+  return flow.formula
+    ? monthlyAmount(flow, liabilityBalance)
+    : monthlyAmount(flow);
+}
+
+function addRecurringFlowLinks(
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+  builder: FlowSankeyBuilder,
+) {
+  for (const flow of flows) {
+    builder.addLink(
+      flow.fromAccountId ?? EXTERNAL_INCOME_NODE,
+      flow.toAccountId ?? EXTERNAL_SPENDING_NODE,
+      recurringFlowValue(flow, liabilityBalances),
+      flow.name,
+    );
+  }
+}
+
+function monthlyIncoming(
+  accountId: string,
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+): number {
+  return flows.reduce((total, flow) => {
+    if (flow.toAccountId !== accountId) return total;
+    return total + recurringFlowValue(flow, liabilityBalances);
+  }, 0);
+}
+
+function addLinkedLiabilityPrincipalFlow(
+  account: FlowSankeyAccount,
+  interestCharged: number,
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+  builder: FlowSankeyBuilder,
+) {
+  if (account.linkedAccountId == null) return;
+
+  const principal =
+    monthlyIncoming(account.id, flows, liabilityBalances) - interestCharged;
+  if (principal < MIN_SYNTHETIC_FLOW) return;
+
+  builder.addLink(
+    account.id,
+    account.linkedAccountId,
+    principal,
+    "Principal repayment",
+  );
+}
+
+function addNegativeExpectedChangeLink(
+  account: FlowSankeyAccount,
+  value: number,
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+  builder: FlowSankeyBuilder,
+) {
+  if ((account.latestBalance ?? 0) < 0) {
+    builder.addLink(
+      account.id,
+      INTEREST_CHARGED_NODE,
+      value,
+      "Interest charged",
+    );
+    addLinkedLiabilityPrincipalFlow(
+      account,
+      value,
+      flows,
+      liabilityBalances,
+      builder,
+    );
+    return;
+  }
+
+  builder.addLink(account.id, EXPECTED_LOSSES_NODE, value, "Expected loss");
+}
+
+function addSyntheticFlowLinks(
+  accounts: FlowSankeyAccount[],
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+  builder: FlowSankeyBuilder,
+) {
+  const today = todayIsoDate();
+  for (const account of accounts) {
+    const balance = account.latestBalance ?? 0;
+    if (balance === 0) continue;
+
+    const rate = effectiveExpectedReturn(account, today);
+    if (rate === 0) continue;
+
+    const change = monthlyExpectedChange(balance, rate);
+    const value = Math.abs(change);
+    if (value < MIN_SYNTHETIC_FLOW) continue;
+
+    if (change > 0) {
+      builder.addLink(
+        EXPECTED_RETURNS_NODE,
+        account.id,
+        value,
+        "Expected return",
+      );
+    } else {
+      addNegativeExpectedChangeLink(
+        account,
+        value,
+        flows,
+        liabilityBalances,
+        builder,
+      );
+    }
+  }
+}
+
+function roundCurrencyValue(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function buildFlowSankeyData(
+  accounts: FlowSankeyAccount[],
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+): FlowSankeyData {
+  const accountById = new Map(accounts.map((account) => [account.id, account]));
+  const nodeIndexes = new Map<string, number>();
+  const nodes: FlowSankeyNode[] = [];
+  const linkTotals = new Map<string, FlowSankeyLink>();
+
+  function addNode(id: string): number {
+    const existing = nodeIndexes.get(id);
+    if (existing != null) return existing;
+
+    const account = accountById.get(id);
+    const index = nodes.length;
+    nodes.push({
+      id,
+      name: nodeName(id, account),
+      color: nodeColor(id, index),
+    });
+    nodeIndexes.set(id, index);
+    return index;
+  }
+
+  const builder: FlowSankeyBuilder = {
+    addLink(sourceId, targetId, value, label) {
+      if (value <= 0) return;
+
+      const source = addNode(sourceId);
+      const target = addNode(targetId);
+      const key = `${source}->${target}`;
+      const existing = linkTotals.get(key);
+      if (existing) {
+        existing.value += value;
+        existing.label = `${existing.label}, ${label}`;
+        return;
+      }
+
+      linkTotals.set(key, {
+        source,
+        target,
+        value,
+        label,
+        sourceName: nodes[source]?.name ?? sourceId,
+        targetName: nodes[target]?.name ?? targetId,
+      });
+    },
+  };
+
+  addRecurringFlowLinks(flows, liabilityBalances, builder);
+  addSyntheticFlowLinks(accounts, flows, liabilityBalances, builder);
+
+  return {
+    nodes,
+    links: Array.from(linkTotals.values()).map((link) => ({
+      ...link,
+      value: roundCurrencyValue(link.value),
+    })),
+  };
+}

--- a/ui/lib/domain/assettracker/flowSankeyData.ts
+++ b/ui/lib/domain/assettracker/flowSankeyData.ts
@@ -83,6 +83,7 @@ function nodeColor(id: string, index: number): string {
 }
 
 function monthlyExpectedChange(balance: number, annualRate: number): number {
+  if (annualRate <= -1 || !Number.isFinite(annualRate)) return 0;
   return balance * ((1 + annualRate) ** (1 / 12) - 1);
 }
 
@@ -232,6 +233,7 @@ function addSyntheticFlowLinks(
 }
 
 function roundCurrencyValue(value: number): number {
+  if (!Number.isFinite(value)) return 0;
   return Math.round(value * 100) / 100;
 }
 
@@ -262,8 +264,8 @@ export function buildFlowSankeyData(
 
   const builder: FlowSankeyBuilder = {
     addLink(sourceId, targetId, value, label) {
-      if (value <= 0) return;
       const roundedValue = roundCurrencyValue(value);
+      if (roundedValue <= 0) return;
 
       const source = addNode(sourceId);
       const target = addNode(targetId);
@@ -271,7 +273,9 @@ export function buildFlowSankeyData(
       const existing = linkTotals.get(key);
       if (existing) {
         existing.value = roundCurrencyValue(existing.value + roundedValue);
-        existing.label = `${existing.label}, ${label}`;
+        const labels = new Set(existing.label.split(", "));
+        labels.add(label);
+        existing.label = Array.from(labels).join(", ");
         return;
       }
 

--- a/ui/lib/domain/assettracker/flowSankeyData.ts
+++ b/ui/lib/domain/assettracker/flowSankeyData.ts
@@ -123,6 +123,27 @@ function monthlyIncoming(
   }, 0);
 }
 
+function monthlyOutgoing(
+  flowAccountId: string,
+  flows: RecurringFlow[],
+): number {
+  return flows.reduce((total, flow) => {
+    if (flow.fromAccountId !== flowAccountId) return total;
+    return total + monthlyAmount(flow);
+  }, 0);
+}
+
+function monthlyNetFlow(
+  accountId: string,
+  flows: RecurringFlow[],
+  liabilityBalances: Record<string, number>,
+): number {
+  return (
+    monthlyIncoming(accountId, flows, liabilityBalances) -
+    monthlyOutgoing(accountId, flows)
+  );
+}
+
 function addLinkedLiabilityPrincipalFlow(
   account: FlowSankeyAccount,
   interestCharged: number,
@@ -132,8 +153,10 @@ function addLinkedLiabilityPrincipalFlow(
 ) {
   if (account.linkedAccountId == null) return;
 
-  const principal =
-    monthlyIncoming(account.id, flows, liabilityBalances) - interestCharged;
+  const principal = Math.max(
+    0,
+    monthlyNetFlow(account.id, flows, liabilityBalances) - interestCharged,
+  );
   if (principal < MIN_SYNTHETIC_FLOW) return;
 
   builder.addLink(
@@ -240,13 +263,14 @@ export function buildFlowSankeyData(
   const builder: FlowSankeyBuilder = {
     addLink(sourceId, targetId, value, label) {
       if (value <= 0) return;
+      const roundedValue = roundCurrencyValue(value);
 
       const source = addNode(sourceId);
       const target = addNode(targetId);
       const key = `${source}->${target}`;
       const existing = linkTotals.get(key);
       if (existing) {
-        existing.value += value;
+        existing.value = roundCurrencyValue(existing.value + roundedValue);
         existing.label = `${existing.label}, ${label}`;
         return;
       }
@@ -254,7 +278,7 @@ export function buildFlowSankeyData(
       linkTotals.set(key, {
         source,
         target,
-        value,
+        value: roundedValue,
         label,
         sourceName: nodes[source]?.name ?? sourceId,
         targetName: nodes[target]?.name ?? targetId,

--- a/ui/lib/domain/assettracker/index.ts
+++ b/ui/lib/domain/assettracker/index.ts
@@ -8,5 +8,6 @@ export * from "./assetTrackerRepository";
 export * from "./assetTrackerViews";
 export * from "./balanceSnapshot";
 export * from "./constants";
+export * from "./flowSankeyData";
 export * from "./recurringFlow";
 export * from "./transfer";

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -1,15 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAssetTracker } from "@/components/assettracker/asset-tracker-provider";
-import {
-  buildFlowSankeyData,
-  FlowSankeyChart,
-} from "@/components/assettracker/flow-sankey-chart";
+import { FlowSankeyChart } from "@/components/assettracker/flow-sankey-chart";
 import { PortfolioGoal } from "@/components/assettracker/portfolio-goal";
 import { UpcomingFlows } from "@/components/assettracker/upcoming-flows";
-import { todayIsoDate } from "@/lib/domain/assettracker";
+import { buildFlowSankeyData, todayIsoDate } from "@/lib/domain/assettracker";
 
 vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: ReactNode }) => (
@@ -26,6 +23,7 @@ vi.mock("@/components/assettracker/asset-tracker-provider", () => ({
 }));
 
 const mockUseAssetTracker = vi.mocked(useAssetTracker);
+const FIXED_NOW = new Date("2026-07-03T12:00:00+01:00");
 
 function mockAssetTracker(
   overrides: Partial<ReturnType<typeof useAssetTracker>> = {},
@@ -60,6 +58,10 @@ function mockAssetTracker(
     ...overrides,
   } as ReturnType<typeof useAssetTracker>);
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("PortfolioGoal", () => {
   beforeEach(() => {
@@ -105,6 +107,9 @@ describe("UpcomingFlows", () => {
   });
 
   it("keeps upcoming rows narrow-first on mobile", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+
     const today = todayIsoDate();
     mockAssetTracker({
       accounts: [
@@ -165,7 +170,7 @@ describe("FlowSankeyChart", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps direct account allocations in their natural Sankey layer", () => {
+  it("keeps direct account allocations in their natural Sankey layer", async () => {
     const today = todayIsoDate();
     mockAssetTracker({
       accountDetails: [
@@ -213,7 +218,7 @@ describe("FlowSankeyChart", () => {
 
     render(<FlowSankeyChart />);
 
-    expect(screen.getByTestId("flow-sankey")).toHaveAttribute(
+    expect(await screen.findByTestId("flow-sankey")).toHaveAttribute(
       "data-align",
       "left",
     );
@@ -442,6 +447,42 @@ describe("buildFlowSankeyData", () => {
         label: "Principal repayment",
         sourceName: "Home Mortgage",
         targetName: "Home",
+      },
+    ]);
+  });
+
+  it("shows expected losses for depreciating assets", () => {
+    const data = buildFlowSankeyData(
+      [
+        {
+          id: "car",
+          name: "Car",
+          provider: "Owned",
+          currency: "GBP",
+          assetType: "property",
+          expectedAnnualReturn: -0.12,
+          isOpen: true,
+          latestBalance: 10000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+      ],
+      [],
+      {},
+    );
+
+    expect(data.nodes.map((node) => node.name)).toEqual([
+      "Car",
+      "Expected losses",
+    ]);
+    expect(data.links).toEqual([
+      {
+        source: 0,
+        target: 1,
+        value: 105.96,
+        label: "Expected loss",
+        sourceName: "Car",
+        targetName: "Expected losses",
       },
     ]);
   });

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -486,4 +486,135 @@ describe("buildFlowSankeyData", () => {
       },
     ]);
   });
+
+  it("skips invalid expected return calculations", () => {
+    const data = buildFlowSankeyData(
+      [
+        {
+          id: "asset",
+          name: "Invalid return asset",
+          provider: "Provider",
+          currency: "GBP",
+          assetType: "stocks",
+          expectedAnnualReturn: -1,
+          isOpen: true,
+          latestBalance: 10000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+      ],
+      [],
+      {},
+    );
+
+    expect(data).toEqual({ nodes: [], links: [] });
+  });
+
+  it("does not create zero-value links after rounding", () => {
+    const data = buildFlowSankeyData(
+      [
+        {
+          id: "current",
+          name: "Current",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+        {
+          id: "savings",
+          name: "Savings",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+      ],
+      [
+        {
+          id: "dust",
+          name: "Dust",
+          fromAccountId: "current",
+          toAccountId: "savings",
+          amount: 0.004,
+          frequency: "monthly",
+          startDate: "2026-07-01",
+        },
+      ],
+      {},
+    );
+
+    expect(data).toEqual({ nodes: [], links: [] });
+  });
+
+  it("deduplicates labels when merging equivalent links", () => {
+    const data = buildFlowSankeyData(
+      [
+        {
+          id: "current",
+          name: "Current",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+        {
+          id: "savings",
+          name: "Savings",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+      ],
+      [
+        {
+          id: "first",
+          name: "Transfer",
+          fromAccountId: "current",
+          toAccountId: "savings",
+          amount: 10,
+          frequency: "monthly",
+          startDate: "2026-07-01",
+        },
+        {
+          id: "second",
+          name: "Transfer",
+          fromAccountId: "current",
+          toAccountId: "savings",
+          amount: 5,
+          frequency: "monthly",
+          startDate: "2026-07-01",
+        },
+      ],
+      {},
+    );
+
+    expect(data.links).toEqual([
+      {
+        source: 0,
+        target: 1,
+        value: 15,
+        label: "Transfer",
+        sourceName: "Current",
+        targetName: "Savings",
+      },
+    ]);
+  });
 });

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -264,12 +264,110 @@ describe("buildFlowSankeyData", () => {
         targetName: "ISA",
       },
       {
-        source: 5,
-        target: 3,
+        source: 3,
+        target: 5,
         value: 30.62,
         label: "Interest charged",
-        sourceName: "Interest charged",
-        targetName: "Credit Card",
+        sourceName: "Credit Card",
+        targetName: "Interest charged",
+      },
+    ]);
+  });
+
+  it("splits linked liability repayments into interest and principal flows", () => {
+    const data = buildFlowSankeyData(
+      [
+        {
+          id: "current",
+          name: "Current",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+        {
+          id: "home",
+          name: "Home",
+          provider: "Property",
+          currency: "GBP",
+          assetType: "property",
+          expectedAnnualReturn: 0.03,
+          isOpen: true,
+          latestBalance: 298000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+        {
+          id: "mortgage",
+          name: "Home Mortgage",
+          provider: "Lender",
+          currency: "GBP",
+          assetType: "debt",
+          expectedAnnualReturn: 0.0425,
+          linkedAccountId: "home",
+          isOpen: true,
+          latestBalance: -212800,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+      ],
+      [
+        {
+          id: "mortgage-payment",
+          name: "Mortgage payment",
+          fromAccountId: "current",
+          toAccountId: "mortgage",
+          amount: 1150,
+          frequency: "monthly",
+          startDate: "2026-07-01",
+        },
+      ],
+      { mortgage: -212800 },
+    );
+
+    expect(data.nodes.map((node) => node.name)).toEqual([
+      "Current",
+      "Home Mortgage",
+      "Expected returns",
+      "Home",
+      "Interest charged",
+    ]);
+    expect(data.links).toEqual([
+      {
+        source: 0,
+        target: 1,
+        value: 1150,
+        label: "Mortgage payment",
+        sourceName: "Current",
+        targetName: "Home Mortgage",
+      },
+      {
+        source: 2,
+        target: 3,
+        value: 734.95,
+        label: "Expected return",
+        sourceName: "Expected returns",
+        targetName: "Home",
+      },
+      {
+        source: 1,
+        target: 4,
+        value: 739.37,
+        label: "Interest charged",
+        sourceName: "Home Mortgage",
+        targetName: "Interest charged",
+      },
+      {
+        source: 1,
+        target: 3,
+        value: 410.63,
+        label: "Principal repayment",
+        sourceName: "Home Mortgage",
+        targetName: "Home",
       },
     ]);
   });

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -227,6 +227,8 @@ describe("buildFlowSankeyData", () => {
       "Current",
       "ISA",
       "Credit Card",
+      "Expected returns",
+      "Interest charged",
     ]);
     expect(data.links).toEqual([
       {
@@ -251,6 +253,22 @@ describe("buildFlowSankeyData", () => {
         value: 50,
         label: "Card minimum",
         sourceName: "Current",
+        targetName: "Credit Card",
+      },
+      {
+        source: 4,
+        target: 2,
+        value: 28.27,
+        label: "Expected return",
+        sourceName: "Expected returns",
+        targetName: "ISA",
+      },
+      {
+        source: 5,
+        target: 3,
+        value: 30.62,
+        label: "Interest charged",
+        sourceName: "Interest charged",
         targetName: "Credit Card",
       },
     ]);

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -229,9 +229,30 @@ describe("buildFlowSankeyData", () => {
       "Credit Card",
     ]);
     expect(data.links).toEqual([
-      { source: 0, target: 1, value: 3200, label: "Salary" },
-      { source: 1, target: 2, value: 500, label: "ISA" },
-      { source: 1, target: 3, value: 50, label: "Card minimum" },
+      {
+        source: 0,
+        target: 1,
+        value: 3200,
+        label: "Salary",
+        sourceName: "External income",
+        targetName: "Current",
+      },
+      {
+        source: 1,
+        target: 2,
+        value: 500,
+        label: "ISA",
+        sourceName: "Current",
+        targetName: "ISA",
+      },
+      {
+        source: 1,
+        target: 3,
+        value: 50,
+        label: "Card minimum",
+        sourceName: "Current",
+        targetName: "Credit Card",
+      },
     ]);
   });
 });

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -170,7 +170,7 @@ describe("FlowSankeyChart", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps direct account allocations in their natural Sankey layer", async () => {
+  it("passes left alignment to the Sankey layout", async () => {
     const today = todayIsoDate();
     mockAssetTracker({
       accountDetails: [

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -1,11 +1,25 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAssetTracker } from "@/components/assettracker/asset-tracker-provider";
-import { buildFlowSankeyData } from "@/components/assettracker/flow-sankey-chart";
+import {
+  buildFlowSankeyData,
+  FlowSankeyChart,
+} from "@/components/assettracker/flow-sankey-chart";
 import { PortfolioGoal } from "@/components/assettracker/portfolio-goal";
 import { UpcomingFlows } from "@/components/assettracker/upcoming-flows";
 import { todayIsoDate } from "@/lib/domain/assettracker";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Sankey: ({ align }: { align?: string }) => (
+    <div data-align={align} data-testid="flow-sankey" />
+  ),
+  Tooltip: () => null,
+}));
 
 vi.mock("@/components/assettracker/asset-tracker-provider", () => ({
   useAssetTracker: vi.fn(),
@@ -143,6 +157,66 @@ describe("UpcomingFlows", () => {
     const row = screen.getByText("Salary").closest("li");
     expect(row).toHaveClass("grid", "min-w-0", "sm:flex");
     expect(row?.querySelector("span")).toHaveClass("shrink-0", "sm:w-24");
+  });
+});
+
+describe("FlowSankeyChart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps direct account allocations in their natural Sankey layer", () => {
+    const today = todayIsoDate();
+    mockAssetTracker({
+      accountDetails: [
+        {
+          id: "current",
+          name: "Current",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: today,
+          cagr: null,
+          createdAt: today,
+          snapshots: [{ date: today, balance: 1000 }],
+        },
+        {
+          id: "isa",
+          name: "ISA",
+          provider: "Broker",
+          currency: "GBP",
+          assetType: "stocks",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 5000,
+          latestSnapshotDate: today,
+          cagr: null,
+          createdAt: today,
+          snapshots: [{ date: today, balance: 5000 }],
+        },
+      ],
+      recurringFlows: [
+        {
+          id: "isa",
+          name: "ISA contribution",
+          fromAccountId: "current",
+          toAccountId: "isa",
+          amount: 500,
+          frequency: "monthly",
+          startDate: today,
+        },
+      ],
+    });
+
+    render(<FlowSankeyChart />);
+
+    expect(screen.getByTestId("flow-sankey")).toHaveAttribute(
+      "data-align",
+      "left",
+    );
   });
 });
 

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAssetTracker } from "@/components/assettracker/asset-tracker-provider";
+import { buildFlowSankeyData } from "@/components/assettracker/flow-sankey-chart";
+import { PortfolioGoal } from "@/components/assettracker/portfolio-goal";
+import { UpcomingFlows } from "@/components/assettracker/upcoming-flows";
+import { todayIsoDate } from "@/lib/domain/assettracker";
+
+vi.mock("@/components/assettracker/asset-tracker-provider", () => ({
+  useAssetTracker: vi.fn(),
+}));
+
+const mockUseAssetTracker = vi.mocked(useAssetTracker);
+
+function mockAssetTracker(
+  overrides: Partial<ReturnType<typeof useAssetTracker>> = {},
+) {
+  mockUseAssetTracker.mockReturnValue({
+    accounts: [],
+    accountDetails: [],
+    netWorthData: [],
+    assetAllocation: [],
+    transfers: [],
+    recurringFlows: [],
+    portfolioReturn: null,
+    inflation: 0.025,
+    netWorthTarget: null,
+    netWorthTargetIsReal: false,
+    hasLocalChanges: false,
+    createAccount: vi.fn(),
+    recordBalance: vi.fn(),
+    recordTransfer: vi.fn(),
+    closeAccount: vi.fn(),
+    deleteSnapshot: vi.fn(),
+    addRecurringFlow: vi.fn(),
+    deleteRecurringFlow: vi.fn(),
+    materializeFlow: vi.fn(),
+    setExpectedReturn: vi.fn(),
+    setInflation: vi.fn(),
+    setNetWorthTarget: vi.fn(),
+    resetData: vi.fn(),
+    exportData: vi.fn(),
+    exportCsv: vi.fn(),
+    importData: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useAssetTracker>);
+}
+
+describe("PortfolioGoal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts whole-number goals that are not offset from the minimum", async () => {
+    const setNetWorthTarget = vi.fn().mockResolvedValue(undefined);
+    mockAssetTracker({ setNetWorthTarget });
+
+    render(<PortfolioGoal />);
+
+    const input = screen.getByLabelText("Target net worth") as HTMLInputElement;
+    await userEvent.type(input, "500000");
+
+    expect(input).toHaveAttribute("step", "any");
+    expect(input.validity.stepMismatch).toBe(false);
+    expect(input.checkValidity()).toBe(true);
+
+    await userEvent.click(screen.getByRole("button", { name: "Set goal" }));
+
+    expect(setNetWorthTarget).toHaveBeenCalledWith(500000, true);
+  });
+
+  it("uses constrained mobile layout classes", () => {
+    mockAssetTracker();
+
+    const { container } = render(<PortfolioGoal />);
+
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass(
+      "min-w-0",
+    );
+    expect(screen.getByRole("button", { name: "Set goal" })).toHaveClass(
+      "w-full",
+      "sm:w-auto",
+    );
+  });
+});
+
+describe("UpcomingFlows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps upcoming rows narrow-first on mobile", () => {
+    const today = todayIsoDate();
+    mockAssetTracker({
+      accounts: [
+        {
+          id: "cash",
+          name: "Current account",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: today,
+          cagr: null,
+        },
+      ],
+      accountDetails: [
+        {
+          id: "cash",
+          name: "Current account",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: today,
+          cagr: null,
+          createdAt: today,
+          snapshots: [{ date: today, balance: 1000 }],
+        },
+      ],
+      recurringFlows: [
+        {
+          id: "salary",
+          name: "Salary",
+          toAccountId: "cash",
+          amount: 2500,
+          frequency: "monthly",
+          startDate: today,
+        },
+      ],
+    });
+
+    const { container } = render(<UpcomingFlows />);
+
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass(
+      "min-w-0",
+    );
+    const row = screen.getByText("Salary").closest("li");
+    expect(row).toHaveClass("grid", "min-w-0", "sm:flex");
+    expect(row?.querySelector("span")).toHaveClass("shrink-0", "sm:w-24");
+  });
+});
+
+describe("buildFlowSankeyData", () => {
+  it("converts regular flows into monthly Sankey links", () => {
+    const data = buildFlowSankeyData(
+      [
+        {
+          id: "current",
+          name: "Current",
+          provider: "Bank",
+          currency: "GBP",
+          assetType: "cash",
+          expectedAnnualReturn: 0,
+          isOpen: true,
+          latestBalance: 1000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+        {
+          id: "isa",
+          name: "ISA",
+          provider: "Broker",
+          currency: "GBP",
+          assetType: "stocks",
+          expectedAnnualReturn: 0.07,
+          isOpen: true,
+          latestBalance: 5000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+        {
+          id: "card",
+          name: "Credit Card",
+          provider: "Card",
+          currency: "GBP",
+          assetType: "debt",
+          expectedAnnualReturn: 0.2,
+          isOpen: true,
+          latestBalance: -2000,
+          latestSnapshotDate: "2026-07-03",
+          cagr: null,
+        },
+      ],
+      [
+        {
+          id: "salary",
+          name: "Salary",
+          toAccountId: "current",
+          amount: 3200,
+          frequency: "monthly",
+          startDate: "2026-07-01",
+        },
+        {
+          id: "isa",
+          name: "ISA",
+          fromAccountId: "current",
+          toAccountId: "isa",
+          amount: 6000,
+          frequency: "yearly",
+          startDate: "2026-07-01",
+        },
+        {
+          id: "card",
+          name: "Card minimum",
+          fromAccountId: "current",
+          toAccountId: "card",
+          formula: {
+            kind: "minimumPayment",
+            percentOfBalance: 0.025,
+            floor: 25,
+          },
+          frequency: "monthly",
+          startDate: "2026-07-01",
+        },
+      ],
+      { card: -2000 },
+    );
+
+    expect(data.nodes.map((node) => node.name)).toEqual([
+      "External income",
+      "Current",
+      "ISA",
+      "Credit Card",
+    ]);
+    expect(data.links).toEqual([
+      { source: 0, target: 1, value: 3200, label: "Salary" },
+      { source: 1, target: 2, value: 500, label: "ISA" },
+      { source: 1, target: 3, value: 50, label: "Card minimum" },
+    ]);
+  });
+});

--- a/ui/tests/setup.ts
+++ b/ui/tests/setup.ts
@@ -1,1 +1,15 @@
 import "@testing-library/jest-dom";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Summary

- Fix mobile overflow in the Net Worth Goal and Upcoming asset tracker cards.
- Fix the net worth goal input rejecting values like `500000` by removing the incompatible `step="1000"` constraint.
- Add a Regular Flow Map Sankey chart that visualises monthly-equivalent recurring flows between external income, accounts, savings, and liabilities.
- Add component tests for the goal input validation, mobile layout contracts, and Sankey flow data transformation.

## Root Cause

The net worth goal input used `min="1"` with `step="1000"`, so browser validation only accepted values offset from 1, such as `499001` and `500001`. Some card rows also forced single-line layouts on narrow screens.

## Validation

- `CI=true mise run //ui:format:check -- components/assettracker/asset-tracker-dashboard.tsx components/assettracker/flow-sankey-chart.tsx components/assettracker/portfolio-goal.tsx components/assettracker/upcoming-flows.tsx tests/components/assettracker/asset-tracker-cards.test.tsx`
- `CI=true mise run //ui:typecheck`
- `CI=true mise run //ui:test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Flow Sankey (“Regular Flow Map”) to the asset tracker dashboard, including hover tooltips, a mobile legend, and an empty-state when no links are available.

* **Improvements**
  * Updated responsive layout and sizing for the portfolio goal and upcoming flows cards for smoother small-screen usability.

* **Tests**
  * Added UI and Sankey graph generation tests for consistent rendering, plus a test environment update to mock `matchMedia` for viewport-dependent layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->