### PR TITLE
Add recipe settings page and avatar account menu

### DIFF
--- a/ui/app/recipes/settings/page.tsx
+++ b/ui/app/recipes/settings/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { SettingsView } from "@/components/recipes/settings/settings-view";
+
+export const metadata: Metadata = {
+  title: "Settings",
+  description: "Manage your account and sign-in for Robbie's Recipes.",
+  robots: { index: false, follow: false },
+};
+
+export default function SettingsPage() {
+  return <SettingsView />;
+}

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -7,37 +7,25 @@ import {
   LoaderCircle,
   LogIn,
   LogOut,
+  Settings,
 } from "lucide-react";
+import Link from "next/link";
 import { useEffect, useState } from "react";
-import { siGithub, siGoogle } from "simple-icons";
+import {
+  type Provider,
+  ProviderIcon,
+  AUTH_PROVIDERS as providers,
+} from "@/components/recipes/auth-providers";
+import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
 import { isPreviewDeployment } from "@/lib/preview-environment";
 
-type Provider = "google" | "github";
-type LinkedAccount = { providerId: string; accountId: string };
 type PreviewScenario = {
   id: string;
   name: string;
   description: string;
 };
-
-const providers: ReadonlyArray<{
-  id: Provider;
-  name: string;
-  iconPath: string;
-}> = [
-  { id: "google", name: "Google", iconPath: siGoogle.path },
-  { id: "github", name: "GitHub", iconPath: siGithub.path },
-];
-
-function ProviderIcon({ path }: { path: string }) {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" className="size-4">
-      <path d={path} fill="currentColor" />
-    </svg>
-  );
-}
 
 export function AuthButton() {
   const previewBackendDisabled =
@@ -50,10 +38,6 @@ export function AuthButton() {
     PreviewScenario[] | null
   >(null);
   const [error, setError] = useState<string | null>(null);
-  const [linkedAccounts, setLinkedAccounts] = useState<LinkedAccount[] | null>(
-    null,
-  );
-  const [accountsError, setAccountsError] = useState(false);
   const [lastUsedProvider, setLastUsedProvider] = useState<Provider | null>(
     null,
   );
@@ -85,23 +69,6 @@ export function AuthButton() {
       .catch(() => setError("Preview sign-in is not configured."));
   }, [previewBackendDisabled]);
 
-  async function loadLinkedAccounts() {
-    setAccountsError(false);
-    const result = await authClient.listAccounts();
-    if (result.error) {
-      setAccountsError(true);
-      return;
-    }
-    setLinkedAccounts(result.data ?? []);
-  }
-
-  function handleOpenChange(nextOpen: boolean) {
-    setOpen(nextOpen);
-    if (nextOpen && session && linkedAccounts === null && !accountsError) {
-      void loadLinkedAccounts();
-    }
-  }
-
   async function signOut() {
     setError(null);
     try {
@@ -127,92 +94,80 @@ export function AuthButton() {
 
   if (session) {
     return (
-      <PopoverPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+      <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
         <PopoverPrimitive.Trigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
+          <button
+            type="button"
             aria-label={`Account for ${session.user.name}`}
             aria-expanded={open}
+            className="rounded-full outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-[var(--terracotta)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--paper)] data-[state=open]:ring-2 data-[state=open]:ring-[var(--terracotta)] data-[state=open]:ring-offset-2 data-[state=open]:ring-offset-[var(--paper)]"
           >
-            <span className="max-w-32 truncate">{session.user.name}</span>
-            <ChevronDown className="size-3.5 opacity-60" />
-          </Button>
+            <RecipeAvatar
+              name={session.user.name}
+              email={session.user.email}
+              image={session.user.image}
+              size={36}
+            />
+          </button>
         </PopoverPrimitive.Trigger>
         <PopoverPrimitive.Portal>
           <PopoverPrimitive.Content
             align="end"
-            sideOffset={6}
-            className="bg-popover text-popover-foreground z-50 w-64 rounded-md border p-3 shadow-md outline-none"
+            sideOffset={8}
+            className="bg-popover text-popover-foreground z-50 w-64 overflow-hidden rounded-xl border shadow-md outline-none"
           >
-            <p className="flex items-center gap-2 text-sm font-medium">
-              {session.user.name}
-              {session.user.role === "admin" && (
-                <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
-                  Admin
-                </span>
-              )}
-            </p>
-            <p className="truncate text-xs text-muted-foreground">
-              {session.user.email}
-            </p>
-
-            <div className="my-3 border-t" />
-            <p className="mb-2 text-xs font-medium text-muted-foreground">
-              Connected identities
-            </p>
-
-            {linkedAccounts === null && !accountsError && (
-              <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
-                <LoaderCircle className="animate-spin" />
-                Checking accounts…
+            <div className="flex items-center gap-3 border-b bg-[var(--paper-warm)] px-4 py-3">
+              <RecipeAvatar
+                name={session.user.name}
+                email={session.user.email}
+                image={session.user.image}
+                size={40}
+              />
+              <div className="min-w-0">
+                <p className="rt-display flex items-center gap-2 text-lg leading-none">
+                  {session.user.name}
+                  {session.user.role === "admin" && (
+                    <span className="rt-mono rounded bg-muted px-1.5 py-0.5 text-[0.625rem] text-muted-foreground">
+                      Admin
+                    </span>
+                  )}
+                </p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {session.user.email}
+                </p>
               </div>
-            )}
+            </div>
 
-            {linkedAccounts?.map((account) => {
-              const provider = providers.find(
-                (candidate) => candidate.id === account.providerId,
-              );
-              if (!provider) return null;
-              const accountSuffix = account.accountId.slice(-6);
+            <div className="p-1.5">
+              <Button
+                variant="ghost"
+                className="w-full justify-start"
+                asChild
+                onClick={() => setOpen(false)}
+              >
+                <Link href="/recipes/settings">
+                  <Settings />
+                  Settings
+                </Link>
+              </Button>
+            </div>
 
-              return (
-                <div
-                  key={`${account.providerId}:${account.accountId}`}
-                  className="flex items-center gap-2 rounded-md bg-muted/50 px-2 py-2"
-                >
-                  <ProviderIcon path={provider.iconPath} />
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium">{provider.name}</p>
-                    <p className="text-xs text-muted-foreground">
-                      Provider account ending {accountSuffix}
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
-
-            {accountsError && (
-              <p className="text-xs text-destructive">
-                Connected identities could not be loaded.
-              </p>
-            )}
+            <div className="border-t p-1.5">
+              <Button
+                variant="ghost"
+                className="w-full justify-start"
+                onClick={signOut}
+              >
+                <LogOut />
+                Sign out
+              </Button>
+            </div>
 
             {error && (
-              <p role="alert" className="text-xs text-destructive">
+              <p role="alert" className="px-3 pb-3 text-xs text-destructive">
                 {error}
               </p>
             )}
-
-            <div className="my-3 border-t" />
-            <Button
-              variant="ghost"
-              className="w-full justify-start"
-              onClick={signOut}
-            >
-              <LogOut />
-              Sign out
-            </Button>
           </PopoverPrimitive.Content>
         </PopoverPrimitive.Portal>
       </PopoverPrimitive.Root>
@@ -265,7 +220,7 @@ export function AuthButton() {
   }
 
   return (
-    <PopoverPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+    <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
       <PopoverPrimitive.Trigger asChild>
         <Button variant="outline" size="sm" aria-expanded={open}>
           <LogIn />

--- a/ui/components/recipes/auth-providers.tsx
+++ b/ui/components/recipes/auth-providers.tsx
@@ -1,0 +1,27 @@
+import { siGithub, siGoogle } from "simple-icons";
+
+// Social sign-in providers and their brand icons.
+export type Provider = "google" | "github";
+
+export const AUTH_PROVIDERS: ReadonlyArray<{
+  id: Provider;
+  name: string;
+  iconPath: string;
+}> = [
+  { id: "google", name: "Google", iconPath: siGoogle.path },
+  { id: "github", name: "GitHub", iconPath: siGithub.path },
+];
+
+export function ProviderIcon({
+  path,
+  className = "size-4",
+}: {
+  path: string;
+  className?: string;
+}) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className={className}>
+      <path d={path} fill="currentColor" />
+    </svg>
+  );
+}

--- a/ui/components/recipes/auth-providers.tsx
+++ b/ui/components/recipes/auth-providers.tsx
@@ -1,6 +1,5 @@
 import { siGithub, siGoogle } from "simple-icons";
 
-// Social sign-in providers and their brand icons.
 export type Provider = "google" | "github";
 
 export const AUTH_PROVIDERS: ReadonlyArray<{

--- a/ui/components/recipes/recipe-avatar.tsx
+++ b/ui/components/recipes/recipe-avatar.tsx
@@ -1,9 +1,5 @@
 import { cn } from "@/lib/generic/styles";
 
-/**
- * A circular avatar: the account photo when there is one, otherwise the first
- * initial on a butter-yellow disc with a handwritten (Caveat) letter.
- */
 export function RecipeAvatar({
   name,
   email,

--- a/ui/components/recipes/recipe-avatar.tsx
+++ b/ui/components/recipes/recipe-avatar.tsx
@@ -1,0 +1,51 @@
+import { cn } from "@/lib/generic/styles";
+
+/**
+ * A circular avatar: the account photo when there is one, otherwise the first
+ * initial on a butter-yellow disc with a handwritten (Caveat) letter.
+ */
+export function RecipeAvatar({
+  name,
+  email,
+  image,
+  size = 40,
+  className,
+}: {
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  size?: number;
+  className?: string;
+}) {
+  const initial = (
+    name?.trim()?.[0] ??
+    email?.trim()?.[0] ??
+    "?"
+  ).toUpperCase();
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "rt-display inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border-[1.5px] border-[var(--ink)] bg-[var(--butter)] text-[var(--terracotta-deep)] leading-none select-none",
+        className,
+      )}
+      style={{ width: size, height: size, fontSize: Math.round(size * 0.55) }}
+    >
+      {image ? (
+        // Avatar hosts vary, so a plain <img> avoids configuring next/image
+        // remotePatterns for each one.
+        // biome-ignore lint/performance/noImgElement: small, external avatar
+        <img
+          src={image}
+          alt=""
+          width={size}
+          height={size}
+          className="h-full w-full object-cover"
+        />
+      ) : (
+        initial
+      )}
+    </span>
+  );
+}

--- a/ui/components/recipes/settings/account-panel.tsx
+++ b/ui/components/recipes/settings/account-panel.tsx
@@ -75,9 +75,13 @@ export function AccountPanel({
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const savedName = useRef(user.name);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saving = useRef(false);
+  const pending = useRef<string | null>(null);
+  const mounted = useRef(true);
 
   useEffect(
     () => () => {
+      mounted.current = false;
       if (timer.current) clearTimeout(timer.current);
     },
     [],
@@ -95,16 +99,32 @@ export function AccountPanel({
       return;
     }
     if (trimmed === savedName.current) return;
+    // One request at a time; hold the newest value to save once it settles so
+    // a debounce firing mid-request can't overlap with a blur.
+    if (saving.current) {
+      pending.current = trimmed;
+      return;
+    }
+    saving.current = true;
     setSaveState("saving");
     setErrorMsg(null);
     const result = await authClient.updateUser({ name: trimmed });
+    saving.current = false;
+    if (!mounted.current) return;
     if (result.error) {
+      pending.current = null;
       setSaveState("error");
       setErrorMsg(result.error.message ?? "Couldn't save your changes.");
       return;
     }
     savedName.current = trimmed;
     setSaveState("saved");
+    // Normalise the field to the stored value, but only if the user hasn't
+    // since typed something different (just whitespace apart).
+    setName((current) => (current.trim() === trimmed ? trimmed : current));
+    const next = pending.current;
+    pending.current = null;
+    if (next !== null) void save(next);
   }
 
   function onNameChange(value: string) {

--- a/ui/components/recipes/settings/account-panel.tsx
+++ b/ui/components/recipes/settings/account-panel.tsx
@@ -68,7 +68,6 @@ export function AccountPanel({
     setName(value);
     setSaveState("idle");
     if (timer.current) clearTimeout(timer.current);
-    // Save a moment after typing stops.
     timer.current = setTimeout(() => void save(value), 800);
   }
 

--- a/ui/components/recipes/settings/account-panel.tsx
+++ b/ui/components/recipes/settings/account-panel.tsx
@@ -50,8 +50,17 @@ export function AccountPanel({
   );
 
   async function save(value: string) {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
     const trimmed = value.trim();
-    if (!trimmed || trimmed === savedName.current) return;
+    if (!trimmed) {
+      setSaveState("error");
+      setErrorMsg("Display name can't be empty.");
+      return;
+    }
+    if (trimmed === savedName.current) return;
     setSaveState("saving");
     setErrorMsg(null);
     const result = await authClient.updateUser({ name: trimmed });

--- a/ui/components/recipes/settings/account-panel.tsx
+++ b/ui/components/recipes/settings/account-panel.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Check, LoaderCircle } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/lib/auth-client";
+import { PanelHead } from "./panel-head";
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 border-b border-dashed border-[var(--line)] py-4 sm:flex-row sm:items-baseline sm:gap-4">
+      <div className="rt-body pt-1 text-[0.95rem] text-[var(--ink)] sm:w-36 sm:shrink-0">
+        {label}
+      </div>
+      <div className="min-w-0 flex-1">
+        {children}
+        {hint && <p className="rt-mono mt-1.5 text-[var(--ink-4)]">{hint}</p>}
+      </div>
+    </div>
+  );
+}
+
+export function AccountPanel({
+  user,
+}: {
+  user: { name: string; email: string; image?: string | null };
+}) {
+  const [name, setName] = useState(user.name);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const savedName = useRef(user.name);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  async function save(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === savedName.current) return;
+    setSaveState("saving");
+    setErrorMsg(null);
+    const result = await authClient.updateUser({ name: trimmed });
+    if (result.error) {
+      setSaveState("error");
+      setErrorMsg(result.error.message ?? "Couldn't save your changes.");
+      return;
+    }
+    savedName.current = trimmed;
+    setSaveState("saved");
+  }
+
+  function onNameChange(value: string) {
+    setName(value);
+    setSaveState("idle");
+    if (timer.current) clearTimeout(timer.current);
+    // Save a moment after typing stops.
+    timer.current = setTimeout(() => void save(value), 800);
+  }
+
+  return (
+    <div>
+      <PanelHead
+        kicker="ACCOUNT"
+        title="Who you are."
+        sub="Your name and photo as they appear across your recipes."
+      />
+
+      <div className="flex items-center gap-4 border-b border-dashed border-[var(--line)] py-4">
+        <RecipeAvatar
+          name={name}
+          email={user.email}
+          image={user.image}
+          size={64}
+        />
+        <p className="rt-mono text-[var(--ink-4)]">
+          Your photo comes from your linked Google or GitHub account.
+        </p>
+      </div>
+
+      <Field label="Display name">
+        <Input
+          value={name}
+          onChange={(event) => onNameChange(event.target.value)}
+          onBlur={() => void save(name)}
+          aria-label="Display name"
+          className="max-w-sm bg-[var(--card)]"
+        />
+      </Field>
+
+      <Field
+        label="Email"
+        hint="From your linked account — used to sign you in and find your recipes."
+      >
+        <span className="rt-mono text-[0.8125rem] normal-case tracking-normal text-[var(--ink)]">
+          {user.email}
+        </span>
+      </Field>
+
+      <div className="mt-4 flex items-center gap-2" aria-live="polite">
+        {saveState === "saving" ? (
+          <>
+            <LoaderCircle className="size-3.5 animate-spin text-[var(--ink-3)]" />
+            <span className="rt-mono text-[var(--ink-3)]">saving…</span>
+          </>
+        ) : saveState === "saved" ? (
+          <>
+            <Check className="size-3.5 text-[var(--sage)]" />
+            <span className="rt-mono text-[var(--sage)]">saved</span>
+          </>
+        ) : saveState === "error" ? (
+          <span role="alert" className="rt-mono text-[var(--destructive)]">
+            {errorMsg}
+          </span>
+        ) : (
+          <>
+            <span className="size-2 rounded-full bg-[var(--sage)]" />
+            <span className="rt-mono text-[var(--sage)]">
+              changes save automatically
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/components/recipes/settings/account-panel.tsx
+++ b/ui/components/recipes/settings/account-panel.tsx
@@ -9,6 +9,40 @@ import { PanelHead } from "./panel-head";
 
 type SaveState = "idle" | "saving" | "saved" | "error";
 
+function renderSaveStatus(state: SaveState, errorMsg: string | null) {
+  switch (state) {
+    case "saving":
+      return (
+        <>
+          <LoaderCircle className="size-3.5 animate-spin text-[var(--ink-3)]" />
+          <span className="rt-mono text-[var(--ink-3)]">saving…</span>
+        </>
+      );
+    case "saved":
+      return (
+        <>
+          <Check className="size-3.5 text-[var(--sage)]" />
+          <span className="rt-mono text-[var(--sage)]">saved</span>
+        </>
+      );
+    case "error":
+      return (
+        <span role="alert" className="rt-mono text-[var(--destructive)]">
+          {errorMsg}
+        </span>
+      );
+    default:
+      return (
+        <>
+          <span className="size-2 rounded-full bg-[var(--sage)]" />
+          <span className="rt-mono text-[var(--sage)]">
+            changes save automatically
+          </span>
+        </>
+      );
+  }
+}
+
 function Field({
   label,
   hint,
@@ -120,28 +154,7 @@ export function AccountPanel({
       </Field>
 
       <div className="mt-4 flex items-center gap-2" aria-live="polite">
-        {saveState === "saving" ? (
-          <>
-            <LoaderCircle className="size-3.5 animate-spin text-[var(--ink-3)]" />
-            <span className="rt-mono text-[var(--ink-3)]">saving…</span>
-          </>
-        ) : saveState === "saved" ? (
-          <>
-            <Check className="size-3.5 text-[var(--sage)]" />
-            <span className="rt-mono text-[var(--sage)]">saved</span>
-          </>
-        ) : saveState === "error" ? (
-          <span role="alert" className="rt-mono text-[var(--destructive)]">
-            {errorMsg}
-          </span>
-        ) : (
-          <>
-            <span className="size-2 rounded-full bg-[var(--sage)]" />
-            <span className="rt-mono text-[var(--sage)]">
-              changes save automatically
-            </span>
-          </>
-        )}
+        {renderSaveStatus(saveState, errorMsg)}
       </div>
     </div>
   );

--- a/ui/components/recipes/settings/panel-head.tsx
+++ b/ui/components/recipes/settings/panel-head.tsx
@@ -1,0 +1,21 @@
+export function PanelHead({
+  kicker,
+  title,
+  sub,
+}: {
+  kicker: string;
+  title: string;
+  sub?: string;
+}) {
+  return (
+    <div className="mb-6">
+      <p className="rt-mono text-[var(--terracotta)]">{kicker}</p>
+      <h2 className="rt-display mt-0.5 text-4xl">{title}</h2>
+      {sub && (
+        <p className="rt-body mt-1.5 max-w-xl text-[0.95rem] text-[var(--ink-2)]">
+          {sub}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/components/recipes/settings/security-panel.tsx
+++ b/ui/components/recipes/settings/security-panel.tsx
@@ -20,31 +20,32 @@ type DeviceSession = {
 
 const KNOWN_PROVIDER_IDS = new Set<string>(AUTH_PROVIDERS.map((p) => p.id));
 
+const BROWSER_MATCHERS: ReadonlyArray<[RegExp, string]> = [
+  [/Edg/, "Edge"],
+  [/Chrome|CriOS/, "Chrome"],
+  [/Firefox/, "Firefox"],
+  [/Safari/, "Safari"],
+];
+const OS_MATCHERS: ReadonlyArray<[RegExp, string]> = [
+  [/iPhone/, "iPhone"],
+  [/iPad/, "iPad"],
+  [/Android/, "Android"],
+  [/Mac OS X|Macintosh/, "Mac"],
+  [/Windows/, "Windows"],
+  [/Linux/, "Linux"],
+];
+
+function matchLabel(
+  ua: string,
+  matchers: ReadonlyArray<[RegExp, string]>,
+  fallback: string,
+): string {
+  return matchers.find(([pattern]) => pattern.test(ua))?.[1] ?? fallback;
+}
+
 function describeDevice(ua?: string | null): string {
   if (!ua) return "Unknown device";
-  const browser = /Edg/.test(ua)
-    ? "Edge"
-    : /Chrome|CriOS/.test(ua)
-      ? "Chrome"
-      : /Firefox/.test(ua)
-        ? "Firefox"
-        : /Safari/.test(ua)
-          ? "Safari"
-          : "Browser";
-  const os = /iPhone/.test(ua)
-    ? "iPhone"
-    : /iPad/.test(ua)
-      ? "iPad"
-      : /Android/.test(ua)
-        ? "Android"
-        : /Mac OS X|Macintosh/.test(ua)
-          ? "Mac"
-          : /Windows/.test(ua)
-            ? "Windows"
-            : /Linux/.test(ua)
-              ? "Linux"
-              : "device";
-  return `${browser} · ${os}`;
+  return `${matchLabel(ua, BROWSER_MATCHERS, "Browser")} · ${matchLabel(ua, OS_MATCHERS, "device")}`;
 }
 
 function isMobileUa(ua?: string | null): boolean {
@@ -132,16 +133,17 @@ export function SecurityPanel({
 
   // A failed link redirects back here with ?error=<code> appended.
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
+    const params = new URLSearchParams(globalThis.location.search);
     if (!params.has("error")) return;
     setError("Couldn't link that account. It may already be linked elsewhere.");
     params.delete("error");
     params.delete("error_description");
     const query = params.toString();
-    window.history.replaceState(
+    const search = query ? `?${query}` : "";
+    globalThis.history.replaceState(
       null,
       "",
-      `${window.location.pathname}${query ? `?${query}` : ""}`,
+      `${globalThis.location.pathname}${search}`,
     );
   }, []);
 

--- a/ui/components/recipes/settings/security-panel.tsx
+++ b/ui/components/recipes/settings/security-panel.tsx
@@ -151,9 +151,12 @@ export function SecurityPanel({
   const linkedKnown = (accounts ?? []).filter((account) =>
     KNOWN_PROVIDER_IDS.has(account.providerId),
   );
-  const unlinked = AUTH_PROVIDERS.filter(
-    (provider) => !linkedIds.has(provider.id),
-  );
+  // Only offer providers to link once we know what's already linked, otherwise
+  // everything looks unlinked while accounts are still loading.
+  const unlinked =
+    accounts === null
+      ? []
+      : AUTH_PROVIDERS.filter((provider) => !linkedIds.has(provider.id));
   const isOnlySignIn = (accounts?.length ?? 0) <= 1;
 
   async function linkProvider(provider: Provider) {
@@ -179,28 +182,38 @@ export function SecurityPanel({
   async function unlinkProvider(account: LinkedAccount) {
     setPending(`unlink:${account.providerId}`);
     setError(null);
-    const result = await authClient.unlinkAccount({
-      providerId: account.providerId,
-      accountId: account.accountId,
-    });
-    if (result.error) {
-      setError(result.error.message ?? "Couldn't unlink that account.");
-    } else {
-      await loadAccounts();
+    try {
+      const result = await authClient.unlinkAccount({
+        providerId: account.providerId,
+        accountId: account.accountId,
+      });
+      if (result.error) {
+        setError(result.error.message ?? "Couldn't unlink that account.");
+      } else {
+        await loadAccounts();
+      }
+    } catch {
+      setError("Couldn't unlink that account. Please try again.");
+    } finally {
+      setPending(null);
     }
-    setPending(null);
   }
 
   async function signOutSession(token: string) {
     setPending(`session:${token}`);
     setError(null);
-    const result = await authClient.revokeSession({ token });
-    if (result.error) {
-      setError(result.error.message ?? "Couldn't sign out that device.");
-    } else {
-      await loadSessions();
+    try {
+      const result = await authClient.revokeSession({ token });
+      if (result.error) {
+        setError(result.error.message ?? "Couldn't sign out that device.");
+      } else {
+        await loadSessions();
+      }
+    } catch {
+      setError("Couldn't sign out that device. Please try again.");
+    } finally {
+      setPending(null);
     }
-    setPending(null);
   }
 
   return (

--- a/ui/components/recipes/settings/security-panel.tsx
+++ b/ui/components/recipes/settings/security-panel.tsx
@@ -133,13 +133,8 @@ export function SecurityPanel({
   // A failed link redirects back here with ?error=<code> appended.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const code = params.get("error");
-    if (!code) return;
-    setError(
-      code === "email_doesn't_match"
-        ? "That account's email doesn't match, so it wasn't linked."
-        : "Couldn't link that account. Please try again.",
-    );
+    if (!params.has("error")) return;
+    setError("Couldn't link that account. It may already be linked elsewhere.");
     params.delete("error");
     params.delete("error_description");
     const query = params.toString();

--- a/ui/components/recipes/settings/security-panel.tsx
+++ b/ui/components/recipes/settings/security-panel.tsx
@@ -130,6 +130,26 @@ export function SecurityPanel({
     void loadSessions();
   }, []);
 
+  // A failed link redirects back here with ?error=<code> appended.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("error");
+    if (!code) return;
+    setError(
+      code === "email_doesn't_match"
+        ? "That account's email doesn't match, so it wasn't linked."
+        : "Couldn't link that account. Please try again.",
+    );
+    params.delete("error");
+    params.delete("error_description");
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${query ? `?${query}` : ""}`,
+    );
+  }, []);
+
   const linkedIds = new Set(accounts?.map((account) => account.providerId));
   const linkedKnown = (accounts ?? []).filter((account) =>
     KNOWN_PROVIDER_IDS.has(account.providerId),
@@ -146,6 +166,7 @@ export function SecurityPanel({
       const result = await authClient.linkSocial({
         provider,
         callbackURL: "/recipes/settings",
+        errorCallbackURL: "/recipes/settings",
       });
       if (result.error) {
         setError(result.error.message ?? "Couldn't start linking.");

--- a/ui/components/recipes/settings/security-panel.tsx
+++ b/ui/components/recipes/settings/security-panel.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { Check, LoaderCircle, Monitor, Plus, Smartphone } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  AUTH_PROVIDERS,
+  type Provider,
+  ProviderIcon,
+} from "@/components/recipes/auth-providers";
+import { Button } from "@/components/ui/button";
+import { authClient } from "@/lib/auth-client";
+import { PanelHead } from "./panel-head";
+
+type LinkedAccount = { providerId: string; accountId: string };
+type DeviceSession = {
+  token: string;
+  userAgent?: string | null;
+  updatedAt: Date;
+};
+
+const KNOWN_PROVIDER_IDS = new Set<string>(AUTH_PROVIDERS.map((p) => p.id));
+
+function describeDevice(ua?: string | null): string {
+  if (!ua) return "Unknown device";
+  const browser = /Edg/.test(ua)
+    ? "Edge"
+    : /Chrome|CriOS/.test(ua)
+      ? "Chrome"
+      : /Firefox/.test(ua)
+        ? "Firefox"
+        : /Safari/.test(ua)
+          ? "Safari"
+          : "Browser";
+  const os = /iPhone/.test(ua)
+    ? "iPhone"
+    : /iPad/.test(ua)
+      ? "iPad"
+      : /Android/.test(ua)
+        ? "Android"
+        : /Mac OS X|Macintosh/.test(ua)
+          ? "Mac"
+          : /Windows/.test(ua)
+            ? "Windows"
+            : /Linux/.test(ua)
+              ? "Linux"
+              : "device";
+  return `${browser} · ${os}`;
+}
+
+function isMobileUa(ua?: string | null): boolean {
+  return !!ua && /iPhone|iPad|Android/.test(ua);
+}
+
+function timeAgo(date: Date): string {
+  const diff = Date.now() - new Date(date).getTime();
+  const minutes = Math.round(diff / 60000);
+  if (minutes < 1) return "active now";
+  if (minutes < 60) return `active ${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `active ${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `active ${days}d ago`;
+}
+
+function SectionLabel({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={`rt-mono mb-2 text-[var(--terracotta)] ${className ?? ""}`}>
+      {children}
+    </p>
+  );
+}
+
+export function SecurityPanel({
+  currentSessionToken,
+}: {
+  currentSessionToken: string;
+}) {
+  const [accounts, setAccounts] = useState<LinkedAccount[] | null>(null);
+  const [accountsError, setAccountsError] = useState(false);
+  const [sessions, setSessions] = useState<DeviceSession[] | null>(null);
+  const [sessionsError, setSessionsError] = useState(false);
+  const [pending, setPending] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadAccounts() {
+    setAccountsError(false);
+    const result = await authClient.listAccounts();
+    if (result.error) {
+      setAccountsError(true);
+      return;
+    }
+    setAccounts(
+      (result.data ?? []).map((account) => ({
+        providerId: account.providerId,
+        accountId: account.accountId,
+      })),
+    );
+  }
+
+  async function loadSessions() {
+    setSessionsError(false);
+    const result = await authClient.listSessions();
+    if (result.error) {
+      setSessionsError(true);
+      return;
+    }
+    const rows = (result.data ?? []).map((session) => ({
+      token: session.token,
+      userAgent: session.userAgent,
+      updatedAt: session.updatedAt,
+    }));
+    // Current device first, then most-recently active.
+    rows.sort((a, b) => {
+      if (a.token === currentSessionToken) return -1;
+      if (b.token === currentSessionToken) return 1;
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    });
+    setSessions(rows);
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: load linked accounts + devices once on mount
+  useEffect(() => {
+    void loadAccounts();
+    void loadSessions();
+  }, []);
+
+  const linkedIds = new Set(accounts?.map((account) => account.providerId));
+  const linkedKnown = (accounts ?? []).filter((account) =>
+    KNOWN_PROVIDER_IDS.has(account.providerId),
+  );
+  const unlinked = AUTH_PROVIDERS.filter(
+    (provider) => !linkedIds.has(provider.id),
+  );
+  const isOnlySignIn = (accounts?.length ?? 0) <= 1;
+
+  async function linkProvider(provider: Provider) {
+    setPending(`link:${provider}`);
+    setError(null);
+    try {
+      const result = await authClient.linkSocial({
+        provider,
+        callbackURL: "/recipes/settings",
+      });
+      if (result.error) {
+        setError(result.error.message ?? "Couldn't start linking.");
+        setPending(null);
+      }
+      // On success the browser is redirected to the provider.
+    } catch {
+      setError("Couldn't start linking. Please try again.");
+      setPending(null);
+    }
+  }
+
+  async function unlinkProvider(account: LinkedAccount) {
+    setPending(`unlink:${account.providerId}`);
+    setError(null);
+    const result = await authClient.unlinkAccount({
+      providerId: account.providerId,
+      accountId: account.accountId,
+    });
+    if (result.error) {
+      setError(result.error.message ?? "Couldn't unlink that account.");
+    } else {
+      await loadAccounts();
+    }
+    setPending(null);
+  }
+
+  async function signOutSession(token: string) {
+    setPending(`session:${token}`);
+    setError(null);
+    const result = await authClient.revokeSession({ token });
+    if (result.error) {
+      setError(result.error.message ?? "Couldn't sign out that device.");
+    } else {
+      await loadSessions();
+    }
+    setPending(null);
+  }
+
+  return (
+    <div>
+      <PanelHead
+        kicker="SIGN-IN & SECURITY"
+        title="How you log in."
+        sub="You sign in with a linked account — there's no password to set or forget. Link both so you're never locked out."
+      />
+
+      <SectionLabel>Linked accounts</SectionLabel>
+      {accounts === null && !accountsError && (
+        <div className="flex items-center gap-2 py-2 text-[var(--ink-3)]">
+          <LoaderCircle className="size-4 animate-spin" />
+          <span className="rt-mono">Checking accounts…</span>
+        </div>
+      )}
+      {accountsError && (
+        <p className="rt-mono text-[var(--destructive)]">
+          Linked accounts couldn't be loaded.
+        </p>
+      )}
+      <div className="flex flex-col gap-2">
+        {linkedKnown.map((account) => {
+          const provider = AUTH_PROVIDERS.find(
+            (candidate) => candidate.id === account.providerId,
+          );
+          if (!provider) return null;
+          return (
+            <div
+              key={account.providerId}
+              className="flex items-center gap-3.5 rounded-xl border border-[var(--line-strong)] bg-[var(--card)] px-4 py-3"
+            >
+              <span className="flex size-9 items-center justify-center rounded-lg border border-[var(--line)] bg-[var(--paper-warm)]">
+                <ProviderIcon path={provider.iconPath} className="size-4" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="rt-body text-[0.95rem] text-[var(--ink)]">
+                  {provider.name}
+                </p>
+                <p className="rt-mono mt-0.5 flex items-center gap-1 text-[var(--sage)]">
+                  <Check className="size-3" />
+                  connected
+                </p>
+              </div>
+              {isOnlySignIn ? (
+                <span className="rt-mono text-right text-[var(--ink-4)]">
+                  can't unlink your only sign-in
+                </span>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-[var(--terracotta-deep)]"
+                  disabled={pending !== null}
+                  onClick={() => void unlinkProvider(account)}
+                >
+                  {pending === `unlink:${account.providerId}` ? (
+                    <LoaderCircle className="animate-spin" />
+                  ) : null}
+                  Unlink
+                </Button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {unlinked.length > 0 && (
+        <>
+          <p className="rt-mono mt-5 mb-2 text-[var(--ink-3)]">Link another</p>
+          <div className="flex flex-wrap gap-2">
+            {unlinked.map((provider) => (
+              <Button
+                key={provider.id}
+                variant="outline"
+                className="bg-[var(--card)]"
+                disabled={pending !== null}
+                onClick={() => void linkProvider(provider.id)}
+              >
+                {pending === `link:${provider.id}` ? (
+                  <LoaderCircle className="animate-spin" />
+                ) : (
+                  <Plus />
+                )}
+                <ProviderIcon path={provider.iconPath} className="size-4" />
+                {provider.name}
+              </Button>
+            ))}
+          </div>
+        </>
+      )}
+
+      <SectionLabel className="mt-8">Where you're signed in</SectionLabel>
+      {sessions === null && !sessionsError && (
+        <div className="flex items-center gap-2 py-2 text-[var(--ink-3)]">
+          <LoaderCircle className="size-4 animate-spin" />
+          <span className="rt-mono">Checking devices…</span>
+        </div>
+      )}
+      {sessionsError && (
+        <p className="rt-mono text-[var(--destructive)]">
+          Active devices couldn't be loaded.
+        </p>
+      )}
+      {sessions?.map((session) => {
+        const here = session.token === currentSessionToken;
+        const Icon = isMobileUa(session.userAgent) ? Smartphone : Monitor;
+        return (
+          <div
+            key={session.token}
+            className="flex items-center gap-3 border-b border-dashed border-[var(--line)] py-3"
+          >
+            <Icon className="size-4 text-[var(--ink-2)]" />
+            <div className="min-w-0 flex-1">
+              <p className="rt-body text-[0.95rem] text-[var(--ink)]">
+                {describeDevice(session.userAgent)}
+              </p>
+              <p className="rt-mono text-[var(--ink-3)]">
+                {here ? "this device" : timeAgo(session.updatedAt)}
+              </p>
+            </div>
+            {here ? (
+              <span className="rt-mono text-[var(--sage)]">● this device</span>
+            ) : (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-[var(--terracotta-deep)]"
+                disabled={pending !== null}
+                onClick={() => void signOutSession(session.token)}
+              >
+                {pending === `session:${session.token}` ? (
+                  <LoaderCircle className="animate-spin" />
+                ) : null}
+                Sign out
+              </Button>
+            )}
+          </div>
+        );
+      })}
+
+      {error && (
+        <p role="alert" className="rt-mono mt-4 text-[var(--destructive)]">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/components/recipes/settings/settings-view.tsx
+++ b/ui/components/recipes/settings/settings-view.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { KeyRound, LoaderCircle, Lock, User } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/generic/styles";
+import { AccountPanel } from "./account-panel";
+import { SecurityPanel } from "./security-panel";
+
+const SECTIONS = [
+  { id: "account", label: "Account", icon: User },
+  { id: "signin", label: "Sign-in & security", icon: KeyRound },
+] as const;
+type SectionId = (typeof SECTIONS)[number]["id"];
+
+export function SettingsView() {
+  const { data: session, isPending } = authClient.useSession();
+  const [section, setSection] = useState<SectionId>("account");
+
+  if (isPending) {
+    return (
+      <div className="container mx-auto flex max-w-5xl items-center justify-center px-4 py-24">
+        <LoaderCircle className="size-6 animate-spin text-[var(--ink-3)]" />
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="container mx-auto max-w-5xl px-4 py-16">
+        <div className="mx-auto max-w-md rounded-2xl border border-[var(--line-strong)] bg-[var(--card)] p-8 text-center">
+          <span className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full border border-[var(--line)] bg-[var(--paper-warm)]">
+            <Lock className="size-5 text-[var(--terracotta)]" />
+          </span>
+          <h1 className="rt-display text-3xl">Sign in to open settings.</h1>
+          <p className="rt-body mt-2 text-[var(--ink-2)]">
+            Use the account menu in the top-right to sign in with Google or
+            GitHub, then manage your account here.
+          </p>
+          <Button
+            asChild
+            className="mt-5 bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+          >
+            <Link href="/recipes">Back to recipes</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-5xl px-4 pt-5 pb-10 md:pt-7 md:pb-14">
+      <header className="mb-6">
+        <p className="rt-mono text-[var(--terracotta)]">Settings</p>
+        <h1 className="rt-display mt-1 text-5xl md:text-6xl">
+          Your kitchen, your way.
+        </h1>
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-[220px_1fr] md:gap-10">
+        <nav
+          aria-label="Settings sections"
+          className="flex gap-2 overflow-x-auto pb-1 md:flex-col md:gap-1 md:overflow-visible md:border-r md:border-[var(--line)] md:pr-4"
+        >
+          {SECTIONS.map(({ id, label, icon: Icon }) => {
+            const on = section === id;
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setSection(id)}
+                aria-current={on ? "page" : undefined}
+                className={cn(
+                  "rt-body flex items-center gap-2.5 whitespace-nowrap rounded-lg px-3 py-2 text-left text-[0.95rem] transition-colors",
+                  on
+                    ? "bg-[var(--ink)] font-semibold text-[var(--paper)]"
+                    : "text-[var(--ink-2)] hover:bg-[var(--paper-warm)]",
+                )}
+              >
+                <Icon className="size-4" />
+                {label}
+              </button>
+            );
+          })}
+        </nav>
+
+        <div className="min-w-0">
+          {section === "account" ? (
+            <AccountPanel user={session.user} />
+          ) : (
+            <SecurityPanel currentSessionToken={session.session.token} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/recipes/settings/settings-view.tsx
+++ b/ui/components/recipes/settings/settings-view.tsx
@@ -2,7 +2,7 @@
 
 import { KeyRound, LoaderCircle, Lock, User } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/generic/styles";
@@ -18,6 +18,14 @@ type SectionId = (typeof SECTIONS)[number]["id"];
 export function SettingsView() {
   const { data: session, isPending } = authClient.useSession();
   const [section, setSection] = useState<SectionId>("account");
+
+  // A failed account link redirects back with ?error=<code>; open on the panel
+  // that surfaces and clears it so the message isn't hidden behind a tab.
+  useEffect(() => {
+    if (new URLSearchParams(globalThis.location.search).has("error")) {
+      setSection("signin");
+    }
+  }, []);
 
   if (isPending) {
     return (

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -153,34 +153,23 @@ describe("AuthButton", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("shows the signed-in user and supports sign out", async () => {
+  it("opens an account menu linking to settings and supports sign out", async () => {
     const user = userEvent.setup();
     mocks.useSession.mockReturnValue({
       data: { user: { name: "Robbie", email: "robbie@example.com" } },
       isPending: false,
     });
-    mocks.listAccounts.mockResolvedValue({
-      data: [
-        {
-          providerId: "github",
-          accountId: "123456789",
-        },
-      ],
-      error: null,
-    });
     render(<AuthButton />);
 
-    expect(screen.getByText("Robbie")).toBeInTheDocument();
     await user.click(
       screen.getByRole("button", { name: "Account for Robbie" }),
     );
 
-    expect(await screen.findByText("Connected identities")).toBeInTheDocument();
-    expect(screen.getByText("GitHub")).toBeInTheDocument();
-    expect(
-      screen.getByText("Provider account ending 456789"),
-    ).toBeInTheDocument();
-    expect(mocks.listAccounts).toHaveBeenCalledOnce();
+    expect(screen.getByText("robbie@example.com")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /settings/i })).toHaveAttribute(
+      "href",
+      "/recipes/settings",
+    );
 
     await user.click(screen.getByRole("button", { name: "Sign out" }));
 

--- a/ui/tests/components/recipes/settings/settings-view.test.tsx
+++ b/ui/tests/components/recipes/settings/settings-view.test.tsx
@@ -37,6 +37,7 @@ const signedIn = {
 describe("SettingsView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.replaceState({}, "", "/recipes/settings");
     mocks.useSession.mockReturnValue(signedIn);
     mocks.updateUser.mockResolvedValue({ data: null, error: null });
     mocks.listAccounts.mockResolvedValue({
@@ -100,5 +101,24 @@ describe("SettingsView", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /github/i })).toBeInTheDocument();
     expect(screen.getByText("this device")).toBeInTheDocument();
+  });
+
+  it("surfaces a link error passed back in the URL", async () => {
+    const user = userEvent.setup();
+    window.history.replaceState(
+      {},
+      "",
+      "/recipes/settings?error=email_doesn't_match",
+    );
+    render(<SettingsView />);
+
+    await user.click(
+      screen.getByRole("button", { name: /sign-in & security/i }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /doesn't match/i,
+    );
+    expect(window.location.search).toBe("");
   });
 });

--- a/ui/tests/components/recipes/settings/settings-view.test.tsx
+++ b/ui/tests/components/recipes/settings/settings-view.test.tsx
@@ -115,8 +115,7 @@ describe("SettingsView", () => {
     expect(screen.getByText("this device")).toBeInTheDocument();
   });
 
-  it("surfaces a link error passed back in the URL", async () => {
-    const user = userEvent.setup();
+  it("opens on the security panel and surfaces a link error from the URL", async () => {
     window.history.replaceState(
       {},
       "",
@@ -124,13 +123,11 @@ describe("SettingsView", () => {
     );
     render(<SettingsView />);
 
-    await user.click(
-      screen.getByRole("button", { name: /sign-in & security/i }),
-    );
-
+    // Lands on Sign-in & security without a manual tab switch.
     expect(await screen.findByRole("alert")).toHaveTextContent(
       /couldn't link that account/i,
     );
+    expect(await screen.findByText("Google")).toBeInTheDocument();
     expect(window.location.search).toBe("");
   });
 });

--- a/ui/tests/components/recipes/settings/settings-view.test.tsx
+++ b/ui/tests/components/recipes/settings/settings-view.test.tsx
@@ -108,7 +108,7 @@ describe("SettingsView", () => {
     window.history.replaceState(
       {},
       "",
-      "/recipes/settings?error=email_doesn't_match",
+      "/recipes/settings?error=account_already_linked",
     );
     render(<SettingsView />);
 
@@ -117,7 +117,7 @@ describe("SettingsView", () => {
     );
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      /doesn't match/i,
+      /couldn't link that account/i,
     );
     expect(window.location.search).toBe("");
   });

--- a/ui/tests/components/recipes/settings/settings-view.test.tsx
+++ b/ui/tests/components/recipes/settings/settings-view.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  updateUser: vi.fn(),
+  listAccounts: vi.fn(),
+  listSessions: vi.fn(),
+  linkSocial: vi.fn(),
+  unlinkAccount: vi.fn(),
+  revokeSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: mocks.useSession,
+    updateUser: mocks.updateUser,
+    listAccounts: mocks.listAccounts,
+    listSessions: mocks.listSessions,
+    linkSocial: mocks.linkSocial,
+    unlinkAccount: mocks.unlinkAccount,
+    revokeSession: mocks.revokeSession,
+  },
+}));
+
+import { SettingsView } from "@/components/recipes/settings/settings-view";
+
+const signedIn = {
+  data: {
+    user: { name: "Robbie", email: "robbie@example.com", image: null },
+    session: { token: "current-token" },
+  },
+  isPending: false,
+};
+
+describe("SettingsView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useSession.mockReturnValue(signedIn);
+    mocks.updateUser.mockResolvedValue({ data: null, error: null });
+    mocks.listAccounts.mockResolvedValue({
+      data: [{ providerId: "google", accountId: "g1" }],
+      error: null,
+    });
+    mocks.listSessions.mockResolvedValue({
+      data: [
+        {
+          token: "current-token",
+          userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) Chrome/120",
+          updatedAt: new Date(),
+        },
+      ],
+      error: null,
+    });
+  });
+
+  it("prompts to sign in when there is no session", () => {
+    mocks.useSession.mockReturnValue({ data: null, isPending: false });
+    render(<SettingsView />);
+
+    expect(screen.getByText("Sign in to open settings.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to recipes/i }),
+    ).toHaveAttribute("href", "/recipes");
+  });
+
+  it("shows the account panel with name and email", () => {
+    render(<SettingsView />);
+
+    expect(screen.getByLabelText("Display name")).toHaveValue("Robbie");
+    expect(screen.getByText("robbie@example.com")).toBeInTheDocument();
+  });
+
+  it("saves a new display name after editing", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    const input = screen.getByLabelText("Display name");
+    await user.clear(input);
+    await user.type(input, "Rob");
+    await user.tab();
+
+    await waitFor(() =>
+      expect(mocks.updateUser).toHaveBeenCalledWith({ name: "Rob" }),
+    );
+  });
+
+  it("shows linked accounts and offers to link the other provider", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    await user.click(
+      screen.getByRole("button", { name: /sign-in & security/i }),
+    );
+
+    expect(await screen.findByText("Google")).toBeInTheDocument();
+    expect(
+      screen.getByText("can't unlink your only sign-in"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /github/i })).toBeInTheDocument();
+    expect(screen.getByText("this device")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/settings/settings-view.test.tsx
+++ b/ui/tests/components/recipes/settings/settings-view.test.tsx
@@ -87,6 +87,18 @@ describe("SettingsView", () => {
     );
   });
 
+  it("rejects an empty display name without saving", async () => {
+    const user = userEvent.setup();
+    render(<SettingsView />);
+
+    const input = screen.getByLabelText("Display name");
+    await user.clear(input);
+    await user.tab();
+
+    expect(await screen.findByText(/can't be empty/i)).toBeInTheDocument();
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
   it("shows linked accounts and offers to link the other provider", async () => {
     const user = userEvent.setup();
     render(<SettingsView />);

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -49,10 +49,16 @@ describe("agent markdown generation", () => {
   });
 
   it("generates a markdown twin for every recipe and technology page", () => {
+    // Interactive, noindex app pages that intentionally have no Markdown twin.
+    const nonContentPages = new Set(["recipes/settings.html"]);
     for (const section of ["recipes", "technologies"]) {
       const htmlPages = fs
         .readdirSync(path.join(OUT_DIR, section))
-        .filter((file) => file.endsWith(".html"));
+        .filter(
+          (file) =>
+            file.endsWith(".html") &&
+            !nonContentPages.has(`${section}/${file}`),
+        );
       expect(htmlPages.length).toBeGreaterThan(0);
       for (const htmlPage of htmlPages) {
         const mdPage = htmlPage.replace(/\.html$/, ".md");

--- a/ui/tests/integration/sitemap.test.ts
+++ b/ui/tests/integration/sitemap.test.ts
@@ -13,6 +13,10 @@ const SUBDOMAIN_PROJECTS = new Set(["assettracker"]);
 // are intentionally excluded from the sitemap.
 const STATIC_ASSET_SEGMENTS = new Set(["recipe-site-design"]);
 
+// Authenticated, noindex app pages (e.g. account settings) — served but kept
+// out of the sitemap on purpose.
+const NOINDEX_APP_PAGES = new Set(["recipes/settings"]);
+
 describe("Sitemap Integration Test", () => {
   it("should have a sitemap.xml that includes all generated pages", () => {
     if (!fs.existsSync(SITEMAP_PATH)) {
@@ -45,6 +49,9 @@ describe("Sitemap Integration Test", () => {
         return;
       }
       if (topLevelSegment && STATIC_ASSET_SEGMENTS.has(topLevelSegment)) {
+        return;
+      }
+      if (NOINDEX_APP_PAGES.has(fileNameWithoutExt)) {
         return;
       }
 

--- a/workers/recipe-api/src/auth.ts
+++ b/workers/recipe-api/src/auth.ts
@@ -103,6 +103,17 @@ export function createAuth(
           autoSignIn: false,
         },
         socialProviders,
+        account: {
+          accountLinking: {
+            enabled: true,
+            // Both verify email, so a matching-email sign-in can auto-attach
+            // to an existing account.
+            trustedProviders: ["google", "github"],
+            // Let a signed-in user link the other provider even when its email
+            // differs from the one already on the account.
+            allowDifferentEmails: true,
+          },
+        },
         session: { cookieCache: { enabled: false } },
         rateLimit: {
           enabled: true,

--- a/workers/recipe-api/src/auth.ts
+++ b/workers/recipe-api/src/auth.ts
@@ -106,11 +106,7 @@ export function createAuth(
         account: {
           accountLinking: {
             enabled: true,
-            // Both verify email, so a matching-email sign-in can auto-attach
-            // to an existing account.
             trustedProviders: ["google", "github"],
-            // Let a signed-in user link the other provider even when its email
-            // differs from the one already on the account.
             allowDifferentEmails: true,
           },
         },


### PR DESCRIPTION
Implements a subset of the settings page from the mid-fi designs and reworks the recipes navbar profile control to reach it. Inspired by, but not beholden to, the mid-fi designs.

## Navbar profile icon
The signed-in control is now the round avatar from the designs (provider photo when present, otherwise the initial on a butter disc). Clicking it opens an account menu with a name/email header, a **Settings** link, and Sign out. The connected-identities list that used to sit in this popover moved into the settings page.

## Settings page (`/recipes/settings`)
Inherits the recipe theme/layout. Two sections, per the requested scope:

- **Account** — avatar, editable display name (debounced auto-save via `updateUser`, with a save-status indicator), and email. Location and bio are intentionally omitted.
- **Sign-in & security** — Google/GitHub only: linked accounts with link/unlink (guarded so you can't remove your only sign-in), and a "Where you're signed in" list of active devices with per-device sign out.

Signed-out visitors get a prompt pointing them at the account menu. The page is `robots: noindex` and stays out of `llms.txt`.

## Account linking across different emails
Enabled `account.accountLinking` on the auth server (`workers/recipe-api/src/auth.ts`) with `allowDifferentEmails: true` and `trustedProviders: ["google", "github"]`, so a signed-in user can link the other provider even when its email differs, and a matching-email sign-in can auto-attach. The link flow now passes an `errorCallbackURL` and surfaces the `?error` code it redirects back with, instead of silently returning.

**Note:** this is a backend behavior change — it only takes effect once `recipe-api` is redeployed.

## Supporting changes
- Shared `RecipeAvatar` used by the navbar and settings.
- Provider metadata extracted to `auth-providers.tsx` so the navbar and settings share one source.

## Verification
- UI: typecheck, lint (changed files clean), `pnpm test` — 378 passed, production build generates `out/recipes/settings.html`
- Worker: typecheck, `pnpm test` — 76 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xi9sw4BYZja8cJo9hhzHHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi9sw4BYZja8cJo9hhzHHN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Settings page with separate Account and Sign-in & security sections.
  * Users can now update their display name with automatic saving.
  * Added options to manage linked sign-in methods and active device sessions.
  * The account menu now includes a Settings link and a clearer profile display.
* **Bug Fixes**
  * Improved handling of sign-in link errors and no-session states.
  * Settings-related pages are excluded from search engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->