### PR TITLE
Add exclude (tri-state) filtering across all list pages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       simple-icons:
         specifier: ^16.0.0
         version: 16.24.1
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       strip-markdown:
         specifier: ^6.0.0
         version: 6.0.0
@@ -5774,6 +5777,12 @@ packages:
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -12186,6 +12195,11 @@ snapshots:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
+
+  sonner@2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   source-map-js@1.2.1: {}
 

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { CommandPaletteProvider } from "@/components/command-palette";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/ui/sonner";
 import { siteConfig } from "@/lib/config/site-config";
 import { loadDomainRepository } from "@/lib/domain";
 import { getAllTechnologyBadgesSorted } from "@/lib/domain/technology";
@@ -75,6 +76,7 @@ export default function RootLayout({
           <CommandPaletteProvider technologies={technologies}>
             {children}
           </CommandPaletteProvider>
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/ui/components/blog/blog-list.tsx
+++ b/ui/components/blog/blog-list.tsx
@@ -2,6 +2,7 @@
 
 import { Briefcase, FileText, Tag } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useEffect, useMemo } from "react";
 import {
   createRoleFilterOptions,
@@ -24,6 +25,7 @@ import { hasTechIcon, TechIcon } from "@/lib/api/tech-icons";
 import type { BlogRoleView } from "@/lib/domain/blog/blogViews";
 import { prioritiseSelected } from "@/lib/generic/array";
 import { formatDate } from "@/lib/generic/date";
+import { cycleFilterFromCard } from "@/lib/generic/filter-cycle";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
 
 function RoleBadge({
@@ -119,6 +121,7 @@ export function BlogList({ posts }: BlogListProps) {
   const selectedTags = filterParams.getValues("tags");
   const selectedTech = filterParams.getValues("tech");
   const selectedRoles = filterParams.getValues("role");
+  const pathname = usePathname();
   const { registerFilters, unregisterFilters } = useCommandPalette();
 
   useEffect(() => {
@@ -257,7 +260,15 @@ export function BlogList({ posts }: BlogListProps) {
                     interactive
                     active={isActive}
                     className="gap-1 cursor-pointer"
-                    onClick={() => filterParams.toggleValue("tags", tag)}
+                    onClick={() =>
+                      cycleFilterFromCard({
+                        filterParams,
+                        paramName: "tags",
+                        value: tag,
+                        label: tag,
+                        page: pathname,
+                      })
+                    }
                   >
                     <Tag className="h-3 w-3" />
                     {tag}
@@ -283,7 +294,13 @@ export function BlogList({ posts }: BlogListProps) {
                         active={isActive}
                         className="gap-1 text-xs cursor-pointer"
                         onClick={() =>
-                          filterParams.toggleValue("tech", tech.slug)
+                          cycleFilterFromCard({
+                            filterParams,
+                            paramName: "tech",
+                            value: tech.slug,
+                            label: tech.name,
+                            page: pathname,
+                          })
                         }
                       >
                         {hasTechIcon(tech.name, tech.iconSlug) && (
@@ -314,7 +331,15 @@ export function BlogList({ posts }: BlogListProps) {
                 <RoleBadge
                   role={post.role}
                   isActive={selectedRoles.includes(post.role.slug)}
-                  onToggle={(slug) => filterParams.toggleValue("role", slug)}
+                  onToggle={(slug) =>
+                    cycleFilterFromCard({
+                      filterParams,
+                      paramName: "role",
+                      value: slug,
+                      label: post.role?.company ?? slug,
+                      page: pathname,
+                    })
+                  }
                 />
               )}
             </div>

--- a/ui/components/experience/searchable-technology-grid.tsx
+++ b/ui/components/experience/searchable-technology-grid.tsx
@@ -97,8 +97,9 @@ export function SearchableTechnologyGrid({
           />
         ),
       })),
-      selectedValues: selectedTypes,
-      onToggle: handleToggleType,
+      getOptionState: (value: string) =>
+        selectedTypes.includes(value) ? "include" : "off",
+      onCycleOption: handleToggleType,
     },
   ];
 

--- a/ui/components/experience/searchable-technology-grid.tsx
+++ b/ui/components/experience/searchable-technology-grid.tsx
@@ -9,7 +9,7 @@ import {
   FilterBar,
   type MobileFilterSection,
 } from "@/components/ui/filter-bar";
-import type { FilterState } from "@/hooks/use-filter-params";
+import { type FilterState, nextFilterState } from "@/hooks/use-filter-params";
 import {
   TECHNOLOGY_TYPE_CONFIG,
   TECHNOLOGY_TYPES,
@@ -53,11 +53,7 @@ export function SearchableTechnologyGrid({
   };
 
   const cycleType = (value: string) => {
-    const current = typeState(value);
-    setTypeState(
-      value,
-      current === "off" ? "include" : current === "include" ? "exclude" : "off",
-    );
+    setTypeState(value, nextFilterState(typeState(value)));
   };
 
   const fuse = useMemo(

--- a/ui/components/experience/searchable-technology-grid.tsx
+++ b/ui/components/experience/searchable-technology-grid.tsx
@@ -9,6 +9,7 @@ import {
   FilterBar,
   type MobileFilterSection,
 } from "@/components/ui/filter-bar";
+import type { FilterState } from "@/hooks/use-filter-params";
 import {
   TECHNOLOGY_TYPE_CONFIG,
   TECHNOLOGY_TYPES,
@@ -30,6 +31,34 @@ export function SearchableTechnologyGrid({
 }: SearchableTechnologyGridProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+  const [excludedTypes, setExcludedTypes] = useState<string[]>([]);
+
+  const typeState = (value: string): FilterState => {
+    if (excludedTypes.includes(value)) return "exclude";
+    if (selectedTypes.includes(value)) return "include";
+    return "off";
+  };
+
+  const setTypeState = (value: string, state: FilterState) => {
+    setSelectedTypes((prev) =>
+      state === "include"
+        ? [...prev.filter((t) => t !== value), value]
+        : prev.filter((t) => t !== value),
+    );
+    setExcludedTypes((prev) =>
+      state === "exclude"
+        ? [...prev.filter((t) => t !== value), value]
+        : prev.filter((t) => t !== value),
+    );
+  };
+
+  const cycleType = (value: string) => {
+    const current = typeState(value);
+    setTypeState(
+      value,
+      current === "off" ? "include" : current === "include" ? "exclude" : "off",
+    );
+  };
 
   const fuse = useMemo(
     () =>
@@ -51,37 +80,49 @@ export function SearchableTechnologyGrid({
         .map((result: FuseResult<RankedTechnology>) => result.item);
     }
 
-    // Apply type filter
+    // Apply type filter: OR over included, then drop excluded.
     if (selectedTypes.length > 0) {
       results = results.filter((tech) =>
         selectedTypes.includes(tech.badge.type as TechnologyType),
       );
     }
+    if (excludedTypes.length > 0) {
+      results = results.filter(
+        (tech) => !excludedTypes.includes(tech.badge.type as TechnologyType),
+      );
+    }
 
     return results;
-  }, [fuse, searchQuery, selectedTypes, technologies]);
+  }, [fuse, searchQuery, selectedTypes, excludedTypes, technologies]);
 
-  const hasActiveFilters = selectedTypes.length > 0;
+  const hasActiveFilters = selectedTypes.length > 0 || excludedTypes.length > 0;
 
-  const activeFilters = selectedTypes.map((type) => {
-    const config = TECHNOLOGY_TYPE_CONFIG[type as TechnologyType];
-    return {
-      paramName: "type",
-      label: "Type",
-      value: type,
-      displayValue: config.label,
-      icon: <Circle className={`size-2 fill-current ${config.color}`} />,
-    };
-  });
+  const activeFilters = [
+    ...selectedTypes.map((type) => {
+      const config = TECHNOLOGY_TYPE_CONFIG[type as TechnologyType];
+      return {
+        paramName: "type",
+        label: "Type",
+        value: type,
+        displayValue: config.label,
+        icon: <Circle className={`size-2 fill-current ${config.color}`} />,
+      };
+    }),
+    ...excludedTypes.map((type) => {
+      const config = TECHNOLOGY_TYPE_CONFIG[type as TechnologyType];
+      return {
+        paramName: "type",
+        label: "Type",
+        value: type,
+        displayValue: config.label,
+        icon: <Circle className={`size-2 fill-current ${config.color}`} />,
+        excluded: true,
+      };
+    }),
+  ];
 
   const handleRemoveFilter = (_paramName: string, value: string) => {
-    setSelectedTypes((prev) => prev.filter((t) => t !== value));
-  };
-
-  const handleToggleType = (value: string) => {
-    setSelectedTypes((prev) =>
-      prev.includes(value) ? prev.filter((t) => t !== value) : [...prev, value],
-    );
+    setTypeState(value, "off");
   };
 
   const mobileFilterSections: MobileFilterSection[] = [
@@ -97,9 +138,8 @@ export function SearchableTechnologyGrid({
           />
         ),
       })),
-      getOptionState: (value: string) =>
-        selectedTypes.includes(value) ? "include" : "off",
-      onCycleOption: handleToggleType,
+      getOptionState: (value: string) => typeState(value),
+      onCycleOption: cycleType,
     },
   ];
 
@@ -111,14 +151,24 @@ export function SearchableTechnologyGrid({
         searchPlaceholder="Search technologies..."
         activeFilters={activeFilters}
         onRemoveFilter={handleRemoveFilter}
-        onClearAll={() => setSelectedTypes([])}
+        onClearAll={() => {
+          setSelectedTypes([]);
+          setExcludedTypes([]);
+        }}
         hasActiveFilters={hasActiveFilters}
-        activeFilterCount={selectedTypes.length}
+        activeFilterCount={selectedTypes.length + excludedTypes.length}
         mobileFilterSections={mobileFilterSections}
       >
         <TechnologyTypeFilter
           value={selectedTypes}
           onChange={setSelectedTypes}
+          triState
+          excludedValues={excludedTypes}
+          onSetState={setTypeState}
+          onClearAll={() => {
+            setSelectedTypes([]);
+            setExcludedTypes([]);
+          }}
           size="sm"
         />
       </FilterBar>

--- a/ui/components/filters/status-filter.tsx
+++ b/ui/components/filters/status-filter.tsx
@@ -4,6 +4,7 @@ import { Circle } from "lucide-react";
 import {
   MultiSelect,
   type MultiSelectOption,
+  type MultiSelectTriStateProps,
 } from "@/components/ui/multi-select";
 import { ADR_STATUS_CONFIG, ADR_STATUSES } from "@/lib/domain/adr/adr";
 import {
@@ -13,7 +14,8 @@ import {
 
 type StatusType = "project" | "adr";
 
-interface StatusFilterProps<T extends StatusType> {
+interface StatusFilterProps<T extends StatusType>
+  extends MultiSelectTriStateProps {
   type: T;
   value: string[];
   onChange: (value: string[]) => void;
@@ -33,6 +35,7 @@ export function StatusFilter<T extends StatusType>({
   className,
   disabled = false,
   size = "default",
+  ...triState
 }: StatusFilterProps<T>) {
   const options: MultiSelectOption[] =
     type === "project"
@@ -68,6 +71,7 @@ export function StatusFilter<T extends StatusType>({
       className={className}
       disabled={disabled}
       size={size}
+      {...triState}
     />
   );
 }

--- a/ui/components/filters/technology-filter.tsx
+++ b/ui/components/filters/technology-filter.tsx
@@ -3,6 +3,7 @@
 import {
   MultiSelect,
   type MultiSelectOption,
+  type MultiSelectTriStateProps,
 } from "@/components/ui/multi-select";
 import { TechIcon } from "@/lib/api/tech-icons";
 
@@ -12,7 +13,7 @@ interface FilterableTechnology {
   iconSlug?: string;
 }
 
-interface TechnologyFilterProps {
+interface TechnologyFilterProps extends MultiSelectTriStateProps {
   technologies: FilterableTechnology[];
   value: string[];
   onChange: (value: string[]) => void;
@@ -32,6 +33,7 @@ export function TechnologyFilter({
   className,
   disabled = false,
   size = "default",
+  ...triState
 }: TechnologyFilterProps) {
   const options: MultiSelectOption[] = technologies.map((tech) => ({
     value: tech.slug,
@@ -52,6 +54,7 @@ export function TechnologyFilter({
       className={className}
       disabled={disabled}
       size={size}
+      {...triState}
     />
   );
 }

--- a/ui/components/filters/technology-type-filter.tsx
+++ b/ui/components/filters/technology-type-filter.tsx
@@ -4,13 +4,14 @@ import { Circle } from "lucide-react";
 import {
   MultiSelect,
   type MultiSelectOption,
+  type MultiSelectTriStateProps,
 } from "@/components/ui/multi-select";
 import {
   TECHNOLOGY_TYPE_CONFIG,
   TECHNOLOGY_TYPES,
 } from "@/lib/domain/technology/technology";
 
-interface TechnologyTypeFilterProps {
+interface TechnologyTypeFilterProps extends MultiSelectTriStateProps {
   value: string[];
   onChange: (value: string[]) => void;
   label?: string;
@@ -28,6 +29,7 @@ export function TechnologyTypeFilter({
   className,
   disabled = false,
   size = "default",
+  ...triState
 }: TechnologyTypeFilterProps) {
   const options: MultiSelectOption[] = TECHNOLOGY_TYPES.map((type) => {
     const typeConfig = TECHNOLOGY_TYPE_CONFIG[type];
@@ -49,6 +51,7 @@ export function TechnologyTypeFilter({
       className={className}
       disabled={disabled}
       size={size}
+      {...triState}
     />
   );
 }

--- a/ui/components/projects/adr-list.tsx
+++ b/ui/components/projects/adr-list.tsx
@@ -68,6 +68,8 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
   });
   const selectedStatus = filterParams.getValues("status");
   const selectedTech = filterParams.getValues("tech");
+  const excludedStatus = filterParams.getExcludedValues("status");
+  const excludedTech = filterParams.getExcludedValues("tech");
 
   const fuse = useMemo(
     () =>
@@ -86,13 +88,30 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
     if (selectedStatus.length > 0) {
       filtered = filtered.filter((adr) => selectedStatus.includes(adr.status));
     }
+    if (excludedStatus.length > 0) {
+      filtered = filtered.filter((adr) => !excludedStatus.includes(adr.status));
+    }
     if (selectedTech.length > 0) {
       filtered = filtered.filter((adr) =>
         adr.technologies?.some((tech) => selectedTech.includes(tech.slug)),
       );
     }
+    if (excludedTech.length > 0) {
+      filtered = filtered.filter(
+        (adr) =>
+          !adr.technologies?.some((tech) => excludedTech.includes(tech.slug)),
+      );
+    }
     return filtered;
-  }, [fuse, searchQuery, adrs, selectedStatus, selectedTech]);
+  }, [
+    fuse,
+    searchQuery,
+    adrs,
+    selectedStatus,
+    selectedTech,
+    excludedStatus,
+    excludedTech,
+  ]);
 
   const sortedADRs = [...filteredADRs].sort((a, b) => {
     const direction = currentSort === "newest" ? -1 : 1;
@@ -109,6 +128,7 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
       label: string;
       value: string;
       displayValue: string;
+      excluded?: boolean;
     }> = [];
 
     for (const status of selectedStatus) {
@@ -117,6 +137,15 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
         label: "Status",
         value: status,
         displayValue: status,
+      });
+    }
+    for (const status of excludedStatus) {
+      filters.push({
+        paramName: "status",
+        label: "Status",
+        value: status,
+        displayValue: status,
+        excluded: true,
       });
     }
     for (const tech of selectedTech) {
@@ -128,14 +157,29 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
         displayValue: techObj?.name ?? tech,
       });
     }
+    for (const tech of excludedTech) {
+      const techObj = allTechnologies.find((t) => t.slug === tech);
+      filters.push({
+        paramName: "tech",
+        label: "Tech",
+        value: tech,
+        displayValue: techObj?.name ?? tech,
+        excluded: true,
+      });
+    }
     return filters;
-  }, [selectedStatus, selectedTech, allTechnologies]);
+  }, [
+    selectedStatus,
+    selectedTech,
+    excludedStatus,
+    excludedTech,
+    allTechnologies,
+  ]);
 
   const handleRemoveFilter = (paramName: string, value: string) => {
-    filterParams.toggleValue(paramName, value);
+    filterParams.setState(paramName, value, "off");
   };
-  const isFiltering =
-    searchQuery || selectedStatus.length > 0 || selectedTech.length > 0;
+  const isFiltering = searchQuery || filterParams.hasActiveFilters;
   const sortButton = (
     <Button
       variant="outline"
@@ -154,12 +198,24 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
         type="adr"
         value={selectedStatus}
         onChange={(v) => filterParams.setValues("status", v)}
+        triState
+        excludedValues={excludedStatus}
+        onSetState={(value, state) =>
+          filterParams.setState("status", value, state)
+        }
+        onClearAll={() => filterParams.clearFilter("status")}
         size="sm"
       />
       {allTechnologies.length > 0 && (
         <TechnologyFilter
           technologies={allTechnologies}
           value={selectedTech}
+          triState
+          excludedValues={excludedTech}
+          onSetState={(value, state) =>
+            filterParams.setState("tech", value, state)
+          }
+          onClearAll={() => filterParams.clearFilter("tech")}
           onChange={(v) => filterParams.setValues("tech", v)}
           size="sm"
         />
@@ -178,9 +234,9 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
         label: "Status",
         options: statusOptions,
         getOptionState: (value: string) =>
-          selectedStatus.includes(value) ? "include" : "off",
+          filterParams.getState("status", value),
         onCycleOption: (value: string) =>
-          filterParams.toggleValue("status", value),
+          filterParams.cycleValue("status", value),
       },
     ];
     if (allTechnologies.length > 0) {
@@ -191,14 +247,13 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
           value: t.slug,
           label: t.name,
         })),
-        getOptionState: (value: string) =>
-          selectedTech.includes(value) ? "include" : "off",
+        getOptionState: (value: string) => filterParams.getState("tech", value),
         onCycleOption: (value: string) =>
-          filterParams.toggleValue("tech", value),
+          filterParams.cycleValue("tech", value),
       });
     }
     return sections;
-  }, [selectedStatus, selectedTech, allTechnologies, filterParams]);
+  }, [allTechnologies, filterParams]);
 
   if (adrs.length === 0) {
     return (

--- a/ui/components/projects/adr-list.tsx
+++ b/ui/components/projects/adr-list.tsx
@@ -177,8 +177,10 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
         paramName: "status",
         label: "Status",
         options: statusOptions,
-        selectedValues: selectedStatus,
-        onToggle: (value: string) => filterParams.toggleValue("status", value),
+        getOptionState: (value: string) =>
+          selectedStatus.includes(value) ? "include" : "off",
+        onCycleOption: (value: string) =>
+          filterParams.toggleValue("status", value),
       },
     ];
     if (allTechnologies.length > 0) {
@@ -189,8 +191,10 @@ export function ADRList({ projectSlug, adrs, description }: ADRListProps) {
           value: t.slug,
           label: t.name,
         })),
-        selectedValues: selectedTech,
-        onToggle: (value: string) => filterParams.toggleValue("tech", value),
+        getOptionState: (value: string) =>
+          selectedTech.includes(value) ? "include" : "off",
+        onCycleOption: (value: string) =>
+          filterParams.toggleValue("tech", value),
       });
     }
     return sections;

