### PR TITLE
Fix toast theme to track DOM class instead of next-themes useTheme

### DIFF
--- a/ui/app/recipes/recipe-theme.css
+++ b/ui/app/recipes/recipe-theme.css
@@ -152,3 +152,30 @@
   color: var(--ink-2);
   font-weight: 600;
 }
+
+/* Toast notifications — styled as warm paper cards to match the recipe site. */
+.recipe-theme [data-sonner-toaster] {
+  font-family: var(--font-kalam), ui-sans-serif, system-ui, sans-serif;
+}
+.recipe-theme [data-sonner-toast] {
+  background: var(--card);
+  color: var(--ink);
+  border-color: var(--line-strong);
+  border-radius: 0.75rem;
+  box-shadow:
+    0 1px 2px rgba(31, 26, 20, 0.06),
+    0 8px 24px rgba(31, 26, 20, 0.08);
+}
+.recipe-theme [data-sonner-toast] [data-description] {
+  color: var(--ink-2);
+}
+.recipe-theme [data-sonner-toast] [data-button] {
+  background: var(--terracotta);
+  color: var(--paper);
+  border-radius: 0.5rem;
+}
+.recipe-theme [data-sonner-toast] [data-cancel] {
+  background: var(--paper-warm);
+  color: var(--ink-2);
+  border-radius: 0.5rem;
+}

--- a/ui/components/recipes/recipe-theme-body.tsx
+++ b/ui/components/recipes/recipe-theme-body.tsx
@@ -10,6 +10,8 @@ import { useEffect } from "react";
  * surfaces inherit the warm tokens. Page content keeps its own wrapper class, so
  * there is no flash before this effect runs.
  */
