### PR TITLE
Add kitchen cupboards view

### DIFF
--- a/ui/app/recipes/kitchen/page.tsx
+++ b/ui/app/recipes/kitchen/page.tsx
@@ -5,6 +5,9 @@ import { getKitchenIngredients, getKitchenRecipes } from "@/lib/api/recipes";
 export const metadata: Metadata = {
   title: "Kitchen",
   description: "Track what is in your kitchen and find recipes you can make.",
+  robots: {
+    index: false,
+  },
 };
 
 export default function KitchenPage() {

--- a/ui/app/recipes/kitchen/page.tsx
+++ b/ui/app/recipes/kitchen/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { KitchenView } from "@/components/recipes/kitchen/kitchen-view";
+import { getKitchenIngredients, getKitchenRecipes } from "@/lib/api/recipes";
+
+export const metadata: Metadata = {
+  title: "Kitchen",
+  description: "Track what is in your kitchen and find recipes you can make.",
+};
+
+export default function KitchenPage() {
+  return (
+    <KitchenView
+      ingredients={getKitchenIngredients()}
+      recipes={getKitchenRecipes()}
+    />
+  );
+}

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -29,6 +29,7 @@ import {
 import { cn } from "@/lib/generic/styles";
 
 const STORAGE_KEY = "recipe-kitchen-stock-v1";
+const CATALOG_RESULT_LIMIT = 18;
 
 const LOCATION_ICONS = {
   fridge: Refrigerator,
@@ -213,7 +214,7 @@ export function KitchenView({
     .filter((recipe) => recipe.missingCount > 0)
     .slice(0, 5);
 
-  const filteredCatalog = useMemo(() => {
+  const catalogMatches = useMemo(() => {
     const query = normalizeQuery(catalogQuery);
     return ingredients
       .filter((ingredient) => !stock[ingredient.slug])
@@ -222,9 +223,10 @@ export function KitchenView({
         return `${ingredient.name} ${ingredient.category ?? ""}`
           .toLowerCase()
           .includes(query);
-      })
-      .slice(0, 18);
+      });
   }, [catalogQuery, ingredients, stock]);
+  const filteredCatalog = catalogMatches.slice(0, CATALOG_RESULT_LIMIT);
+  const isCatalogTruncated = catalogMatches.length > filteredCatalog.length;
 
   const stockQueryNormalized = normalizeQuery(stockQuery);
   const groupedStock = useMemo(
@@ -477,6 +479,12 @@ export function KitchenView({
                   </button>
                 ))}
               </div>
+              {isCatalogTruncated && (
+                <p className="rt-body mt-3 text-sm text-[var(--ink-3)]">
+                  Showing {filteredCatalog.length} of {catalogMatches.length}
+                  matching ingredients.
+                </p>
+              )}
               {filteredCatalog.length === 0 && (
                 <p className="rt-body text-sm text-[var(--ink-3)]">
                   No matching ingredients left to add.
@@ -517,9 +525,15 @@ export function KitchenView({
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              {closeMatches.map((recipe) => (
-                <RecipeMatchCard key={recipe.slug} recipe={recipe} />
-              ))}
+              {closeMatches.length > 0 ? (
+                closeMatches.map((recipe) => (
+                  <RecipeMatchCard key={recipe.slug} recipe={recipe} />
+                ))
+              ) : (
+                <p className="rt-body text-sm text-[var(--ink-3)]">
+                  No close matches right now.
+                </p>
+              )}
             </CardContent>
           </Card>
         </aside>

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -1,0 +1,482 @@
+"use client";
+
+import {
+  Check,
+  ChefHat,
+  CirclePlus,
+  Refrigerator,
+  Search,
+  ShoppingBasket,
+  Sprout,
+  Trash2,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { IngredientSlug } from "@/lib/domain/recipe/ingredient";
+import {
+  getKitchenRecipeMatches,
+  isKitchenLocation,
+  KITCHEN_LOCATIONS,
+  type KitchenIngredientView,
+  type KitchenLocation,
+  type KitchenRecipeView,
+} from "@/lib/domain/recipe/kitchen";
+import { cn } from "@/lib/generic/styles";
+
+const STORAGE_KEY = "recipe-kitchen-stock-v1";
+
+const LOCATION_ICONS = {
+  fridge: Refrigerator,
+  cupboards: ShoppingBasket,
+  fresh: Sprout,
+} satisfies Record<KitchenLocation, typeof Refrigerator>;
+
+type StockBySlug = Record<string, KitchenLocation>;
+
+function normalizeQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function formatTime(minutes?: number) {
+  if (minutes == null) return null;
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+function readStoredStock(): StockBySlug | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, KitchenLocation] =>
+          isKitchenLocation(entry[1]),
+      ),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function RecipeMatchCard({
+  recipe,
+}: {
+  recipe: ReturnType<typeof getKitchenRecipeMatches>[number];
+}) {
+  const timeLabel = formatTime(recipe.totalTime);
+  const canCook = recipe.missingCount === 0;
+  const progress = Math.round(recipe.matchRatio * 100);
+
+  return (
+    <Card className="overflow-hidden rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)] py-0">
+      <CardContent className="p-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <div
+            className={cn(
+              "flex size-11 shrink-0 items-center justify-center rounded-md",
+              canCook
+                ? "bg-[var(--sage)] text-white"
+                : "bg-[var(--paper-warm)] text-[var(--terracotta)]",
+            )}
+          >
+            {canCook ? (
+              <Check className="size-5" />
+            ) : (
+              <ChefHat className="size-5" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <Link
+              href={`/recipes/${recipe.slug}`}
+              className="rt-display block truncate text-2xl leading-none transition-colors hover:text-[var(--terracotta)]"
+            >
+              {recipe.title}
+            </Link>
+            <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-[var(--ink-3)]">
+              {timeLabel && <span>{timeLabel}</span>}
+              {recipe.cuisine.slice(0, 2).map((cuisine) => (
+                <span key={cuisine}>{cuisine}</span>
+              ))}
+              <span>
+                {recipe.haveCount}/{recipe.totalCount} ingredients
+              </span>
+            </div>
+          </div>
+          <Badge
+            variant={canCook ? "default" : "outline"}
+            className={cn(
+              "shrink-0",
+              canCook
+                ? "bg-[var(--sage)] text-white"
+                : "text-[var(--terracotta)]",
+            )}
+          >
+            {canCook ? "cook" : `+${recipe.missingCount}`}
+          </Badge>
+        </div>
+        <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--paper-warm)]">
+          <div
+            className={cn(
+              "h-full rounded-full",
+              canCook ? "bg-[var(--sage)]" : "bg-[var(--terracotta)]",
+            )}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        {recipe.missingIngredients.length > 0 && (
+          <p className="rt-body mt-2 line-clamp-2 text-sm text-[var(--ink-2)]">
+            Need:{" "}
+            <span className="text-[var(--terracotta)]">
+              {recipe.missingIngredients
+                .slice(0, 5)
+                .map((ingredient) => ingredient.name)
+                .join(", ")}
+              {recipe.missingIngredients.length > 5 ? "..." : ""}
+            </span>
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function LocationIcon({ location }: { location: KitchenLocation }) {
+  const Icon = LOCATION_ICONS[location];
+  return <Icon className="size-4" />;
+}
+
+export function KitchenView({
+  ingredients,
+  recipes,
+}: {
+  ingredients: KitchenIngredientView[];
+  recipes: KitchenRecipeView[];
+}) {
+  const ingredientBySlug = useMemo(
+    () =>
+      new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient])),
+    [ingredients],
+  );
+  const [stock, setStock] = useState<StockBySlug>({});
+  const [hasHydrated, setHasHydrated] = useState(false);
+  const [stockQuery, setStockQuery] = useState("");
+  const [catalogQuery, setCatalogQuery] = useState("");
+  const [targetLocation, setTargetLocation] =
+    useState<KitchenLocation>("cupboards");
+
+  useEffect(() => {
+    setStock(readStoredStock() ?? {});
+    setHasHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!hasHydrated) return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stock));
+  }, [hasHydrated, stock]);
+
+  const stockedSlugs = useMemo(
+    () =>
+      Object.keys(stock).filter((slug) =>
+        ingredientBySlug.has(slug as IngredientSlug),
+      ) as IngredientSlug[],
+    [ingredientBySlug, stock],
+  );
+
+  const matches = useMemo(
+    () => getKitchenRecipeMatches(recipes, stockedSlugs),
+    [recipes, stockedSlugs],
+  );
+  const cookNow = matches
+    .filter((recipe) => recipe.missingCount === 0)
+    .slice(0, 4);
+  const closeMatches = matches
+    .filter((recipe) => recipe.missingCount > 0)
+    .slice(0, 5);
+
+  const filteredCatalog = useMemo(() => {
+    const query = normalizeQuery(catalogQuery);
+    return ingredients
+      .filter((ingredient) => !stock[ingredient.slug])
+      .filter((ingredient) => {
+        if (!query) return true;
+        return `${ingredient.name} ${ingredient.category ?? ""}`
+          .toLowerCase()
+          .includes(query);
+      })
+      .slice(0, 18);
+  }, [catalogQuery, ingredients, stock]);
+
+  const stockQueryNormalized = normalizeQuery(stockQuery);
+  const groupedStock = useMemo(
+    () =>
+      KITCHEN_LOCATIONS.map((location) => ({
+        ...location,
+        icon: LOCATION_ICONS[location.id],
+        items: stockedSlugs
+          .filter((slug) => stock[slug] === location.id)
+          .map((slug) => ingredientBySlug.get(slug))
+          .filter((ingredient): ingredient is KitchenIngredientView =>
+            Boolean(ingredient),
+          )
+          .filter((ingredient) => {
+            if (!stockQueryNormalized) return true;
+            return ingredient.name.toLowerCase().includes(stockQueryNormalized);
+          })
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      })),
+    [ingredientBySlug, stock, stockQueryNormalized, stockedSlugs],
+  );
+
+  const addIngredient = (
+    ingredient: KitchenIngredientView,
+    location = targetLocation,
+  ) => {
+    setStock((current) => ({ ...current, [ingredient.slug]: location }));
+  };
+
+  const removeIngredient = (slug: IngredientSlug) => {
+    setStock((current) => {
+      const next = { ...current };
+      delete next[slug];
+      return next;
+    });
+  };
+
+  const stockedCount = stockedSlugs.length;
+
+  return (
+    <div className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-16 md:pt-7">
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
+        <div className="min-w-0">
+          <p className="rt-mono text-[var(--terracotta)]">
+            Kitchen · stock match
+          </p>
+          <h1 className="rt-display mt-2 text-5xl sm:text-6xl lg:text-7xl">
+            What can I <span className="text-[var(--terracotta)]">make?</span>
+          </h1>
+          <p className="rt-body mt-3 max-w-2xl text-[var(--ink-2)]">
+            Add ingredients from the canonical recipe catalog, split them across
+            fridge, cupboards and fresh, then compare your kitchen against the
+            recipe box.
+          </p>
+        </div>
+        <div className="flex w-full flex-wrap gap-2 sm:w-auto">
+          {stockedCount > 0 && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="min-w-0 flex-1 text-[var(--ink-3)] hover:text-[var(--berry)] sm:flex-none"
+              onClick={() => setStock({})}
+            >
+              <Trash2 className="size-4" />
+              Clear
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid min-w-0 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.85fr)]">
+        <div className="min-w-0 space-y-6">
+          <Card className="rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)]">
+            <CardHeader className="gap-3">
+              <div className="flex flex-wrap items-end justify-between gap-3">
+                <div>
+                  <p className="rt-mono text-[var(--terracotta)]">In stock</p>
+                  <CardTitle className="rt-display text-4xl">
+                    Your kitchen.
+                  </CardTitle>
+                </div>
+                <Badge variant="outline" className="text-[var(--ink-2)]">
+                  {stockedCount} {stockedCount === 1 ? "item" : "items"}
+                </Badge>
+              </div>
+              <div className="relative">
+                <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-[var(--ink-3)]" />
+                <Input
+                  value={stockQuery}
+                  onChange={(event) => setStockQuery(event.target.value)}
+                  placeholder="Search what you have..."
+                  className="h-10 border-[var(--line-strong)] bg-[var(--paper)] pl-9"
+                />
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {groupedStock.map((group) => {
+                const Icon = group.icon;
+                return (
+                  <section key={group.id} className="min-w-0">
+                    <div className="mb-3 flex flex-wrap items-end justify-between gap-2 border-b border-[var(--line)] pb-2">
+                      <div className="min-w-0">
+                        <h2 className="rt-display flex items-center gap-2 text-3xl text-[var(--terracotta)]">
+                          <Icon className="size-5" />
+                          {group.label}
+                        </h2>
+                        <p className="rt-body text-sm text-[var(--ink-3)]">
+                          {group.description}
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-[var(--terracotta)]"
+                        onClick={() => setTargetLocation(group.id)}
+                      >
+                        <CirclePlus className="size-4" />
+                        Add here
+                      </Button>
+                    </div>
+                    {group.items.length > 0 ? (
+                      <div className="flex min-w-0 flex-wrap gap-2">
+                        {group.items.map((ingredient) => (
+                          <Badge
+                            key={ingredient.slug}
+                            variant="outline"
+                            className="max-w-full gap-1.5 bg-[var(--paper-warm)] px-2 py-1 text-sm text-[var(--ink)]"
+                          >
+                            <span className="truncate">{ingredient.name}</span>
+                            <button
+                              type="button"
+                              onClick={() => removeIngredient(ingredient.slug)}
+                              className="rounded-sm p-0.5 text-[var(--ink-3)] transition-colors hover:bg-[var(--paper)] hover:text-[var(--berry)]"
+                              aria-label={`Remove ${ingredient.name}`}
+                            >
+                              <X className="size-3" />
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="rt-body text-sm text-[var(--ink-3)]">
+                        Nothing here yet.
+                      </p>
+                    )}
+                  </section>
+                );
+              })}
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)]">
+            <CardHeader className="gap-3">
+              <div>
+                <p className="rt-mono text-[var(--terracotta)]">
+                  Canonical ingredients
+                </p>
+                <CardTitle className="rt-display text-4xl">
+                  Add to your kitchen.
+                </CardTitle>
+              </div>
+              <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
+                <div className="relative min-w-0">
+                  <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-[var(--ink-3)]" />
+                  <Input
+                    value={catalogQuery}
+                    onChange={(event) => setCatalogQuery(event.target.value)}
+                    placeholder={`Search ${ingredients.length} ingredients...`}
+                    className="h-10 border-[var(--line-strong)] bg-[var(--paper)] pl-9"
+                  />
+                </div>
+                <div className="grid grid-cols-3 rounded-md border border-[var(--line-strong)] bg-[var(--paper-warm)] p-1">
+                  {KITCHEN_LOCATIONS.map((location) => (
+                    <button
+                      key={location.id}
+                      type="button"
+                      onClick={() => setTargetLocation(location.id)}
+                      className={cn(
+                        "inline-flex items-center justify-center gap-1 rounded-sm px-2 py-1.5 text-sm transition-colors",
+                        targetLocation === location.id
+                          ? "bg-[var(--card)] text-[var(--ink)] shadow-xs"
+                          : "text-[var(--ink-3)] hover:text-[var(--ink)]",
+                      )}
+                    >
+                      <LocationIcon location={location.id} />
+                      <span className="hidden sm:inline">{location.label}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid min-w-0 gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                {filteredCatalog.map((ingredient) => (
+                  <button
+                    key={ingredient.slug}
+                    type="button"
+                    onClick={() => addIngredient(ingredient)}
+                    className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-[var(--line)] bg-[var(--paper)] px-3 py-2 text-left transition-colors hover:border-[var(--terracotta)] hover:bg-[var(--butter-soft)]"
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate text-sm font-medium text-[var(--ink)]">
+                        {ingredient.name}
+                      </span>
+                      <span className="rt-mono block truncate text-[var(--ink-3)]">
+                        {ingredient.category ?? "ingredient"}
+                      </span>
+                    </span>
+                    <CirclePlus className="size-4 shrink-0 text-[var(--terracotta)]" />
+                  </button>
+                ))}
+              </div>
+              {filteredCatalog.length === 0 && (
+                <p className="rt-body text-sm text-[var(--ink-3)]">
+                  No matching ingredients left to add.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <aside className="min-w-0 space-y-6 lg:sticky lg:top-24 lg:self-start">
+          <Card className="rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)]">
+            <CardHeader>
+              <p className="rt-mono text-[var(--sage)]">Cook now</p>
+              <CardTitle className="rt-display text-4xl">
+                Ready recipes.
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {cookNow.length > 0 ? (
+                cookNow.map((recipe) => (
+                  <RecipeMatchCard key={recipe.slug} recipe={recipe} />
+                ))
+              ) : (
+                <p className="rt-body text-sm text-[var(--ink-3)]">
+                  Add a few more staples to see fully stocked recipes.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)]">
+            <CardHeader>
+              <p className="rt-mono text-[var(--terracotta)]">
+                Just need a few
+              </p>
+              <CardTitle className="rt-display text-4xl">
+                Close matches.
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {closeMatches.map((recipe) => (
+                <RecipeMatchCard key={recipe.slug} recipe={recipe} />
+              ))}
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -72,9 +72,9 @@ function readStoredStock(): StockBySlug | null {
 
 function RecipeMatchCard({
   recipe,
-}: {
+}: Readonly<{
   recipe: ReturnType<typeof getKitchenRecipeMatches>[number];
-}) {
+}>) {
   const timeLabel = formatTime(recipe.totalTime);
   const canCook = recipe.missingCount === 0;
   const progress = Math.round(recipe.matchRatio * 100);
@@ -155,7 +155,7 @@ function RecipeMatchCard({
   );
 }
 
-function LocationIcon({ location }: { location: KitchenLocation }) {
+function LocationIcon({ location }: Readonly<{ location: KitchenLocation }>) {
   const Icon = LOCATION_ICONS[location];
   return <Icon className="size-4" />;
 }
@@ -163,10 +163,10 @@ function LocationIcon({ location }: { location: KitchenLocation }) {
 export function KitchenView({
   ingredients,
   recipes,
-}: {
+}: Readonly<{
   ingredients: KitchenIngredientView[];
   recipes: KitchenRecipeView[];
-}) {
+}>) {
   const ingredientBySlug = useMemo(
     () =>
       new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient])),

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -52,6 +52,8 @@ function formatTime(minutes?: number) {
 }
 
 function readStoredStock(): StockBySlug | null {
+  if (typeof window === "undefined") return null;
+
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return null;
@@ -60,15 +62,35 @@ function readStoredStock(): StockBySlug | null {
       return null;
     }
 
-    return Object.fromEntries(
-      Object.entries(parsed).filter(
-        (entry): entry is [string, KitchenLocation] =>
-          isKitchenLocation(entry[1]),
-      ),
-    );
+    const stock: StockBySlug = {};
+    for (const [slug, location] of Object.entries(parsed)) {
+      if (isKitchenLocation(location)) {
+        stock[slug] = location;
+      }
+    }
+    return stock;
   } catch {
     return null;
   }
+}
+
+function pruneStock(
+  stock: StockBySlug,
+  knownIngredientSlugs: ReadonlySet<string>,
+): StockBySlug {
+  const pruned: StockBySlug = {};
+  for (const [slug, location] of Object.entries(stock)) {
+    if (knownIngredientSlugs.has(slug) && isKitchenLocation(location)) {
+      pruned[slug] = location;
+    }
+  }
+  return pruned;
+}
+
+function stocksEqual(a: StockBySlug, b: StockBySlug) {
+  const aEntries = Object.entries(a);
+  if (aEntries.length !== Object.keys(b).length) return false;
+  return aEntries.every(([slug, location]) => b[slug] === location);
 }
 
 function RecipeMatchCard({
@@ -77,7 +99,7 @@ function RecipeMatchCard({
   recipe: ReturnType<typeof getKitchenRecipeMatches>[number];
 }>) {
   const timeLabel = formatTime(recipe.totalTime);
-  const canCook = recipe.missingCount === 0;
+  const canCook = recipe.totalCount > 0 && recipe.missingCount === 0;
   const progress = Math.round(recipe.matchRatio * 100);
 
   return (
@@ -173,6 +195,10 @@ export function KitchenView({
       new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient])),
     [ingredients],
   );
+  const knownIngredientSlugs = useMemo(
+    () => new Set<string>(ingredients.map((ingredient) => ingredient.slug)),
+    [ingredients],
+  );
   const [stock, setStock] = useState<StockBySlug>({});
   const [hasHydrated, setHasHydrated] = useState(false);
   const [stockQuery, setStockQuery] = useState("");
@@ -186,21 +212,40 @@ export function KitchenView({
   const catalogSearchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    setStock(readStoredStock() ?? {});
+    setStock(pruneStock(readStoredStock() ?? {}, knownIngredientSlugs));
     setHasHydrated(true);
-  }, []);
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) return;
+      setStock(pruneStock(readStoredStock() ?? {}, knownIngredientSlugs));
+      setLastClearedStock(null);
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [knownIngredientSlugs]);
 
   useEffect(() => {
     if (!hasHydrated) return;
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stock));
-  }, [hasHydrated, stock]);
+    const prunedStock = pruneStock(stock, knownIngredientSlugs);
+    if (!stocksEqual(stock, prunedStock)) {
+      setStock(prunedStock);
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prunedStock));
+    } catch {
+      // Keep in-memory kitchen state even if browser storage is unavailable.
+    }
+  }, [hasHydrated, knownIngredientSlugs, stock]);
 
   const stockedSlugs = useMemo(
     () =>
-      Object.keys(stock).filter((slug) =>
-        ingredientBySlug.has(slug as IngredientSlug),
-      ) as IngredientSlug[],
-    [ingredientBySlug, stock],
+      Object.keys(stock).filter((slug): slug is IngredientSlug =>
+        knownIngredientSlugs.has(slug),
+      ),
+    [knownIngredientSlugs, stock],
   );
 
   const matches = useMemo(
@@ -208,7 +253,7 @@ export function KitchenView({
     [recipes, stockedSlugs],
   );
   const cookNow = matches
-    .filter((recipe) => recipe.missingCount === 0)
+    .filter((recipe) => recipe.totalCount > 0 && recipe.missingCount === 0)
     .slice(0, 4);
   const closeMatches = matches
     .filter((recipe) => recipe.missingCount > 0)
@@ -217,7 +262,7 @@ export function KitchenView({
   const catalogMatches = useMemo(() => {
     const query = normalizeQuery(catalogQuery);
     return ingredients
-      .filter((ingredient) => !stock[ingredient.slug])
+      .filter((ingredient) => !(ingredient.slug in stock))
       .filter((ingredient) => {
         if (!query) return true;
         return `${ingredient.name} ${ingredient.category ?? ""}`
@@ -232,7 +277,9 @@ export function KitchenView({
   const groupedStock = useMemo(
     () =>
       KITCHEN_LOCATIONS.map((location) => ({
-        ...location,
+        id: location.id,
+        label: location.label,
+        description: location.description,
         icon: LOCATION_ICONS[location.id],
         items: stockedSlugs
           .filter((slug) => stock[slug] === location.id)

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -80,75 +80,78 @@ function RecipeMatchCard({
   const progress = Math.round(recipe.matchRatio * 100);
 
   return (
-    <Card className="overflow-hidden rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)] py-0">
-      <CardContent className="p-3">
-        <div className="flex min-w-0 items-start gap-3">
-          <div
-            className={cn(
-              "flex size-11 shrink-0 items-center justify-center rounded-md",
-              canCook
-                ? "bg-[var(--sage)] text-white"
-                : "bg-[var(--paper-warm)] text-[var(--terracotta)]",
-            )}
-          >
-            {canCook ? (
-              <Check className="size-5" />
-            ) : (
-              <ChefHat className="size-5" />
-            )}
-          </div>
-          <div className="min-w-0 flex-1">
-            <Link
-              href={`/recipes/${recipe.slug}`}
-              className="rt-display block truncate text-2xl leading-none transition-colors hover:text-[var(--terracotta)]"
+    <Link
+      href={`/recipes/${recipe.slug}`}
+      className="group block rounded-lg focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--ring)]/50"
+      aria-label={`Open ${recipe.title}`}
+    >
+      <Card className="overflow-hidden rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)] py-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]">
+        <CardContent className="p-3">
+          <div className="flex min-w-0 items-start gap-3">
+            <div
+              className={cn(
+                "flex size-11 shrink-0 items-center justify-center rounded-md",
+                canCook
+                  ? "bg-[var(--sage)] text-white"
+                  : "bg-[var(--paper-warm)] text-[var(--terracotta)]",
+              )}
             >
-              {recipe.title}
-            </Link>
-            <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-[var(--ink-3)]">
-              {timeLabel && <span>{timeLabel}</span>}
-              {recipe.cuisine.slice(0, 2).map((cuisine) => (
-                <span key={cuisine}>{cuisine}</span>
-              ))}
-              <span>
-                {recipe.haveCount}/{recipe.totalCount} ingredients
-              </span>
+              {canCook ? (
+                <Check className="size-5" />
+              ) : (
+                <ChefHat className="size-5" />
+              )}
             </div>
+            <div className="min-w-0 flex-1">
+              <div className="rt-display text-2xl leading-none transition-colors group-hover:text-[var(--terracotta)]">
+                {recipe.title}
+              </div>
+              <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-[var(--ink-3)]">
+                {timeLabel && <span>{timeLabel}</span>}
+                {recipe.cuisine.slice(0, 2).map((cuisine) => (
+                  <span key={cuisine}>{cuisine}</span>
+                ))}
+                <span>
+                  {recipe.haveCount}/{recipe.totalCount} ingredients
+                </span>
+              </div>
+            </div>
+            <Badge
+              variant={canCook ? "default" : "outline"}
+              className={cn(
+                "shrink-0",
+                canCook
+                  ? "bg-[var(--sage)] text-white"
+                  : "text-[var(--terracotta)]",
+              )}
+            >
+              {canCook ? "cook" : `+${recipe.missingCount}`}
+            </Badge>
           </div>
-          <Badge
-            variant={canCook ? "default" : "outline"}
-            className={cn(
-              "shrink-0",
-              canCook
-                ? "bg-[var(--sage)] text-white"
-                : "text-[var(--terracotta)]",
-            )}
-          >
-            {canCook ? "cook" : `+${recipe.missingCount}`}
-          </Badge>
-        </div>
-        <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--paper-warm)]">
-          <div
-            className={cn(
-              "h-full rounded-full",
-              canCook ? "bg-[var(--sage)]" : "bg-[var(--terracotta)]",
-            )}
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-        {recipe.missingIngredients.length > 0 && (
-          <p className="rt-body mt-2 line-clamp-2 text-sm text-[var(--ink-2)]">
-            Need:{" "}
-            <span className="text-[var(--terracotta)]">
-              {recipe.missingIngredients
-                .slice(0, 5)
-                .map((ingredient) => ingredient.name)
-                .join(", ")}
-              {recipe.missingIngredients.length > 5 ? "..." : ""}
-            </span>
-          </p>
-        )}
-      </CardContent>
-    </Card>
+          <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--paper-warm)]">
+            <div
+              className={cn(
+                "h-full rounded-full",
+                canCook ? "bg-[var(--sage)]" : "bg-[var(--terracotta)]",
+              )}
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          {recipe.missingIngredients.length > 0 && (
+            <p className="rt-body mt-2 line-clamp-2 text-sm text-[var(--ink-2)]">
+              Need:{" "}
+              <span className="text-[var(--terracotta)]">
+                {recipe.missingIngredients
+                  .slice(0, 5)
+                  .map((ingredient) => ingredient.name)
+                  .join(", ")}
+                {recipe.missingIngredients.length > 5 ? "..." : ""}
+              </span>
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -12,7 +12,7 @@ import {
   X,
 } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -173,8 +173,13 @@ export function KitchenView({
   const [hasHydrated, setHasHydrated] = useState(false);
   const [stockQuery, setStockQuery] = useState("");
   const [catalogQuery, setCatalogQuery] = useState("");
+  const [lastClearedStock, setLastClearedStock] = useState<StockBySlug | null>(
+    null,
+  );
   const [targetLocation, setTargetLocation] =
     useState<KitchenLocation>("cupboards");
+  const catalogCardRef = useRef<HTMLDivElement>(null);
+  const catalogSearchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setStock(readStoredStock() ?? {});
@@ -244,6 +249,7 @@ export function KitchenView({
     location = targetLocation,
   ) => {
     setStock((current) => ({ ...current, [ingredient.slug]: location }));
+    setLastClearedStock(null);
   };
 
   const removeIngredient = (slug: IngredientSlug) => {
@@ -252,6 +258,28 @@ export function KitchenView({
       delete next[slug];
       return next;
     });
+  };
+
+  const focusAddIngredients = (location: KitchenLocation) => {
+    setTargetLocation(location);
+    window.requestAnimationFrame(() => {
+      catalogCardRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+      catalogSearchRef.current?.focus({ preventScroll: true });
+    });
+  };
+
+  const clearStock = () => {
+    setLastClearedStock(stock);
+    setStock({});
+  };
+
+  const undoClear = () => {
+    if (!lastClearedStock) return;
+    setStock(lastClearedStock);
+    setLastClearedStock(null);
   };
 
   const stockedCount = stockedSlugs.length;
@@ -278,10 +306,20 @@ export function KitchenView({
               type="button"
               variant="ghost"
               className="min-w-0 flex-1 text-[var(--ink-3)] hover:text-[var(--berry)] sm:flex-none"
-              onClick={() => setStock({})}
+              onClick={clearStock}
             >
               <Trash2 className="size-4" />
               Clear
+            </Button>
+          )}
+          {lastClearedStock && stockedCount === 0 && (
+            <Button
+              type="button"
+              variant="outline"
+              className="min-w-0 flex-1 border-[var(--line-strong)] bg-[var(--card)] text-[var(--ink)] sm:flex-none"
+              onClick={undoClear}
+            >
+              Undo clear
             </Button>
           )}
         </div>
@@ -332,7 +370,8 @@ export function KitchenView({
                         variant="ghost"
                         size="sm"
                         className="text-[var(--terracotta)]"
-                        onClick={() => setTargetLocation(group.id)}
+                        onClick={() => focusAddIngredients(group.id)}
+                        aria-label={`Add ingredients to ${group.label}`}
                       >
                         <CirclePlus className="size-4" />
                         Add here
@@ -369,7 +408,10 @@ export function KitchenView({
             </CardContent>
           </Card>
 
-          <Card className="rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)]">
+          <Card
+            ref={catalogCardRef}
+            className="scroll-mt-24 rounded-lg border-[1.25px] border-[var(--line-strong)] bg-[var(--card)]"
+          >
             <CardHeader className="gap-3">
               <div>
                 <p className="rt-mono text-[var(--terracotta)]">
@@ -383,6 +425,7 @@ export function KitchenView({
                 <div className="relative min-w-0">
                   <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-[var(--ink-3)]" />
                   <Input
+                    ref={catalogSearchRef}
                     value={catalogQuery}
                     onChange={(event) => setCatalogQuery(event.target.value)}
                     placeholder={`Search ${ingredients.length} ingredients...`}
@@ -395,6 +438,7 @@ export function KitchenView({
                       key={location.id}
                       type="button"
                       onClick={() => setTargetLocation(location.id)}
+                      aria-label={`Add ingredients to ${location.label}`}
                       className={cn(
                         "inline-flex items-center justify-center gap-1 rounded-sm px-2 py-1.5 text-sm transition-colors",
                         targetLocation === location.id

--- a/ui/components/recipes/recipe-nav-tabs.tsx
+++ b/ui/components/recipes/recipe-nav-tabs.tsx
@@ -9,10 +9,11 @@ export function RecipeNavTabs() {
   const count = useSelectedRecipeCount();
 
   const onShopping = pathname === "/recipes/shopping";
+  const onKitchen = pathname === "/recipes/kitchen";
   const onSettings = pathname?.startsWith("/recipes/settings") ?? false;
   // Recipes covers the index and individual recipe pages, but not the shopping
-  // or settings sections.
-  const onRecipes = !onShopping && !onSettings;
+  // or utility sections.
+  const onRecipes = !onShopping && !onKitchen && !onSettings;
 
   return (
     <div className="flex items-baseline gap-2 md:gap-4">
@@ -22,6 +23,13 @@ export function RecipeNavTabs() {
         data-active={onRecipes || undefined}
       >
         Recipes
+      </Link>
+      <Link
+        href="/recipes/kitchen"
+        className="rt-tab text-base lg:text-lg"
+        data-active={onKitchen || undefined}
+      >
+        Kitchen
       </Link>
       <Link
         href="/recipes/shopping"

--- a/ui/lib/api/recipes.ts
+++ b/ui/lib/api/recipes.ts
@@ -3,9 +3,13 @@ import {
   getAllRecipeCards,
   getRecipeDetail,
   getRecipeNeighbors,
+  type IngredientSlug,
+  type KitchenIngredientView,
+  type KitchenRecipeView,
   loadRecipeRepository,
   type RecipeCardView,
   type RecipeDetailView,
+  toKitchenIngredientView,
 } from "@/lib/domain/recipe";
 
 const repository = loadRecipeRepository();
@@ -26,6 +30,49 @@ export function getRecipeBySlug(slug: string): RecipeDetailView {
 
 export function getAllRecipes(): RecipeCardView[] {
   return getAllRecipeCards(repository).sort(compareRecipesByDateAndSlug);
+}
+
+export function getKitchenIngredients(): KitchenIngredientView[] {
+  return Array.from(repository.ingredients.values())
+    .map(toKitchenIngredientView)
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function getKitchenRecipes(): KitchenRecipeView[] {
+  return Array.from(repository.recipes.values())
+    .sort(compareRecipesByDateAndSlug)
+    .map((recipe) => {
+      const ingredientsBySlug = new Map<
+        IngredientSlug,
+        KitchenRecipeView["ingredients"][number]
+      >();
+
+      for (const group of recipe.ingredientGroups) {
+        for (const item of group.items) {
+          const ingredient = repository.ingredients.get(item.ingredient);
+          ingredientsBySlug.set(item.ingredient, {
+            slug: item.ingredient,
+            name: ingredient?.name ?? item.ingredient,
+          });
+        }
+      }
+
+      const totalTime =
+        recipe.prepTime != null && recipe.cookTime != null
+          ? recipe.prepTime + recipe.cookTime
+          : (recipe.prepTime ?? recipe.cookTime);
+
+      return {
+        slug: recipe.slug,
+        title: recipe.title,
+        description: recipe.description,
+        cuisine: recipe.cuisine,
+        totalTime,
+        ingredients: Array.from(ingredientsBySlug.values()).sort((a, b) =>
+          a.name.localeCompare(b.name),
+        ),
+      };
+    });
 }
 
 export function getRecipeNavigation(slug: string): {

--- a/ui/lib/api/recipes.ts
+++ b/ui/lib/api/recipes.ts
@@ -65,7 +65,6 @@ export function getKitchenRecipes(): KitchenRecipeView[] {
       return {
         slug: recipe.slug,
         title: recipe.title,
-        description: recipe.description,
         cuisine: recipe.cuisine,
         totalTime,
         ingredients: Array.from(ingredientsBySlug.values()).sort((a, b) =>

--- a/ui/lib/domain/recipe/index.ts
+++ b/ui/lib/domain/recipe/index.ts
@@ -1,4 +1,5 @@
 export * from "./ingredient";
+export * from "./kitchen";
 export * from "./recipe";
 export * from "./recipeGraph";
 export * from "./recipeQueries";

--- a/ui/lib/domain/recipe/kitchen.ts
+++ b/ui/lib/domain/recipe/kitchen.ts
@@ -1,0 +1,141 @@
+import type {
+  Ingredient,
+  IngredientCategory,
+  IngredientSlug,
+} from "./ingredient";
+
+export type KitchenLocation = "fridge" | "cupboards" | "fresh";
+
+export type KitchenLocationView = {
+  id: KitchenLocation;
+  label: string;
+  description: string;
+};
+
+export const KITCHEN_LOCATIONS: KitchenLocationView[] = [
+  {
+    id: "fridge",
+    label: "Fridge",
+    description: "Dairy, eggs, proteins, opened jars.",
+  },
+  {
+    id: "cupboards",
+    label: "Cupboards",
+    description: "Pasta, tins, oils, spices, dry goods.",
+  },
+  {
+    id: "fresh",
+    label: "Fresh",
+    description: "Fruit, vegetables, herbs.",
+  },
+];
+
+export type KitchenIngredientView = {
+  slug: IngredientSlug;
+  name: string;
+  category?: IngredientCategory;
+  defaultLocation: KitchenLocation;
+};
+
+export type KitchenRecipeIngredientView = {
+  slug: IngredientSlug;
+  name: string;
+};
+
+export type KitchenRecipeView = {
+  slug: string;
+  title: string;
+  description: string;
+  cuisine: string[];
+  totalTime?: number;
+  ingredients: KitchenRecipeIngredientView[];
+};
+
+export type KitchenRecipeMatch = KitchenRecipeView & {
+  haveCount: number;
+  missingCount: number;
+  totalCount: number;
+  matchRatio: number;
+  missingIngredients: KitchenRecipeIngredientView[];
+};
+
+const FRIDGE_CATEGORIES = new Set<IngredientCategory>(["dairy", "protein"]);
+const FRESH_CATEGORIES = new Set<IngredientCategory>([
+  "fruit",
+  "herb",
+  "vegetable",
+]);
+
+export function isKitchenLocation(value: unknown): value is KitchenLocation {
+  return KITCHEN_LOCATIONS.some((location) => location.id === value);
+}
+
+export function getDefaultKitchenLocation(
+  ingredient: Pick<Ingredient, "category" | "name">,
+): KitchenLocation {
+  if (ingredient.category && FRIDGE_CATEGORIES.has(ingredient.category)) {
+    return "fridge";
+  }
+
+  if (ingredient.category && FRESH_CATEGORIES.has(ingredient.category)) {
+    return "fresh";
+  }
+
+  return "cupboards";
+}
+
+export function toKitchenIngredientView(
+  ingredient: Ingredient,
+): KitchenIngredientView {
+  return {
+    slug: ingredient.slug,
+    name: ingredient.name,
+    category: ingredient.category,
+    defaultLocation: getDefaultKitchenLocation(ingredient),
+  };
+}
+
+export function getKitchenRecipeMatches(
+  recipes: KitchenRecipeView[],
+  availableIngredientSlugs: Iterable<IngredientSlug>,
+): KitchenRecipeMatch[] {
+  const available = new Set(availableIngredientSlugs);
+
+  return recipes
+    .map((recipe) => {
+      const requiredBySlug = new Map<
+        IngredientSlug,
+        KitchenRecipeIngredientView
+      >();
+      for (const ingredient of recipe.ingredients) {
+        requiredBySlug.set(ingredient.slug, ingredient);
+      }
+
+      const required = Array.from(requiredBySlug.values());
+      const missingIngredients = required.filter(
+        (ingredient) => !available.has(ingredient.slug),
+      );
+      const totalCount = required.length;
+      const missingCount = missingIngredients.length;
+      const haveCount = totalCount - missingCount;
+
+      return {
+        ...recipe,
+        ingredients: required,
+        haveCount,
+        missingCount,
+        totalCount,
+        matchRatio: totalCount > 0 ? haveCount / totalCount : 0,
+        missingIngredients,
+      };
+    })
+    .sort((a, b) => {
+      const missingComparison = a.missingCount - b.missingCount;
+      if (missingComparison !== 0) return missingComparison;
+
+      const ratioComparison = b.matchRatio - a.matchRatio;
+      if (ratioComparison !== 0) return ratioComparison;
+
+      return a.title.localeCompare(b.title);
+    });
+}

--- a/ui/lib/domain/recipe/kitchen.ts
+++ b/ui/lib/domain/recipe/kitchen.ts
@@ -103,25 +103,15 @@ export function getKitchenRecipeMatches(
 
   return recipes
     .map((recipe) => {
-      const requiredBySlug = new Map<
-        IngredientSlug,
-        KitchenRecipeIngredientView
-      >();
-      for (const ingredient of recipe.ingredients) {
-        requiredBySlug.set(ingredient.slug, ingredient);
-      }
-
-      const required = Array.from(requiredBySlug.values());
-      const missingIngredients = required.filter(
+      const missingIngredients = recipe.ingredients.filter(
         (ingredient) => !available.has(ingredient.slug),
       );
-      const totalCount = required.length;
+      const totalCount = recipe.ingredients.length;
       const missingCount = missingIngredients.length;
       const haveCount = totalCount - missingCount;
 
       return {
         ...recipe,
-        ingredients: required,
         haveCount,
         missingCount,
         totalCount,
@@ -130,11 +120,11 @@ export function getKitchenRecipeMatches(
       };
     })
     .sort((a, b) => {
-      const missingComparison = a.missingCount - b.missingCount;
-      if (missingComparison !== 0) return missingComparison;
-
       const ratioComparison = b.matchRatio - a.matchRatio;
       if (ratioComparison !== 0) return ratioComparison;
+
+      const missingComparison = a.missingCount - b.missingCount;
+      if (missingComparison !== 0) return missingComparison;
 
       return a.title.localeCompare(b.title);
     });

--- a/ui/lib/domain/recipe/kitchen.ts
+++ b/ui/lib/domain/recipe/kitchen.ts
@@ -34,7 +34,6 @@ export type KitchenIngredientView = {
   slug: IngredientSlug;
   name: string;
   category?: IngredientCategory;
-  defaultLocation: KitchenLocation;
 };
 
 export type KitchenRecipeIngredientView = {
@@ -45,7 +44,6 @@ export type KitchenRecipeIngredientView = {
 export type KitchenRecipeView = {
   slug: string;
   title: string;
-  description: string;
   cuisine: string[];
   totalTime?: number;
   ingredients: KitchenRecipeIngredientView[];
@@ -59,29 +57,8 @@ export type KitchenRecipeMatch = KitchenRecipeView & {
   missingIngredients: KitchenRecipeIngredientView[];
 };
 
-const FRIDGE_CATEGORIES = new Set<IngredientCategory>(["dairy", "protein"]);
-const FRESH_CATEGORIES = new Set<IngredientCategory>([
-  "fruit",
-  "herb",
-  "vegetable",
-]);
-
 export function isKitchenLocation(value: unknown): value is KitchenLocation {
   return KITCHEN_LOCATIONS.some((location) => location.id === value);
-}
-
-export function getDefaultKitchenLocation(
-  ingredient: Pick<Ingredient, "category" | "name">,
-): KitchenLocation {
-  if (ingredient.category && FRIDGE_CATEGORIES.has(ingredient.category)) {
-    return "fridge";
-  }
-
-  if (ingredient.category && FRESH_CATEGORIES.has(ingredient.category)) {
-    return "fresh";
-  }
-
-  return "cupboards";
 }
 
 export function toKitchenIngredientView(
@@ -91,7 +68,6 @@ export function toKitchenIngredientView(
     slug: ingredient.slug,
     name: ingredient.name,
     category: ingredient.category,
-    defaultLocation: getDefaultKitchenLocation(ingredient),
   };
 }
 

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -51,6 +51,7 @@ describe("agent markdown generation", () => {
   it("generates a markdown twin for every recipe and technology page", () => {
     // Interactive, noindex app pages that intentionally have no Markdown twin.
     const nonContentPages = new Set([
+      "recipes/kitchen.html",
       "recipes/settings.html",
       "recipes/shopping.html",
     ]);

--- a/ui/tests/integration/markdown-negotiation.test.ts
+++ b/ui/tests/integration/markdown-negotiation.test.ts
@@ -1,6 +1,10 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { killProcessGroup, waitForServer } from "./wrangler-test-utils";
+import {
+  killProcessGroup,
+  WRANGLER_TEST_COMPATIBILITY_DATE,
+  waitForServer,
+} from "./wrangler-test-utils";
 
 const WRANGLER_PORT = 8791;
 const BASE_URL = `http://localhost:${WRANGLER_PORT}`;
@@ -15,14 +19,21 @@ describe("Markdown content negotiation middleware", () => {
 
   beforeAll(async () => {
     wranglerProcess = spawn(
-      "npx",
+      "pnpm",
       [
+        "--dir",
+        "ui",
+        "exec",
         "wrangler",
+        "--cwd",
+        "..",
         "pages",
         "dev",
         "ui/out",
         "--port",
         String(WRANGLER_PORT),
+        "--compatibility-date",
+        WRANGLER_TEST_COMPATIBILITY_DATE,
         // Distinct inspector port so this can run alongside other wrangler
         // instances (e.g. the PostHog proxy test)
         "--inspector-port",

--- a/ui/tests/integration/markdown-negotiation.test.ts
+++ b/ui/tests/integration/markdown-negotiation.test.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  getWranglerTestRepoRoot,
   killProcessGroup,
   WRANGLER_TEST_COMPATIBILITY_DATE,
   waitForServer,
@@ -40,7 +41,7 @@ describe("Markdown content negotiation middleware", () => {
         "9239",
       ],
       {
-        cwd: process.cwd().replace(/\/ui$/, ""),
+        cwd: getWranglerTestRepoRoot(),
         stdio: ["ignore", "pipe", "pipe"],
         // Own process group so cleanup also kills spawned workerd children
         detached: true,

--- a/ui/tests/integration/posthog-proxy.test.ts
+++ b/ui/tests/integration/posthog-proxy.test.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+  getWranglerTestRepoRoot,
   killProcessGroup,
   WRANGLER_TEST_COMPATIBILITY_DATE,
   waitForServer,
@@ -100,7 +101,7 @@ describe("PostHog Proxy Integration Test", () => {
         `POSTHOG_ASSETS_HOST=http://localhost:${MOCK_ASSETS_PORT}`,
       ],
       {
-        cwd: process.cwd().replace(/\/ui$/, ""),
+        cwd: getWranglerTestRepoRoot(),
         stdio: ["ignore", "pipe", "pipe"],
         // Own process group so cleanup also kills spawned workerd children
         detached: true,

--- a/ui/tests/integration/posthog-proxy.test.ts
+++ b/ui/tests/integration/posthog-proxy.test.ts
@@ -1,7 +1,11 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { killProcessGroup, waitForServer } from "./wrangler-test-utils";
+import {
+  killProcessGroup,
+  WRANGLER_TEST_COMPATIBILITY_DATE,
+  waitForServer,
+} from "./wrangler-test-utils";
 
 const WRANGLER_PORT = 8788;
 const MOCK_API_PORT = 8789;
@@ -75,14 +79,21 @@ describe("PostHog Proxy Integration Test", () => {
 
     // Start wrangler pages dev with mock server URLs
     wranglerProcess = spawn(
-      "npx",
+      "pnpm",
       [
+        "--dir",
+        "ui",
+        "exec",
         "wrangler",
+        "--cwd",
+        "..",
         "pages",
         "dev",
         "ui/out",
         "--port",
         String(WRANGLER_PORT),
+        "--compatibility-date",
+        WRANGLER_TEST_COMPATIBILITY_DATE,
         "--binding",
         `POSTHOG_API_HOST=http://localhost:${MOCK_API_PORT}`,
         "--binding",

--- a/ui/tests/integration/sitemap.test.ts
+++ b/ui/tests/integration/sitemap.test.ts
@@ -15,7 +15,11 @@ const STATIC_ASSET_SEGMENTS = new Set(["recipe-site-design"]);
 
 // Authenticated, noindex app pages (e.g. account settings) — served but kept
 // out of the sitemap on purpose.
-const NOINDEX_APP_PAGES = new Set(["recipes/settings", "recipes/shopping"]);
+const NOINDEX_APP_PAGES = new Set([
+  "recipes/kitchen",
+  "recipes/settings",
+  "recipes/shopping",
+]);
 
 describe("Sitemap Integration Test", () => {
   it("should have a sitemap.xml that includes all generated pages", () => {

--- a/ui/tests/integration/wrangler-test-utils.ts
+++ b/ui/tests/integration/wrangler-test-utils.ts
@@ -1,5 +1,10 @@
 import type { ChildProcess } from "node:child_process";
 
+// Keep Pages dev deterministic in CI. Wrangler otherwise defaults to today's
+// date, which can be newer than the workerd binary bundled with the installed
+// package. Match the repo's explicit Worker compatibility date.
+export const WRANGLER_TEST_COMPATIBILITY_DATE = "2026-05-28";
+
 /**
  * Kills a spawned process and its children. Wrangler spawns workerd
  * subprocesses that survive a plain kill() and keep holding ports, so the

--- a/ui/tests/integration/wrangler-test-utils.ts
+++ b/ui/tests/integration/wrangler-test-utils.ts
@@ -1,9 +1,17 @@
 import type { ChildProcess } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
 // Keep Pages dev deterministic in CI. Wrangler otherwise defaults to today's
 // date, which can be newer than the workerd binary bundled with the installed
 // package. Match the repo's explicit Worker compatibility date.
 export const WRANGLER_TEST_COMPATIBILITY_DATE = "2026-05-28";
+
+export function getWranglerTestRepoRoot(): string {
+  return REPO_ROOT;
+}
 
 /**
  * Kills a spawned process and its children. Wrangler spawns workerd

--- a/ui/tests/lib/domain/recipe/kitchen.test.ts
+++ b/ui/tests/lib/domain/recipe/kitchen.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDefaultKitchenLocation,
+  getKitchenRecipeMatches,
+  isKitchenLocation,
+  KITCHEN_LOCATIONS,
+} from "@/lib/domain/recipe/kitchen";
+
+describe("kitchen helpers", () => {
+  it("defines the supported locations once for kitchen features", () => {
+    expect(KITCHEN_LOCATIONS.map((location) => location.id)).toEqual([
+      "fridge",
+      "cupboards",
+      "fresh",
+    ]);
+    expect(isKitchenLocation("freezer")).toBe(false);
+    expect(isKitchenLocation("fridge")).toBe(true);
+  });
+
+  it("places ingredients into practical default kitchen locations", () => {
+    expect(getDefaultKitchenLocation({ name: "milk", category: "dairy" })).toBe(
+      "fridge",
+    );
+    expect(
+      getDefaultKitchenLocation({ name: "fresh basil", category: "herb" }),
+    ).toBe("fresh");
+    expect(
+      getDefaultKitchenLocation({ name: "penne pasta", category: "grain" }),
+    ).toBe("cupboards");
+  });
+
+  it("ranks recipes by missing ingredients then match ratio", () => {
+    const matches = getKitchenRecipeMatches(
+      [
+        {
+          slug: "risotto",
+          title: "Risotto",
+          description: "",
+          cuisine: [],
+          ingredients: [
+            { slug: "rice", name: "rice" },
+            { slug: "parmesan", name: "parmesan" },
+            { slug: "stock", name: "stock" },
+          ],
+        },
+        {
+          slug: "pasta",
+          title: "Pasta",
+          description: "",
+          cuisine: [],
+          ingredients: [
+            { slug: "pasta", name: "pasta" },
+            { slug: "tomatoes", name: "tomatoes" },
+          ],
+        },
+      ],
+      ["pasta", "tomatoes", "rice"],
+    );
+
+    expect(matches[0]?.slug).toBe("pasta");
+    expect(matches[0]?.missingIngredients).toEqual([]);
+    expect(matches[1]?.slug).toBe("risotto");
+    expect(matches[1]?.missingIngredients).toEqual([
+      { slug: "parmesan", name: "parmesan" },
+      { slug: "stock", name: "stock" },
+    ]);
+  });
+});

--- a/ui/tests/lib/domain/recipe/kitchen.test.ts
+++ b/ui/tests/lib/domain/recipe/kitchen.test.ts
@@ -29,23 +29,12 @@ describe("kitchen helpers", () => {
     ).toBe("cupboards");
   });
 
-  it("ranks recipes by missing ingredients then match ratio", () => {
+  it("ranks recipes by match ratio then missing ingredients", () => {
     const matches = getKitchenRecipeMatches(
       [
         {
-          slug: "risotto",
-          title: "Risotto",
-          description: "",
-          cuisine: [],
-          ingredients: [
-            { slug: "rice", name: "rice" },
-            { slug: "parmesan", name: "parmesan" },
-            { slug: "stock", name: "stock" },
-          ],
-        },
-        {
-          slug: "pasta",
-          title: "Pasta",
+          slug: "small-recipe",
+          title: "Small Recipe",
           description: "",
           cuisine: [],
           ingredients: [
@@ -53,16 +42,32 @@ describe("kitchen helpers", () => {
             { slug: "tomatoes", name: "tomatoes" },
           ],
         },
+        {
+          slug: "larger-recipe",
+          title: "Larger Recipe",
+          description: "",
+          cuisine: [],
+          ingredients: [
+            { slug: "rice", name: "rice" },
+            { slug: "parmesan", name: "parmesan" },
+            { slug: "stock", name: "stock" },
+            { slug: "peas", name: "peas" },
+            { slug: "butter", name: "butter" },
+          ],
+        },
       ],
-      ["pasta", "tomatoes", "rice"],
+      ["pasta", "rice", "parmesan", "stock", "peas"],
     );
 
-    expect(matches[0]?.slug).toBe("pasta");
-    expect(matches[0]?.missingIngredients).toEqual([]);
-    expect(matches[1]?.slug).toBe("risotto");
+    expect(matches[0]?.slug).toBe("larger-recipe");
+    expect(matches[0]?.matchRatio).toBe(0.8);
+    expect(matches[0]?.missingIngredients).toEqual([
+      { slug: "butter", name: "butter" },
+    ]);
+    expect(matches[1]?.slug).toBe("small-recipe");
+    expect(matches[1]?.matchRatio).toBe(0.5);
     expect(matches[1]?.missingIngredients).toEqual([
-      { slug: "parmesan", name: "parmesan" },
-      { slug: "stock", name: "stock" },
+      { slug: "tomatoes", name: "tomatoes" },
     ]);
   });
 });

--- a/ui/tests/lib/domain/recipe/kitchen.test.ts
+++ b/ui/tests/lib/domain/recipe/kitchen.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  getDefaultKitchenLocation,
   getKitchenRecipeMatches,
   isKitchenLocation,
   KITCHEN_LOCATIONS,
@@ -17,25 +16,12 @@ describe("kitchen helpers", () => {
     expect(isKitchenLocation("fridge")).toBe(true);
   });
 
-  it("places ingredients into practical default kitchen locations", () => {
-    expect(getDefaultKitchenLocation({ name: "milk", category: "dairy" })).toBe(
-      "fridge",
-    );
-    expect(
-      getDefaultKitchenLocation({ name: "fresh basil", category: "herb" }),
-    ).toBe("fresh");
-    expect(
-      getDefaultKitchenLocation({ name: "penne pasta", category: "grain" }),
-    ).toBe("cupboards");
-  });
-
   it("ranks recipes by match ratio then missing ingredients", () => {
     const matches = getKitchenRecipeMatches(
       [
         {
           slug: "small-recipe",
           title: "Small Recipe",
-          description: "",
           cuisine: [],
           ingredients: [
             { slug: "pasta", name: "pasta" },
@@ -45,7 +31,6 @@ describe("kitchen helpers", () => {
         {
           slug: "larger-recipe",
           title: "Larger Recipe",
-          description: "",
           cuisine: [],
           ingredients: [
             { slug: "rice", name: "rice" },


### PR DESCRIPTION
## Summary

Adds a client-side Kitchen page for recipe matching against a user's own saved food store.

- Adds `/recipes/kitchen` and a Kitchen nav tab.
- Lets users add canonical ingredients to Fridge, Cupboards, or Fresh lists.
- Persists only user-entered kitchen state in localStorage; there is no demo seed data.
- Matches saved ingredients against recipe requirements to show ready recipes and close matches.
- Centralizes kitchen locations and matching helpers in the recipe domain layer.

## Validation

- `CI=true mise run //ui:typecheck`
- `CI=true mise run //ui:test -- tests/lib/domain/recipe/kitchen.test.ts`
- focused Biome check on touched files
- local browser checks for clean default state, add flow, and desktop/mobile horizontal overflow
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder CI=true mise run //ui:build`

Note: the production build still emits existing schema.org image warnings for recipes without images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Kitchen recipe page with its own navigation tab.
  * Introduced a Kitchen view where users can track stocked ingredients and see matching recipes.
  * Recipes are now grouped into “Cook now” and “Close matches”, with progress and missing-ingredient details.

* **Bug Fixes**
  * Improved recipe matching and ingredient handling for more accurate kitchen results.
  * Kitchen-related pages are now excluded from sitemap and content-twin checks where appropriate.

* **Tests**
  * Added coverage for Kitchen matching logic and updated integration tests for the new route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->