### PR TITLE
Add weekly meal planning to shopping

### DIFF
--- a/ui/app/recipes/shopping/page.tsx
+++ b/ui/app/recipes/shopping/page.tsx
@@ -5,7 +5,7 @@ import { getShoppingRecipes } from "@/lib/api/shopping";
 export const metadata: Metadata = {
   title: "Shopping List",
   description:
-    "Pick the recipes you want to cook and build a combined shopping list, grouped by aisle, by recipe, or as one ingredient list.",
+    "Plan weekly meals, pick recipes, and build a combined shopping list grouped by aisle, by recipe, or as one ingredient list.",
   // Interactive tool whose content lives in the browser (localStorage); there's
   // nothing meaningful to index, so keep it out of search like the other app
   // pages (settings).

--- a/ui/components/recipes/shopping/meal-planner.tsx
+++ b/ui/components/recipes/shopping/meal-planner.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { CalendarDays, Minus, Plus, Trash2, Utensils, X } from "lucide-react";
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import { useShoppingList } from "@/hooks/use-shopping-list";
+import type { ShoppingRecipe } from "@/lib/api/shopping";
+import {
+  clearMealPlan,
+  MEAL_PLAN_DAYS,
+  MEAL_PLAN_SLOTS,
+  type MealPlanDay,
+  type MealPlanSlot,
+  removeRecipe,
+  setPlannedMeal,
+  setRecipeServings,
+} from "@/lib/shopping/shoppingListStore";
+
+function planKey(day: MealPlanDay, slot: MealPlanSlot): string {
+  return `${day}:${slot}`;
+}
+
+function mealCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "meal" : "meals"}`;
+}
+
+function recipeCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "recipe" : "recipes"}`;
+}
+
+function ServingsStepper({
+  slug,
+  servings,
+}: {
+  slug: string;
+  servings: number;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Button
+        variant="outline"
+        size="icon-sm"
+        onClick={() => setRecipeServings(slug, servings - 1)}
+        disabled={servings <= 1}
+        aria-label="Decrease servings"
+      >
+        <Minus className="h-3 w-3" />
+      </Button>
+      <span className="rt-mono min-w-12 text-center text-[var(--ink-2)]">
+        {servings}
+      </span>
+      <Button
+        variant="outline"
+        size="icon-sm"
+        onClick={() => setRecipeServings(slug, servings + 1)}
+        aria-label="Increase servings"
+      >
+        <Plus className="h-3 w-3" />
+      </Button>
+    </div>
+  );
+}
+
+function MealSelect({
+  day,
+  slot,
+  value,
+  recipeOptions,
+}: {
+  day: MealPlanDay;
+  slot: MealPlanSlot;
+  value?: string;
+  recipeOptions: ShoppingRecipe[];
+}) {
+  return (
+    <select
+      value={value ?? ""}
+      onChange={(event) =>
+        setPlannedMeal(day, slot, event.target.value || null)
+      }
+      aria-label={`${day} ${slot}`}
+      className="h-8 w-full rounded-md border border-[var(--line-strong)] bg-[var(--card)] px-2 text-xs text-[var(--ink-2)] outline-none transition-colors hover:border-[var(--terracotta)] focus:border-[var(--terracotta)] focus:ring-2 focus:ring-[var(--terracotta)]/15"
+    >
+      <option value="">Add meal</option>
+      {recipeOptions.map((recipe) => (
+        <option key={recipe.slug} value={recipe.slug}>
+          {recipe.title}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function PlannedRecipePill({
+  recipe,
+  onRemove,
+}: {
+  recipe?: ShoppingRecipe;
+  onRemove: () => void;
+}) {
+  if (!recipe) return null;
+  return (
+    <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--line)] bg-[var(--paper-warm)] px-2 py-1.5">
+      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded bg-[var(--butter-soft)] text-[var(--terracotta)]">
+        <Utensils className="h-3.5 w-3.5" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate rt-body text-sm leading-tight text-[var(--ink)]">
+          {recipe.title}
+        </span>
+        <span className="block truncate rt-mono text-[0.65rem] text-[var(--ink-3)]">
+          {recipe.cuisine.join(" · ").toLowerCase() || "planned"}
+        </span>
+      </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`Remove ${recipe.title} from this meal`}
+        className="text-[var(--ink-4)] transition-colors hover:text-[var(--berry)]"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function PlanCell({
+  day,
+  slot,
+  plannedRecipe,
+  recipeOptions,
+}: {
+  day: MealPlanDay;
+  slot: MealPlanSlot;
+  plannedRecipe?: ShoppingRecipe;
+  recipeOptions: ShoppingRecipe[];
+}) {
+  return (
+    <div className="min-h-28 rounded-md border border-[var(--line-strong)] bg-[var(--card)] p-2">
+      <MealSelect
+        day={day}
+        slot={slot}
+        value={plannedRecipe?.slug}
+        recipeOptions={recipeOptions}
+      />
+      <PlannedRecipePill
+        recipe={plannedRecipe}
+        onRemove={() => setPlannedMeal(day, slot, null)}
+      />
+    </div>
+  );
+}
+
+export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
+  const state = useShoppingList();
+
+  const bySlug = useMemo(() => {
+    const map = new Map<string, ShoppingRecipe>();
+    for (const recipe of recipes) map.set(recipe.slug, recipe);
+    return map;
+  }, [recipes]);
+
+  const planBySlot = useMemo(() => {
+    const map = new Map<string, ShoppingRecipe>();
+    for (const meal of state.plan) {
+      const recipe = bySlug.get(meal.slug);
+      if (recipe) map.set(planKey(meal.day, meal.slot), recipe);
+    }
+    return map;
+  }, [state.plan, bySlug]);
+
+  const usageBySlug = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const meal of state.plan) {
+      map.set(meal.slug, (map.get(meal.slug) ?? 0) + 1);
+    }
+    return map;
+  }, [state.plan]);
+
+  const selected = useMemo(() => {
+    return state.recipes.flatMap((entry) => {
+      const recipe = bySlug.get(entry.slug);
+      if (!recipe) return [];
+      return [
+        {
+          recipe,
+          servings: entry.servings ?? recipe.servings,
+          plannedMeals: usageBySlug.get(entry.slug) ?? 0,
+        },
+      ];
+    });
+  }, [state.recipes, bySlug, usageBySlug]);
+
+  const plannedMealCount = state.plan.filter((meal) =>
+    bySlug.has(meal.slug),
+  ).length;
+  const unscheduled = selected.filter((entry) => entry.plannedMeals === 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-[var(--line)] bg-[var(--paper-warm)] px-3 py-2">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-[var(--card)] text-[var(--terracotta)]">
+          <CalendarDays className="h-4 w-4" />
+        </span>
+        <p className="rt-body text-sm text-[var(--ink-2)]">
+          <b className="text-[var(--ink)]">
+            {recipeCountLabel(selected.length)}
+          </b>{" "}
+          in the plan pool ·{" "}
+          <b className="text-[var(--ink)]">
+            {mealCountLabel(plannedMealCount)}
+          </b>{" "}
+          scheduled
+          {unscheduled.length > 0
+            ? ` · ${recipeCountLabel(unscheduled.length)} unscheduled`
+            : ""}
+        </p>
+        {state.plan.length > 0 && (
+          <button
+            type="button"
+            onClick={clearMealPlan}
+            className="ml-auto inline-flex items-center gap-1 rt-mono text-[var(--ink-3)] transition-colors hover:text-[var(--terracotta)]"
+          >
+            <Trash2 className="h-3.5 w-3.5" /> clear calendar
+          </button>
+        )}
+      </div>
+
+      <div>
+        <div className="hidden lg:grid lg:grid-cols-[7rem_repeat(7,minmax(0,1fr))] lg:gap-2">
+          <div />
+          {MEAL_PLAN_DAYS.map((day) => (
+            <div
+              key={day.id}
+              className="rt-mono text-center text-[0.7rem] text-[var(--terracotta)]"
+            >
+              {day.short.toUpperCase()}
+            </div>
+          ))}
+          {MEAL_PLAN_SLOTS.map((slot) => (
+            <div key={slot.id} className="contents">
+              <div className="self-center pr-2 text-right rt-mono text-xs text-[var(--ink-3)]">
+                {slot.label}
+              </div>
+              {MEAL_PLAN_DAYS.map((day) => {
+                const recipe = planBySlot.get(planKey(day.id, slot.id));
+                return (
+                  <PlanCell
+                    key={`${day.id}-${slot.id}`}
+                    day={day.id}
+                    slot={slot.id}
+                    plannedRecipe={recipe}
+                    recipeOptions={recipes}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-4 lg:hidden">
+          {MEAL_PLAN_DAYS.map((day) => (
+            <div key={day.id}>
+              <h2 className="rt-display text-2xl text-[var(--terracotta)]">
+                · {day.label}
+              </h2>
+              <div className="mt-2 grid gap-2 sm:grid-cols-3">
+                {MEAL_PLAN_SLOTS.map((slot) => {
+                  const recipe = planBySlot.get(planKey(day.id, slot.id));
+                  return (
+                    <div key={slot.id}>
+                      <div className="mb-1 rt-mono text-xs text-[var(--ink-3)]">
+                        {slot.label}
+                      </div>
+                      <PlanCell
+                        day={day.id}
+                        slot={slot.id}
+                        plannedRecipe={recipe}
+                        recipeOptions={recipes}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {selected.length > 0 && (
+        <div>
+          <div className="mb-2 flex items-baseline justify-between gap-3">
+            <h2 className="rt-display text-3xl text-[var(--terracotta)]">
+              · recipe pool
+            </h2>
+            <p className="rt-mono text-[var(--ink-3)]">
+              servings feed the shopping list
+            </p>
+          </div>
+          <div className="grid gap-2 md:grid-cols-2">
+            {selected.map(({ recipe, servings, plannedMeals }) => (
+              <div
+                key={recipe.slug}
+                className="flex flex-wrap items-center gap-3 rounded-lg border border-[var(--line-strong)] bg-[var(--card)] p-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate rt-display text-xl leading-tight">
+                    {recipe.title}
+                  </p>
+                  <p className="rt-mono text-[var(--ink-3)]">
+                    {plannedMeals > 0
+                      ? mealCountLabel(plannedMeals)
+                      : "unscheduled"}
+                  </p>
+                </div>
+                <ServingsStepper slug={recipe.slug} servings={servings} />
+                <button
+                  type="button"
+                  onClick={() => removeRecipe(recipe.slug)}
+                  aria-label={`Remove ${recipe.title}`}
+                  className="text-[var(--ink-4)] transition-colors hover:text-[var(--berry)]"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {unscheduled.length > 0 && (
+        <div className="rounded-lg border border-dashed border-[var(--line-strong)] bg-[var(--card)] p-3">
+          <p className="rt-mono text-[var(--terracotta)]">
+            Unscheduled recipes
+          </p>
+          <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
+            These stay in the shopping list. Drop them into a calendar slot when
+            you know when they are being cooked.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {unscheduled.map(({ recipe }) => (
+              <span
+                key={recipe.slug}
+                className="rounded-md border border-[var(--line)] bg-[var(--paper-warm)] px-2 py-1 rt-body text-sm text-[var(--ink-2)]"
+              >
+                {recipe.title}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/components/recipes/shopping/meal-planner.tsx
+++ b/ui/components/recipes/shopping/meal-planner.tsx
@@ -28,13 +28,16 @@ function recipeCountLabel(count: number): string {
   return `${count} ${count === 1 ? "recipe" : "recipes"}`;
 }
 
-function ServingsStepper({
-  slug,
-  servings,
-}: {
+function servingCountLabel(count: number): string {
+  return `${count} ${count === 1 ? "serving" : "servings"}`;
+}
+
+type ServingsStepperProps = Readonly<{
   slug: string;
   servings: number;
-}) {
+}>;
+
+function ServingsStepper({ slug, servings }: ServingsStepperProps) {
   return (
     <div className="flex items-center gap-1.5">
       <Button
@@ -61,17 +64,14 @@ function ServingsStepper({
   );
 }
 
-function MealSelect({
-  day,
-  slot,
-  value,
-  recipeOptions,
-}: {
+type MealSelectProps = Readonly<{
   day: MealPlanDay;
   slot: MealPlanSlot;
   value?: string;
-  recipeOptions: ShoppingRecipe[];
-}) {
+  recipeOptions: readonly ShoppingRecipe[];
+}>;
+
+function MealSelect({ day, slot, value, recipeOptions }: MealSelectProps) {
   return (
     <select
       value={value ?? ""}
@@ -79,7 +79,7 @@ function MealSelect({
         setPlannedMeal(day, slot, event.target.value || null)
       }
       aria-label={`${day} ${slot}`}
-      className="h-8 w-full rounded-md border border-[var(--line-strong)] bg-[var(--card)] px-2 text-xs text-[var(--ink-2)] outline-none transition-colors hover:border-[var(--terracotta)] focus:border-[var(--terracotta)] focus:ring-2 focus:ring-[var(--terracotta)]/15"
+      className="h-8 w-full min-w-0 max-w-full truncate rounded-md border border-[var(--line-strong)] bg-[var(--card)] px-2 text-xs text-[var(--ink-2)] outline-none transition-colors hover:border-[var(--terracotta)] focus:border-[var(--terracotta)] focus:ring-2 focus:ring-[var(--terracotta)]/15"
     >
       <option value="">Add meal</option>
       {recipeOptions.map((recipe) => (
@@ -91,16 +91,15 @@ function MealSelect({
   );
 }
 
-function PlannedRecipePill({
-  recipe,
-  onRemove,
-}: {
+type PlannedRecipePillProps = Readonly<{
   recipe?: ShoppingRecipe;
   onRemove: () => void;
-}) {
+}>;
+
+function PlannedRecipePill({ recipe, onRemove }: PlannedRecipePillProps) {
   if (!recipe) return null;
   return (
-    <div className="mt-2 flex items-center gap-2 rounded-md border border-[var(--line)] bg-[var(--paper-warm)] px-2 py-1.5">
+    <div className="mt-2 flex min-w-0 items-center gap-2 rounded-md border border-[var(--line)] bg-[var(--paper-warm)] px-2 py-1.5">
       <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded bg-[var(--butter-soft)] text-[var(--terracotta)]">
         <Utensils className="h-3.5 w-3.5" />
       </span>
@@ -116,7 +115,7 @@ function PlannedRecipePill({
         type="button"
         onClick={onRemove}
         aria-label={`Remove ${recipe.title} from this meal`}
-        className="text-[var(--ink-4)] transition-colors hover:text-[var(--berry)]"
+        className="shrink-0 text-[var(--ink-4)] transition-colors hover:text-[var(--berry)]"
       >
         <X className="h-3.5 w-3.5" />
       </button>
@@ -124,19 +123,16 @@ function PlannedRecipePill({
   );
 }
 
-function PlanCell({
-  day,
-  slot,
-  plannedRecipe,
-  recipeOptions,
-}: {
+type PlanCellProps = Readonly<{
   day: MealPlanDay;
   slot: MealPlanSlot;
   plannedRecipe?: ShoppingRecipe;
-  recipeOptions: ShoppingRecipe[];
-}) {
+  recipeOptions: readonly ShoppingRecipe[];
+}>;
+
+function PlanCell({ day, slot, plannedRecipe, recipeOptions }: PlanCellProps) {
   return (
-    <div className="min-h-28 rounded-md border border-[var(--line-strong)] bg-[var(--card)] p-2">
+    <div className="min-w-0 overflow-hidden rounded-md border border-[var(--line-strong)] bg-[var(--card)] p-2 lg:min-h-28">
       <MealSelect
         day={day}
         slot={slot}
@@ -151,13 +147,19 @@ function PlanCell({
   );
 }
 
-export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
+type MealPlannerProps = Readonly<{ recipes: ShoppingRecipe[] }>;
+
+export function MealPlanner({ recipes }: MealPlannerProps) {
   const state = useShoppingList();
 
   const bySlug = useMemo(() => {
     const map = new Map<string, ShoppingRecipe>();
     for (const recipe of recipes) map.set(recipe.slug, recipe);
     return map;
+  }, [recipes]);
+
+  const sortedRecipes = useMemo(() => {
+    return [...recipes].sort((a, b) => a.title.localeCompare(b.title));
   }, [recipes]);
 
   const planBySlot = useMemo(() => {
@@ -195,6 +197,10 @@ export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
     bySlug.has(meal.slug),
   ).length;
   const unscheduled = selected.filter((entry) => entry.plannedMeals === 0);
+  const totalServings = selected.reduce(
+    (sum, entry) => sum + entry.servings,
+    0,
+  );
 
   return (
     <div className="space-y-6">
@@ -210,7 +216,10 @@ export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
           <b className="text-[var(--ink)]">
             {mealCountLabel(plannedMealCount)}
           </b>{" "}
-          scheduled
+          scheduled ·{" "}
+          <b className="text-[var(--ink)]">
+            {servingCountLabel(totalServings)}
+          </b>
           {unscheduled.length > 0
             ? ` · ${recipeCountLabel(unscheduled.length)} unscheduled`
             : ""}
@@ -250,7 +259,7 @@ export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
                     day={day.id}
                     slot={slot.id}
                     plannedRecipe={recipe}
-                    recipeOptions={recipes}
+                    recipeOptions={sortedRecipes}
                   />
                 );
               })}
@@ -268,7 +277,7 @@ export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
                 {MEAL_PLAN_SLOTS.map((slot) => {
                   const recipe = planBySlot.get(planKey(day.id, slot.id));
                   return (
-                    <div key={slot.id}>
+                    <div key={slot.id} className="min-w-0">
                       <div className="mb-1 rt-mono text-xs text-[var(--ink-3)]">
                         {slot.label}
                       </div>
@@ -276,7 +285,7 @@ export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
                         day={day.id}
                         slot={slot.id}
                         plannedRecipe={recipe}
-                        recipeOptions={recipes}
+                        recipeOptions={sortedRecipes}
                       />
                     </div>
                   );
@@ -341,7 +350,7 @@ export function MealPlanner({ recipes }: { recipes: ShoppingRecipe[] }) {
             {unscheduled.map(({ recipe }) => (
               <span
                 key={recipe.slug}
-                className="rounded-md border border-[var(--line)] bg-[var(--paper-warm)] px-2 py-1 rt-body text-sm text-[var(--ink-2)]"
+                className="max-w-full truncate rounded-md border border-[var(--line)] bg-[var(--paper-warm)] px-2 py-1 rt-body text-sm text-[var(--ink-2)]"
               >
                 {recipe.title}
               </span>

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -256,6 +256,18 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
     (total, group) => total + group.servings,
     0,
   );
+  const stats = [
+    selected.length > 0
+      ? `${selected.length} ${selected.length === 1 ? "recipe" : "recipes"}`
+      : null,
+    selected.length > 0
+      ? `${servingCount} ${servingCount === 1 ? "serving" : "servings"}`
+      : null,
+    `${itemCount} ${itemCount === 1 ? "item" : "items"}`,
+    `${tickedCount} ticked`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
   const hasTicked = tickedCount > 0;
 
   if (selected.length === 0 && state.extras.length === 0) {
@@ -275,12 +287,7 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
   return (
     <div className="rounded-xl border-[1.25px] border-[var(--line-strong)] bg-[var(--card)] p-4 sm:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <p className="rt-mono text-[var(--ink-3)]">
-          {selected.length} {selected.length === 1 ? "recipe" : "recipes"} ·{" "}
-          {servingCount} {servingCount === 1 ? "serving" : "servings"} ·{" "}
-          {itemCount} {itemCount === 1 ? "item" : "items"} · {tickedCount}{" "}
-          ticked
-        </p>
+        <p className="rt-mono text-[var(--ink-3)]">{stats}</p>
         <div className="flex flex-wrap gap-1.5">
           {VIEWS.map((v) => (
             <Badge

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -252,9 +252,13 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
     aggregated.filter((l) => checkedSet.has(l.ingredient)).length +
     state.extras.filter((e) => e.checked).length;
   const itemCount = aggregated.length + state.extras.length;
+  const servingCount = recipeGroups.reduce(
+    (total, group) => total + group.servings,
+    0,
+  );
   const hasTicked = tickedCount > 0;
 
-  if (selected.length === 0) {
+  if (selected.length === 0 && state.extras.length === 0) {
     return (
       <div className="rounded-xl border-[1.25px] border-dashed border-[var(--line-strong)] bg-[var(--card)] p-10 text-center">
         <p className="rt-display text-3xl text-[var(--ink-2)]">
@@ -273,6 +277,7 @@ export function ShoppingList({ recipes }: { recipes: ShoppingRecipe[] }) {
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="rt-mono text-[var(--ink-3)]">
           {selected.length} {selected.length === 1 ? "recipe" : "recipes"} ·{" "}
+          {servingCount} {servingCount === 1 ? "serving" : "servings"} ·{" "}
           {itemCount} {itemCount === 1 ? "item" : "items"} · {tickedCount}{" "}
           ticked
         </p>

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -25,6 +25,13 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
   const plannedNoun = plannedCount === 1 ? "meal" : "meals";
   const extraNoun = extras.length === 1 ? "extra item" : "extra items";
   const hasListContent = count > 0 || extras.length > 0;
+  let summary =
+    "Plan meals for the week or choose recipes directly and we'll build the list.";
+  if (count > 0) {
+    summary = `${count} ${recipeNoun} selected · ${plannedCount} ${plannedNoun} scheduled.`;
+  } else if (extras.length > 0) {
+    summary = `${extras.length} ${extraNoun} on the shopping list.`;
+  }
 
   return (
     <div className="container mx-auto px-4 pt-5 pb-16 md:pt-7 max-w-5xl">
@@ -36,13 +43,7 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
           <h1 className="rt-display text-5xl md:text-6xl mt-2">
             {step === "plan" ? "What's the plan?" : "Shopping list."}
           </h1>
-          <p className="rt-body mt-2 text-[var(--ink-2)]">
-            {count > 0
-              ? `${count} ${recipeNoun} selected · ${plannedCount} ${plannedNoun} scheduled.`
-              : extras.length > 0
-                ? `${extras.length} ${extraNoun} on the shopping list.`
-                : "Plan meals for the week or choose recipes directly and we'll build the list."}
-          </p>
+          <p className="rt-body mt-2 text-[var(--ink-2)]">{summary}</p>
         </div>
         {hasListContent && (
           <button

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -2,37 +2,42 @@
 
 import { ArrowLeft, ArrowRight, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { MealPlanner } from "@/components/recipes/shopping/meal-planner";
 import { RecipePicker } from "@/components/recipes/shopping/recipe-picker";
 import { ShoppingList } from "@/components/recipes/shopping/shopping-list";
 import { useShoppingList } from "@/hooks/use-shopping-list";
 import type { ShoppingRecipe } from "@/lib/api/shopping";
 import { clearList } from "@/lib/shopping/shoppingListStore";
 
-type Step = "pick" | "list";
+type Step = "plan" | "list";
 
 const STEPS: { id: Step; label: string }[] = [
-  { id: "pick", label: "1 · Pick recipes" },
+  { id: "plan", label: "1 · Plan the week" },
   { id: "list", label: "2 · Shopping list" },
 ];
 
 export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
-  const { recipes: selected } = useShoppingList();
-  const [step, setStep] = useState<Step>("pick");
+  const { recipes: selected, plan } = useShoppingList();
+  const [step, setStep] = useState<Step>("plan");
   const count = selected.length;
   const recipeNoun = count === 1 ? "recipe" : "recipes";
+  const plannedCount = plan.length;
+  const plannedNoun = plannedCount === 1 ? "meal" : "meals";
 
   return (
     <div className="container mx-auto px-4 pt-5 pb-16 md:pt-7 max-w-5xl">
       <div className="flex flex-wrap items-end justify-between gap-4 mb-4">
         <div>
-          <p className="rt-mono text-[var(--terracotta)]">Shopping</p>
+          <p className="rt-mono text-[var(--terracotta)]">
+            Shopping · weekly plan
+          </p>
           <h1 className="rt-display text-5xl md:text-6xl mt-2">
-            {step === "pick" ? "What are you cooking?" : "Shopping list."}
+            {step === "plan" ? "What's the plan?" : "Shopping list."}
           </h1>
           <p className="rt-body mt-2 text-[var(--ink-2)]">
             {count === 0
-              ? "Choose the recipes you want to cook and we'll build the list."
-              : `${count} ${recipeNoun} selected.`}
+              ? "Plan meals for the week or choose recipes directly and we'll build the list."
+              : `${count} ${recipeNoun} selected · ${plannedCount} ${plannedNoun} scheduled.`}
           </p>
         </div>
         {count > 0 && (
@@ -40,7 +45,7 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
             type="button"
             onClick={() => {
               clearList();
-              setStep("pick");
+              setStep("plan");
             }}
             className="inline-flex items-center gap-1.5 rt-mono text-[var(--ink-3)] hover:text-[var(--berry)] transition-colors"
           >
@@ -72,9 +77,25 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
         })}
       </div>
 
-      {step === "pick" ? (
-        <div>
-          <RecipePicker recipes={recipes} />
+      {step === "plan" ? (
+        <div className="space-y-8">
+          <MealPlanner recipes={recipes} />
+          <div>
+            <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
+              <div>
+                <p className="rt-mono text-[var(--terracotta)]">
+                  Recipe picker
+                </p>
+                <h2 className="rt-display text-3xl text-[var(--ink)]">
+                  Add anything else.
+                </h2>
+              </div>
+              <p className="rt-body text-sm text-[var(--ink-3)]">
+                Selected recipes appear in the plan pool and shopping list.
+              </p>
+            </div>
+            <RecipePicker recipes={recipes} />
+          </div>
           <div className="mt-6 flex justify-end">
             <button
               type="button"
@@ -91,10 +112,10 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
         <div>
           <button
             type="button"
-            onClick={() => setStep("pick")}
+            onClick={() => setStep("plan")}
             className="inline-flex items-center gap-1.5 rt-mono text-[var(--ink-3)] hover:text-[var(--terracotta)] mb-3 transition-colors"
           >
-            <ArrowLeft className="h-3.5 w-3.5" /> back to recipes
+            <ArrowLeft className="h-3.5 w-3.5" /> back to plan
           </button>
           <ShoppingList recipes={recipes} />
         </div>

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -17,12 +17,14 @@ const STEPS: { id: Step; label: string }[] = [
 ];
 
 export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
-  const { recipes: selected, plan } = useShoppingList();
+  const { recipes: selected, plan, extras } = useShoppingList();
   const [step, setStep] = useState<Step>("plan");
   const count = selected.length;
   const recipeNoun = count === 1 ? "recipe" : "recipes";
   const plannedCount = plan.length;
   const plannedNoun = plannedCount === 1 ? "meal" : "meals";
+  const extraNoun = extras.length === 1 ? "extra item" : "extra items";
+  const hasListContent = count > 0 || extras.length > 0;
 
   return (
     <div className="container mx-auto px-4 pt-5 pb-16 md:pt-7 max-w-5xl">
@@ -35,12 +37,14 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
             {step === "plan" ? "What's the plan?" : "Shopping list."}
           </h1>
           <p className="rt-body mt-2 text-[var(--ink-2)]">
-            {count === 0
-              ? "Plan meals for the week or choose recipes directly and we'll build the list."
-              : `${count} ${recipeNoun} selected · ${plannedCount} ${plannedNoun} scheduled.`}
+            {count > 0
+              ? `${count} ${recipeNoun} selected · ${plannedCount} ${plannedNoun} scheduled.`
+              : extras.length > 0
+                ? `${extras.length} ${extraNoun} on the shopping list.`
+                : "Plan meals for the week or choose recipes directly and we'll build the list."}
           </p>
         </div>
-        {count > 0 && (
+        {hasListContent && (
           <button
             type="button"
             onClick={() => {
@@ -100,7 +104,7 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
             <button
               type="button"
               onClick={() => setStep("list")}
-              disabled={count === 0}
+              disabled={!hasListContent}
               className="inline-flex items-center gap-2 rounded-md bg-[var(--terracotta)] px-4 py-2 text-white font-medium hover:bg-[var(--terracotta-deep)] disabled:opacity-40 disabled:hover:bg-[var(--terracotta)] transition-colors"
             >
               View shopping list

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -24,11 +24,13 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
   const plannedCount = plan.length;
   const plannedNoun = plannedCount === 1 ? "meal" : "meals";
   const extraNoun = extras.length === 1 ? "extra item" : "extra items";
-  const hasListContent = count > 0 || extras.length > 0;
+  const hasListContent = count > 0 || plannedCount > 0 || extras.length > 0;
   let summary =
     "Plan meals for the week or choose recipes directly and we'll build the list.";
   if (count > 0) {
     summary = `${count} ${recipeNoun} selected · ${plannedCount} ${plannedNoun} scheduled.`;
+  } else if (plannedCount > 0) {
+    summary = `${plannedCount} ${plannedNoun} scheduled.`;
   } else if (extras.length > 0) {
     summary = `${extras.length} ${extraNoun} on the shopping list.`;
   }

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -38,16 +38,16 @@ export const MEAL_PLAN_SLOTS = [
   { id: "dinner", label: "Dinner", short: "D" },
 ] as const;
 
-const MEAL_PLAN_DAY_SET: ReadonlySet<unknown> = new Set(
-  MEAL_PLAN_DAYS.map((day) => day.id),
-);
-const MEAL_PLAN_SLOT_SET: ReadonlySet<unknown> = new Set(
-  MEAL_PLAN_SLOTS.map((slot) => slot.id),
-);
-
 export type MealPlanDay = (typeof MEAL_PLAN_DAYS)[number]["id"];
 
 export type MealPlanSlot = (typeof MEAL_PLAN_SLOTS)[number]["id"];
+
+const MEAL_PLAN_DAY_SET: ReadonlySet<MealPlanDay> = new Set(
+  MEAL_PLAN_DAYS.map((day) => day.id),
+);
+const MEAL_PLAN_SLOT_SET: ReadonlySet<MealPlanSlot> = new Set(
+  MEAL_PLAN_SLOTS.map((slot) => slot.id),
+);
 
 export type PlannedMealEntry = {
   day: MealPlanDay;
@@ -84,11 +84,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isMealPlanDay(value: unknown): value is MealPlanDay {
-  return MEAL_PLAN_DAY_SET.has(value);
+  return (
+    typeof value === "string" && MEAL_PLAN_DAY_SET.has(value as MealPlanDay)
+  );
 }
 
 function isMealPlanSlot(value: unknown): value is MealPlanSlot {
-  return MEAL_PLAN_SLOT_SET.has(value);
+  return (
+    typeof value === "string" && MEAL_PLAN_SLOT_SET.has(value as MealPlanSlot)
+  );
 }
 
 function parseState(raw: string | null): ShoppingListState {
@@ -130,10 +134,11 @@ function parseState(raw: string | null): ShoppingListState {
         })
       : [];
 
-    const recipeSlugs = new Set(recipes.map((recipe) => recipe.slug));
+    const hydratedRecipes = [...recipes];
+    const recipeSlugs = new Set(hydratedRecipes.map((recipe) => recipe.slug));
     for (const meal of plan) {
       if (!recipeSlugs.has(meal.slug)) {
-        recipes.push({ slug: meal.slug });
+        hydratedRecipes.push({ slug: meal.slug });
         recipeSlugs.add(meal.slug);
       }
     }
@@ -155,7 +160,7 @@ function parseState(raw: string | null): ShoppingListState {
         })
       : [];
 
-    return { recipes, plan, checked, extras };
+    return { recipes: hydratedRecipes, plan, checked, extras };
   } catch {
     return EMPTY_STATE;
   }

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -22,9 +22,44 @@ export type ExtraItem = {
   checked: boolean;
 };
 
+export const MEAL_PLAN_DAYS = [
+  { id: "mon", label: "Monday", short: "Mon" },
+  { id: "tue", label: "Tuesday", short: "Tue" },
+  { id: "wed", label: "Wednesday", short: "Wed" },
+  { id: "thu", label: "Thursday", short: "Thu" },
+  { id: "fri", label: "Friday", short: "Fri" },
+  { id: "sat", label: "Saturday", short: "Sat" },
+  { id: "sun", label: "Sunday", short: "Sun" },
+] as const;
+
+export const MEAL_PLAN_SLOTS = [
+  { id: "breakfast", label: "Breakfast", short: "B" },
+  { id: "lunch", label: "Lunch", short: "L" },
+  { id: "dinner", label: "Dinner", short: "D" },
+] as const;
+
+const MEAL_PLAN_DAY_SET: ReadonlySet<unknown> = new Set(
+  MEAL_PLAN_DAYS.map((day) => day.id),
+);
+const MEAL_PLAN_SLOT_SET: ReadonlySet<unknown> = new Set(
+  MEAL_PLAN_SLOTS.map((slot) => slot.id),
+);
+
+export type MealPlanDay = (typeof MEAL_PLAN_DAYS)[number]["id"];
+
+export type MealPlanSlot = (typeof MEAL_PLAN_SLOTS)[number]["id"];
+
+export type PlannedMealEntry = {
+  day: MealPlanDay;
+  slot: MealPlanSlot;
+  slug: string;
+};
+
 export type ShoppingListState = {
   /** Selected recipes, kept in the order they were added. */
   recipes: SelectedRecipeEntry[];
+  /** Weekly calendar slots that reference selected recipes. */
+  plan: PlannedMealEntry[];
   /** Ticked-off ingredient slugs. */
   checked: string[];
   /** Freeform extras (milk, bread…). */
@@ -35,6 +70,7 @@ const STORAGE_KEY = "recipe-shopping-list:v1";
 
 const EMPTY_STATE: ShoppingListState = {
   recipes: [],
+  plan: [],
   checked: [],
   extras: [],
 };
@@ -45,6 +81,14 @@ const listeners = new Set<() => void>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function isMealPlanDay(value: unknown): value is MealPlanDay {
+  return MEAL_PLAN_DAY_SET.has(value);
+}
+
+function isMealPlanSlot(value: unknown): value is MealPlanSlot {
+  return MEAL_PLAN_SLOT_SET.has(value);
 }
 
 function parseState(raw: string | null): ShoppingListState {
@@ -68,6 +112,24 @@ function parseState(raw: string | null): ShoppingListState {
         })
       : [];
 
+    const seenPlanSlots = new Set<string>();
+    const plan = Array.isArray(parsed.plan)
+      ? parsed.plan.flatMap((entry): PlannedMealEntry[] => {
+          if (
+            !isRecord(entry) ||
+            !isMealPlanDay(entry.day) ||
+            !isMealPlanSlot(entry.slot) ||
+            typeof entry.slug !== "string"
+          ) {
+            return [];
+          }
+          const key = `${entry.day}:${entry.slot}`;
+          if (seenPlanSlots.has(key)) return [];
+          seenPlanSlots.add(key);
+          return [{ day: entry.day, slot: entry.slot, slug: entry.slug }];
+        })
+      : [];
+
     const checked = Array.isArray(parsed.checked)
       ? parsed.checked.filter((v): v is string => typeof v === "string")
       : [];
@@ -85,7 +147,7 @@ function parseState(raw: string | null): ShoppingListState {
         })
       : [];
 
-    return { recipes, checked, extras };
+    return { recipes, plan, checked, extras };
   } catch {
     return EMPTY_STATE;
   }
@@ -170,6 +232,7 @@ export function removeRecipe(slug: string): void {
   setState({
     ...state,
     recipes: state.recipes.filter((r) => r.slug !== slug),
+    plan: state.plan.filter((meal) => meal.slug !== slug),
   });
 }
 
@@ -186,6 +249,30 @@ export function setRecipeServings(slug: string, servings: number): void {
       r.slug === slug ? { ...r, servings: safe } : r,
     ),
   });
+}
+
+export function setPlannedMeal(
+  day: MealPlanDay,
+  slot: MealPlanSlot,
+  slug: string | null,
+): void {
+  const plan = state.plan.filter(
+    (meal) => meal.day !== day || meal.slot !== slot,
+  );
+  const recipes =
+    slug && !state.recipes.some((recipe) => recipe.slug === slug)
+      ? [...state.recipes, { slug }]
+      : state.recipes;
+  setState({
+    ...state,
+    recipes,
+    plan: slug ? [...plan, { day, slot, slug }] : plan,
+  });
+}
+
+export function clearMealPlan(): void {
+  if (state.plan.length === 0) return;
+  setState({ ...state, plan: [] });
 }
 
 export function toggleChecked(key: string): void {

--- a/ui/lib/shopping/shoppingListStore.ts
+++ b/ui/lib/shopping/shoppingListStore.ts
@@ -130,6 +130,14 @@ function parseState(raw: string | null): ShoppingListState {
         })
       : [];
 
+    const recipeSlugs = new Set(recipes.map((recipe) => recipe.slug));
+    for (const meal of plan) {
+      if (!recipeSlugs.has(meal.slug)) {
+        recipes.push({ slug: meal.slug });
+        recipeSlugs.add(meal.slug);
+      }
+    }
+
     const checked = Array.isArray(parsed.checked)
       ? parsed.checked.filter((v): v is string => typeof v === "string")
       : [];

--- a/ui/tests/lib/shopping/shoppingListStore.test.ts
+++ b/ui/tests/lib/shopping/shoppingListStore.test.ts
@@ -5,9 +5,11 @@ import {
   addRecipe,
   clearChecked,
   clearList,
+  clearMealPlan,
   getShoppingListSnapshot,
   removeExtra,
   removeRecipe,
+  setPlannedMeal,
   setRecipeServings,
   subscribeShoppingList,
   toggleChecked,
@@ -90,6 +92,43 @@ describe("shoppingListStore", () => {
     expect(getShoppingListSnapshot().recipes).toEqual([
       { slug: "risotto", servings: 3 },
     ]);
+    expect(getShoppingListSnapshot().plan).toEqual([]);
+  });
+
+  it("adds scheduled meals and auto-adds the recipe to the shopping pool", () => {
+    setPlannedMeal("mon", "dinner", "risotto");
+    expect(getShoppingListSnapshot()).toMatchObject({
+      recipes: [{ slug: "risotto" }],
+      plan: [{ day: "mon", slot: "dinner", slug: "risotto" }],
+    });
+  });
+
+  it("replaces one calendar slot without duplicating recipes", () => {
+    setPlannedMeal("mon", "dinner", "risotto");
+    setPlannedMeal("mon", "dinner", "paella");
+    expect(getShoppingListSnapshot().recipes).toEqual([
+      { slug: "risotto" },
+      { slug: "paella" },
+    ]);
+    expect(getShoppingListSnapshot().plan).toEqual([
+      { day: "mon", slot: "dinner", slug: "paella" },
+    ]);
+  });
+
+  it("clears a slot while keeping the recipe in the shopping pool", () => {
+    setPlannedMeal("mon", "dinner", "risotto");
+    setPlannedMeal("mon", "dinner", null);
+    expect(getShoppingListSnapshot().recipes).toEqual([{ slug: "risotto" }]);
+    expect(getShoppingListSnapshot().plan).toEqual([]);
+  });
+
+  it("clears only the calendar plan", () => {
+    setPlannedMeal("mon", "dinner", "risotto");
+    addExtra("foil");
+    clearMealPlan();
+    expect(getShoppingListSnapshot().recipes).toEqual([{ slug: "risotto" }]);
+    expect(getShoppingListSnapshot().plan).toEqual([]);
+    expect(getShoppingListSnapshot().extras).toHaveLength(1);
   });
 
   it("installs a single shared storage listener regardless of subscriber count", () => {
@@ -117,8 +156,10 @@ describe("shoppingListStore", () => {
   it("removes a recipe by slug", () => {
     addRecipe("a");
     addRecipe("b");
+    setPlannedMeal("mon", "dinner", "a");
     removeRecipe("a");
     expect(getShoppingListSnapshot().recipes).toEqual([{ slug: "b" }]);
+    expect(getShoppingListSnapshot().plan).toEqual([]);
   });
 
   it("clearChecked unticks ingredients and extras but keeps them", () => {
@@ -139,6 +180,7 @@ describe("shoppingListStore", () => {
     clearList();
     expect(getShoppingListSnapshot()).toEqual({
       recipes: [],
+      plan: [],
       checked: [],
       extras: [],
     });
@@ -154,12 +196,14 @@ describe("shoppingListStore", () => {
         key: STORAGE_KEY,
         newValue: JSON.stringify({
           recipes: [{ slug: "x" }, { slug: "y" }],
+          plan: [{ day: "tue", slot: "lunch", slug: "x" }],
           checked: [],
           extras: [],
         }),
       }),
     );
     expect(getShoppingListSnapshot().recipes).toHaveLength(2);
+    expect(getShoppingListSnapshot().plan).toHaveLength(1);
     expect(seen).toContain(2); // subscribers were notified
     unsub();
   });

--- a/ui/tests/lib/shopping/shoppingListStore.test.ts
+++ b/ui/tests/lib/shopping/shoppingListStore.test.ts
@@ -196,15 +196,16 @@ describe("shoppingListStore", () => {
         key: STORAGE_KEY,
         newValue: JSON.stringify({
           recipes: [{ slug: "x" }, { slug: "y" }],
-          plan: [{ day: "tue", slot: "lunch", slug: "x" }],
+          plan: [{ day: "tue", slot: "lunch", slug: "z" }],
           checked: [],
           extras: [],
         }),
       }),
     );
-    expect(getShoppingListSnapshot().recipes).toHaveLength(2);
+    expect(getShoppingListSnapshot().recipes).toHaveLength(3);
+    expect(getShoppingListSnapshot().recipes).toContainEqual({ slug: "z" });
     expect(getShoppingListSnapshot().plan).toHaveLength(1);
-    expect(seen).toContain(2); // subscribers were notified
+    expect(seen).toContain(3); // subscribers were notified
     unsub();
   });
 });


### PR DESCRIPTION
## Summary

Adds a client-side weekly meal planning layer to the recipe shopping view. The shopping flow now starts with a calendar-style plan step, lets planned recipes feed the existing recipe pool, and keeps the consolidated checkable shopping list as the final step.

## Changes

- Add a responsive weekly meal planner for breakfast, lunch, and dinner slots.
- Persist meal plan entries in the existing localStorage-backed shopping list store.
- Derive meal plan day and slot types from exported metadata constants used by both store validation and UI rendering.
- Keep unscheduled selected recipes in the shopping pool so quick list building still works.
- Extend shopping store tests around scheduling, replacing, clearing, and removing planned meals.

## Validation

- `CI=true mise //ui:typecheck`
- `CI=true mise //ui:test -- tests/lib/shopping/shoppingListStore.test.ts`
- `CI=true mise //ui:lint`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder CI=true mise //ui:build`
- Local Brave smoke test: scheduled a recipe, verified persisted plan state, opened the shopping list, and confirmed the consolidated ingredient list rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a meal-planning step to the shopping flow, letting you schedule recipes into weekly slots before viewing the shopping list.
  * Shopping lists now reflect total servings, with clearer counts in the header.

* **Bug Fixes**
  * Improved handling of saved shopping plans so scheduled meals stay in sync when recipes are added, removed, or cleared.
  * Updated the shopping page description copy for a clearer weekly-planning message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->