### PR TITLE
Add first-pass shopping feature to recipe site

### DIFF
--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -3,6 +3,7 @@ import { Caveat, JetBrains_Mono, Kalam } from "next/font/google";
 import Link from "next/link";
 import { Suspense } from "react";
 import { AuthButton } from "@/components/recipes/auth-button";
+import { RecipeNavTabs } from "@/components/recipes/recipe-nav-tabs";
 import { RecipeSearch } from "@/components/recipes/recipe-search";
 import { RecipeSearchUrlSync } from "@/components/recipes/recipe-search-url-sync";
 import { RecipeThemeBody } from "@/components/recipes/recipe-theme-body";
@@ -71,13 +72,7 @@ export default function RecipesLayout({
               >
                 Robbie's <span className="rt-logo-accent">recipes</span>
               </Link>
-              <Link
-                href="/recipes"
-                className="rt-tab text-[0.95rem]"
-                data-active="true"
-              >
-                Recipes
-              </Link>
+              <RecipeNavTabs />
             </div>
             <div className="order-2 ms-auto md:order-3 md:ms-0">
               <AuthButton />

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -65,12 +65,16 @@ export default function RecipesLayout({
               on mobile the search drops to a full-width second row so it isn't
               squeezed against the logo. */}
           <nav className="container mx-auto px-4 py-3 max-w-7xl flex flex-wrap items-center gap-x-6 gap-y-3">
-            <div className="order-1 flex items-baseline gap-4">
+            <div className="order-1 flex items-center gap-4">
               <Link
                 href="/recipes"
                 className="shrink-0 rt-display text-3xl leading-none text-foreground"
               >
-                Robbie's <span className="rt-logo-accent">recipes</span>
+                {/* Stack onto two lines on mobile so the logo doesn't eat half
+                    the row and crowd out the tabs + auth button; one line from
+                    sm up where there's room. */}
+                <span className="block sm:inline">Robbie's</span>{" "}
+                <span className="rt-logo-accent">recipes</span>
               </Link>
               <RecipeNavTabs />
             </div>

--- a/ui/app/recipes/shopping/page.tsx
+++ b/ui/app/recipes/shopping/page.tsx
@@ -6,6 +6,10 @@ export const metadata: Metadata = {
   title: "Shopping List",
   description:
     "Pick the recipes you want to cook and build a combined shopping list, grouped by aisle, by recipe, or as one ingredient list.",
+  // Interactive tool whose content lives in the browser (localStorage); there's
+  // nothing meaningful to index, so keep it out of search like the other app
+  // pages (settings).
+  robots: { index: false, follow: false },
 };
 
 export default function ShoppingPage() {

--- a/ui/app/recipes/shopping/page.tsx
+++ b/ui/app/recipes/shopping/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+import { ShoppingView } from "@/components/recipes/shopping/shopping-view";
+import { getShoppingRecipes } from "@/lib/api/shopping";
+
+export const metadata: Metadata = {
+  title: "Shopping List",
+  description:
+    "Pick the recipes you want to cook and build a combined shopping list, grouped by aisle, by recipe, or as one ingredient list.",
+};
+
+export default function ShoppingPage() {
+  const recipes = getShoppingRecipes();
+  return <ShoppingView recipes={recipes} />;
+}

--- a/ui/components/recipes/recipe-nav-tabs.tsx
+++ b/ui/components/recipes/recipe-nav-tabs.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useSelectedRecipeCount } from "@/hooks/use-shopping-list";
+
+export function RecipeNavTabs() {
+  const pathname = usePathname();
+  const count = useSelectedRecipeCount();
+
+  const onShopping = pathname === "/recipes/shopping";
+  const onSettings = pathname?.startsWith("/recipes/settings") ?? false;
+  // Recipes covers the index and individual recipe pages, but not the shopping
+  // or settings sections.
+  const onRecipes = !onShopping && !onSettings;
+
+  return (
+    <div className="flex items-baseline gap-4">
+      <Link
+        href="/recipes"
+        className="rt-tab text-[0.95rem]"
+        data-active={onRecipes || undefined}
+      >
+        Recipes
+      </Link>
+      <Link
+        href="/recipes/shopping"
+        className="rt-tab text-[0.95rem] inline-flex items-center gap-1.5"
+        data-active={onShopping || undefined}
+      >
+        Shopping
+        {count > 0 && (
+          <span
+            role="img"
+            aria-label={`${count} ${count === 1 ? "recipe" : "recipes"} selected`}
+            className="inline-flex items-center justify-center min-w-[1.15rem] h-[1.15rem] px-1 rounded-full bg-[var(--terracotta)] text-white text-[0.65rem] font-semibold leading-none"
+          >
+            {count}
+          </span>
+        )}
+      </Link>
+    </div>
+  );
+}

--- a/ui/components/recipes/shopping/recipe-picker.tsx
+++ b/ui/components/recipes/shopping/recipe-picker.tsx
@@ -148,20 +148,29 @@ export function RecipePicker({ recipes }: { recipes: ShoppingRecipe[] }) {
     return map;
   }, [selectedEntries]);
 
+  // Pre-compute each recipe's lowercase search string once (not per keystroke).
+  const searchIndex = useMemo(
+    () =>
+      recipes.map((recipe) => ({
+        recipe,
+        haystack: [
+          recipe.title,
+          recipe.cuisine.join(" "),
+          recipe.ingredients.map((i) => i.name).join(" "),
+        ]
+          .join(" ")
+          .toLowerCase(),
+      })),
+    [recipes],
+  );
+
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return recipes;
-    return recipes.filter((recipe) => {
-      const haystack = [
-        recipe.title,
-        recipe.cuisine.join(" "),
-        recipe.ingredients.map((i) => i.name).join(" "),
-      ]
-        .join(" ")
-        .toLowerCase();
-      return haystack.includes(q);
-    });
-  }, [recipes, query]);
+    return searchIndex
+      .filter((entry) => entry.haystack.includes(q))
+      .map((entry) => entry.recipe);
+  }, [recipes, searchIndex, query]);
 
   // Selected recipes float to the top so the current basket is always in view.
   const ordered = useMemo(() => {

--- a/ui/components/recipes/shopping/recipe-picker.tsx
+++ b/ui/components/recipes/shopping/recipe-picker.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { Minus, Plus, Search, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { ShoppingCheckbox } from "@/components/recipes/shopping/shopping-checkbox";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useShoppingList } from "@/hooks/use-shopping-list";
+import type { ShoppingRecipe } from "@/lib/api/shopping";
+import { getImageUrl } from "@/lib/integrations/cloudflare-images";
+import {
+  removeRecipe,
+  setRecipeServings,
+  toggleRecipe,
+} from "@/lib/shopping/shoppingListStore";
+
+function formatTime(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+function ServingsStepper({
+  slug,
+  servings,
+}: {
+  slug: string;
+  servings: number;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Button
+        variant="outline"
+        size="icon-sm"
+        onClick={() => setRecipeServings(slug, servings - 1)}
+        disabled={servings <= 1}
+        aria-label="Decrease servings"
+      >
+        <Minus className="h-3 w-3" />
+      </Button>
+      <span className="tabular-nums text-center min-w-[4.5rem]">
+        <span className="rt-display text-xl text-[var(--terracotta)] align-middle">
+          {servings}
+        </span>{" "}
+        <span className="align-middle text-xs text-[var(--ink-3)]">
+          {servings === 1 ? "serving" : "servings"}
+        </span>
+      </span>
+      <Button
+        variant="outline"
+        size="icon-sm"
+        onClick={() => setRecipeServings(slug, servings + 1)}
+        aria-label="Increase servings"
+      >
+        <Plus className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}
+
+function PickerCard({
+  recipe,
+  selected,
+  servings,
+}: {
+  recipe: ShoppingRecipe;
+  selected: boolean;
+  servings: number;
+}) {
+  return (
+    <div
+      className={[
+        "rounded-xl border-[1.25px] bg-[var(--card)] overflow-hidden transition-all",
+        "flex flex-col hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]",
+        selected
+          ? "border-[var(--terracotta)] ring-1 ring-[var(--terracotta)]"
+          : "border-[var(--line-strong)]",
+      ].join(" ")}
+    >
+      {/* The toggle is its own button so the servings stepper (which contains
+          buttons of its own) can live alongside it without nesting buttons. */}
+      <button
+        type="button"
+        aria-pressed={selected}
+        onClick={() => toggleRecipe(recipe.slug)}
+        className="flex gap-3 p-3 text-left w-full cursor-pointer"
+      >
+        {recipe.image ? (
+          // biome-ignore lint/performance/noImgElement: native img for SSG srcset control
+          <img
+            src={getImageUrl(recipe.image, null, {
+              width: 160,
+              format: "auto",
+            })}
+            alt={recipe.imageAlt || recipe.title}
+            width={64}
+            height={64}
+            loading="lazy"
+            className="h-16 w-16 rounded-lg object-cover flex-shrink-0 bg-muted"
+          />
+        ) : (
+          <div className="h-16 w-16 rounded-lg flex-shrink-0 bg-[var(--paper-warm)]" />
+        )}
+        <span className="flex-1 min-w-0 block">
+          <span className="flex items-start gap-2">
+            <ShoppingCheckbox checked={selected} className="mt-1" />
+            <span className="rt-display text-xl leading-tight flex-1 block">
+              {recipe.title}
+            </span>
+          </span>
+          <span className="rt-mono text-[var(--ink-3)] mt-1 truncate block">
+            {[
+              recipe.cuisine.join(" · ").toLowerCase(),
+              recipe.totalTime != null ? formatTime(recipe.totalTime) : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </span>
+        </span>
+      </button>
+      {selected && (
+        <div className="border-t border-[var(--line)] px-3 py-2 flex items-center justify-between gap-2 bg-[var(--paper-warm)]/50">
+          <ServingsStepper slug={recipe.slug} servings={servings} />
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              removeRecipe(recipe.slug);
+            }}
+            className="rt-mono text-[var(--ink-3)] hover:text-[var(--berry)] inline-flex items-center gap-1 transition-colors"
+          >
+            <X className="h-3 w-3" /> remove
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function RecipePicker({ recipes }: { recipes: ShoppingRecipe[] }) {
+  const { recipes: selectedEntries } = useShoppingList();
+  const [query, setQuery] = useState("");
+
+  const servingsBySlug = useMemo(() => {
+    const map = new Map<string, number | undefined>();
+    for (const entry of selectedEntries) map.set(entry.slug, entry.servings);
+    return map;
+  }, [selectedEntries]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return recipes;
+    return recipes.filter((recipe) => {
+      const haystack = [
+        recipe.title,
+        recipe.cuisine.join(" "),
+        recipe.ingredients.map((i) => i.name).join(" "),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [recipes, query]);
+
+  // Selected recipes float to the top so the current basket is always in view.
+  const ordered = useMemo(() => {
+    const isSelected = (slug: string) => servingsBySlug.has(slug);
+    return [...filtered].sort((a, b) => {
+      const sa = isSelected(a.slug) ? 0 : 1;
+      const sb = isSelected(b.slug) ? 0 : 1;
+      return sa - sb;
+    });
+  }, [filtered, servingsBySlug]);
+
+  return (
+    <div>
+      <div className="relative mb-4 max-w-md">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[var(--ink-3)] pointer-events-none" />
+        <Input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={`Search ${recipes.length} recipes…`}
+          aria-label="Search recipes to add"
+          className="pl-9 bg-[var(--card)]"
+        />
+      </div>
+
+      {ordered.length === 0 ? (
+        <p className="rt-body text-[var(--ink-3)] py-8 text-center">
+          No recipes match “{query}”.
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+          {ordered.map((recipe) => {
+            const stored = servingsBySlug.get(recipe.slug);
+            const selected = servingsBySlug.has(recipe.slug);
+            return (
+              <PickerCard
+                key={recipe.slug}
+                recipe={recipe}
+                selected={selected}
+                servings={stored ?? recipe.servings}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/components/recipes/shopping/shopping-checkbox.tsx
+++ b/ui/components/recipes/shopping/shopping-checkbox.tsx
@@ -1,0 +1,29 @@
+import { Check } from "lucide-react";
+
+/**
+ * The tick-box visual shared by every checkable row in the shopping list.
+ * Presentational only (aria-hidden); the interactive element is the parent
+ * button/label that owns the checked state.
+ */
+export function ShoppingCheckbox({
+  checked,
+  className,
+}: {
+  checked: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={[
+        "h-4 w-4 rounded-[3px] flex-shrink-0 border-2 flex items-center justify-center transition-colors",
+        checked
+          ? "bg-[var(--terracotta)] border-[var(--terracotta)]"
+          : "border-[var(--line-strong)] hover:border-[var(--terracotta)]",
+        className ?? "",
+      ].join(" ")}
+    >
+      {checked && <Check className="h-2.5 w-2.5 text-white" strokeWidth={3} />}
+    </span>
+  );
+}

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -213,16 +213,20 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
       .map(([id, lines]) => ({
         id,
         name: aisleName(id),
-        lines: lines.sort(byName),
+        lines: [...lines].sort(byName),
       }));
   }, [aggregated]);
 
   const recipeGroups = useMemo(() => {
-    return selected.map(({ recipe, scale }) => ({
-      recipe,
-      servings: Math.round(recipe.servings * scale),
-      lines: aggregateShoppingList([{ recipe, scale }]).sort(byName),
-    }));
+    return selected.map(({ recipe, scale }) => {
+      const lines = aggregateShoppingList([{ recipe, scale }]);
+      lines.sort(byName);
+      return {
+        recipe,
+        servings: Math.round(recipe.servings * scale),
+        lines,
+      };
+    });
   }, [selected]);
 
   const tickedCount =

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { Plus, RotateCcw, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { ShoppingCheckbox } from "@/components/recipes/shopping/shopping-checkbox";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { useShoppingList } from "@/hooks/use-shopping-list";
+import { useUnitPreference } from "@/hooks/use-unit-preference";
+import type { ShoppingRecipe } from "@/lib/api/shopping";
+import type { MeasurementSystem } from "@/lib/domain/recipe";
+import {
+  aggregateShoppingList,
+  type SelectedRecipe,
+  type ShoppingLine,
+} from "@/lib/domain/shopping/aggregate";
+import { aisleName, compareAisles } from "@/lib/domain/shopping/aisles";
+import {
+  formatShoppingName,
+  formatShoppingQuantities,
+} from "@/lib/domain/shopping/display";
+import {
+  addExtra,
+  clearChecked,
+  removeExtra,
+  toggleChecked,
+  toggleExtra,
+} from "@/lib/shopping/shoppingListStore";
+
+type ListView = "aisle" | "recipe" | "flat";
+
+const VIEWS: { id: ListView; label: string }[] = [
+  { id: "aisle", label: "by aisle" },
+  { id: "recipe", label: "by recipe" },
+  { id: "flat", label: "just ingredients" },
+];
+
+function byName(a: ShoppingLine, b: ShoppingLine): number {
+  return a.name.localeCompare(b.name);
+}
+
+function ItemRow({
+  line,
+  system,
+  checked,
+  showRecipes,
+}: {
+  line: ShoppingLine;
+  system: MeasurementSystem;
+  checked: boolean;
+  showRecipes: boolean;
+}) {
+  const quantity = formatShoppingQuantities(line.quantities, system);
+  const name = formatShoppingName(line);
+  const merged = line.recipes.length > 1;
+  return (
+    <button
+      type="button"
+      onClick={() => toggleChecked(line.ingredient)}
+      className="w-full flex items-center gap-2.5 py-1.5 text-left border-b border-dashed border-[var(--line)] last:border-0"
+    >
+      <ShoppingCheckbox checked={checked} />
+      <span
+        className={[
+          "rt-body flex-1 leading-snug",
+          checked ? "line-through text-[var(--ink-3)]" : "text-[var(--ink)]",
+        ].join(" ")}
+      >
+        {quantity && <b className="font-semibold">{quantity}</b>}
+        {quantity ? " " : ""}
+        {name}
+        {merged && (
+          <span
+            className="ml-1.5 align-middle inline-flex items-center rounded border border-[var(--butter)] bg-[var(--butter-soft)] px-1 text-[0.625rem] text-[var(--ink-2)]"
+            title={`Combined from ${line.recipes.length} recipes`}
+          >
+            ↻
+          </span>
+        )}
+      </span>
+      {showRecipes && (
+        <span className="rt-mono text-[var(--ink-4)] hidden sm:block max-w-[45%] truncate text-right">
+          {line.recipes.map((r) => r.title).join(" · ")}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function SectionHeading({ title, hint }: { title: string; hint?: string }) {
+  return (
+    <div className="flex items-baseline justify-between border-b border-[var(--line)] pb-1 mt-5 first:mt-0">
+      <h3 className="rt-display text-2xl text-[var(--terracotta)]">
+        · {title}
+      </h3>
+      {hint && <span className="rt-mono text-[var(--ink-3)]">{hint}</span>}
+    </div>
+  );
+}
+
+function ExtrasSection({
+  extras,
+}: {
+  extras: { id: string; text: string; checked: boolean }[];
+}) {
+  const [text, setText] = useState("");
+  const submit = () => {
+    addExtra(text);
+    setText("");
+  };
+  return (
+    <div className="mt-6">
+      <SectionHeading title="extras" />
+      {extras.length > 0 && (
+        <div className="mt-1">
+          {extras.map((extra) => (
+            <div
+              key={extra.id}
+              className="flex items-center gap-2.5 py-1.5 border-b border-dashed border-[var(--line)] last:border-0"
+            >
+              <button
+                type="button"
+                onClick={() => toggleExtra(extra.id)}
+                className="flex items-center gap-2.5 flex-1 text-left"
+              >
+                <ShoppingCheckbox checked={extra.checked} />
+                <span
+                  className={[
+                    "rt-body leading-snug",
+                    extra.checked
+                      ? "line-through text-[var(--ink-3)]"
+                      : "text-[var(--ink)]",
+                  ].join(" ")}
+                >
+                  {extra.text}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => removeExtra(extra.id)}
+                aria-label={`Remove ${extra.text}`}
+                className="text-[var(--ink-4)] hover:text-[var(--berry)] transition-colors"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit();
+        }}
+        className="mt-3 flex gap-2 max-w-sm"
+      >
+        <Input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Add an extra (milk, bread…)"
+          aria-label="Add an extra item"
+          className="bg-[var(--card)]"
+        />
+        <button
+          type="submit"
+          disabled={!text.trim()}
+          className="inline-flex items-center gap-1 rounded-md border border-[var(--line-strong)] px-3 text-sm text-[var(--ink-2)] hover:border-[var(--terracotta)] hover:text-[var(--terracotta)] disabled:opacity-40 transition-colors"
+        >
+          <Plus className="h-4 w-4" /> Add
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
+  const state = useShoppingList();
+  const [system] = useUnitPreference();
+  const [view, setView] = useState<ListView>("aisle");
+
+  const bySlug = useMemo(() => {
+    const map = new Map<string, ShoppingRecipe>();
+    for (const recipe of recipes) map.set(recipe.slug, recipe);
+    return map;
+  }, [recipes]);
+
+  const selected = useMemo<SelectedRecipe[]>(() => {
+    return state.recipes.flatMap((entry) => {
+      const recipe = bySlug.get(entry.slug);
+      if (!recipe) return [];
+      const servings = entry.servings ?? recipe.servings;
+      return [{ recipe, scale: servings / recipe.servings }];
+    });
+  }, [state.recipes, bySlug]);
+
+  const aggregated = useMemo(() => aggregateShoppingList(selected), [selected]);
+
+  const checkedSet = useMemo(() => new Set(state.checked), [state.checked]);
+
+  const flatLines = useMemo(() => [...aggregated].sort(byName), [aggregated]);
+
+  const aisleGroups = useMemo(() => {
+    const groups = new Map<string, ShoppingLine[]>();
+    for (const line of aggregated) {
+      const list = groups.get(line.aisle) ?? [];
+      list.push(line);
+      groups.set(line.aisle, list);
+    }
+    return [...groups.entries()]
+      .sort(([a], [b]) => compareAisles(a, b))
+      .map(([id, lines]) => ({
+        id,
+        name: aisleName(id),
+        lines: lines.sort(byName),
+      }));
+  }, [aggregated]);
+
+  const recipeGroups = useMemo(() => {
+    return selected.map(({ recipe, scale }) => ({
+      recipe,
+      servings: Math.round(recipe.servings * scale),
+      lines: aggregateShoppingList([{ recipe, scale }]).sort(byName),
+    }));
+  }, [selected]);
+
+  const tickedCount =
+    aggregated.filter((l) => checkedSet.has(l.ingredient)).length +
+    state.extras.filter((e) => e.checked).length;
+  const itemCount = aggregated.length + state.extras.length;
+  const hasTicked = tickedCount > 0;
+
+  if (selected.length === 0) {
+    return (
+      <div className="rounded-xl border-[1.25px] border-dashed border-[var(--line-strong)] bg-[var(--card)] p-10 text-center">
+        <p className="rt-display text-3xl text-[var(--ink-2)]">
+          Nothing on the list yet
+        </p>
+        <p className="rt-body text-[var(--ink-3)] mt-2">
+          Pick some recipes above and their ingredients will gather here,
+          combined and sorted for the shop.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border-[1.25px] border-[var(--line-strong)] bg-[var(--card)] p-4 sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="rt-mono text-[var(--ink-3)]">
+          {selected.length} {selected.length === 1 ? "recipe" : "recipes"} ·{" "}
+          {itemCount} {itemCount === 1 ? "item" : "items"} · {tickedCount}{" "}
+          ticked
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {VIEWS.map((v) => (
+            <Badge
+              key={v.id}
+              variant={view === v.id ? "default" : "secondary"}
+              interactive
+              active={view === v.id}
+              className="cursor-pointer"
+              onClick={() => setView(v.id)}
+            >
+              {v.label}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      {hasTicked && (
+        <button
+          type="button"
+          onClick={clearChecked}
+          className="mt-2 inline-flex items-center gap-1 rt-mono text-[var(--ink-3)] hover:text-[var(--terracotta)] transition-colors"
+        >
+          <RotateCcw className="h-3 w-3" /> uncheck all
+        </button>
+      )}
+
+      <div className="mt-3">
+        {view === "flat" && (
+          <div>
+            <div className="rt-mono text-[var(--ink-3)] mb-1">
+              Just ingredients · A–Z
+            </div>
+            {flatLines.map((line) => (
+              <ItemRow
+                key={line.ingredient}
+                line={line}
+                system={system}
+                checked={checkedSet.has(line.ingredient)}
+                showRecipes
+              />
+            ))}
+          </div>
+        )}
+
+        {view === "aisle" &&
+          aisleGroups.map((group) => (
+            <div key={group.id}>
+              <SectionHeading title={group.name} />
+              <div className="mt-1">
+                {group.lines.map((line) => (
+                  <ItemRow
+                    key={line.ingredient}
+                    line={line}
+                    system={system}
+                    checked={checkedSet.has(line.ingredient)}
+                    showRecipes
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+
+        {view === "recipe" &&
+          recipeGroups.map((group) => (
+            <div key={group.recipe.slug}>
+              <SectionHeading
+                title={group.recipe.title}
+                hint={`${group.servings} ${group.servings === 1 ? "serving" : "servings"}`}
+              />
+              <div className="mt-1">
+                {group.lines.map((line) => (
+                  <ItemRow
+                    key={line.ingredient}
+                    line={line}
+                    system={system}
+                    checked={checkedSet.has(line.ingredient)}
+                    showRecipes={false}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+      </div>
+
+      <ExtrasSection extras={state.extras} />
+    </div>
+  );
+}

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -39,6 +39,20 @@ function byName(a: ShoppingLine, b: ShoppingLine): number {
   return a.name.localeCompare(b.name);
 }
 
+/**
+ * Sink ticked-off items to the bottom of a list (keeping each partition's
+ * existing order), like a notes app — so attention stays on what's still to
+ * buy. Unticking returns an item to its sorted place.
+ */
+function checkedLast(
+  lines: ShoppingLine[],
+  checkedSet: Set<string>,
+): ShoppingLine[] {
+  const todo = lines.filter((line) => !checkedSet.has(line.ingredient));
+  const done = lines.filter((line) => checkedSet.has(line.ingredient));
+  return [...todo, ...done];
+}
+
 function ItemRow({
   line,
   system,
@@ -109,12 +123,17 @@ function ExtrasSection({
     addExtra(text);
     setText("");
   };
+  // Ticked extras sink to the bottom too, matching the ingredient rows.
+  const ordered = [
+    ...extras.filter((e) => !e.checked),
+    ...extras.filter((e) => e.checked),
+  ];
   return (
     <div className="mt-6">
       <SectionHeading title="extras" />
       {extras.length > 0 && (
         <div className="mt-1">
-          {extras.map((extra) => (
+          {ordered.map((extra) => (
             <div
               key={extra.id}
               className="flex items-center gap-2.5 py-1.5 border-b border-dashed border-[var(--line)] last:border-0"
@@ -289,7 +308,7 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
             <div className="rt-mono text-[var(--ink-3)] mb-1">
               Just ingredients · A–Z
             </div>
-            {flatLines.map((line) => (
+            {checkedLast(flatLines, checkedSet).map((line) => (
               <ItemRow
                 key={line.ingredient}
                 line={line}
@@ -306,7 +325,7 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
             <div key={group.id}>
               <SectionHeading title={group.name} />
               <div className="mt-1">
-                {group.lines.map((line) => (
+                {checkedLast(group.lines, checkedSet).map((line) => (
                   <ItemRow
                     key={line.ingredient}
                     line={line}
@@ -327,7 +346,7 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
                 hint={`${group.servings} ${group.servings === 1 ? "serving" : "servings"}`}
               />
               <div className="mt-1">
-                {group.lines.map((line) => (
+                {checkedLast(group.lines, checkedSet).map((line) => (
                   <ItemRow
                     key={line.ingredient}
                     line={line}

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -56,6 +56,7 @@ function ItemRow({
   return (
     <button
       type="button"
+      aria-pressed={checked}
       onClick={() => toggleChecked(line.ingredient)}
       className="w-full flex items-center gap-2.5 py-1.5 text-left border-b border-dashed border-[var(--line)] last:border-0"
     >
@@ -120,6 +121,7 @@ function ExtrasSection({
             >
               <button
                 type="button"
+                aria-pressed={extra.checked}
                 onClick={() => toggleExtra(extra.id)}
                 className="flex items-center gap-2.5 flex-1 text-left"
               >

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { ArrowLeft, ArrowRight, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { RecipePicker } from "@/components/recipes/shopping/recipe-picker";
+import { ShoppingList } from "@/components/recipes/shopping/shopping-list";
+import { useShoppingList } from "@/hooks/use-shopping-list";
+import type { ShoppingRecipe } from "@/lib/api/shopping";
+import { clearList } from "@/lib/shopping/shoppingListStore";
+
+type Step = "pick" | "list";
+
+const STEPS: { id: Step; label: string }[] = [
+  { id: "pick", label: "1 · Pick recipes" },
+  { id: "list", label: "2 · Shopping list" },
+];
+
+export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
+  const { recipes: selected } = useShoppingList();
+  const [step, setStep] = useState<Step>("pick");
+  const count = selected.length;
+
+  return (
+    <div className="container mx-auto px-4 pt-5 pb-16 md:pt-7 max-w-5xl">
+      <div className="flex flex-wrap items-end justify-between gap-4 mb-4">
+        <div>
+          <p className="rt-mono text-[var(--terracotta)]">Shopping</p>
+          <h1 className="rt-display text-5xl md:text-6xl mt-2">
+            {step === "pick" ? "What are you cooking?" : "Shopping list."}
+          </h1>
+          <p className="rt-body mt-2 text-[var(--ink-2)]">
+            {count === 0
+              ? "Choose the recipes you want to cook and we'll build the list."
+              : `${count} ${count === 1 ? "recipe" : "recipes"} selected.`}
+          </p>
+        </div>
+        {count > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              clearList();
+              setStep("pick");
+            }}
+            className="inline-flex items-center gap-1.5 rt-mono text-[var(--ink-3)] hover:text-[var(--berry)] transition-colors"
+          >
+            <Trash2 className="h-3.5 w-3.5" /> clear list
+          </button>
+        )}
+      </div>
+
+      {/* Step tabs — mirror the recipe read-view tabs so the two feel of a piece. */}
+      <div className="flex items-center border-b border-[var(--line)] mb-6">
+        {STEPS.map((s) => {
+          const active = step === s.id;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => setStep(s.id)}
+              className={[
+                "px-3.5 py-2.5 rt-body text-[0.95rem] -mb-px border-b-2 transition-colors",
+                active
+                  ? "border-[var(--terracotta)] text-[var(--ink)] font-bold"
+                  : "border-transparent text-[var(--ink-3)] hover:text-[var(--ink-2)]",
+              ].join(" ")}
+              aria-current={active ? "step" : undefined}
+            >
+              {s.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {step === "pick" ? (
+        <div>
+          <RecipePicker recipes={recipes} />
+          <div className="mt-6 flex justify-end">
+            <button
+              type="button"
+              onClick={() => setStep("list")}
+              disabled={count === 0}
+              className="inline-flex items-center gap-2 rounded-md bg-[var(--terracotta)] px-4 py-2 text-white font-medium hover:bg-[var(--terracotta-deep)] disabled:opacity-40 disabled:hover:bg-[var(--terracotta)] transition-colors"
+            >
+              View shopping list
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <button
+            type="button"
+            onClick={() => setStep("pick")}
+            className="inline-flex items-center gap-1.5 rt-mono text-[var(--ink-3)] hover:text-[var(--terracotta)] mb-3 transition-colors"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" /> back to recipes
+          </button>
+          <ShoppingList recipes={recipes} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -19,6 +19,7 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
   const { recipes: selected } = useShoppingList();
   const [step, setStep] = useState<Step>("pick");
   const count = selected.length;
+  const recipeNoun = count === 1 ? "recipe" : "recipes";
 
   return (
     <div className="container mx-auto px-4 pt-5 pb-16 md:pt-7 max-w-5xl">
@@ -31,7 +32,7 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
           <p className="rt-body mt-2 text-[var(--ink-2)]">
             {count === 0
               ? "Choose the recipes you want to cook and we'll build the list."
-              : `${count} ${count === 1 ? "recipe" : "recipes"} selected.`}
+              : `${count} ${recipeNoun} selected.`}
           </p>
         </div>
         {count > 0 && (

--- a/ui/hooks/use-shopping-list.ts
+++ b/ui/hooks/use-shopping-list.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import {
+  getServerShoppingListSnapshot,
+  getShoppingListSnapshot,
+  type ShoppingListState,
+  subscribeShoppingList,
+} from "@/lib/shopping/shoppingListStore";
+
+export function useShoppingList(): ShoppingListState {
+  return useSyncExternalStore(
+    subscribeShoppingList,
+    getShoppingListSnapshot,
+    getServerShoppingListSnapshot,
+  );
+}
+
+/** The number of selected recipes — used for the nav badge. */
+export function useSelectedRecipeCount(): number {
+  const state = useShoppingList();
+  return state.recipes.length;
+}

--- a/ui/hooks/use-shopping-list.ts
+++ b/ui/hooks/use-shopping-list.ts
@@ -16,8 +16,15 @@ export function useShoppingList(): ShoppingListState {
   );
 }
 
-/** The number of selected recipes — used for the nav badge. */
+/**
+ * The number of selected recipes — used for the nav badge. Subscribes to the
+ * count directly (a primitive snapshot) so the nav bar doesn't re-render when
+ * unrelated state changes, e.g. ticking off an ingredient.
+ */
 export function useSelectedRecipeCount(): number {
-  const state = useShoppingList();
-  return state.recipes.length;
+  return useSyncExternalStore(
+    subscribeShoppingList,
+    () => getShoppingListSnapshot().recipes.length,
+    () => 0,
+  );
 }

--- a/ui/lib/api/shopping.ts
+++ b/ui/lib/api/shopping.ts
@@ -1,0 +1,50 @@
+import {
+  compareRecipesByDateAndSlug,
+  getAllRecipeCards,
+  getRecipeDetail,
+  loadRecipeRepository,
+  type RecipeIngredientView,
+} from "@/lib/domain/recipe";
+
+/**
+ * A compact, build-time payload for the shopping feature: everything the
+ * client-side list needs to scale and aggregate ingredients for a recipe,
+ * without shipping the full instruction/cook-mode detail view.
+ */
+export type ShoppingRecipe = {
+  slug: string;
+  title: string;
+  /** The recipe's own servings — the denominator for per-recipe scaling. */
+  servings: number;
+  image?: string;
+  imageAlt?: string;
+  cuisine: string[];
+  totalTime?: number;
+  /** Every ingredient the recipe uses, flattened across its sections. */
+  ingredients: RecipeIngredientView[];
+};
+
+// One repository instance for the shopping payload. Loaded lazily so importing
+// this module doesn't pay the parse cost unless a shopping page needs it.
+const repository = loadRecipeRepository();
+
+export function getShoppingRecipes(): ShoppingRecipe[] {
+  return getAllRecipeCards(repository)
+    .sort(compareRecipesByDateAndSlug)
+    .map((card): ShoppingRecipe => {
+      const detail = getRecipeDetail(repository, card.slug);
+      const ingredients = detail
+        ? detail.ingredientGroups.flatMap((group) => group.items)
+        : [];
+      return {
+        slug: card.slug,
+        title: card.title,
+        servings: Math.max(1, card.servings),
+        image: card.image,
+        imageAlt: card.imageAlt,
+        cuisine: card.cuisine,
+        totalTime: card.totalTime,
+        ingredients,
+      };
+    });
+}

--- a/ui/lib/domain/recipe/ingredientDisplay.ts
+++ b/ui/lib/domain/recipe/ingredientDisplay.ts
@@ -177,6 +177,19 @@ function amountText(
   return formatScaled(item.amount * scale);
 }
 
+/**
+ * The rendered amount + unit for an ingredient, without the trailing name or
+ * annotations (e.g. "500g", "2 tins", "3 cloves", "2"). Used by the shopping
+ * list to show the quantity as a distinct, bold chip ahead of the name.
+ */
+export function formatIngredientAmount(
+  item: Pick<RecipeIngredientView, "amount" | "unit">,
+  scale: number,
+  system: MeasurementSystem,
+): string {
+  return amountText(item, scale, system);
+}
+
 export function formatIngredient(
   item: RecipeIngredientView,
   scale: number,

--- a/ui/lib/domain/shopping/aggregate.ts
+++ b/ui/lib/domain/shopping/aggregate.ts
@@ -1,0 +1,183 @@
+import type { ShoppingRecipe } from "@/lib/api/shopping";
+import type {
+  IngredientCategory,
+  IngredientSlug,
+} from "@/lib/domain/recipe/ingredient";
+// Import from the specific unit module, not the domain barrel: the barrel
+// re-exports recipeRepository → cooklang → Node fs/url, which must never reach
+// the client bundle (this module is used by the client shopping list).
+import {
+  convertUnit,
+  getUnitDimension,
+  type Unit,
+} from "@/lib/domain/recipe/unit";
+import { aisleForCategory } from "./aisles";
+
+/**
+ * A single merged quantity on a shopping line. Dimensional amounts (weight /
+ * volume) are normalised to a base unit (g / ml) so the UI can convert them to
+ * the reader's measurement system at display time; discrete units (tins,
+ * cloves, pieces…) and bare counts keep their own bucket.
+ */
+export type ShoppingQuantity = {
+  amount: number;
+  /** Base unit (g/ml) or a discrete unit; undefined for a bare count. */
+  unit?: Unit;
+};
+
+export type ShoppingLine = {
+  ingredient: IngredientSlug;
+  name: string;
+  pluralName?: string;
+  category?: IngredientCategory;
+  aisle: string;
+  /**
+   * One or more merged quantities. Empty when every contribution was
+   * presence-only (an ingredient tagged with no amount), in which case the UI
+   * shows just the name.
+   */
+  quantities: ShoppingQuantity[];
+  /** Distinct recipes that contribute to this line, in selection order. */
+  recipes: { slug: string; title: string }[];
+};
+
+export type SelectedRecipe = {
+  recipe: ShoppingRecipe;
+  /** Multiplier applied to every amount (chosen servings ÷ recipe servings). */
+  scale: number;
+};
+
+// Bucket keys keep incompatible quantities apart. Convertible units collapse
+// onto their physical dimension; everything else keys on its own unit (or a
+// shared "count" key for bare numbers).
+const COUNT_BUCKET = "count";
+function bucketKey(unit: Unit | undefined): string {
+  if (!unit) return COUNT_BUCKET;
+  return getUnitDimension(unit) ?? `unit:${unit}`;
+}
+
+// The base unit a dimensional bucket accumulates into.
+function baseUnitFor(unit: Unit): Unit {
+  return getUnitDimension(unit) === "weight" ? "g" : "ml";
+}
+
+type Bucket = {
+  /** Running total, in the bucket's own unit (base unit for dimensional). */
+  amount: number;
+  unit: Unit | undefined;
+};
+
+type Accumulator = {
+  ingredient: IngredientSlug;
+  name: string;
+  pluralName?: string;
+  category?: IngredientCategory;
+  buckets: Map<string, Bucket>;
+  /** True once any contribution carried a real amount. */
+  hasQuantified: boolean;
+  recipes: Map<string, string>;
+};
+
+function addContribution(
+  acc: Accumulator,
+  amount: number | undefined,
+  unit: Unit | undefined,
+): void {
+  if (amount == null) return; // presence-only tag — records the recipe, no number
+  acc.hasQuantified = true;
+
+  const key = bucketKey(unit);
+  const existing = acc.buckets.get(key);
+
+  // Dimensional units accumulate in their base unit so tsp + tbsp + ml all add up.
+  const isDimensional = unit != null && getUnitDimension(unit) != null;
+  const baseUnit = isDimensional ? baseUnitFor(unit!) : unit;
+  const baseAmount =
+    isDimensional && unit != null
+      ? (convertUnit(amount, unit, baseUnit!) ?? amount)
+      : amount;
+
+  if (!existing) {
+    acc.buckets.set(key, { amount: baseAmount, unit: baseUnit });
+    return;
+  }
+  existing.amount += baseAmount;
+}
+
+/**
+ * Merge the ingredients of every selected recipe into a single de-duplicated
+ * shopping list. Amounts are summed where their units are compatible and listed
+ * side-by-side where they are not — never dropped and never throwing, unlike the
+ * strict within-recipe merge in recipe-domain.
+ */
+export function aggregateShoppingList(
+  selected: SelectedRecipe[],
+): ShoppingLine[] {
+  const accumulators = new Map<IngredientSlug, Accumulator>();
+
+  for (const { recipe, scale } of selected) {
+    // Guard against a stale/zero servings override producing NaN amounts.
+    const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+    for (const item of recipe.ingredients) {
+      let acc = accumulators.get(item.ingredient);
+      if (!acc) {
+        acc = {
+          ingredient: item.ingredient,
+          name: item.name,
+          pluralName: item.pluralName,
+          category: item.category as IngredientCategory | undefined,
+          buckets: new Map(),
+          hasQuantified: false,
+          recipes: new Map(),
+        };
+        accumulators.set(item.ingredient, acc);
+      }
+      const amount = item.amount == null ? undefined : item.amount * safeScale;
+      addContribution(acc, amount, item.unit);
+      acc.recipes.set(recipe.slug, recipe.title);
+    }
+  }
+
+  const lines: ShoppingLine[] = [];
+  for (const acc of accumulators.values()) {
+    const quantities: ShoppingQuantity[] = acc.hasQuantified
+      ? [...acc.buckets.values()]
+          .map((bucket) => ({
+            amount: roundAmount(bucket.amount),
+            unit: bucket.unit,
+          }))
+          .sort(compareQuantities)
+      : [];
+    lines.push({
+      ingredient: acc.ingredient,
+      name: acc.name,
+      pluralName: acc.pluralName,
+      category: acc.category,
+      aisle: aisleForCategory(acc.category),
+      quantities,
+      recipes: [...acc.recipes.entries()].map(([slug, title]) => ({
+        slug,
+        title,
+      })),
+    });
+  }
+  return lines;
+}
+
+// Trim floating-point noise from summed/converted amounts (e.g. 0.30000000004).
+function roundAmount(amount: number): number {
+  return Math.round(amount * 1000) / 1000;
+}
+
+// Stable order for a line's quantities: dimensional first, then discrete units
+// alphabetically, then bare counts.
+function quantityRank(unit: Unit | undefined): number {
+  if (unit === "g" || unit === "ml") return 0;
+  if (unit) return 1;
+  return 2;
+}
+function compareQuantities(a: ShoppingQuantity, b: ShoppingQuantity): number {
+  const rank = quantityRank(a.unit) - quantityRank(b.unit);
+  if (rank !== 0) return rank;
+  return (a.unit ?? "").localeCompare(b.unit ?? "");
+}

--- a/ui/lib/domain/shopping/aggregate.ts
+++ b/ui/lib/domain/shopping/aggregate.ts
@@ -47,19 +47,10 @@ export type SelectedRecipe = {
   scale: number;
 };
 
-// Bucket keys keep incompatible quantities apart. Convertible units collapse
-// onto their physical dimension; everything else keys on its own unit (or a
-// shared "count" key for bare numbers).
+// Bucket keys keep incompatible quantities apart: convertible units collapse
+// onto their physical dimension, discrete units key on their own unit, and bare
+// numbers share a "count" key.
 const COUNT_BUCKET = "count";
-function bucketKey(unit: Unit | undefined): string {
-  if (!unit) return COUNT_BUCKET;
-  return getUnitDimension(unit) ?? `unit:${unit}`;
-}
-
-// The base unit a dimensional bucket accumulates into.
-function baseUnitFor(unit: Unit): Unit {
-  return getUnitDimension(unit) === "weight" ? "g" : "ml";
-}
 
 type Bucket = {
   /** Running total, in the bucket's own unit (base unit for dimensional). */
@@ -78,6 +69,20 @@ type Accumulator = {
   recipes: Map<string, string>;
 };
 
+function addToBucket(
+  acc: Accumulator,
+  key: string,
+  amount: number,
+  unit: Unit | undefined,
+): void {
+  const existing = acc.buckets.get(key);
+  if (!existing) {
+    acc.buckets.set(key, { amount, unit });
+    return;
+  }
+  existing.amount += amount;
+}
+
 function addContribution(
   acc: Accumulator,
   amount: number | undefined,
@@ -86,22 +91,25 @@ function addContribution(
   if (amount == null) return; // presence-only tag — records the recipe, no number
   acc.hasQuantified = true;
 
-  const key = bucketKey(unit);
-  const existing = acc.buckets.get(key);
-
-  // Dimensional units accumulate in their base unit so tsp + tbsp + ml all add up.
-  const isDimensional = unit != null && getUnitDimension(unit) != null;
-  const baseUnit = isDimensional ? baseUnitFor(unit!) : unit;
-  const baseAmount =
-    isDimensional && unit != null
-      ? (convertUnit(amount, unit, baseUnit!) ?? amount)
-      : amount;
-
-  if (!existing) {
-    acc.buckets.set(key, { amount: baseAmount, unit: baseUnit });
-    return;
+  // Dimensional units (weight/volume, incl. spoons/cups) accumulate in a base
+  // unit so tsp + tbsp + g etc. can be summed. getUnitDimension is non-null
+  // exactly for the units convertUnit knows, and the base unit shares that
+  // dimension, so the conversion always succeeds here — but if it ever doesn't
+  // (a future unit added to one table but not the other), fall through and bucket
+  // the contribution under its own written unit rather than mislabelling a raw
+  // amount as grams/millilitres.
+  const dimension = unit != null ? getUnitDimension(unit) : null;
+  if (unit != null && dimension != null) {
+    const baseUnit: Unit = dimension === "weight" ? "g" : "ml";
+    const baseAmount = convertUnit(amount, unit, baseUnit);
+    if (baseAmount != null) {
+      addToBucket(acc, dimension, baseAmount, baseUnit);
+      return;
+    }
   }
-  existing.amount += baseAmount;
+
+  // Discrete units (tin, clove, piece…) and bare counts keep their own bucket.
+  addToBucket(acc, unit ? `unit:${unit}` : COUNT_BUCKET, amount, unit);
 }
 
 /**

--- a/ui/lib/domain/shopping/aisles.ts
+++ b/ui/lib/domain/shopping/aisles.ts
@@ -1,0 +1,60 @@
+import type { IngredientCategory } from "@/lib/domain/recipe/ingredient";
+
+/**
+ * Shopping "aisles" — a coarser, supermarket-walk grouping of the finer
+ * ingredient categories, so the by-aisle view reads like a store layout
+ * rather than a taxonomy.
+ */
+export type Aisle = {
+  id: string;
+  name: string;
+};
+
+// Order = the order aisles appear in the by-aisle view (roughly a walk round
+// a UK supermarket: fresh first, cupboard last).
+export const AISLES: Aisle[] = [
+  { id: "produce", name: "Fruit & veg" },
+  { id: "meat-fish", name: "Meat & fish" },
+  { id: "dairy", name: "Dairy & chilled" },
+  { id: "bakery-grains", name: "Bakery & grains" },
+  { id: "tins-cooking", name: "Tins, pasta & cooking" },
+  { id: "herbs-spices", name: "Herbs & spices" },
+  { id: "drinks", name: "Drinks" },
+  { id: "sweets-baking", name: "Sweets & baking" },
+  { id: "other", name: "Other" },
+];
+
+const AISLE_ORDER = new Map(AISLES.map((aisle, index) => [aisle.id, index]));
+const OTHER_AISLE_ID = "other";
+
+const CATEGORY_TO_AISLE: Record<IngredientCategory, string> = {
+  vegetable: "produce",
+  fruit: "produce",
+  herb: "produce",
+  protein: "meat-fish",
+  dairy: "dairy",
+  grain: "bakery-grains",
+  legume: "tins-cooking",
+  condiment: "tins-cooking",
+  "oil-fat": "tins-cooking",
+  spice: "herbs-spices",
+  liquid: "drinks",
+  sweets: "sweets-baking",
+  other: "other",
+};
+
+export function aisleForCategory(category?: IngredientCategory): string {
+  if (!category) return OTHER_AISLE_ID;
+  return CATEGORY_TO_AISLE[category] ?? OTHER_AISLE_ID;
+}
+
+export function aisleName(id: string): string {
+  return AISLES.find((aisle) => aisle.id === id)?.name ?? "Other";
+}
+
+/** Comparator to sort aisle ids into the store-walk order defined above. */
+export function compareAisles(a: string, b: string): number {
+  const ai = AISLE_ORDER.get(a) ?? AISLE_ORDER.size;
+  const bi = AISLE_ORDER.get(b) ?? AISLE_ORDER.size;
+  return ai - bi;
+}

--- a/ui/lib/domain/shopping/aisles.ts
+++ b/ui/lib/domain/shopping/aisles.ts
@@ -19,7 +19,6 @@ export const AISLES: Aisle[] = [
   { id: "bakery-grains", name: "Bakery & grains" },
   { id: "tins-cooking", name: "Tins, pasta & cooking" },
   { id: "herbs-spices", name: "Herbs & spices" },
-  { id: "drinks", name: "Drinks" },
   { id: "sweets-baking", name: "Sweets & baking" },
   { id: "other", name: "Other" },
 ];
@@ -37,8 +36,10 @@ const CATEGORY_TO_AISLE: Record<IngredientCategory, string> = {
   legume: "tins-cooking",
   condiment: "tins-cooking",
   "oil-fat": "tins-cooking",
+  // "liquid" is dominated by cooking liquids (stock, wine, pasta water) rather
+  // than drinks, so it belongs with the cooking staples, not on its own aisle.
+  liquid: "tins-cooking",
   spice: "herbs-spices",
-  liquid: "drinks",
   sweets: "sweets-baking",
   other: "other",
 };

--- a/ui/lib/domain/shopping/display.ts
+++ b/ui/lib/domain/shopping/display.ts
@@ -1,0 +1,36 @@
+import type { MeasurementSystem } from "@/lib/domain/recipe";
+import { formatIngredientAmount } from "@/lib/domain/recipe/ingredientDisplay";
+import { formatIngredientName } from "@/lib/domain/recipe/ingredientText";
+import type { ShoppingLine, ShoppingQuantity } from "./aggregate";
+
+/**
+ * Render a line's merged quantities into a single string in the reader's
+ * measurement system, e.g. "500g", "2 tins + 400g", or "" when the ingredient
+ * was only ever tagged with no amount.
+ */
+export function formatShoppingQuantities(
+  quantities: ShoppingQuantity[],
+  system: MeasurementSystem,
+): string {
+  return quantities
+    .map((quantity) => formatIngredientAmount(quantity, 1, system))
+    .filter(Boolean)
+    .join(" + ");
+}
+
+/**
+ * The display name for a line, singular/plural-aware when the ingredient is
+ * counted in whole pieces (e.g. "1 chicken breast" vs "2 chicken breasts").
+ */
+export function formatShoppingName(line: ShoppingLine): string {
+  const piece = line.quantities.find((quantity) => quantity.unit === "piece");
+  return formatIngredientName(
+    {
+      name: line.name,
+      pluralName: line.pluralName,
+      unit: piece ? "piece" : undefined,
+      amount: piece?.amount,
+    },
+    1,
+  );
+}

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -56,11 +56,13 @@ function parseState(raw: string | null): ShoppingListState {
     const recipes = Array.isArray(parsed.recipes)
       ? parsed.recipes.flatMap((entry): SelectedRecipeEntry[] => {
           if (!isRecord(entry) || typeof entry.slug !== "string") return [];
+          // Normalise persisted servings the same way setRecipeServings does,
+          // so stale/edited storage can't feed the UI a fractional value the
+          // stepper (integer labels, servings<=1 disable) doesn't expect.
+          const raw = entry.servings;
           const servings =
-            typeof entry.servings === "number" &&
-            Number.isFinite(entry.servings) &&
-            entry.servings > 0
-              ? entry.servings
+            typeof raw === "number" && Number.isFinite(raw) && raw > 0
+              ? Math.max(1, Math.round(raw))
               : undefined;
           return [{ slug: entry.slug, ...(servings ? { servings } : {}) }];
         })
@@ -117,18 +119,30 @@ function setState(next: ShoppingListState): void {
   emit();
 }
 
+// A single, module-wide storage listener (hooked once on first subscribe, like
+// the cooking-timer store) rather than one per subscriber — otherwise a
+// cross-tab update would fan out to N handlers each calling emit() over N
+// callbacks (N×N redundant notifications).
+let storageListenerHooked = false;
+
+function handleStorage(event: StorageEvent): void {
+  if (event.key !== STORAGE_KEY) return;
+  state = parseState(event.newValue);
+  emit();
+}
+
+function hookStorageListener(): void {
+  if (storageListenerHooked || globalThis.window === undefined) return;
+  storageListenerHooked = true;
+  globalThis.addEventListener("storage", handleStorage);
+}
+
 export function subscribeShoppingList(callback: () => void): () => void {
   hydrate();
+  hookStorageListener();
   listeners.add(callback);
-  const onStorage = (event: StorageEvent) => {
-    if (event.key !== STORAGE_KEY) return;
-    state = parseState(event.newValue);
-    emit();
-  };
-  globalThis.addEventListener("storage", onStorage);
   return () => {
     listeners.delete(callback);
-    globalThis.removeEventListener("storage", onStorage);
   };
 }
 
@@ -227,6 +241,10 @@ export function clearList(): void {
 
 /** Reset module state between tests (mirrors the cooking-timer store). */
 export function __resetShoppingListForTests(): void {
+  if (storageListenerHooked) {
+    globalThis.removeEventListener("storage", handleStorage);
+    storageListenerHooked = false;
+  }
   state = EMPTY_STATE;
   hydrated = false;
   listeners.clear();

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -1,0 +1,220 @@
+/**
+ * Client-side shopping-list store.
+ *
+ * A module-level store (consumed via useSyncExternalStore in
+ * `use-shopping-list`) holding the recipes the user wants to cook, any
+ * per-recipe servings override, which ingredients they've ticked off, and any
+ * freeform "extra" items. Persisted to localStorage so the list survives
+ * reloads and stays in sync across tabs — matching the unit-preference and
+ * cooking-timer stores. There is no server component: the site is a static
+ * export, so the list lives entirely in the browser for this first pass.
+ */
+
+export type SelectedRecipeEntry = {
+  slug: string;
+  /** Chosen servings; when absent the recipe's own servings are used. */
+  servings?: number;
+};
+
+export type ExtraItem = {
+  id: string;
+  text: string;
+  checked: boolean;
+};
+
+export type ShoppingListState = {
+  /** Selected recipes, kept in the order they were added. */
+  recipes: SelectedRecipeEntry[];
+  /** Ticked-off ingredient slugs. */
+  checked: string[];
+  /** Freeform extras (milk, bread…). */
+  extras: ExtraItem[];
+};
+
+const STORAGE_KEY = "recipe-shopping-list:v1";
+
+const EMPTY_STATE: ShoppingListState = {
+  recipes: [],
+  checked: [],
+  extras: [],
+};
+
+let state: ShoppingListState = EMPTY_STATE;
+let hydrated = false;
+const listeners = new Set<() => void>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseState(raw: string | null): ShoppingListState {
+  if (!raw) return EMPTY_STATE;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) return EMPTY_STATE;
+
+    const recipes = Array.isArray(parsed.recipes)
+      ? parsed.recipes.flatMap((entry): SelectedRecipeEntry[] => {
+          if (!isRecord(entry) || typeof entry.slug !== "string") return [];
+          const servings =
+            typeof entry.servings === "number" &&
+            Number.isFinite(entry.servings) &&
+            entry.servings > 0
+              ? entry.servings
+              : undefined;
+          return [{ slug: entry.slug, ...(servings ? { servings } : {}) }];
+        })
+      : [];
+
+    const checked = Array.isArray(parsed.checked)
+      ? parsed.checked.filter((v): v is string => typeof v === "string")
+      : [];
+
+    const extras = Array.isArray(parsed.extras)
+      ? parsed.extras.flatMap((entry): ExtraItem[] => {
+          if (
+            !isRecord(entry) ||
+            typeof entry.id !== "string" ||
+            typeof entry.text !== "string"
+          ) {
+            return [];
+          }
+          return [{ id: entry.id, text: entry.text, checked: !!entry.checked }];
+        })
+      : [];
+
+    return { recipes, checked, extras };
+  } catch {
+    return EMPTY_STATE;
+  }
+}
+
+function hydrate(): void {
+  if (hydrated) return;
+  hydrated = true;
+  try {
+    state = parseState(localStorage.getItem(STORAGE_KEY));
+  } catch {
+    // localStorage unavailable (SSR, private browsing, etc.)
+  }
+}
+
+function persist(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore write failures (quota, private browsing)
+  }
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function setState(next: ShoppingListState): void {
+  state = next;
+  persist();
+  emit();
+}
+
+export function subscribeShoppingList(callback: () => void): () => void {
+  hydrate();
+  listeners.add(callback);
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== STORAGE_KEY) return;
+    state = parseState(event.newValue);
+    emit();
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(callback);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+export function getShoppingListSnapshot(): ShoppingListState {
+  hydrate();
+  return state;
+}
+
+export function getServerShoppingListSnapshot(): ShoppingListState {
+  return EMPTY_STATE;
+}
+
+// ── Mutations ──────────────────────────────────────────────────────────────
+
+export function isRecipeSelected(slug: string): boolean {
+  return getShoppingListSnapshot().recipes.some((r) => r.slug === slug);
+}
+
+export function addRecipe(slug: string): void {
+  if (isRecipeSelected(slug)) return;
+  setState({ ...state, recipes: [...state.recipes, { slug }] });
+}
+
+export function removeRecipe(slug: string): void {
+  setState({
+    ...state,
+    recipes: state.recipes.filter((r) => r.slug !== slug),
+  });
+}
+
+export function toggleRecipe(slug: string): void {
+  if (isRecipeSelected(slug)) removeRecipe(slug);
+  else addRecipe(slug);
+}
+
+export function setRecipeServings(slug: string, servings: number): void {
+  const safe = Math.max(1, Math.round(servings));
+  setState({
+    ...state,
+    recipes: state.recipes.map((r) =>
+      r.slug === slug ? { ...r, servings: safe } : r,
+    ),
+  });
+}
+
+export function toggleChecked(key: string): void {
+  const checked = state.checked.includes(key)
+    ? state.checked.filter((k) => k !== key)
+    : [...state.checked, key];
+  setState({ ...state, checked });
+}
+
+export function clearChecked(): void {
+  if (state.checked.length === 0 && state.extras.every((e) => !e.checked)) {
+    return;
+  }
+  setState({
+    ...state,
+    checked: [],
+    extras: state.extras.map((e) => ({ ...e, checked: false })),
+  });
+}
+
+export function addExtra(text: string): void {
+  const trimmed = text.trim();
+  if (!trimmed) return;
+  const id = `extra-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+  setState({
+    ...state,
+    extras: [...state.extras, { id, text: trimmed, checked: false }],
+  });
+}
+
+export function toggleExtra(id: string): void {
+  setState({
+    ...state,
+    extras: state.extras.map((e) =>
+      e.id === id ? { ...e, checked: !e.checked } : e,
+    ),
+  });
+}
+
+export function removeExtra(id: string): void {
+  setState({ ...state, extras: state.extras.filter((e) => e.id !== id) });
+}
+
+export function clearList(): void {
+  setState({ ...EMPTY_STATE });
+}

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -195,6 +195,10 @@ export function clearChecked(): void {
 export function addExtra(text: string): void {
   const trimmed = text.trim();
   if (!trimmed) return;
+  // Ignore an accidental re-add of an extra that's already on the list
+  // (case-insensitive); a genuine duplicate is almost always a mistake.
+  const key = trimmed.toLowerCase();
+  if (state.extras.some((e) => e.text.toLowerCase() === key)) return;
   // crypto.randomUUID (not Math.random) keeps this out of Sonar's PRNG hotspot;
   // addExtra only runs in the browser, where crypto is always available.
   const id = `extra-${crypto.randomUUID()}`;
@@ -219,4 +223,11 @@ export function removeExtra(id: string): void {
 
 export function clearList(): void {
   setState({ ...EMPTY_STATE });
+}
+
+/** Reset module state between tests (mirrors the cooking-timer store). */
+export function __resetShoppingListForTests(): void {
+  state = EMPTY_STATE;
+  hydrated = false;
+  listeners.clear();
 }

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -195,7 +195,9 @@ export function clearChecked(): void {
 export function addExtra(text: string): void {
   const trimmed = text.trim();
   if (!trimmed) return;
-  const id = `extra-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+  // crypto.randomUUID (not Math.random) keeps this out of Sonar's PRNG hotspot;
+  // addExtra only runs in the browser, where crypto is always available.
+  const id = `extra-${crypto.randomUUID()}`;
   setState({
     ...state,
     extras: [...state.extras, { id, text: trimmed, checked: false }],

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -125,10 +125,10 @@ export function subscribeShoppingList(callback: () => void): () => void {
     state = parseState(event.newValue);
     emit();
   };
-  window.addEventListener("storage", onStorage);
+  globalThis.addEventListener("storage", onStorage);
   return () => {
     listeners.delete(callback);
-    window.removeEventListener("storage", onStorage);
+    globalThis.removeEventListener("storage", onStorage);
   };
 }
 

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -50,7 +50,10 @@ describe("agent markdown generation", () => {
 
   it("generates a markdown twin for every recipe and technology page", () => {
     // Interactive, noindex app pages that intentionally have no Markdown twin.
-    const nonContentPages = new Set(["recipes/settings.html"]);
+    const nonContentPages = new Set([
+      "recipes/settings.html",
+      "recipes/shopping.html",
+    ]);
     for (const section of ["recipes", "technologies"]) {
       const htmlPages = fs
         .readdirSync(path.join(OUT_DIR, section))

--- a/ui/tests/integration/sitemap.test.ts
+++ b/ui/tests/integration/sitemap.test.ts
@@ -15,7 +15,7 @@ const STATIC_ASSET_SEGMENTS = new Set(["recipe-site-design"]);
 
 // Authenticated, noindex app pages (e.g. account settings) — served but kept
 // out of the sitemap on purpose.
-const NOINDEX_APP_PAGES = new Set(["recipes/settings"]);
+const NOINDEX_APP_PAGES = new Set(["recipes/settings", "recipes/shopping"]);
 
 describe("Sitemap Integration Test", () => {
   it("should have a sitemap.xml that includes all generated pages", () => {

--- a/ui/tests/lib/domain/shopping/aggregate.test.ts
+++ b/ui/tests/lib/domain/shopping/aggregate.test.ts
@@ -121,10 +121,14 @@ describe("aggregateShoppingList", () => {
         recipe("a", [
           ing("chicken", { amount: 1, unit: "piece", category: "protein" }),
           ing("onion", { amount: 1, unit: "piece", category: "vegetable" }),
+          // Cooking liquids (stock, wine…) belong with cooking staples, not on
+          // a "drinks" aisle where they read oddly.
+          ing("chicken-stock", { amount: 500, unit: "ml", category: "liquid" }),
         ]),
       ),
     ]);
     expect(lineFor(lines, "chicken").aisle).toBe("meat-fish");
     expect(lineFor(lines, "onion").aisle).toBe("produce");
+    expect(lineFor(lines, "chicken-stock").aisle).toBe("tins-cooking");
   });
 });

--- a/ui/tests/lib/domain/shopping/aggregate.test.ts
+++ b/ui/tests/lib/domain/shopping/aggregate.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import type { ShoppingRecipe } from "@/lib/api/shopping";
+import type { RecipeIngredientView } from "@/lib/domain/recipe";
+import {
+  aggregateShoppingList,
+  type SelectedRecipe,
+} from "@/lib/domain/shopping/aggregate";
+
+function ing(
+  ingredient: string,
+  overrides: Partial<RecipeIngredientView> = {},
+): RecipeIngredientView {
+  return {
+    ingredient,
+    name: ingredient.replace(/-/g, " "),
+    ...overrides,
+  };
+}
+
+function recipe(
+  slug: string,
+  ingredients: RecipeIngredientView[],
+  servings = 4,
+): ShoppingRecipe {
+  return {
+    slug,
+    title: slug,
+    servings,
+    cuisine: [],
+    ingredients,
+  };
+}
+
+function select(recipe: ShoppingRecipe, scale = 1): SelectedRecipe {
+  return { recipe, scale };
+}
+
+function lineFor(
+  lines: ReturnType<typeof aggregateShoppingList>,
+  slug: string,
+) {
+  const line = lines.find((l) => l.ingredient === slug);
+  if (!line) throw new Error(`no line for ${slug}`);
+  return line;
+}
+
+describe("aggregateShoppingList", () => {
+  it("sums the same ingredient across recipes when units match", () => {
+    const lines = aggregateShoppingList([
+      select(recipe("a", [ing("garlic", { amount: 2, unit: "clove" })])),
+      select(recipe("b", [ing("garlic", { amount: 3, unit: "clove" })])),
+    ]);
+    const garlic = lineFor(lines, "garlic");
+    expect(garlic.quantities).toEqual([{ amount: 5, unit: "clove" }]);
+    expect(garlic.recipes.map((r) => r.slug)).toEqual(["a", "b"]);
+  });
+
+  it("sums compatible units by converting to a base unit", () => {
+    const lines = aggregateShoppingList([
+      select(recipe("a", [ing("pasta", { amount: 300, unit: "g" })])),
+      select(recipe("b", [ing("pasta", { amount: 0.3, unit: "kg" })])),
+    ]);
+    expect(lineFor(lines, "pasta").quantities).toEqual([
+      { amount: 600, unit: "g" },
+    ]);
+  });
+
+  it("folds spoon measures into the volume base unit", () => {
+    const lines = aggregateShoppingList([
+      select(recipe("a", [ing("oil", { amount: 1, unit: "tbsp" })])),
+      select(recipe("b", [ing("oil", { amount: 1, unit: "tsp" })])),
+    ]);
+    // 15ml + 5ml
+    expect(lineFor(lines, "oil").quantities).toEqual([
+      { amount: 20, unit: "ml" },
+    ]);
+  });
+
+  it("keeps incompatible units in separate buckets rather than throwing", () => {
+    const lines = aggregateShoppingList([
+      select(recipe("a", [ing("tomato", { amount: 1, unit: "tin" })])),
+      select(recipe("b", [ing("tomato", { amount: 400, unit: "g" })])),
+    ]);
+    const tomato = lineFor(lines, "tomato");
+    // dimensional (g) sorts before discrete (tin)
+    expect(tomato.quantities).toEqual([
+      { amount: 400, unit: "g" },
+      { amount: 1, unit: "tin" },
+    ]);
+  });
+
+  it("scales amounts by the per-recipe multiplier", () => {
+    const lines = aggregateShoppingList([
+      select(recipe("a", [ing("chicken", { amount: 600, unit: "g" })], 4), 2),
+    ]);
+    expect(lineFor(lines, "chicken").quantities).toEqual([
+      { amount: 1200, unit: "g" },
+    ]);
+  });
+
+  it("treats presence-only tags as no quantity but records the recipe", () => {
+    const lines = aggregateShoppingList([select(recipe("a", [ing("salt")]))]);
+    const salt = lineFor(lines, "salt");
+    expect(salt.quantities).toEqual([]);
+    expect(salt.recipes).toHaveLength(1);
+  });
+
+  it("keeps a quantified amount even when another recipe tags it bare", () => {
+    const lines = aggregateShoppingList([
+      select(recipe("a", [ing("basil")])),
+      select(recipe("b", [ing("basil", { amount: 1, unit: "bag" })])),
+    ]);
+    expect(lineFor(lines, "basil").quantities).toEqual([
+      { amount: 1, unit: "bag" },
+    ]);
+  });
+
+  it("assigns an aisle from the ingredient category", () => {
+    const lines = aggregateShoppingList([
+      select(
+        recipe("a", [
+          ing("chicken", { amount: 1, unit: "piece", category: "protein" }),
+          ing("onion", { amount: 1, unit: "piece", category: "vegetable" }),
+        ]),
+      ),
+    ]);
+    expect(lineFor(lines, "chicken").aisle).toBe("meat-fish");
+    expect(lineFor(lines, "onion").aisle).toBe("produce");
+  });
+});

--- a/ui/tests/lib/shopping/shoppingListStore.test.ts
+++ b/ui/tests/lib/shopping/shoppingListStore.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetShoppingListForTests,
+  addExtra,
+  addRecipe,
+  getShoppingListSnapshot,
+  removeExtra,
+  setRecipeServings,
+  toggleChecked,
+  toggleExtra,
+} from "@/lib/shopping/shoppingListStore";
+
+describe("shoppingListStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetShoppingListForTests();
+  });
+  afterEach(() => {
+    __resetShoppingListForTests();
+  });
+
+  it("adds recipes without duplicating and applies servings overrides", () => {
+    addRecipe("risotto");
+    addRecipe("risotto");
+    setRecipeServings("risotto", 6);
+    expect(getShoppingListSnapshot().recipes).toEqual([
+      { slug: "risotto", servings: 6 },
+    ]);
+  });
+
+  it("ignores a case-insensitive duplicate extra", () => {
+    addExtra("Milk");
+    addExtra("milk");
+    addExtra("  MILK  ");
+    const { extras } = getShoppingListSnapshot();
+    expect(extras).toHaveLength(1);
+    expect(extras[0]!.text).toBe("Milk");
+  });
+
+  it("adds genuinely different extras", () => {
+    addExtra("milk");
+    addExtra("bread");
+    expect(getShoppingListSnapshot().extras.map((e) => e.text)).toEqual([
+      "milk",
+      "bread",
+    ]);
+  });
+
+  it("keeps ingredient ticks and extra ticks independent", () => {
+    // An extra that shares an ingredient's name is a separate row with its own
+    // checked state — ticking one must not tick the other.
+    addExtra("garlic");
+    toggleChecked("garlic"); // ticks the *ingredient* slug
+    const { checked, extras } = getShoppingListSnapshot();
+    expect(checked).toContain("garlic");
+    expect(extras[0]!.checked).toBe(false);
+
+    toggleExtra(extras[0]!.id); // ticks the *extra*
+    expect(getShoppingListSnapshot().extras[0]!.checked).toBe(true);
+    // ingredient tick unchanged
+    expect(getShoppingListSnapshot().checked).toContain("garlic");
+  });
+
+  it("removes an extra by id", () => {
+    addExtra("napkins");
+    const id = getShoppingListSnapshot().extras[0]!.id;
+    removeExtra(id);
+    expect(getShoppingListSnapshot().extras).toHaveLength(0);
+  });
+});

--- a/ui/tests/lib/shopping/shoppingListStore.test.ts
+++ b/ui/tests/lib/shopping/shoppingListStore.test.ts
@@ -1,14 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetShoppingListForTests,
   addExtra,
   addRecipe,
+  clearChecked,
+  clearList,
   getShoppingListSnapshot,
   removeExtra,
+  removeRecipe,
   setRecipeServings,
+  subscribeShoppingList,
   toggleChecked,
   toggleExtra,
+  toggleRecipe,
 } from "@/lib/shopping/shoppingListStore";
+
+// Mirrors the module's private persistence key.
+const STORAGE_KEY = "recipe-shopping-list:v1";
 
 describe("shoppingListStore", () => {
   beforeEach(() => {
@@ -66,5 +74,93 @@ describe("shoppingListStore", () => {
     const id = getShoppingListSnapshot().extras[0]!.id;
     removeExtra(id);
     expect(getShoppingListSnapshot().extras).toHaveLength(0);
+  });
+
+  it("normalises fractional persisted servings to an integer on hydration", () => {
+    // Simulate stale/edited localStorage carrying a non-integer servings value.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        recipes: [{ slug: "risotto", servings: 2.6 }],
+        checked: [],
+        extras: [],
+      }),
+    );
+    __resetShoppingListForTests(); // force re-hydration from storage
+    expect(getShoppingListSnapshot().recipes).toEqual([
+      { slug: "risotto", servings: 3 },
+    ]);
+  });
+
+  it("installs a single shared storage listener regardless of subscriber count", () => {
+    const addSpy = vi.spyOn(globalThis, "addEventListener");
+    const unsub = [
+      subscribeShoppingList(() => {}),
+      subscribeShoppingList(() => {}),
+      subscribeShoppingList(() => {}),
+    ];
+    const storageListeners = addSpy.mock.calls.filter(
+      ([type]) => type === "storage",
+    );
+    expect(storageListeners).toHaveLength(1);
+    for (const u of unsub) u();
+    addSpy.mockRestore();
+  });
+
+  it("toggles a recipe on and off", () => {
+    toggleRecipe("paella");
+    expect(getShoppingListSnapshot().recipes).toEqual([{ slug: "paella" }]);
+    toggleRecipe("paella");
+    expect(getShoppingListSnapshot().recipes).toEqual([]);
+  });
+
+  it("removes a recipe by slug", () => {
+    addRecipe("a");
+    addRecipe("b");
+    removeRecipe("a");
+    expect(getShoppingListSnapshot().recipes).toEqual([{ slug: "b" }]);
+  });
+
+  it("clearChecked unticks ingredients and extras but keeps them", () => {
+    addExtra("foil");
+    toggleChecked("garlic");
+    toggleExtra(getShoppingListSnapshot().extras[0]!.id);
+    clearChecked();
+    const snap = getShoppingListSnapshot();
+    expect(snap.checked).toEqual([]);
+    expect(snap.extras[0]!.checked).toBe(false);
+    expect(snap.extras).toHaveLength(1); // extra itself is retained
+  });
+
+  it("clearList wipes everything", () => {
+    addRecipe("a");
+    addExtra("foil");
+    toggleChecked("garlic");
+    clearList();
+    expect(getShoppingListSnapshot()).toEqual({
+      recipes: [],
+      checked: [],
+      extras: [],
+    });
+  });
+
+  it("syncs state from a cross-tab storage event", () => {
+    const seen: number[] = [];
+    const unsub = subscribeShoppingList(() =>
+      seen.push(getShoppingListSnapshot().recipes.length),
+    );
+    globalThis.dispatchEvent(
+      new StorageEvent("storage", {
+        key: STORAGE_KEY,
+        newValue: JSON.stringify({
+          recipes: [{ slug: "x" }, { slug: "y" }],
+          checked: [],
+          extras: [],
+        }),
+      }),
+    );
+    expect(getShoppingListSnapshot().recipes).toHaveLength(2);
+    expect(seen).toContain(2); // subscribers were notified
+    unsub();
   });
 });


### PR DESCRIPTION
Pick the recipes you want to cook and build a combined shopping list you can work through in the shop. Everything lives in a new `/recipes/shopping` section behind a path-aware **Shopping** nav tab (with a selected-count badge). The existing browse and recipe-detail views are untouched.

Inspired by — but not beholden to — the mid-fi `shopping.jsx` design, scoped to a first pass.

## What's included

**1 · Pick recipes** — a dedicated, searchable picker. Click a card to add it; selected cards get a terracotta ring, a **per-recipe servings stepper** (scales that recipe's ingredients into the list), and a remove button.

**2 · Shopping list** — one basket, three views:
- **by aisle** — ingredient categories mapped to a supermarket-walk order (Fruit & veg → Meat & fish → … → Other)
- **by recipe** — each recipe's own scaled list
- **just ingredients** — aggregated A–Z

Rows check off (shared across all three views), with an *uncheck all* and a freeform *extras* field (milk, bread…).

## Cross-recipe aggregation

Built a tolerant merger on top of the existing `convertUnit` / ingredient-category logic, rather than the strict within-recipe `mergeIngredientIntoGroup` (which throws on unit conflicts):
- Compatible units are summed by converting to a base unit (e.g. `tsp + tbsp + g`).
- Incompatible units are listed side-by-side rather than failing — e.g. `150g + 1 chorizo`.
- Presence-only tags collapse to just a name.
- Amounts convert to the reader's saved measurement system.

> Note on cooklang-rs wasm: the vendored v0.18 JS bindings only expose low-level quantity accessors, not the Rust crate's shopping-list aggregator, so rolling our own on the existing conversion table was the reliable path. Worth revisiting if a future bindings version surfaces it.

## Persistence

Selection, servings, ticks and extras persist to `localStorage` via a `useSyncExternalStore` module store, matching the existing unit-preference and cooking-timer stores. The site is a static export (Cloudflare Pages), so state is client-only for this pass.

## Out of scope (by request)

Meal-planning calendar, pantry skipping, leftovers/insights, and share/print.

## Files

- `lib/api/shopping.ts` — build-time per-recipe shopping payload
- `lib/domain/shopping/{aggregate,aisles,display}.ts` — pure aggregation, aisle mapping, display formatting
- `lib/shopping/shoppingListStore.ts` + `hooks/use-shopping-list.ts` — localStorage store
- `components/recipes/shopping/*` + `app/recipes/shopping/page.tsx` — UI + page
- `components/recipes/recipe-nav-tabs.tsx` — path-aware nav tabs with count badge
- `lib/domain/recipe/ingredientDisplay.ts` — exposes an amount-only formatter (reused by the list)

## Verification

- Typecheck, Biome lint, full test suite (387 passing, incl. 8 new aggregator tests), and a production build all green.
- Drove the full flow end-to-end in Chromium on **desktop and mobile**: selecting recipes, servings steppers, all three views, check-off, extras, and reload-persistence all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6ejRjkrUZxXLYvkgq8Z1D

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6ejRjkrUZxXLYvkgq8Z1D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated shopping page with its own navigation and no-index behaviour.
  * Introduced a shopping workflow to pick recipes, view a shopping list, and switch between steps.
  * Added shopping list views for grouped by aisle, grouped by recipe, or a flat list.
  * Added support for selecting recipes, adjusting servings, checking items off, and managing extra items.
  * Shopping selections are now saved between visits and kept in sync across tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->