### PR TITLE
Place equipment alongside ingredients on recipe detail pages (desktop)

### DIFF
--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -62,10 +62,10 @@ export default function RecipesLayout({
       >
         <header className="sticky top-0 z-50 border-b border-[var(--line)] bg-[var(--paper)]/95 backdrop-blur supports-[backdrop-filter]:bg-[var(--paper)]/75">
           {/* On desktop everything sits on one row (logo · tab · search · auth);
-              on mobile the search drops to a full-width second row so it isn't
-              squeezed against the logo. */}
-          <nav className="container mx-auto px-4 py-3 max-w-7xl flex flex-wrap items-center gap-x-6 gap-y-3">
-            <div className="order-1 flex items-center gap-4">
+              on mobile/tablet the search drops to a full-width second row so it
+              isn't squeezed against the logo. */}
+          <nav className="container mx-auto px-4 py-3 max-w-7xl flex flex-wrap items-center gap-x-2 sm:gap-x-4 lg:gap-x-6 gap-y-3">
+            <div className="order-1 flex items-baseline gap-2 sm:gap-4 md:gap-6">
               <Link
                 href="/recipes"
                 className="shrink-0 rt-display text-3xl leading-none text-foreground"
@@ -78,10 +78,10 @@ export default function RecipesLayout({
               </Link>
               <RecipeNavTabs />
             </div>
-            <div className="order-2 ms-auto md:order-3 md:ms-0">
+            <div className="order-2 ms-auto lg:order-3 lg:ms-0">
               <AuthButton />
             </div>
-            <div className="order-3 w-full md:order-2 md:w-64 md:ms-auto">
+            <div className="order-3 w-full lg:order-2 lg:w-64 lg:ms-auto">
               <RecipeSearch />
             </div>
           </nav>

--- a/ui/app/recipes/recipe-theme.css
+++ b/ui/app/recipes/recipe-theme.css
@@ -107,13 +107,14 @@
 
 /* active nav tab — terracotta underline like the design */
 .recipe-theme .rt-tab {
-  border-bottom: 1.5px solid transparent;
-  padding-bottom: 2px;
+  text-underline-offset: 6px;
   color: var(--ink-2);
 }
 .recipe-theme .rt-tab[data-active="true"] {
   color: var(--ink);
-  border-color: var(--terracotta);
+  text-decoration: underline;
+  text-decoration-color: var(--terracotta);
+  text-decoration-thickness: 1.5px;
 }
 
 /* Pills (cuisine/time badges, active-filter chips, inline timers) use a paper-

--- a/ui/app/recipes/recipe-theme.css
+++ b/ui/app/recipes/recipe-theme.css
@@ -108,6 +108,7 @@
 /* active nav tab — terracotta underline like the design */
 .recipe-theme .rt-tab {
   border-bottom: 1.5px solid transparent;
+  padding-bottom: 2px;
   color: var(--ink-2);
 }
 .recipe-theme .rt-tab[data-active="true"] {

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -422,7 +422,13 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
         )}
       </header>
 
-      <div className="mb-8 lg:grid lg:grid-cols-[1fr_280px] lg:gap-8 lg:items-start">
+      <div
+        className={
+          effectiveRecipe.cookware.length > 0
+            ? "mb-8 lg:grid lg:grid-cols-[1fr_280px] lg:gap-8 lg:items-start"
+            : "mb-8"
+        }
+      >
         <section className="mb-8 lg:mb-0">
           <div className="flex items-baseline justify-between mb-4">
             <h2 className="rt-display text-4xl text-[var(--terracotta)]">
@@ -447,7 +453,7 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
                     ? group.name
                       ? "border-t border-border/50 pt-4 mt-4"
                       : "mt-4"
-                    : ""
+                    : undefined
                 }
               >
                 <IngredientGroup

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -422,51 +422,65 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
         )}
       </header>
 