+let sonnerThemeRefCount = 0;
+
 export function RecipeThemeBody({ classNames }: { classNames: string }) {
   useEffect(() => {
     const classes = classNames.split(" ").filter(Boolean);
@@ -18,11 +20,15 @@ export function RecipeThemeBody({ classNames }: { classNames: string }) {
     body.classList.add(...added);
 
     const html = document.documentElement;
+    sonnerThemeRefCount++;
     html.dataset.sonnerTheme = "light";
 
     return () => {
       body.classList.remove(...added);
-      delete html.dataset.sonnerTheme;
+      sonnerThemeRefCount--;
+      if (sonnerThemeRefCount <= 0) {
+        delete html.dataset.sonnerTheme;
+      }
     };
   }, [classNames]);
 

--- a/ui/components/recipes/recipe-theme-body.tsx
+++ b/ui/components/recipes/recipe-theme-body.tsx
@@ -16,8 +16,13 @@ export function RecipeThemeBody({ classNames }: { classNames: string }) {
     const body = document.body;
     const added = classes.filter((c) => !body.classList.contains(c));
     body.classList.add(...added);
+
+    const html = document.documentElement;
+    html.dataset.sonnerTheme = "light";
+
     return () => {
       body.classList.remove(...added);
+      delete html.dataset.sonnerTheme;
     };
   }, [classNames]);
 

--- a/ui/components/ui/sonner.tsx
+++ b/ui/components/ui/sonner.tsx
@@ -29,6 +29,8 @@ const classNames = {
   cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
 };
 
+const toastOptions = { classNames };
+
 export function Toaster({ theme: propsTheme, ...props }: ToasterProps) {
   const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
@@ -37,7 +39,7 @@ export function Toaster({ theme: propsTheme, ...props }: ToasterProps) {
       theme={propsTheme ?? theme}
       className="toaster group"
       position="bottom-center"
-      toastOptions={{ classNames }}
+      toastOptions={toastOptions}
       {...props}
     />
   );

--- a/ui/components/ui/sonner.tsx
+++ b/ui/components/ui/sonner.tsx
@@ -4,7 +4,12 @@ import { useEffect, useState } from "react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 export function Toaster(props: ToasterProps) {
-  const [theme, setTheme] = useState<"light" | "dark">("dark");
+  const [theme, setTheme] = useState<"light" | "dark">(() =>
+    typeof document !== "undefined" &&
+    document.documentElement.classList.contains("dark")
+      ? "dark"
+      : "light",
+  );
 
   useEffect(() => {
     const updateTheme = () => {

--- a/ui/components/ui/sonner.tsx
+++ b/ui/components/ui/sonner.tsx
@@ -1,37 +1,28 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
-export function Toaster(props: ToasterProps) {
-  const [theme, setTheme] = useState<"light" | "dark">(() =>
-    typeof document !== "undefined" &&
-    document.documentElement.classList.contains("dark")
-      ? "dark"
-      : "light",
-  );
+const subscribe = (callback: () => void) => {
+  const observer = new MutationObserver(callback);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+  return () => observer.disconnect();
+};
 
-  useEffect(() => {
-    const updateTheme = () => {
-      setTheme(
-        document.documentElement.classList.contains("dark") ? "dark" : "light",
-      );
-    };
+const getSnapshot = (): "light" | "dark" =>
+  document.documentElement.classList.contains("dark") ? "dark" : "light";
 
-    updateTheme();
+const getServerSnapshot = (): "light" | "dark" => "dark";
 
-    const observer = new MutationObserver(updateTheme);
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-
-    return () => observer.disconnect();
-  }, []);
+export function Toaster({ theme: propsTheme, ...props }: ToasterProps) {
+  const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
   return (
     <Sonner
-      theme={theme}
+      theme={propsTheme ?? theme}
       className="toaster group"
       position="bottom-center"
       toastOptions={{

--- a/ui/components/ui/sonner.tsx
+++ b/ui/components/ui/sonner.tsx
@@ -7,15 +7,27 @@ const subscribe = (callback: () => void) => {
   const observer = new MutationObserver(callback);
   observer.observe(document.documentElement, {
     attributes: true,
-    attributeFilter: ["class"],
+    attributeFilter: ["class", "data-sonner-theme"],
   });
   return () => observer.disconnect();
 };
 
-const getSnapshot = (): "light" | "dark" =>
-  document.documentElement.classList.contains("dark") ? "dark" : "light";
+const getSnapshot = (): "light" | "dark" => {
+  const override = document.documentElement.dataset.sonnerTheme;
+  if (override === "light" || override === "dark") return override;
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+};
 
 const getServerSnapshot = (): "light" | "dark" => "dark";
+
+const classNames = {
+  toast:
+    "group toast group-[.toaster]:bg-popover group-[.toaster]:text-popover-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+  description: "group-[.toast]:text-muted-foreground",
+  actionButton:
+    "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+  cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+};
 
 export function Toaster({ theme: propsTheme, ...props }: ToasterProps) {
   const theme = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
@@ -25,17 +37,7 @@ export function Toaster({ theme: propsTheme, ...props }: ToasterProps) {
       theme={propsTheme ?? theme}
       className="toaster group"
       position="bottom-center"
-      toastOptions={{
-        classNames: {
-          toast:
-            "group toast group-[.toaster]:bg-popover group-[.toaster]:text-popover-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
-          actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
-          cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
-        },
-      }}
+      toastOptions={{ classNames }}
       {...props}
     />
   );

--- a/ui/components/ui/sonner.tsx
+++ b/ui/components/ui/sonner.tsx
@@ -1,14 +1,32 @@
 "use client";
 
-import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 export function Toaster(props: ToasterProps) {
-  const { theme = "dark" } = useTheme();
+  const [theme, setTheme] = useState<"light" | "dark">("dark");
+
+  useEffect(() => {
+    const updateTheme = () => {
+      setTheme(
+        document.documentElement.classList.contains("dark") ? "dark" : "light",
+      );
+    };
+
+    updateTheme();
+
+    const observer = new MutationObserver(updateTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme={theme}
       className="toaster group"
       position="bottom-center"
       toastOptions={{


### PR DESCRIPTION
The Toaster component used `useTheme()` from next-themes with a `"dark"` fallback, but the site's theme toggler (`AnimatedThemeToggler`) bypasses next-themes `setTheme()` and manipulates the DOM class directly. This caused the toast theme to decouple from the actual page theme, keeping toasts permanently in dark mode.

Replaced with a `MutationObserver` on `document.documentElement.classList` that mirrors the `AnimatedThemeToggler`'s approach, ensuring Sonner's theme always matches the current DOM state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications now automatically stay in sync with the app’s light/dark theme, including when the theme changes at runtime and for portaled UI.
  * Improved notification theming consistency, including support for an explicit theme override where provided.
* **Style**
  * Added warm “paper” styling for toast notifications within the recipe theme experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->