--- a/ui/components/projects/project-card.tsx
+++ b/ui/components/projects/project-card.tsx
@@ -2,7 +2,6 @@
 
 import { ExternalLink, Github, Globe, Tag } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
 import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -46,7 +45,6 @@ export function ProjectCard({
     () => prioritiseSelected(project.technologies, selectedTech, (t) => t.slug),
     [project.technologies, selectedTech],
   );
-  const pathname = usePathname();
   return (
     <Card className="flex flex-col h-full hover:shadow-lg transition-all hover:border-primary/50 group relative overflow-hidden">
       {/* Clickable Area for the whole card */}
@@ -65,14 +63,6 @@ export function ProjectCard({
                 active={selectedStatuses.includes(project.status)}
                 onClick={(e) => {
                   e.stopPropagation();
-                  posthog.capture("filter_applied", {
-                    page: pathname,
-                    filter_type: "status",
-                    filter_value: project.status,
-                    action: selectedStatuses.includes(project.status)
-                      ? "removed"
-                      : "added",
-                  });
                   onStatusClick(project.status);
                 }}
               />
@@ -93,14 +83,6 @@ export function ProjectCard({
                     active={selectedRoles.includes(role.slug)}
                     onClick={(e) => {
                       e.stopPropagation();
-                      posthog.capture("filter_applied", {
-                        page: pathname,
-                        filter_type: "role",
-                        filter_value: role.slug,
-                        action: selectedRoles.includes(role.slug)
-                          ? "removed"
-                          : "added",
-                      });
                       onRoleClick(role.slug);
                     }}
                   />
@@ -194,12 +176,6 @@ export function ProjectCard({
                   className="gap-1 cursor-pointer"
                   onClick={(e) => {
                     e.stopPropagation();
-                    posthog.capture("filter_applied", {
-                      page: pathname,
-                      filter_type: "tag",
-                      filter_value: tag,
-                      action: isActive ? "removed" : "added",
-                    });
                     onTagClick(tag);
                   }}
                 >
@@ -223,12 +199,6 @@ export function ProjectCard({
                 className="flex items-center gap-1 cursor-pointer"
                 onClick={(e) => {
                   e.stopPropagation();
-                  posthog.capture("filter_applied", {
-                    page: pathname,
-                    filter_type: "tech",
-                    filter_value: tech.slug,
-                    action: isActive ? "removed" : "added",
-                  });
                   onTechClick(tech.slug);
                 }}
               >

--- a/ui/components/projects/project-list.tsx
+++ b/ui/components/projects/project-list.tsx
@@ -2,6 +2,7 @@
 
 import { Circle, FolderGit2, Tag } from "lucide-react";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import { useEffect, useMemo } from "react";
 import {
   createRoleFilterOptions,
@@ -15,6 +16,7 @@ import { useFilterParams } from "@/hooks/use-filter-params";
 import type { Project, ProjectStatus } from "@/lib/api/projects";
 import { hasTechIcon, TechIcon } from "@/lib/api/tech-icons";
 import { PROJECT_STATUS_CONFIG } from "@/lib/domain/project/project";
+import { cycleFilterFromCard } from "@/lib/generic/filter-cycle";
 import { ProjectCard } from "./project-card";
 
 interface ProjectListProps {
@@ -78,6 +80,7 @@ export function ProjectList({ projects }: ProjectListProps) {
   const selectedTags = filterParams.getValues("tags");
   const selectedStatuses = filterParams.getValues("status");
   const selectedRoles = filterParams.getValues("role");
+  const pathname = usePathname();
   const { registerFilters, unregisterFilters } = useCommandPalette();
 
   useEffect(() => {
@@ -198,13 +201,46 @@ export function ProjectList({ projects }: ProjectListProps) {
         <ProjectCard
           project={project}
           selectedTech={selectedTech}
-          onTechClick={(tech) => filterParams.toggleValue("tech", tech)}
+          onTechClick={(tech) =>
+            cycleFilterFromCard({
+              filterParams,
+              paramName: "tech",
+              value: tech,
+              label: allTechnologies.find((t) => t.slug === tech)?.name ?? tech,
+              page: pathname,
+            })
+          }
           selectedTags={selectedTags}
-          onTagClick={(tag) => filterParams.toggleValue("tags", tag)}
+          onTagClick={(tag) =>
+            cycleFilterFromCard({
+              filterParams,
+              paramName: "tags",
+              value: tag,
+              label: tag,
+              page: pathname,
+            })
+          }
           selectedStatuses={selectedStatuses}
-          onStatusClick={(status) => filterParams.toggleValue("status", status)}
+          onStatusClick={(status) =>
+            cycleFilterFromCard({
+              filterParams,
+              paramName: "status",
+              value: status,
+              label:
+                PROJECT_STATUS_CONFIG[status as ProjectStatus]?.label ?? status,
+              page: pathname,
+            })
+          }
           selectedRoles={selectedRoles}
-          onRoleClick={(role) => filterParams.toggleValue("role", role)}
+          onRoleClick={(role) =>
+            cycleFilterFromCard({
+              filterParams,
+              paramName: "role",
+              value: role,
+              label: allRolesMap.get(role)?.company ?? role,
+              page: pathname,
+            })
+          }
         />
       )}
     />

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -9,7 +9,7 @@ import {
   UtensilsCrossed,
 } from "lucide-react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import {
   memo,
   type ReactNode,
@@ -35,6 +35,7 @@ import { useRecipeSearch } from "@/contexts/recipe-search-context";
 import { useFilterParams } from "@/hooks/use-filter-params";
 import type { RecipeCardView } from "@/lib/api/recipes";
 import { formatDate } from "@/lib/generic/date";
+import { cycleFilterFromCard } from "@/lib/generic/filter-cycle";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
 
 const TIME_RANGES = [
@@ -323,23 +324,44 @@ export function RecipeList({ recipes }: RecipeListProps) {
   // identities passed to the memoized cards constant. The ref is updated in a
   // commit-phase effect (not during render) so it always reflects committed
   // state, even under concurrent rendering.
+  const pathname = usePathname();
   const filterParamsRef = useRef(filterParams);
+  const pathnameRef = useRef(pathname);
   useEffect(() => {
     filterParamsRef.current = filterParams;
+    pathnameRef.current = pathname;
   });
   const onToggleCuisine = useCallback(
     (cuisine: string) =>
-      filterParamsRef.current.toggleValue("cuisine", cuisine),
+      cycleFilterFromCard({
+        filterParams: filterParamsRef.current,
+        paramName: "cuisine",
+        value: cuisine,
+        label: cuisine,
+        page: pathnameRef.current,
+      }),
     [],
   );
   const onTogglePrepTime = useCallback(
     (rangeLabel: string) =>
-      filterParamsRef.current.toggleValue("prepTime", rangeLabel),
+      cycleFilterFromCard({
+        filterParams: filterParamsRef.current,
+        paramName: "prepTime",
+        value: rangeLabel,
+        label: `prep ${rangeLabel}`,
+        page: pathnameRef.current,
+      }),
     [],
   );
   const onToggleTotalTime = useCallback(
     (rangeLabel: string) =>
-      filterParamsRef.current.toggleValue("totalTime", rangeLabel),
+      cycleFilterFromCard({
+        filterParams: filterParamsRef.current,
+        paramName: "totalTime",
+        value: rangeLabel,
+        label: `total ${rangeLabel}`,
+        page: pathnameRef.current,
+      }),
     [],
   );
 

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Check, Filter, Search, X } from "lucide-react";
+import { Check, Filter, Minus, Search, X } from "lucide-react";
 import type * as React from "react";
 import { useState } from "react";
-
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,6 +14,7 @@ import {
 } from "@/components/ui/drawer";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { Input } from "@/components/ui/input";
+import type { FilterState } from "@/hooks/use-filter-params";
 import { cn } from "@/lib/generic/styles";
 
 interface ActiveFilter {
@@ -23,6 +23,7 @@ interface ActiveFilter {
   value: string;
   displayValue: string;
   icon?: React.ReactNode;
+  excluded?: boolean;
 }
 
 export interface MobileFilterOption {
@@ -35,8 +36,8 @@ export interface MobileFilterSection {
   paramName: string;
   label: string;
   options: MobileFilterOption[];
-  selectedValues: string[];
-  onToggle: (value: string) => void;
+  getOptionState: (value: string) => FilterState;
+  onCycleOption: (value: string) => void;
 }
 
 interface FilterBarProps {
@@ -162,22 +163,36 @@ export function FilterBar({
                       </h4>
                       <div className="flex flex-wrap gap-2">
                         {section.options.map((option) => {
-                          const isSelected = section.selectedValues.includes(
-                            option.value,
-                          );
+                          const state = section.getOptionState(option.value);
+                          const isIncluded = state === "include";
+                          const isExcluded = state === "exclude";
                           return (
                             <Badge
                               key={option.value}
-                              variant={isSelected ? "default" : "outline"}
+                              variant={
+                                isExcluded
+                                  ? "destructive"
+                                  : isIncluded
+                                    ? "default"
+                                    : "outline"
+                              }
                               interactive
-                              active={isSelected}
-                              className="cursor-pointer gap-1.5 py-1.5 px-3"
-                              onClick={() => section.onToggle(option.value)}
+                              active={isIncluded || isExcluded}
+                              className={cn(
+                                "cursor-pointer gap-1.5 py-1.5 px-3",
+                                isExcluded && "line-through",
+                              )}
+                              onClick={() =>
+                                section.onCycleOption(option.value)
+                              }
                             >
                               {option.icon}
                               <span>{option.label}</span>
-                              {isSelected && (
+                              {isIncluded && (
                                 <Check className="size-3 ml-0.5" />
+                              )}
+                              {isExcluded && (
+                                <Minus className="size-3 ml-0.5" />
                               )}
                             </Badge>
                           );
@@ -214,8 +229,9 @@ export function FilterBar({
           <span className="text-sm text-muted-foreground">Active filters:</span>
           {activeFilters.map((filter) => (
             <FilterChip
-              key={`${filter.paramName}-${filter.value}`}
+              key={`${filter.paramName}-${filter.excluded ? "!" : ""}${filter.value}`}
               icon={filter.icon}
+              excluded={filter.excluded}
               onRemove={() => onRemoveFilter?.(filter.paramName, filter.value)}
             >
               {filter.displayValue}

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -14,7 +14,10 @@ import {
 } from "@/components/ui/drawer";
 import { FilterChip } from "@/components/ui/filter-chip";
 import { Input } from "@/components/ui/input";
-import type { FilterState } from "@/hooks/use-filter-params";
+import {
+  type FilterState,
+  filterStateAriaLabel,
+} from "@/hooks/use-filter-params";
 import { cn } from "@/lib/generic/styles";
 
 function chipVariantForState(
@@ -180,6 +183,10 @@ export function FilterBar({
                               variant={chipVariantForState(state)}
                               interactive
                               active={isIncluded || isExcluded}
+                              aria-label={filterStateAriaLabel(
+                                option.label,
+                                state,
+                              )}
                               className={cn(
                                 "cursor-pointer gap-1.5 py-1.5 px-3",
                                 isExcluded && "line-through",

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -17,6 +17,14 @@ import { Input } from "@/components/ui/input";
 import type { FilterState } from "@/hooks/use-filter-params";
 import { cn } from "@/lib/generic/styles";
 
+function chipVariantForState(
+  state: FilterState,
+): "destructive" | "default" | "outline" {
+  if (state === "exclude") return "destructive";
+  if (state === "include") return "default";
+  return "outline";
+}
+
 interface ActiveFilter {
   paramName: string;
   label: string;
@@ -169,13 +177,7 @@ export function FilterBar({
                           return (
                             <Badge
                               key={option.value}
-                              variant={
-                                isExcluded
-                                  ? "destructive"
-                                  : isIncluded
-                                    ? "default"
-                                    : "outline"
-                              }
+                              variant={chipVariantForState(state)}
                               interactive
                               active={isIncluded || isExcluded}
                               className={cn(

--- a/ui/components/ui/filter-chip.tsx
+++ b/ui/components/ui/filter-chip.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { VariantProps } from "class-variance-authority";
-import { X } from "lucide-react";
+import { Minus, X } from "lucide-react";
 import type * as React from "react";
 import { Badge, type badgeVariants } from "@/components/ui/badge";
 import { cn } from "@/lib/generic/styles";
@@ -13,6 +13,8 @@ interface FilterChipProps
   icon?: React.ReactNode;
   children: React.ReactNode;
   disabled?: boolean;
+  /** Render as an exclude filter (destructive, struck through, minus glyph). */
+  excluded?: boolean;
 }
 
 export function FilterChip({
@@ -20,6 +22,7 @@ export function FilterChip({
   icon,
   children,
   disabled = false,
+  excluded = false,
   variant = "secondary",
   className,
   ...props
@@ -34,7 +37,7 @@ export function FilterChip({
 
   return (
     <Badge
-      variant={variant}
+      variant={excluded ? "destructive" : variant}
       className={cn(
         "flex items-center gap-1.5 pr-1",
         disabled && "opacity-50",
@@ -42,8 +45,14 @@ export function FilterChip({
       )}
       {...props}
     >
-      {icon && <span className="shrink-0 [&>svg]:size-3">{icon}</span>}
-      <span className="truncate">{children}</span>
+      {excluded ? (
+        <Minus className="size-3 shrink-0" aria-hidden />
+      ) : (
+        icon && <span className="shrink-0 [&>svg]:size-3">{icon}</span>
+      )}
+      <span className={cn("truncate", excluded && "line-through")}>
+        {children}
+      </span>
       <button
         type="button"
         onClick={handleRemove}

--- a/ui/components/ui/filter-chip.tsx
+++ b/ui/components/ui/filter-chip.tsx
@@ -52,6 +52,7 @@ export function FilterChip({
       )}
       <span className={cn("truncate", excluded && "line-through")}>
         {children}
+        {excluded && <span className="sr-only"> (excluded)</span>}
       </span>
       <button
         type="button"

--- a/ui/components/ui/filterable-card-grid.tsx
+++ b/ui/components/ui/filterable-card-grid.tsx
@@ -125,6 +125,7 @@ export function FilterableCardGrid<T>({
     getExcludedValues,
     getSelection,
     getState,
+    peekState,
     cycleValue,
     setValues,
     setState,
@@ -335,13 +336,22 @@ export function FilterableCardGrid<T>({
           .sort((a, b) => a.label.localeCompare(b.label)),
         getOptionState: (value: string) => getState(fc.paramName, value),
         onCycleOption: (value: string) => {
-          const next = nextFilterState(getState(fc.paramName, value));
+          // Derive the analytics action from the same latest read cycleValue
+          // writes from, so the recorded action can't drift from the URL.
+          const next = nextFilterState(peekState(fc.paramName, value));
           captureFilterChange(fc.paramName, value, next);
           cycleValue(fc.paramName, value);
         },
       };
     });
-  }, [filterConfigs, items, getState, cycleValue, captureFilterChange]);
+  }, [
+    filterConfigs,
+    items,
+    getState,
+    peekState,
+    cycleValue,
+    captureFilterChange,
+  ]);
 
   const handleRemoveFilter = (paramName: string, value: string) => {
     captureFilterChange(paramName, value, "off");

--- a/ui/components/ui/filterable-card-grid.tsx
+++ b/ui/components/ui/filterable-card-grid.tsx
@@ -19,6 +19,7 @@ import {
 import { useDebouncedSearchTracking } from "@/hooks/use-debounced-search-tracking";
 import {
   type FilterParamConfig,
+  type FilterState,
   useFilterParams,
 } from "@/hooks/use-filter-params";
 import { useSortParam } from "@/hooks/use-sort-param";
@@ -119,8 +120,12 @@ export function FilterableCardGrid<T>({
 
   const {
     getValues,
+    getExcludedValues,
+    getSelection,
+    getState,
+    cycleValue,
     setValues,
-    toggleValue,
+    setState,
     clearFilter,
     clearAllFilters,
     hasActiveFilters,
@@ -157,16 +162,20 @@ export function FilterableCardGrid<T>({
       ? fuse.search(searchQuery).map((result: FuseResult<T>) => result.item)
       : items;
 
-    // Apply multi-filters (AND between different filters, OR within same filter)
+    // Apply multi-filters. Across different filters: AND. Within one filter:
+    // OR over included values, then drop anything carrying an excluded value.
     if (filterConfigs) {
       for (const fc of filterConfigs) {
-        const selectedValues = getValues(fc.paramName);
-        if (selectedValues.length > 0) {
-          filtered = filtered.filter((item: T) => {
-            const itemValues = fc.getItemValues(item);
-            return selectedValues.some((v) => itemValues.includes(v));
-          });
-        }
+        const { include, exclude } = getSelection(fc.paramName);
+        if (include.length === 0 && exclude.length === 0) continue;
+        filtered = filtered.filter((item: T) => {
+          const itemValues = fc.getItemValues(item);
+          if (exclude.some((v) => itemValues.includes(v))) return false;
+          if (include.length > 0) {
+            return include.some((v) => itemValues.includes(v));
+          }
+          return true;
+        });
       }
     }
 
@@ -193,7 +202,7 @@ export function FilterableCardGrid<T>({
     searchQuery,
     items,
     filterConfigs,
-    getValues,
+    getSelection,
     dateRangeConfig,
     getDateRange,
   ]);
@@ -257,12 +266,13 @@ export function FilterableCardGrid<T>({
       value: string;
       displayValue: string;
       icon?: ReactNode;
+      excluded?: boolean;
     }> = [];
 
     if (filterConfigs) {
       for (const fc of filterConfigs) {
-        const values = getValues(fc.paramName);
-        for (const value of values) {
+        const { include, exclude } = getSelection(fc.paramName);
+        for (const value of include) {
           filters.push({
             paramName: fc.paramName,
             label: fc.label,
@@ -271,11 +281,38 @@ export function FilterableCardGrid<T>({
             icon: fc.icon,
           });
         }
+        for (const value of exclude) {
+          filters.push({
+            paramName: fc.paramName,
+            label: fc.label,
+            value,
+            displayValue: fc.getValueLabel?.(value) ?? value,
+            icon: fc.icon,
+            excluded: true,
+          });
+        }
       }
     }
 
     return filters;
-  }, [filterConfigs, getValues]);
+  }, [filterConfigs, getSelection]);
+
+  const captureFilterChange = useCallback(
+    (paramName: string, value: string, nextState: FilterState) => {
+      posthog.capture("filter_applied", {
+        page: pathname,
+        filter_type: paramName,
+        filter_value: value,
+        action:
+          nextState === "off"
+            ? "removed"
+            : nextState === "exclude"
+              ? "excluded"
+              : "added",
+      });
+    },
+    [pathname],
+  );
 
   const mobileFilterSections: MobileFilterSection[] = useMemo(() => {
     if (!filterConfigs) return [];
@@ -299,30 +336,26 @@ export function FilterableCardGrid<T>({
             icon: fc.getOptionIcon?.(value) ?? fc.icon,
           }))
           .sort((a, b) => a.label.localeCompare(b.label)),
-        selectedValues: getValues(fc.paramName),
-        onToggle: (value: string) => {
-          const isSelected = getValues(fc.paramName).includes(value);
-          posthog.capture("filter_applied", {
-            page: pathname,
-            filter_type: fc.paramName,
-            filter_value: value,
-            action: isSelected ? "removed" : "added",
-          });
-          toggleValue(fc.paramName, value);
+        getOptionState: (value: string) => getState(fc.paramName, value),
+        onCycleOption: (value: string) => {
+          const current = getState(fc.paramName, value);
+          const next: FilterState =
+            current === "off"
+              ? "include"
+              : current === "include"
+                ? "exclude"
+                : "off";
+          captureFilterChange(fc.paramName, value, next);
+          cycleValue(fc.paramName, value);
         },
       };
     });
-  }, [filterConfigs, items, getValues, toggleValue, pathname]);
+  }, [filterConfigs, items, getState, cycleValue, captureFilterChange]);
 
   const handleRemoveFilter = (paramName: string, value: string) => {
-    posthog.capture("filter_applied", {
-      page: pathname,
-      filter_type: paramName,
-      filter_value: value,
-      action: "removed",
-    });
+    captureFilterChange(paramName, value, "off");
     if (filterConfigs) {
-      toggleValue(paramName, value);
+      setState(paramName, value, "off");
     } else {
       clearFilter(paramName);
     }
@@ -398,29 +431,15 @@ export function FilterableCardGrid<T>({
                 <MultiSelect
                   key={fc.paramName}
                   options={options}
+                  triState
                   value={getValues(fc.paramName)}
-                  onChange={(v) => {
-                    const prev = getValues(fc.paramName);
-                    const added = v.filter((val) => !prev.includes(val));
-                    const removed = prev.filter((val) => !v.includes(val));
-                    for (const val of added) {
-                      posthog.capture("filter_applied", {
-                        page: pathname,
-                        filter_type: fc.paramName,
-                        filter_value: val,
-                        action: "added",
-                      });
-                    }
-                    for (const val of removed) {
-                      posthog.capture("filter_applied", {
-                        page: pathname,
-                        filter_type: fc.paramName,
-                        filter_value: val,
-                        action: "removed",
-                      });
-                    }
-                    setValues(fc.paramName, v);
+                  excludedValues={getExcludedValues(fc.paramName)}
+                  onSetState={(value, state) => {
+                    captureFilterChange(fc.paramName, value, state);
+                    setState(fc.paramName, value, state);
                   }}
+                  onClearAll={() => clearFilter(fc.paramName)}
+                  onChange={(v) => setValues(fc.paramName, v)}
                   label={fc.label}
                   placeholder={`All ${fc.label.toLowerCase()}`}
                   icon={fc.icon}

--- a/ui/components/ui/filterable-card-grid.tsx
+++ b/ui/components/ui/filterable-card-grid.tsx
@@ -20,6 +20,8 @@ import { useDebouncedSearchTracking } from "@/hooks/use-debounced-search-trackin
 import {
   type FilterParamConfig,
   type FilterState,
+  filterAppliedAction,
+  nextFilterState,
   useFilterParams,
 } from "@/hooks/use-filter-params";
 import { useSortParam } from "@/hooks/use-sort-param";
@@ -303,12 +305,7 @@ export function FilterableCardGrid<T>({
         page: pathname,
         filter_type: paramName,
         filter_value: value,
-        action:
-          nextState === "off"
-            ? "removed"
-            : nextState === "exclude"
-              ? "excluded"
-              : "added",
+        action: filterAppliedAction(nextState),
       });
     },
     [pathname],
@@ -338,13 +335,7 @@ export function FilterableCardGrid<T>({
           .sort((a, b) => a.label.localeCompare(b.label)),
         getOptionState: (value: string) => getState(fc.paramName, value),
         onCycleOption: (value: string) => {
-          const current = getState(fc.paramName, value);
-          const next: FilterState =
-            current === "off"
-              ? "include"
-              : current === "include"
-                ? "exclude"
-                : "off";
+          const next = nextFilterState(getState(fc.paramName, value));
           captureFilterChange(fc.paramName, value, next);
           cycleValue(fc.paramName, value);
         },

--- a/ui/components/ui/multi-select.tsx
+++ b/ui/components/ui/multi-select.tsx
@@ -6,7 +6,11 @@ import type * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
-import { type FilterState, nextFilterState } from "@/hooks/use-filter-params";
+import {
+  type FilterState,
+  filterStateAriaLabel,
+  nextFilterState,
+} from "@/hooks/use-filter-params";
 import { cn } from "@/lib/generic/styles";
 
 export interface MultiSelectOption {
@@ -14,12 +18,6 @@ export interface MultiSelectOption {
   label: string;
   icon?: React.ReactNode;
   disabled?: boolean;
-}
-
-function optionAriaLabel(label: string, state: FilterState): string {
-  if (state === "exclude") return `${label} (excluded)`;
-  if (state === "include") return `${label} (included)`;
-  return label;
 }
 
 /**
@@ -91,16 +89,29 @@ export function MultiSelect({
     [excludedValues, value],
   );
 
-  const includedOptions = useMemo(
-    () => options.filter((option) => value.includes(option.value)),
-    [options, value],
+  // Build chips straight from the selected values (not by filtering options),
+  // so a stale token in the URL — one whose option no longer exists after the
+  // data changed — still renders a labelled, removable chip instead of a
+  // phantom count with no affordance.
+  const optionByValue = useMemo(
+    () => new Map(options.map((option) => [option.value, option])),
+    [options],
   );
-  const excludedOptions = useMemo(
-    () => options.filter((option) => excludedValues.includes(option.value)),
-    [options, excludedValues],
+  const includedOptions = useMemo<MultiSelectOption[]>(
+    () => value.map((v) => optionByValue.get(v) ?? { value: v, label: v }),
+    [value, optionByValue],
+  );
+  const excludedOptions = useMemo<MultiSelectOption[]>(
+    () =>
+      isTri
+        ? excludedValues.map(
+            (v) => optionByValue.get(v) ?? { value: v, label: v },
+          )
+        : [],
+    [isTri, excludedValues, optionByValue],
   );
 
-  const activeCount = value.length + (isTri ? excludedValues.length : 0);
+  const activeCount = includedOptions.length + excludedOptions.length;
 
   const handleToggle = useCallback(
     (optionValue: string) => {
@@ -277,7 +288,7 @@ export function MultiSelect({
                     type="button"
                     onClick={() => !isDisabled && handleToggle(option.value)}
                     disabled={isDisabled}
-                    aria-label={optionAriaLabel(option.label, state)}
+                    aria-label={filterStateAriaLabel(option.label, state)}
                     className={cn(
                       "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-2 text-sm outline-hidden select-none",
                       "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",

--- a/ui/components/ui/multi-select.tsx
+++ b/ui/components/ui/multi-select.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import { CheckIcon, ChevronDownIcon, Search, X } from "lucide-react";
+import { CheckIcon, ChevronDownIcon, Minus, Search, X } from "lucide-react";
 import type * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
+import type { FilterState } from "@/hooks/use-filter-params";
 import { cn } from "@/lib/generic/styles";
 
 export interface MultiSelectOption {
@@ -17,6 +18,7 @@ export interface MultiSelectOption {
 
 interface MultiSelectProps {
   options: MultiSelectOption[];
+  /** Included values. */
   value: string[];
   onChange: (value: string[]) => void;
   placeholder?: string;
@@ -28,6 +30,16 @@ interface MultiSelectProps {
   className?: string;
   disabled?: boolean;
   size?: "sm" | "default";
+  /**
+   * Tri-state (opt-in). When enabled, a row cycles off → include → exclude →
+   * off instead of a plain checkbox toggle. Requires `onSetState`; excluded
+   * values are supplied via `excludedValues`.
+   */
+  triState?: boolean;
+  excludedValues?: string[];
+  onSetState?: (value: string, state: FilterState) => void;
+  /** Clears both included and excluded values. Falls back to `onChange([])`. */
+  onClearAll?: () => void;
 }
 
 export function MultiSelect({
@@ -43,9 +55,14 @@ export function MultiSelect({
   className,
   disabled = false,
   size = "default",
+  triState = false,
+  excludedValues = [],
+  onSetState,
+  onClearAll,
 }: MultiSelectProps) {
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const isTri = triState && typeof onSetState === "function";
 
   const filteredOptions = useMemo(() => {
     if (!searchQuery.trim()) return options;
@@ -55,12 +72,39 @@ export function MultiSelect({
     );
   }, [options, searchQuery]);
 
-  const selectedOptions = useMemo(() => {
-    return options.filter((option) => value.includes(option.value));
-  }, [options, value]);
+  const stateOf = useCallback(
+    (optionValue: string): FilterState => {
+      if (excludedValues.includes(optionValue)) return "exclude";
+      if (value.includes(optionValue)) return "include";
+      return "off";
+    },
+    [excludedValues, value],
+  );
+
+  const includedOptions = useMemo(
+    () => options.filter((option) => value.includes(option.value)),
+    [options, value],
+  );
+  const excludedOptions = useMemo(
+    () => options.filter((option) => excludedValues.includes(option.value)),
+    [options, excludedValues],
+  );
+
+  const activeCount = value.length + (isTri ? excludedValues.length : 0);
 
   const handleToggle = useCallback(
     (optionValue: string) => {
+      if (isTri && onSetState) {
+        const current = stateOf(optionValue);
+        const next: FilterState =
+          current === "off"
+            ? "include"
+            : current === "include"
+              ? "exclude"
+              : "off";
+        onSetState(optionValue, next);
+        return;
+      }
       const isSelected = value.includes(optionValue);
       if (isSelected) {
         onChange(value.filter((v) => v !== optionValue));
@@ -69,44 +113,54 @@ export function MultiSelect({
         onChange([...value, optionValue]);
       }
     },
-    [value, onChange, maxSelections],
+    [isTri, onSetState, stateOf, value, onChange, maxSelections],
   );
 
   const handleClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
+      if (isTri && onClearAll) {
+        onClearAll();
+        return;
+      }
       onChange([]);
     },
-    [onChange],
+    [isTri, onClearAll, onChange],
   );
 
   const handleRemove = useCallback(
     (optionValue: string, e: React.MouseEvent) => {
       e.stopPropagation();
+      if (isTri && onSetState) {
+        onSetState(optionValue, "off");
+        return;
+      }
       onChange(value.filter((v) => v !== optionValue));
     },
-    [value, onChange],
+    [isTri, onSetState, value, onChange],
   );
 
   const displayValue = useMemo(() => {
-    if (selectedOptions.length === 0) {
+    if (activeCount === 0) {
       return <span className="text-muted-foreground">{placeholder}</span>;
     }
-    if (selectedOptions.length === 1) {
-      const option = selectedOptions[0];
+    if (activeCount === 1) {
+      const option = includedOptions[0] ?? excludedOptions[0];
+      const excluded = includedOptions.length === 0;
       return (
         <span className="flex items-center gap-1.5 truncate">
+          {excluded && <Minus className="size-3 text-destructive" />}
           {option?.icon}
-          {option?.label}
+          <span className={cn(excluded && "line-through")}>
+            {option?.label}
+          </span>
         </span>
       );
     }
     return (
-      <span className="flex items-center gap-1.5">
-        {selectedOptions.length} selected
-      </span>
+      <span className="flex items-center gap-1.5">{activeCount} selected</span>
     );
-  }, [selectedOptions, placeholder]);
+  }, [activeCount, includedOptions, excludedOptions, placeholder]);
 
   return (
     <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
@@ -133,7 +187,7 @@ export function MultiSelect({
             <span className="truncate">{displayValue}</span>
           </span>
           <span className="flex items-center gap-1 shrink-0">
-            {value.length > 0 && (
+            {activeCount > 0 && (
               <button
                 type="button"
                 onClick={handleClear}
@@ -191,6 +245,12 @@ export function MultiSelect({
             </div>
           )}
 
+          {isTri && (
+            <p className="border-b px-3 py-1.5 text-[11px] text-muted-foreground">
+              Click to include · click again to exclude
+            </p>
+          )}
+
           <div className="max-h-[300px] overflow-y-auto p-1">
             {filteredOptions.length === 0 ? (
               <div className="py-6 text-center text-sm text-muted-foreground">
@@ -198,10 +258,13 @@ export function MultiSelect({
               </div>
             ) : (
               filteredOptions.map((option) => {
-                const isSelected = value.includes(option.value);
+                const state = stateOf(option.value);
+                const isSelected = state === "include";
+                const isExcluded = state === "exclude";
                 const isDisabled =
                   option.disabled ||
-                  (!isSelected &&
+                  (!isTri &&
+                    !isSelected &&
                     maxSelections !== undefined &&
                     value.length >= maxSelections);
 
@@ -211,6 +274,13 @@ export function MultiSelect({
                     type="button"
                     onClick={() => !isDisabled && handleToggle(option.value)}
                     disabled={isDisabled}
+                    aria-label={
+                      isExcluded
+                        ? `${option.label} (excluded)`
+                        : isSelected
+                          ? `${option.label} (included)`
+                          : option.label
+                    }
                     className={cn(
                       "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-2 text-sm outline-hidden select-none",
                       "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
@@ -221,28 +291,38 @@ export function MultiSelect({
                       className={cn(
                         "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow flex items-center justify-center",
                         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-                        isSelected
-                          ? "bg-primary border-primary text-primary-foreground"
-                          : "bg-background",
+                        isSelected &&
+                          "bg-primary border-primary text-primary-foreground",
+                        isExcluded &&
+                          "bg-destructive border-destructive text-white",
+                        state === "off" && "bg-background",
                         isDisabled && "cursor-not-allowed opacity-50",
                       )}
                     >
                       {isSelected && <CheckIcon className="size-3" />}
+                      {isExcluded && <Minus className="size-3" />}
                     </div>
                     {option.icon && (
                       <span className="shrink-0">{option.icon}</span>
                     )}
-                    <span className="truncate">{option.label}</span>
+                    <span
+                      className={cn(
+                        "truncate",
+                        isExcluded && "line-through text-muted-foreground",
+                      )}
+                    >
+                      {option.label}
+                    </span>
                   </button>
                 );
               })
             )}
           </div>
 
-          {selectedOptions.length > 0 && (
+          {activeCount > 0 && (
             <div className="border-t p-2">
               <div className="flex flex-wrap gap-1">
-                {selectedOptions.map((option) => (
+                {includedOptions.map((option) => (
                   <Badge
                     key={option.value}
                     variant="secondary"
@@ -250,6 +330,26 @@ export function MultiSelect({
                   >
                     {option.icon}
                     <span className="truncate max-w-[100px]">
+                      {option.label}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={(e) => handleRemove(option.value, e)}
+                      className="rounded-full p-0.5 hover:bg-background/50 transition-colors"
+                      aria-label={`Remove ${option.label}`}
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </Badge>
+                ))}
+                {excludedOptions.map((option) => (
+                  <Badge
+                    key={option.value}
+                    variant="destructive"
+                    className="text-xs gap-1 pr-1"
+                  >
+                    <Minus className="size-3" />
+                    <span className="truncate max-w-[100px] line-through">
                       {option.label}
                     </span>
                     <button

--- a/ui/components/ui/multi-select.tsx
+++ b/ui/components/ui/multi-select.tsx
@@ -16,7 +16,21 @@ export interface MultiSelectOption {
   disabled?: boolean;
 }
 
-interface MultiSelectProps {
+/**
+ * Tri-state (opt-in) props. When enabled, a row cycles off → include →
+ * exclude → off instead of a plain checkbox toggle. Requires `onSetState`;
+ * excluded values are supplied via `excludedValues`. Kept as a standalone
+ * interface so thin filter wrappers can forward it with a single spread.
+ */
+export interface MultiSelectTriStateProps {
+  triState?: boolean;
+  excludedValues?: string[];
+  onSetState?: (value: string, state: FilterState) => void;
+  /** Clears both included and excluded values. Falls back to `onChange([])`. */
+  onClearAll?: () => void;
+}
+
+interface MultiSelectProps extends MultiSelectTriStateProps {
   options: MultiSelectOption[];
   /** Included values. */
   value: string[];
@@ -30,16 +44,6 @@ interface MultiSelectProps {
   className?: string;
   disabled?: boolean;
   size?: "sm" | "default";
-  /**
-   * Tri-state (opt-in). When enabled, a row cycles off → include → exclude →
-   * off instead of a plain checkbox toggle. Requires `onSetState`; excluded
-   * values are supplied via `excludedValues`.
-   */
-  triState?: boolean;
-  excludedValues?: string[];
-  onSetState?: (value: string, state: FilterState) => void;
-  /** Clears both included and excluded values. Falls back to `onChange([])`. */
-  onClearAll?: () => void;
 }
 
 export function MultiSelect({

--- a/ui/components/ui/multi-select.tsx
+++ b/ui/components/ui/multi-select.tsx
@@ -6,7 +6,7 @@ import type * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
-import type { FilterState } from "@/hooks/use-filter-params";
+import { type FilterState, nextFilterState } from "@/hooks/use-filter-params";
 import { cn } from "@/lib/generic/styles";
 
 export interface MultiSelectOption {
@@ -14,6 +14,12 @@ export interface MultiSelectOption {
   label: string;
   icon?: React.ReactNode;
   disabled?: boolean;
+}
+
+function optionAriaLabel(label: string, state: FilterState): string {
+  if (state === "exclude") return `${label} (excluded)`;
+  if (state === "include") return `${label} (included)`;
+  return label;
 }
 
 /**
@@ -99,14 +105,7 @@ export function MultiSelect({
   const handleToggle = useCallback(
     (optionValue: string) => {
       if (isTri && onSetState) {
-        const current = stateOf(optionValue);
-        const next: FilterState =
-          current === "off"
-            ? "include"
-            : current === "include"
-              ? "exclude"
-              : "off";
-        onSetState(optionValue, next);
+        onSetState(optionValue, nextFilterState(stateOf(optionValue)));
         return;
       }
       const isSelected = value.includes(optionValue);
@@ -278,13 +277,7 @@ export function MultiSelect({
                     type="button"
                     onClick={() => !isDisabled && handleToggle(option.value)}
                     disabled={isDisabled}
-                    aria-label={
-                      isExcluded
-                        ? `${option.label} (excluded)`
-                        : isSelected
-                          ? `${option.label} (included)`
-                          : option.label
-                    }
+                    aria-label={optionAriaLabel(option.label, state)}
                     className={cn(
                       "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-2 text-sm outline-hidden select-none",
                       "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",

--- a/ui/components/ui/sonner.tsx
+++ b/ui/components/ui/sonner.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+export function Toaster(props: ToasterProps) {
+  const { theme = "dark" } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      position="bottom-center"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group toast group-[.toaster]:bg-popover group-[.toaster]:text-popover-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+          description: "group-[.toast]:text-muted-foreground",
+          actionButton:
+            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+          cancelButton:
+            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+        },
+      }}
+      {...props}
+    />
+  );
+}

--- a/ui/hooks/use-filter-params.ts
+++ b/ui/hooks/use-filter-params.ts
@@ -1,7 +1,12 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useMemo } from "react";
+import {
+  type ReadonlyURLSearchParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
+import { useCallback, useMemo, useRef } from "react";
 
 export interface FilterParamConfig {
   paramName: string;
@@ -32,6 +37,38 @@ function parseToken(token: string): { value: string; excluded: boolean } {
 
 function toToken(value: string, state: Exclude<FilterState, "off">): string {
   return state === "exclude" ? `${EXCLUDE_PREFIX}${value}` : value;
+}
+
+/** Advances a tri-state: off → include → exclude → off. */
+export function nextFilterState(current: FilterState): FilterState {
+  if (current === "off") return "include";
+  if (current === "include") return "exclude";
+  return "off";
+}
+
+/** Maps a tri-state to the analytics action recorded for it. */
+export function filterAppliedAction(
+  state: FilterState,
+): "added" | "removed" | "excluded" {
+  if (state === "off") return "removed";
+  if (state === "exclude") return "excluded";
+  return "added";
+}
+
+function parseSelection(
+  searchParams: ReadonlyURLSearchParams,
+  paramName: string,
+  delimiter: string,
+): FilterSelection {
+  const value = searchParams.get(paramName);
+  const include: string[] = [];
+  const exclude: string[] = [];
+  if (!value) return { include, exclude };
+  for (const token of value.split(delimiter).filter(Boolean)) {
+    const { value: v, excluded } = parseToken(token);
+    (excluded ? exclude : include).push(v);
+  }
+  return { include, exclude };
 }
 
 export interface UseFilterParamsOptions {
@@ -73,6 +110,13 @@ export function useFilterParams(
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
+  // Write handlers may run in async contexts (e.g. the "Undo" action on the
+  // sonner toast fired when excluding from a card). A ref pinned to the latest
+  // searchParams lets those writes merge onto the current URL rather than a
+  // stale snapshot captured when the handler was created.
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
+
   const { filters, delimiter = ",", preserveScroll = true } = options;
   const filterParamNames = useMemo(
     () => new Set(filters.map((f) => f.paramName)),
@@ -99,18 +143,11 @@ export function useFilterParams(
     [searchParams],
   );
 
+  // Reactive reads — their identity changes with searchParams so render-time
+  // consumers (filtering/active-chip memos) recompute when the URL changes.
   const getSelection = useCallback(
-    (paramName: string): FilterSelection => {
-      const value = searchParams.get(paramName);
-      const include: string[] = [];
-      const exclude: string[] = [];
-      if (!value) return { include, exclude };
-      for (const token of value.split(delimiter).filter(Boolean)) {
-        const { value: v, excluded } = parseToken(token);
-        (excluded ? exclude : include).push(v);
-      }
-      return { include, exclude };
-    },
+    (paramName: string): FilterSelection =>
+      parseSelection(searchParams, paramName, delimiter),
     [searchParams, delimiter],
   );
 
@@ -134,9 +171,26 @@ export function useFilterParams(
     [getSelection],
   );
 
+  // Latest-value reads for use inside write handlers (see searchParamsRef).
+  const readSelection = useCallback(
+    (paramName: string): FilterSelection =>
+      parseSelection(searchParamsRef.current, paramName, delimiter),
+    [delimiter],
+  );
+
+  const readState = useCallback(
+    (paramName: string, value: string): FilterState => {
+      const { include, exclude } = readSelection(paramName);
+      if (exclude.includes(value)) return "exclude";
+      if (include.includes(value)) return "include";
+      return "off";
+    },
+    [readSelection],
+  );
+
   const setValue = useCallback(
     (paramName: string, value: string | undefined) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(searchParamsRef.current.toString());
       if (value) {
         params.set(paramName, value);
       } else {
@@ -144,12 +198,12 @@ export function useFilterParams(
       }
       updateUrl(params);
     },
-    [searchParams, updateUrl],
+    [updateUrl],
   );
 
   const writeSelection = useCallback(
     (paramName: string, selection: FilterSelection) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(searchParamsRef.current.toString());
       const tokens = [
         ...selection.include,
         ...selection.exclude.map((v) => toToken(v, "exclude")),
@@ -161,42 +215,37 @@ export function useFilterParams(
       }
       updateUrl(params);
     },
-    [searchParams, delimiter, updateUrl],
+    [delimiter, updateUrl],
   );
 
   const setValues = useCallback(
     (paramName: string, values: string[]) => {
-      // Replaces the included set while preserving any excluded values.
-      const { exclude } = getSelection(paramName);
-      writeSelection(paramName, { include: values, exclude });
+      // Replaces the included set while preserving excludes — minus any value
+      // that is now included, so a value can't be both included and excluded.
+      const { exclude } = readSelection(paramName);
+      const nextExclude = exclude.filter((v) => !values.includes(v));
+      writeSelection(paramName, { include: values, exclude: nextExclude });
     },
-    [getSelection, writeSelection],
+    [readSelection, writeSelection],
   );
 
   const setState = useCallback(
     (paramName: string, value: string, state: FilterState) => {
-      const { include, exclude } = getSelection(paramName);
+      const { include, exclude } = readSelection(paramName);
       const nextInclude = include.filter((v) => v !== value);
       const nextExclude = exclude.filter((v) => v !== value);
       if (state === "include") nextInclude.push(value);
       if (state === "exclude") nextExclude.push(value);
       writeSelection(paramName, { include: nextInclude, exclude: nextExclude });
     },
-    [getSelection, writeSelection],
+    [readSelection, writeSelection],
   );
 
   const cycleValue = useCallback(
     (paramName: string, value: string) => {
-      const current = getState(paramName, value);
-      const next: FilterState =
-        current === "off"
-          ? "include"
-          : current === "include"
-            ? "exclude"
-            : "off";
-      setState(paramName, value, next);
+      setState(paramName, value, nextFilterState(readState(paramName, value)));
     },
-    [getState, setState],
+    [readState, setState],
   );
 
   const toggleValue = useCallback(
@@ -205,23 +254,23 @@ export function useFilterParams(
       setState(
         paramName,
         value,
-        getState(paramName, value) === "include" ? "off" : "include",
+        readState(paramName, value) === "include" ? "off" : "include",
       );
     },
-    [getState, setState],
+    [readState, setState],
   );
 
   const clearFilter = useCallback(
     (paramName: string) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(searchParamsRef.current.toString());
       params.delete(paramName);
       updateUrl(params);
     },
-    [searchParams, updateUrl],
+    [updateUrl],
   );
 
   const clearAllFilters = useCallback(() => {
-    const params = new URLSearchParams(searchParams.toString());
+    const params = new URLSearchParams(searchParamsRef.current.toString());
     // Clear all filter params but preserve others (like sort, tab)
     for (const paramName of filterParamNames) {
       params.delete(paramName);
@@ -229,7 +278,7 @@ export function useFilterParams(
     params.delete("dateFrom");
     params.delete("dateTo");
     updateUrl(params);
-  }, [searchParams, filterParamNames, updateUrl]);
+  }, [filterParamNames, updateUrl]);
 
   const hasActiveFilters = useMemo(() => {
     for (const paramName of filterParamNames) {
@@ -266,7 +315,7 @@ export function useFilterParams(
 
   const setDateRange = useCallback(
     (from: string | undefined, to: string | undefined) => {
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams(searchParamsRef.current.toString());
       if (from) {
         params.set("dateFrom", from);
       } else {
@@ -279,7 +328,7 @@ export function useFilterParams(
       }
       updateUrl(params);
     },
-    [searchParams, updateUrl],
+    [updateUrl],
   );
 
   return {

--- a/ui/hooks/use-filter-params.ts
+++ b/ui/hooks/use-filter-params.ts
@@ -8,6 +8,32 @@ export interface FilterParamConfig {
   isMulti?: boolean;
 }
 
+/** Tri-state a value can hold within a filter: neutral, included, or excluded. */
+export type FilterState = "off" | "include" | "exclude";
+
+/** The include/exclude split of a single filter's selected values. */
+export interface FilterSelection {
+  include: string[];
+  exclude: string[];
+}
+
+/**
+ * Excluded values live in the same comma-delimited param as includes, marked
+ * with a leading "!" (e.g. `ingredient=chicken,!mushroom`). This keeps one
+ * param per category and stays human-readable/shareable in the URL.
+ */
+const EXCLUDE_PREFIX = "!";
+
+function parseToken(token: string): { value: string; excluded: boolean } {
+  return token.startsWith(EXCLUDE_PREFIX)
+    ? { value: token.slice(EXCLUDE_PREFIX.length), excluded: true }
+    : { value: token, excluded: false };
+}
+
+function toToken(value: string, state: Exclude<FilterState, "off">): string {
+  return state === "exclude" ? `${EXCLUDE_PREFIX}${value}` : value;
+}
+
 export interface UseFilterParamsOptions {
   filters: FilterParamConfig[];
   delimiter?: string;
@@ -17,10 +43,21 @@ export interface UseFilterParamsOptions {
 
 export interface UseFilterParamsReturn {
   getValue: (paramName: string) => string | undefined;
+  /** Included values only (excludes are stripped). */
   getValues: (paramName: string) => string[];
+  /** Excluded values only. */
+  getExcludedValues: (paramName: string) => string[];
+  /** Full include/exclude split for a filter. */
+  getSelection: (paramName: string) => FilterSelection;
+  /** Tri-state of a single value within a filter. */
+  getState: (paramName: string, value: string) => FilterState;
   setValue: (paramName: string, value: string | undefined) => void;
   setValues: (paramName: string, values: string[]) => void;
   toggleValue: (paramName: string, value: string) => void;
+  /** Force a value into a specific tri-state. */
+  setState: (paramName: string, value: string, state: FilterState) => void;
+  /** Advance a value: off → include → exclude → off. */
+  cycleValue: (paramName: string, value: string) => void;
   clearFilter: (paramName: string) => void;
   clearAllFilters: () => void;
   hasActiveFilters: boolean;
@@ -62,13 +99,39 @@ export function useFilterParams(
     [searchParams],
   );
 
-  const getValues = useCallback(
-    (paramName: string): string[] => {
+  const getSelection = useCallback(
+    (paramName: string): FilterSelection => {
       const value = searchParams.get(paramName);
-      if (!value) return [];
-      return value.split(delimiter).filter(Boolean);
+      const include: string[] = [];
+      const exclude: string[] = [];
+      if (!value) return { include, exclude };
+      for (const token of value.split(delimiter).filter(Boolean)) {
+        const { value: v, excluded } = parseToken(token);
+        (excluded ? exclude : include).push(v);
+      }
+      return { include, exclude };
     },
     [searchParams, delimiter],
+  );
+
+  const getValues = useCallback(
+    (paramName: string): string[] => getSelection(paramName).include,
+    [getSelection],
+  );
+
+  const getExcludedValues = useCallback(
+    (paramName: string): string[] => getSelection(paramName).exclude,
+    [getSelection],
+  );
+
+  const getState = useCallback(
+    (paramName: string, value: string): FilterState => {
+      const { include, exclude } = getSelection(paramName);
+      if (exclude.includes(value)) return "exclude";
+      if (include.includes(value)) return "include";
+      return "off";
+    },
+    [getSelection],
   );
 
   const setValue = useCallback(
@@ -84,11 +147,15 @@ export function useFilterParams(
     [searchParams, updateUrl],
   );
 
-  const setValues = useCallback(
-    (paramName: string, values: string[]) => {
+  const writeSelection = useCallback(
+    (paramName: string, selection: FilterSelection) => {
       const params = new URLSearchParams(searchParams.toString());
-      if (values.length > 0) {
-        params.set(paramName, values.join(delimiter));
+      const tokens = [
+        ...selection.include,
+        ...selection.exclude.map((v) => toToken(v, "exclude")),
+      ];
+      if (tokens.length > 0) {
+        params.set(paramName, tokens.join(delimiter));
       } else {
         params.delete(paramName);
       }
@@ -97,15 +164,51 @@ export function useFilterParams(
     [searchParams, delimiter, updateUrl],
   );
 
+  const setValues = useCallback(
+    (paramName: string, values: string[]) => {
+      // Replaces the included set while preserving any excluded values.
+      const { exclude } = getSelection(paramName);
+      writeSelection(paramName, { include: values, exclude });
+    },
+    [getSelection, writeSelection],
+  );
+
+  const setState = useCallback(
+    (paramName: string, value: string, state: FilterState) => {
+      const { include, exclude } = getSelection(paramName);
+      const nextInclude = include.filter((v) => v !== value);
+      const nextExclude = exclude.filter((v) => v !== value);
+      if (state === "include") nextInclude.push(value);
+      if (state === "exclude") nextExclude.push(value);
+      writeSelection(paramName, { include: nextInclude, exclude: nextExclude });
+    },
+    [getSelection, writeSelection],
+  );
+
+  const cycleValue = useCallback(
+    (paramName: string, value: string) => {
+      const current = getState(paramName, value);
+      const next: FilterState =
+        current === "off"
+          ? "include"
+          : current === "include"
+            ? "exclude"
+            : "off";
+      setState(paramName, value, next);
+    },
+    [getState, setState],
+  );
+
   const toggleValue = useCallback(
     (paramName: string, value: string) => {
-      const currentValues = getValues(paramName);
-      const newValues = currentValues.includes(value)
-        ? currentValues.filter((v) => v !== value)
-        : [...currentValues, value];
-      setValues(paramName, newValues);
+      // Two-state toggle between off and include (clears any exclude).
+      setState(
+        paramName,
+        value,
+        getState(paramName, value) === "include" ? "off" : "include",
+      );
     },
-    [getValues, setValues],
+    [getState, setState],
   );
 
   const clearFilter = useCallback(
@@ -182,9 +285,14 @@ export function useFilterParams(
   return {
     getValue,
     getValues,
+    getExcludedValues,
+    getSelection,
+    getState,
     setValue,
     setValues,
     toggleValue,
+    setState,
+    cycleValue,
     clearFilter,
     clearAllFilters,
     hasActiveFilters,

--- a/ui/hooks/use-filter-params.ts
+++ b/ui/hooks/use-filter-params.ts
@@ -26,6 +26,11 @@ export interface FilterSelection {
  * Excluded values live in the same comma-delimited param as includes, marked
  * with a leading "!" (e.g. `ingredient=chicken,!mushroom`). This keeps one
  * param per category and stays human-readable/shareable in the URL.
+ *
+ * Invariant: filter values themselves must not begin with "!" — such a value
+ * would round-trip as an exclude. This holds for every current source (recipe
+ * ingredient names, tech/role slugs, tags, kebab-case labels); introducing a
+ * value that can start with "!" would need a different sentinel/encoding.
  */
 const EXCLUDE_PREFIX = "!";
 
@@ -53,6 +58,16 @@ export function filterAppliedAction(
   if (state === "off") return "removed";
   if (state === "exclude") return "excluded";
   return "added";
+}
+
+/** Screen-reader label describing a value's tri-state. */
+export function filterStateAriaLabel(
+  label: string,
+  state: FilterState,
+): string {
+  if (state === "exclude") return `${label} (excluded)`;
+  if (state === "include") return `${label} (included)`;
+  return label;
 }
 
 function parseSelection(
@@ -86,8 +101,14 @@ export interface UseFilterParamsReturn {
   getExcludedValues: (paramName: string) => string[];
   /** Full include/exclude split for a filter. */
   getSelection: (paramName: string) => FilterSelection;
-  /** Tri-state of a single value within a filter. */
+  /** Tri-state of a single value within a filter (reactive). */
   getState: (paramName: string, value: string) => FilterState;
+  /**
+   * Latest tri-state read straight from the current URL, not tied to a render.
+   * Safe inside async handlers (e.g. a toast Undo) where the reactive
+   * `getState` closure may be stale.
+   */
+  peekState: (paramName: string, value: string) => FilterState;
   setValue: (paramName: string, value: string | undefined) => void;
   setValues: (paramName: string, values: string[]) => void;
   toggleValue: (paramName: string, value: string) => void;
@@ -178,7 +199,7 @@ export function useFilterParams(
     [delimiter],
   );
 
-  const readState = useCallback(
+  const peekState = useCallback(
     (paramName: string, value: string): FilterState => {
       const { include, exclude } = readSelection(paramName);
       if (exclude.includes(value)) return "exclude";
@@ -243,9 +264,9 @@ export function useFilterParams(
 
   const cycleValue = useCallback(
     (paramName: string, value: string) => {
-      setState(paramName, value, nextFilterState(readState(paramName, value)));
+      setState(paramName, value, nextFilterState(peekState(paramName, value)));
     },
-    [readState, setState],
+    [peekState, setState],
   );
 
   const toggleValue = useCallback(
@@ -254,10 +275,10 @@ export function useFilterParams(
       setState(
         paramName,
         value,
-        readState(paramName, value) === "include" ? "off" : "include",
+        peekState(paramName, value) === "include" ? "off" : "include",
       );
     },
-    [readState, setState],
+    [peekState, setState],
   );
 
   const clearFilter = useCallback(
@@ -337,6 +358,7 @@ export function useFilterParams(
     getExcludedValues,
     getSelection,
     getState,
+    peekState,
     setValue,
     setValues,
     toggleValue,

--- a/ui/lib/generic/filter-cycle.ts
+++ b/ui/lib/generic/filter-cycle.ts
@@ -30,7 +30,7 @@ export function cycleFilterFromCard({
   label,
   page,
 }: CycleFromCardArgs): void {
-  const previous = filterParams.getState(paramName, value);
+  const previous = filterParams.peekState(paramName, value);
   const next = nextFilterState(previous);
 
   posthog.capture("filter_applied", {
@@ -43,11 +43,20 @@ export function cycleFilterFromCard({
   filterParams.setState(paramName, value, next);
 
   if (next === "exclude") {
+    // A stable id keeps one toast per value (the same value can appear on many
+    // cards), so a re-exclude replaces rather than stacks. The Undo restores
+    // the prior state, but only if the value is still excluded — the user may
+    // have already changed it via another surface while the toast was up.
     toast(`Excluded ${label ?? value}`, {
+      id: `filter-exclude:${paramName}:${value}`,
       description: "Hidden from results.",
       action: {
         label: "Undo",
-        onClick: () => filterParams.setState(paramName, value, previous),
+        onClick: () => {
+          if (filterParams.peekState(paramName, value) === "exclude") {
+            filterParams.setState(paramName, value, previous);
+          }
+        },
       },
     });
   }

--- a/ui/lib/generic/filter-cycle.ts
+++ b/ui/lib/generic/filter-cycle.ts
@@ -1,8 +1,9 @@
 import posthog from "posthog-js";
 import { toast } from "sonner";
-import type {
-  FilterState,
-  UseFilterParamsReturn,
+import {
+  filterAppliedAction,
+  nextFilterState,
+  type UseFilterParamsReturn,
 } from "@/hooks/use-filter-params";
 
 interface CycleFromCardArgs {
@@ -30,15 +31,13 @@ export function cycleFilterFromCard({
   page,
 }: CycleFromCardArgs): void {
   const previous = filterParams.getState(paramName, value);
-  const next: FilterState =
-    previous === "off" ? "include" : previous === "include" ? "exclude" : "off";
+  const next = nextFilterState(previous);
 
   posthog.capture("filter_applied", {
     page,
     filter_type: paramName,
     filter_value: value,
-    action:
-      next === "off" ? "removed" : next === "exclude" ? "excluded" : "added",
+    action: filterAppliedAction(next),
   });
 
   filterParams.setState(paramName, value, next);

--- a/ui/lib/generic/filter-cycle.ts
+++ b/ui/lib/generic/filter-cycle.ts
@@ -1,0 +1,55 @@
+import posthog from "posthog-js";
+import { toast } from "sonner";
+import type {
+  FilterState,
+  UseFilterParamsReturn,
+} from "@/hooks/use-filter-params";
+
+interface CycleFromCardArgs {
+  filterParams: UseFilterParamsReturn;
+  paramName: string;
+  value: string;
+  /** Human-readable label used in the toast (defaults to the raw value). */
+  label?: string;
+  /** Current page path, for analytics. */
+  page: string;
+}
+
+/**
+ * Advances a filter value off → include → exclude → off from a card badge.
+ *
+ * Because excluding a value hides the very card that was clicked, the exclude
+ * step also raises an "Undo" toast so the action stays reversible in one tap
+ * without hunting for the value in the filter bar.
+ */
+export function cycleFilterFromCard({
+  filterParams,
+  paramName,
+  value,
+  label,
+  page,
+}: CycleFromCardArgs): void {
+  const previous = filterParams.getState(paramName, value);
+  const next: FilterState =
+    previous === "off" ? "include" : previous === "include" ? "exclude" : "off";
+
+  posthog.capture("filter_applied", {
+    page,
+    filter_type: paramName,
+    filter_value: value,
+    action:
+      next === "off" ? "removed" : next === "exclude" ? "excluded" : "added",
+  });
+
+  filterParams.setState(paramName, value, next);
+
+  if (next === "exclude") {
+    toast(`Excluded ${label ?? value}`, {
+      description: "Hidden from results.",
+      action: {
+        label: "Undo",
+        onClick: () => filterParams.setState(paramName, value, previous),
+      },
+    });
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -73,6 +73,7 @@
     "shiki": "^4.0.0",
     "sigma": "^3.0.2",
     "simple-icons": "^16.0.0",
+    "sonner": "^2.0.7",
     "strip-markdown": "^6.0.0",
     "tailwind-merge": "^3.3.1",
     "unist-util-visit": "^5.0.0",


### PR DESCRIPTION
## What & why

Filters throughout the site were **include-only**. Every filter value now cycles **neutral → include → exclude → off**, so a value can be required *or* ruled out. The sharpest win is the recipe list — e.g. "hide anything with mushrooms" — but exclude now works on every faceted filter in the app.

The interaction model is a **tri-state cycle** (chosen over Grafana-style ctrl-click/solo): one gesture, identical on desktop and touch, no modifier keys. Excluded values render destructively (red, struck through, minus glyph) so include vs. exclude read at a glance.

## Behaviour

- **Dropdowns**: a row cycles include (✓) → exclude (red −) → off. Excluded selections shown struck through in the footer.
- **Card badges**: same cycle. Because excluding a value hides the very card you clicked, the exclude step raises a one-tap **Undo toast** (new `sonner` Toaster) so recovery doesn't require hunting in the filter bar.
- **Active-filter chips & mobile drawer**: excluded entries styled destructively with a minus.
- **Predicate**: within a category, OR over includes, then drop any item carrying an excluded value (AND-NOT); AND across categories.
- **URL**: excludes are `!`-prefixed tokens in the existing param, e.g. `ingredient=chicken,!mushroom` — human-readable and shareable.

## Scope

Applied to **all faceted filters**: blog, projects, and recipe list pages (the shared `FilterableCardGrid` engine), plus the project ADR list and the experience technology grid, which rolled their own filter plumbing.

## Implementation notes

- `useFilterParams` models the tri-state (`getState`/`setState`/`cycleValue`/`getExcludedValues`); `getValues` still returns includes only for back-compat.
- `MultiSelect` gains an opt-in tri-state mode via a shared `MultiSelectTriStateProps` interface that thin wrappers forward with one spread.
- Analytics: `filter_applied` gains an `"excluded"` action.

## Verification

- Typecheck, Biome lint, and production build (273 pages) all green.
- 353 unit tests pass, including the recipe-list filter-interaction test.
- Pre-existing note: 6 test files and some typecheck errors come from the uninstalled `packages/recipe-domain` workspace deps (`zod`/`pluralize`) in the CI sandbox — unrelated to this change (confirmed by stashing the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K25qNUKgUry3CM8jyS9392

---
_Generated by [Claude Code](https://claude.ai/code/session_01K25qNUKgUry3CM8jyS9392)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added app-wide toast support for user feedback.
  * Upgraded filtering to support include/exclude (tri-state) across card grids and filter chips, including “excluded” visual states.
  * Card interactions now cycle filter states with route-aware updates for more consistent behaviour.

* **Bug Fixes**
  * Filter changes are now correctly aligned with the current page during interactions.
  * Removed/cleared filters now reset state more reliably across list views (including mobile filter UI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->