-      <section className="mb-8">
-        <div className="flex items-baseline justify-between mb-4">
-          <h2 className="rt-display text-4xl text-[var(--terracotta)]">
-            Ingredients
-          </h2>
-          {checkedIngredients.size > 0 && (
-            <button
-              type="button"
-              onClick={() => setCheckedIngredients(new Set())}
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Reset
-            </button>
-          )}
-        </div>
-        <div className="space-y-4">
-          {effectiveRecipe.ingredientGroups.map((group, i) => (
-            <IngredientGroup
-              key={group.name ?? i}
-              group={group}
-              scale={scale}
-              system={unitSystem}
-              annotations={ingredientAnnotations}
-              checked={checkedIngredients}
-              onToggle={toggleIngredient}
-            />
-          ))}
-        </div>
-      </section>
-
-      {effectiveRecipe.cookware.length > 0 && (
-        <section className="mb-8">
-          <h2 className="rt-display text-3xl text-[var(--terracotta)] mb-4">
-            Equipment
-          </h2>
-          <ul className="space-y-1">
-            {effectiveRecipe.cookware.map((item) => (
-              <li key={item} className="flex items-start gap-2">
-                <span className="text-muted-foreground mt-1.5 h-1.5 w-1.5 rounded-full bg-current flex-shrink-0" />
-                <span>{item}</span>
-              </li>
+      <div className="mb-8 lg:grid lg:grid-cols-[1fr_280px] lg:gap-8 lg:items-start">
+        <section className="mb-8 lg:mb-0">
+          <div className="flex items-baseline justify-between mb-4">
+            <h2 className="rt-display text-4xl text-[var(--terracotta)]">
+              Ingredients
+            </h2>
+            {checkedIngredients.size > 0 && (
+              <button
+                type="button"
+                onClick={() => setCheckedIngredients(new Set())}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Reset
+              </button>
+            )}
+          </div>
+          <div>
+            {effectiveRecipe.ingredientGroups.map((group, i) => (
+              <div
+                key={group.name ?? i}
+                className={
+                  i > 0
+                    ? group.name
+                      ? "border-t border-border/50 pt-4 mt-4"
+                      : "mt-4"
+                    : ""
+                }
+              >
+                <IngredientGroup
+                  group={group}
+                  scale={scale}
+                  system={unitSystem}
+                  annotations={ingredientAnnotations}
+                  checked={checkedIngredients}
+                  onToggle={toggleIngredient}
+                />
+              </div>
             ))}
-          </ul>
+          </div>
         </section>
-      )}
+
+        {effectiveRecipe.cookware.length > 0 && (
+          <aside>
+            <section className="mb-8 lg:mb-0 lg:rounded-lg lg:border lg:border-border/50 lg:p-4">
+              <h2 className="rt-display text-3xl text-[var(--terracotta)] mb-4">
+                Equipment
+              </h2>
+              <ul className="space-y-1">
+                {effectiveRecipe.cookware.map((item) => (
+                  <li key={item} className="flex items-start gap-2">
+                    <span className="text-muted-foreground mt-1.5 h-1.5 w-1.5 rounded-full bg-current flex-shrink-0" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </aside>
+        )}
+      </div>
 
       <section>
         <h2 className="rt-display text-4xl text-[var(--terracotta)] mb-4">

--- a/ui/components/recipes/recipe-nav-tabs.tsx
+++ b/ui/components/recipes/recipe-nav-tabs.tsx
@@ -15,17 +15,17 @@ export function RecipeNavTabs() {
   const onRecipes = !onShopping && !onSettings;
 
   return (
-    <div className="flex items-center gap-4">
+    <div className="flex items-baseline gap-2 md:gap-4">
       <Link
         href="/recipes"
-        className="rt-tab text-lg"
+        className="rt-tab text-base lg:text-lg"
         data-active={onRecipes || undefined}
       >
         Recipes
       </Link>
       <Link
         href="/recipes/shopping"
-        className="rt-tab text-lg inline-flex items-center gap-1.5"
+        className="rt-tab text-base lg:text-lg inline-flex items-center gap-1.5"
         data-active={onShopping || undefined}
       >
         Shopping

--- a/ui/components/recipes/recipe-nav-tabs.tsx
+++ b/ui/components/recipes/recipe-nav-tabs.tsx
@@ -15,17 +15,17 @@ export function RecipeNavTabs() {
   const onRecipes = !onShopping && !onSettings;
 
   return (
-    <div className="flex items-baseline gap-4">
+    <div className="flex items-center gap-4">
       <Link
         href="/recipes"
-        className="rt-tab text-[0.95rem]"
+        className="rt-tab text-lg"
         data-active={onRecipes || undefined}
       >
         Recipes
       </Link>
       <Link
         href="/recipes/shopping"
-        className="rt-tab text-[0.95rem] inline-flex items-center gap-1.5"
+        className="rt-tab text-lg inline-flex items-center gap-1.5"
         data-active={onShopping || undefined}
       >
         Shopping


### PR DESCRIPTION
On larger screens, equipment is now displayed alongside ingredients in a sidebar layout instead of stacked below. Also adds visual separators between named ingredient groups (e.g. "For the dough", "For the sauce").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the recipes area layout for better responsiveness across screen sizes.
  * Reworked the ingredients and equipment sections into a clearer two-column layout on larger screens.
  * Updated navigation spacing and tab sizing for a more balanced header.
  * Refined the active tab underline styling for a cleaner selected-state appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->