### PR TITLE
Propagate diet preferences across recipe surfaces

### DIFF
--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -15,6 +15,7 @@ export type RecipeApiProxyContext = {
 const FORWARDED_REQUEST_HEADERS = [
   "accept",
   "authorization",
+  "cf-access-jwt-assertion",
   "cf-connecting-ip",
   "content-type",
   "cookie",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,9 @@ importers:
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
+      recipe-domain:
+        specifier: workspace:*
+        version: link:../../packages/recipe-domain
       zod:
         specifier: ^4.2.1
         version: 4.4.3

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Caveat, JetBrains_Mono, Kalam } from "next/font/google";
 import Link from "next/link";
 import { AuthButton } from "@/components/recipes/auth-button";
+import { DietProvider } from "@/components/recipes/diet-provider";
 import { RecipeNavTabs } from "@/components/recipes/recipe-nav-tabs";
 import { RecipeThemeBody } from "@/components/recipes/recipe-theme-body";
 import { TimerDock } from "@/components/recipes/timer-dock";
@@ -71,7 +72,9 @@ export default function RecipesLayout({
           </nav>
         </header>
 
-        <main className="relative z-0 flex-1 flex flex-col">{children}</main>
+        <DietProvider>
+          <main className="relative z-0 flex-1 flex flex-col">{children}</main>
+        </DietProvider>
 
         <footer className="border-t border-[var(--line)] mt-auto">
           <div className="container mx-auto px-4 py-8">

--- a/ui/app/recipes/page.tsx
+++ b/ui/app/recipes/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
-import { RecipeList } from "@/components/recipes/recipe-list";
+import { RecipeBoxView } from "@/components/recipes/recipe-box-view";
 import { JsonLdScript } from "@/components/seo/json-ld-script";
-import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
 import { getAllRecipes } from "@/lib/api/recipes";
 import { siteConfig } from "@/lib/config/site-config";
 import { buildRecipeListJsonLd } from "@/lib/seo/recipe-jsonld";
@@ -16,7 +14,6 @@ export default function RecipesPage() {
   const recipes = getAllRecipes();
   const jsonLd = buildRecipeListJsonLd(recipes, siteConfig.url);
 
-  const recipeCount = recipes.length;
   const cuisineCount = new Set(recipes.flatMap((recipe) => recipe.cuisine))
     .size;
   const ingredientCount = new Set(
@@ -24,8 +21,7 @@ export default function RecipesPage() {
   ).size;
   const cookwareCount = new Set(recipes.flatMap((recipe) => recipe.cookware))
     .size;
-  const stats = [
-    `${recipeCount.toLocaleString()} ${recipeCount === 1 ? "recipe" : "recipes"}`,
+  const catalogStats = [
     cuisineCount > 0 &&
       `${cuisineCount} ${cuisineCount === 1 ? "cuisine" : "cuisines"}`,
     `${ingredientCount} ${ingredientCount === 1 ? "ingredient" : "ingredients"}`,
@@ -33,28 +29,9 @@ export default function RecipesPage() {
   ].filter((stat): stat is string => Boolean(stat));
 
   return (
-    <div className="container mx-auto px-4 pt-5 pb-10 md:pt-7 md:pb-14 min-h-screen max-w-7xl">
+    <>
       <JsonLdScript data={jsonLd} />
-      <div className="mb-6 md:mb-8">
-        <p className="rt-mono text-[var(--terracotta)]">Your recipe box</p>
-        <h1 className="rt-display text-5xl sm:text-6xl lg:text-7xl mt-2">
-          What's <span className="text-[var(--terracotta)]">cooking?</span>
-        </h1>
-        <p className="rt-body mt-3 flex flex-wrap gap-x-2 gap-y-1 text-base leading-snug text-[var(--ink-2)] sm:text-lg">
-          {stats.map((stat, index) => (
-            <span key={stat} className="whitespace-nowrap">
-              {stat}
-              {index < stats.length - 1 && (
-                <span className="text-[var(--ink-3)]"> ·</span>
-              )}
-            </span>
-          ))}
-        </p>
-      </div>
-
-      <Suspense fallback={<CardGridSkeleton variant="filters" />}>
-        <RecipeList recipes={recipes} />
-      </Suspense>
-    </div>
+      <RecipeBoxView recipes={recipes} catalogStats={catalogStats} />
+    </>
   );
 }

--- a/ui/components/recipes/diet-notice.tsx
+++ b/ui/components/recipes/diet-notice.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Leaf, TriangleAlert } from "lucide-react";
+import Link from "next/link";
+import type { DietMatch } from "@/lib/domain/diet";
+import { cn } from "@/lib/generic/styles";
+
+export function DietListNotice({
+  hiddenCount,
+  labels,
+  mode,
+  showingHidden,
+  onToggleHidden,
+}: Readonly<{
+  hiddenCount: number;
+  labels: string[];
+  mode: "hide" | "warn";
+  showingHidden: boolean;
+  onToggleHidden?: () => void;
+}>) {
+  const summary =
+    labels.length > 0 ? labels.join(", ") : "your saved exclusions";
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg border border-dashed border-[var(--sage)] bg-[var(--sage)]/10 px-3 py-2.5">
+      <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--sage)] text-white">
+        <Leaf className="size-3.5" />
+      </span>
+      <p className="rt-body min-w-0 flex-1 text-sm text-[var(--ink-2)]">
+        <b className="text-[var(--ink)]">Your diet</b> · {summary}.{" "}
+        <span className="text-[var(--ink-3)]">
+          {mode === "hide"
+            ? hiddenCount === 0
+              ? "No recipes hidden."
+              : `${hiddenCount} ${hiddenCount === 1 ? "recipe" : "recipes"} hidden.`
+            : "Recipes that don't match are marked with a warning."}
+        </span>
+      </p>
+      <Link
+        href="/recipes/settings?section=diet"
+        className="rt-mono text-[var(--sage)] hover:underline"
+      >
+        edit diet →
+      </Link>
+      {mode === "hide" && hiddenCount > 0 && onToggleHidden && (
+        <button
+          type="button"
+          onClick={onToggleHidden}
+          className="rt-mono text-[var(--ink-3)] hover:text-[var(--ink)]"
+        >
+          {showingHidden ? "respect diet" : "show anyway"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function DietWarning({
+  match,
+  compact = false,
+  className,
+}: Readonly<{
+  match: DietMatch;
+  compact?: boolean;
+  className?: string;
+}>) {
+  if (match.matches) return null;
+  const names = match.excludedIngredients.map((ingredient) => ingredient.name);
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex items-start gap-2 rounded-md border border-[var(--butter)] bg-[var(--butter-soft)] text-[var(--terracotta-deep)]",
+        compact ? "px-2 py-1 text-xs" : "px-3 py-2 text-sm",
+        className,
+      )}
+    >
+      <TriangleAlert
+        className={cn("shrink-0", compact ? "size-3.5" : "size-4")}
+      />
+      <span className="rt-body leading-tight">
+        Doesn't match your diet: {names.join(", ")}.
+      </span>
+    </div>
+  );
+}

--- a/ui/components/recipes/diet-notice.tsx
+++ b/ui/components/recipes/diet-notice.tsx
@@ -5,6 +5,26 @@ import Link from "next/link";
 import type { DietMatch } from "@/lib/domain/diet";
 import { cn } from "@/lib/generic/styles";
 
+function summariseDietLabels(labels: string[]): string {
+  if (labels.length === 0) return "your saved exclusions";
+
+  const displayedLabels = labels.slice(0, 2);
+  const remainingLabelCount = labels.length - displayedLabels.length;
+  const remainingSummary =
+    remainingLabelCount > 0 ? ` +${remainingLabelCount} more` : "";
+  return `${displayedLabels.join(", ")}${remainingSummary}`;
+}
+
+function getDietStatusText(mode: "hide" | "warn", hiddenCount: number) {
+  if (mode === "warn") {
+    return "Recipes that don't match are marked with a warning.";
+  }
+  if (hiddenCount === 0) return "No recipes hidden.";
+
+  const recipeNoun = hiddenCount === 1 ? "recipe" : "recipes";
+  return `${hiddenCount} ${recipeNoun} hidden.`;
+}
+
 export function DietListNotice({
   hiddenCount,
   labels,
@@ -18,14 +38,8 @@ export function DietListNotice({
   showingHidden: boolean;
   onToggleHidden?: () => void;
 }>) {
-  const displayedLabels = labels.slice(0, 2);
-  const remainingLabelCount = labels.length - displayedLabels.length;
-  const summary =
-    labels.length > 0
-      ? `${displayedLabels.join(", ")}${
-          remainingLabelCount > 0 ? ` +${remainingLabelCount} more` : ""
-        }`
-      : "your saved exclusions";
+  const summary = summariseDietLabels(labels);
+  const statusText = getDietStatusText(mode, hiddenCount);
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg border border-dashed border-[var(--sage)] bg-[var(--sage)]/10 px-3 py-2.5">
       <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--sage)] text-white">
@@ -33,13 +47,7 @@ export function DietListNotice({
       </span>
       <p className="rt-body min-w-0 flex-1 text-sm text-[var(--ink-2)]">
         <b className="text-[var(--ink)]">Your diet</b> · {summary}.{" "}
-        <span className="text-[var(--ink-3)]">
-          {mode === "hide"
-            ? hiddenCount === 0
-              ? "No recipes hidden."
-              : `${hiddenCount} ${hiddenCount === 1 ? "recipe" : "recipes"} hidden.`
-            : "Recipes that don't match are marked with a warning."}
-        </span>
+        <span className="text-[var(--ink-3)]">{statusText}</span>
       </p>
       <Link
         href="/recipes/settings?section=diet"
@@ -72,8 +80,7 @@ export function DietWarning({
   if (match.matches) return null;
   const names = match.excludedIngredients.map((ingredient) => ingredient.name);
   return (
-    <div
-      role="status"
+    <output
       className={cn(
         "flex items-start gap-2 rounded-md border border-[var(--butter)] bg-[var(--butter-soft)] text-[var(--terracotta-deep)]",
         compact ? "px-2 py-1 text-xs" : "px-3 py-2 text-sm",
@@ -86,6 +93,27 @@ export function DietWarning({
       <span className="rt-body leading-tight">
         Doesn't match your diet: {names.join(", ")}.
       </span>
+    </output>
+  );
+}
+
+export function DietLoadErrorNotice() {
+  return (
+    <div className="container mx-auto max-w-7xl px-4 pt-5">
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded-lg border border-[var(--berry)] bg-[var(--berry)]/10 px-3 py-2.5 text-[var(--berry)]"
+      >
+        <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+        <p className="rt-body text-sm">
+          <b>Diet preferences are unavailable.</b> Refresh before relying on
+          recipe filtering, or check your{" "}
+          <Link href="/recipes/settings?section=diet" className="underline">
+            diet settings
+          </Link>
+          .
+        </p>
+      </div>
     </div>
   );
 }

--- a/ui/components/recipes/diet-notice.tsx
+++ b/ui/components/recipes/diet-notice.tsx
@@ -18,8 +18,14 @@ export function DietListNotice({
   showingHidden: boolean;
   onToggleHidden?: () => void;
 }>) {
+  const displayedLabels = labels.slice(0, 2);
+  const remainingLabelCount = labels.length - displayedLabels.length;
   const summary =
-    labels.length > 0 ? labels.join(", ") : "your saved exclusions";
+    labels.length > 0
+      ? `${displayedLabels.join(", ")}${
+          remainingLabelCount > 0 ? ` +${remainingLabelCount} more` : ""
+        }`
+      : "your saved exclusions";
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg border border-dashed border-[var(--sage)] bg-[var(--sage)]/10 px-3 py-2.5">
       <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--sage)] text-white">

--- a/ui/components/recipes/diet-provider.tsx
+++ b/ui/components/recipes/diet-provider.tsx
@@ -35,12 +35,7 @@ type DietContextValue = {
 export const DIET_PROFILE_UPDATED_EVENT = "recipe-diet-profile-updated";
 
 const fallbackDiet = buildEffectiveDiet(emptyDietProfile, emptyDietOptions);
-const DietContext = createContext<DietContextValue>({
-  diet: fallbackDiet,
-  error: false,
-  loading: false,
-  matchRecipe: (recipe) => matchRecipeToDiet(recipe, fallbackDiet),
-});
+const DietContext = createContext<DietContextValue | null>(null);
 
 export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
   const { data: session, isPending } = authClient.useSession();
@@ -116,5 +111,9 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
 }
 
 export function useDiet() {
-  return useContext(DietContext);
+  const context = useContext(DietContext);
+  if (!context) {
+    throw new Error("useDiet must be used within a DietProvider.");
+  }
+  return context;
 }

--- a/ui/components/recipes/diet-provider.tsx
+++ b/ui/components/recipes/diet-provider.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { DietLoadErrorNotice } from "@/components/recipes/diet-notice";
 import {
   emptyDietOptions,
   emptyDietProfile,
@@ -26,6 +27,7 @@ import {
 
 type DietContextValue = {
   diet: EffectiveDiet;
+  error: boolean;
   loading: boolean;
   matchRecipe: (recipe: DietRecipe) => DietMatch;
 };
@@ -35,6 +37,7 @@ export const DIET_PROFILE_UPDATED_EVENT = "recipe-diet-profile-updated";
 const fallbackDiet = buildEffectiveDiet(emptyDietProfile, emptyDietOptions);
 const DietContext = createContext<DietContextValue>({
   diet: fallbackDiet,
+  error: false,
   loading: false,
   matchRecipe: (recipe) => matchRecipeToDiet(recipe, fallbackDiet),
 });
@@ -43,12 +46,14 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
   const { data: session, isPending } = authClient.useSession();
   const sessionUserId = session?.user.id;
   const [diet, setDiet] = useState(fallbackDiet);
+  const [error, setError] = useState(false);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (isPending) return;
     if (!sessionUserId) {
       setDiet(fallbackDiet);
+      setError(false);
       setLoading(false);
       return;
     }
@@ -58,13 +63,16 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
       controller?.abort();
       controller = new AbortController();
       const signal = controller.signal;
+      setError(false);
       setLoading(true);
       void Promise.all([getDietProfile(signal), getDietOptions(signal)])
-        .then(([profile, options]) =>
-          setDiet(buildEffectiveDiet(profile, options)),
-        )
+        .then(([profile, options]) => {
+          setDiet(buildEffectiveDiet(profile, options));
+          setError(false);
+        })
         .catch((error: unknown) => {
           if (!signal.aborted) {
+            setError(true);
             console.error(
               "[DietProvider] Failed to load diet preferences.",
               error,
@@ -92,13 +100,19 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
   const value = useMemo<DietContextValue>(
     () => ({
       diet,
+      error,
       loading: isPending || loading,
       matchRecipe,
     }),
-    [diet, isPending, loading, matchRecipe],
+    [diet, error, isPending, loading, matchRecipe],
   );
 
-  return <DietContext.Provider value={value}>{children}</DietContext.Provider>;
+  return (
+    <DietContext.Provider value={value}>
+      {error && !isPending && <DietLoadErrorNotice />}
+      {children}
+    </DietContext.Provider>
+  );
 }
 
 export function useDiet() {

--- a/ui/components/recipes/diet-provider.tsx
+++ b/ui/components/recipes/diet-provider.tsx
@@ -3,6 +3,7 @@
 import {
   createContext,
   type ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -83,13 +84,18 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
     };
   }, [isPending, sessionUserId]);
 
+  const matchRecipe = useCallback(
+    (recipe: DietRecipe) => matchRecipeToDiet(recipe, diet),
+    [diet],
+  );
+
   const value = useMemo<DietContextValue>(
     () => ({
       diet,
       loading: isPending || loading,
-      matchRecipe: (recipe) => matchRecipeToDiet(recipe, diet),
+      matchRecipe,
     }),
-    [diet, isPending, loading],
+    [diet, isPending, loading, matchRecipe],
   );
 
   return <DietContext.Provider value={value}>{children}</DietContext.Provider>;

--- a/ui/components/recipes/diet-provider.tsx
+++ b/ui/components/recipes/diet-provider.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  emptyDietOptions,
+  emptyDietProfile,
+  getDietOptions,
+  getDietProfile,
+} from "@/lib/api/diet";
+import { authClient } from "@/lib/auth-client";
+import {
+  buildEffectiveDiet,
+  type DietMatch,
+  type DietRecipe,
+  type EffectiveDiet,
+  matchRecipeToDiet,
+} from "@/lib/domain/diet";
+
+type DietContextValue = {
+  diet: EffectiveDiet;
+  loading: boolean;
+  matchRecipe: (recipe: DietRecipe) => DietMatch;
+};
+
+export const DIET_PROFILE_UPDATED_EVENT = "recipe-diet-profile-updated";
+
+const fallbackDiet = buildEffectiveDiet(emptyDietProfile, emptyDietOptions);
+const DietContext = createContext<DietContextValue>({
+  diet: fallbackDiet,
+  loading: false,
+  matchRecipe: (recipe) => matchRecipeToDiet(recipe, fallbackDiet),
+});
+
+export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const { data: session, isPending } = authClient.useSession();
+  const sessionUserId = session?.user.id;
+  const [diet, setDiet] = useState(fallbackDiet);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isPending) return;
+    if (!sessionUserId) {
+      setDiet(fallbackDiet);
+      setLoading(false);
+      return;
+    }
+
+    let controller: AbortController | null = null;
+    const load = () => {
+      controller?.abort();
+      controller = new AbortController();
+      const signal = controller.signal;
+      setLoading(true);
+      void Promise.all([getDietProfile(signal), getDietOptions(signal)])
+        .then(([profile, options]) =>
+          setDiet(buildEffectiveDiet(profile, options)),
+        )
+        .catch((error: unknown) => {
+          if (!signal.aborted) {
+            console.error(
+              "[DietProvider] Failed to load diet preferences.",
+              error,
+            );
+          }
+        })
+        .finally(() => {
+          if (!signal.aborted) setLoading(false);
+        });
+    };
+
+    load();
+    globalThis.addEventListener(DIET_PROFILE_UPDATED_EVENT, load);
+    return () => {
+      globalThis.removeEventListener(DIET_PROFILE_UPDATED_EVENT, load);
+      controller?.abort();
+    };
+  }, [isPending, sessionUserId]);
+
+  const value = useMemo<DietContextValue>(
+    () => ({
+      diet,
+      loading: isPending || loading,
+      matchRecipe: (recipe) => matchRecipeToDiet(recipe, diet),
+    }),
+    [diet, isPending, loading],
+  );
+
+  return <DietContext.Provider value={value}>{children}</DietContext.Provider>;
+}
+
+export function useDiet() {
+  return useContext(DietContext);
+}

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -21,6 +21,10 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { useKitchenStock } from "@/hooks/use-kitchen-stock";
 import { useShoppingList } from "@/hooks/use-shopping-list";
+import {
+  applyDietRecipeVisibility,
+  buildDietRecipeMatches,
+} from "@/lib/domain/diet";
 import type { IngredientSlug } from "@/lib/domain/recipe/ingredient";
 import {
   getDietRelevantKitchenIngredients,
@@ -125,22 +129,19 @@ export function KitchenView({
 
   const dietMatches = useMemo(
     () =>
-      new Map(
-        recipes.map((recipe) => [
-          recipe.slug,
-          matchRecipe({ ingredients: recipe.ingredients }),
-        ]),
-      ),
+      buildDietRecipeMatches(recipes, matchRecipe, (recipe) => ({
+        ingredients: recipe.ingredients,
+      })),
     [matchRecipe, recipes],
   );
-  const hiddenCount = Array.from(dietMatches.values()).filter(
-    (match) => !match.matches,
-  ).length;
-  const dietFilteredRecipes = useMemo(
+  const { visibleRecipes: dietFilteredRecipes, hiddenCount } = useMemo(
     () =>
-      diet.active && diet.mode === "hide" && !showHidden
-        ? recipes.filter((recipe) => dietMatches.get(recipe.slug)?.matches)
-        : recipes,
+      applyDietRecipeVisibility(
+        recipes,
+        dietMatches,
+        { active: diet.active, mode: diet.mode },
+        { showHidden },
+      ),
     [diet.active, diet.mode, dietMatches, recipes, showHidden],
   );
   const matches = useMemo(

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -22,6 +22,7 @@ import { useKitchenStock } from "@/hooks/use-kitchen-stock";
 import { useShoppingList } from "@/hooks/use-shopping-list";
 import type { IngredientSlug } from "@/lib/domain/recipe/ingredient";
 import {
+  getDietRelevantKitchenIngredients,
   getKitchenRecipeMatches,
   KITCHEN_LOCATIONS,
   type KitchenIngredientView,
@@ -89,6 +90,17 @@ export function KitchenView({
   const catalogCardRef = useRef<HTMLDivElement>(null);
   const catalogSearchRef = useRef<HTMLInputElement>(null);
 
+  const dietRelevantIngredients = useMemo(
+    () =>
+      getDietRelevantKitchenIngredients(
+        ingredients,
+        diet.excludedIngredientSlugs,
+      ),
+    [diet.excludedIngredientSlugs, ingredients],
+  );
+  const dietHiddenIngredientCount =
+    ingredients.length - dietRelevantIngredients.length;
+
   const stockedSlugs = useMemo(
     () =>
       Object.keys(stock).filter((slug): slug is IngredientSlug =>
@@ -130,7 +142,7 @@ export function KitchenView({
 
   const catalogMatches = useMemo(() => {
     const query = normalizeQuery(catalogQuery);
-    return ingredients
+    return dietRelevantIngredients
       .filter((ingredient) => !(ingredient.slug in stock))
       .filter((ingredient) => {
         if (!query) return true;
@@ -138,7 +150,7 @@ export function KitchenView({
           .toLowerCase()
           .includes(query);
       });
-  }, [catalogQuery, ingredients, stock]);
+  }, [catalogQuery, dietRelevantIngredients, stock]);
   const filteredCatalog = catalogMatches.slice(0, CATALOG_RESULT_LIMIT);
   const isCatalogTruncated = catalogMatches.length > filteredCatalog.length;
 
@@ -344,6 +356,13 @@ export function KitchenView({
                 <CardTitle className="rt-display text-4xl">
                   Add to your kitchen.
                 </CardTitle>
+                {dietHiddenIngredientCount > 0 && (
+                  <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
+                    {dietHiddenIngredientCount} diet-excluded ingredient
+                    {dietHiddenIngredientCount === 1 ? " is" : "s are"} hidden
+                    from this catalog.
+                  </p>
+                )}
               </div>
               <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
                 <div className="relative min-w-0">
@@ -352,7 +371,7 @@ export function KitchenView({
                     ref={catalogSearchRef}
                     value={catalogQuery}
                     onChange={(event) => setCatalogQuery(event.target.value)}
-                    placeholder={`Search ${ingredients.length} ingredients...`}
+                    placeholder={`Search ${dietRelevantIngredients.length} ingredients...`}
                     className="h-10 border-[var(--line-strong)] bg-[var(--paper)] pl-9"
                   />
                 </div>

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -11,6 +11,8 @@ import {
   X,
 } from "lucide-react";
 import { useMemo, useRef, useState } from "react";
+import { DietListNotice } from "@/components/recipes/diet-notice";
+import { useDiet } from "@/components/recipes/diet-provider";
 import { RecipeMatchCard } from "@/components/recipes/recipe-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -60,6 +62,8 @@ export function KitchenView({
   ingredients: KitchenIngredientView[];
   recipes: KitchenRecipeView[];
 }>) {
+  const { diet, matchRecipe } = useDiet();
+  const [showHidden, setShowHidden] = useState(false);
   const ingredientBySlug = useMemo(
     () =>
       new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient])),
@@ -93,9 +97,29 @@ export function KitchenView({
     [knownIngredientSlugs, stock],
   );
 
+  const dietMatches = useMemo(
+    () =>
+      new Map(
+        recipes.map((recipe) => [
+          recipe.slug,
+          matchRecipe({ ingredients: recipe.ingredients }),
+        ]),
+      ),
+    [matchRecipe, recipes],
+  );
+  const hiddenCount = Array.from(dietMatches.values()).filter(
+    (match) => !match.matches,
+  ).length;
+  const dietFilteredRecipes = useMemo(
+    () =>
+      diet.active && diet.mode === "hide" && !showHidden
+        ? recipes.filter((recipe) => dietMatches.get(recipe.slug)?.matches)
+        : recipes,
+    [diet.active, diet.mode, dietMatches, recipes, showHidden],
+  );
   const matches = useMemo(
-    () => getKitchenRecipeMatches(recipes, stockedSlugs),
-    [recipes, stockedSlugs],
+    () => getKitchenRecipeMatches(dietFilteredRecipes, stockedSlugs),
+    [dietFilteredRecipes, stockedSlugs],
   );
   const cookNow = matches
     .filter((recipe) => recipe.totalCount > 0 && recipe.missingCount === 0)
@@ -194,6 +218,16 @@ export function KitchenView({
           </p>
         </div>
       </div>
+
+      {diet.active && (
+        <DietListNotice
+          hiddenCount={hiddenCount}
+          labels={diet.labels}
+          mode={diet.mode}
+          showingHidden={showHidden}
+          onToggleHidden={() => setShowHidden((current) => !current)}
+        />
+      )}
 
       <div className="grid min-w-0 gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.85fr)]">
         <div className="min-w-0 space-y-6">
@@ -395,6 +429,7 @@ export function KitchenView({
                     recipe={recipe}
                     inList={selectedRecipeSlugs.has(recipe.slug)}
                     onToggleList={() => toggleRecipe(recipe.slug)}
+                    dietMatch={dietMatches.get(recipe.slug)}
                   />
                 ))
               ) : (
@@ -422,6 +457,7 @@ export function KitchenView({
                     recipe={recipe}
                     inList={selectedRecipeSlugs.has(recipe.slug)}
                     onToggleList={() => toggleRecipe(recipe.slug)}
+                    dietMatch={dietMatches.get(recipe.slug)}
                   />
                 ))
               ) : (

--- a/ui/components/recipes/kitchen/kitchen-view.tsx
+++ b/ui/components/recipes/kitchen/kitchen-view.tsx
@@ -7,6 +7,7 @@ import {
   ShoppingBasket,
   Sprout,
   Trash2,
+  TriangleAlert,
   Undo2,
   X,
 } from "lucide-react";
@@ -65,6 +66,8 @@ export function KitchenView({
 }>) {
   const { diet, matchRecipe } = useDiet();
   const [showHidden, setShowHidden] = useState(false);
+  const [showDietExcludedIngredients, setShowDietExcludedIngredients] =
+    useState(false);
   const ingredientBySlug = useMemo(
     () =>
       new Map(ingredients.map((ingredient) => [ingredient.slug, ingredient])),
@@ -95,11 +98,22 @@ export function KitchenView({
       getDietRelevantKitchenIngredients(
         ingredients,
         diet.excludedIngredientSlugs,
+        diet.mode === "warn" || showDietExcludedIngredients,
       ),
+    [
+      diet.excludedIngredientSlugs,
+      diet.mode,
+      ingredients,
+      showDietExcludedIngredients,
+    ],
+  );
+  const dietExcludedIngredientCount = useMemo(
+    () =>
+      ingredients.filter((ingredient) =>
+        diet.excludedIngredientSlugs.has(ingredient.slug),
+      ).length,
     [diet.excludedIngredientSlugs, ingredients],
   );
-  const dietHiddenIngredientCount =
-    ingredients.length - dietRelevantIngredients.length;
 
   const stockedSlugs = useMemo(
     () =>
@@ -356,12 +370,30 @@ export function KitchenView({
                 <CardTitle className="rt-display text-4xl">
                   Add to your kitchen.
                 </CardTitle>
-                {dietHiddenIngredientCount > 0 && (
-                  <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
-                    {dietHiddenIngredientCount} diet-excluded ingredient
-                    {dietHiddenIngredientCount === 1 ? " is" : "s are"} hidden
-                    from this catalog.
-                  </p>
+                {dietExcludedIngredientCount > 0 && (
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <p className="rt-body text-sm text-[var(--ink-3)]">
+                      {dietExcludedIngredientCount} diet-excluded ingredient
+                      {dietExcludedIngredientCount === 1 ? " is" : "s are"}{" "}
+                      {diet.mode === "warn" || showDietExcludedIngredients
+                        ? "shown with warnings."
+                        : "hidden from this catalog."}
+                    </p>
+                    {diet.mode === "hide" && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          setShowDietExcludedIngredients((current) => !current)
+                        }
+                      >
+                        {showDietExcludedIngredients
+                          ? "Hide diet exclusions"
+                          : "Show anyway"}
+                      </Button>
+                    )}
+                  </div>
                 )}
               </div>
               <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
@@ -371,7 +403,7 @@ export function KitchenView({
                     ref={catalogSearchRef}
                     value={catalogQuery}
                     onChange={(event) => setCatalogQuery(event.target.value)}
-                    placeholder={`Search ${dietRelevantIngredients.length} ingredients...`}
+                    placeholder="Search ingredients..."
                     className="h-10 border-[var(--line-strong)] bg-[var(--paper)] pl-9"
                   />
                 </div>
@@ -398,28 +430,53 @@ export function KitchenView({
             </CardHeader>
             <CardContent>
               <div className="grid min-w-0 gap-2 sm:grid-cols-2 xl:grid-cols-3">
-                {filteredCatalog.map((ingredient) => (
-                  <button
-                    key={ingredient.slug}
-                    type="button"
-                    onClick={() => addIngredient(ingredient)}
-                    className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-[var(--line)] bg-[var(--paper)] px-3 py-2 text-left transition-colors hover:border-[var(--terracotta)] hover:bg-[var(--butter-soft)]"
-                  >
-                    <span className="min-w-0">
-                      <span className="block truncate text-sm font-medium text-[var(--ink)]">
-                        {ingredient.name}
+                {filteredCatalog.map((ingredient) => {
+                  const isDietExcluded = diet.excludedIngredientSlugs.has(
+                    ingredient.slug,
+                  );
+                  return (
+                    <button
+                      key={ingredient.slug}
+                      type="button"
+                      onClick={() => addIngredient(ingredient)}
+                      aria-label={`Add ${ingredient.name}${
+                        isDietExcluded ? " — diet warning" : ""
+                      }`}
+                      className={cn(
+                        "flex min-w-0 items-center justify-between gap-3 rounded-md border bg-[var(--paper)] px-3 py-2 text-left transition-colors hover:border-[var(--terracotta)] hover:bg-[var(--butter-soft)]",
+                        isDietExcluded
+                          ? "border-[var(--berry)]"
+                          : "border-[var(--line)]",
+                      )}
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium text-[var(--ink)]">
+                          {ingredient.name}
+                        </span>
+                        <span
+                          className={cn(
+                            "rt-mono flex items-center gap-1 truncate",
+                            isDietExcluded
+                              ? "text-[var(--berry)]"
+                              : "text-[var(--ink-3)]",
+                          )}
+                        >
+                          {isDietExcluded && (
+                            <TriangleAlert className="size-3 shrink-0" />
+                          )}
+                          {isDietExcluded
+                            ? "Diet warning"
+                            : (ingredient.category ?? "ingredient")}
+                        </span>
                       </span>
-                      <span className="rt-mono block truncate text-[var(--ink-3)]">
-                        {ingredient.category ?? "ingredient"}
-                      </span>
-                    </span>
-                    <CirclePlus className="size-4 shrink-0 text-[var(--terracotta)]" />
-                  </button>
-                ))}
+                      <CirclePlus className="size-4 shrink-0 text-[var(--terracotta)]" />
+                    </button>
+                  );
+                })}
               </div>
               {isCatalogTruncated && (
                 <p className="rt-body mt-3 text-sm text-[var(--ink-3)]">
-                  Showing {filteredCatalog.length} of {catalogMatches.length}
+                  Showing {filteredCatalog.length} of {catalogMatches.length}{" "}
                   matching ingredients.
                 </p>
               )}

--- a/ui/components/recipes/recipe-box-view.tsx
+++ b/ui/components/recipes/recipe-box-view.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Suspense, useCallback, useState } from "react";
+import { RecipeList } from "@/components/recipes/recipe-list";
+import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
+import type { RecipeCardView } from "@/lib/api/recipes";
+
+export function RecipeBoxView({
+  recipes,
+  catalogStats,
+}: Readonly<{
+  recipes: RecipeCardView[];
+  catalogStats: string[];
+}>) {
+  const [visibleRecipeCount, setVisibleRecipeCount] = useState(recipes.length);
+  const updateVisibleRecipeCount = useCallback(
+    (count: number) => setVisibleRecipeCount(count),
+    [],
+  );
+  const recipeCountLabel = `${visibleRecipeCount.toLocaleString()} ${
+    visibleRecipeCount === 1 ? "recipe" : "recipes"
+  }`;
+  const stats = [recipeCountLabel, ...catalogStats];
+
+  return (
+    <div className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-10 md:pt-7 md:pb-14">
+      <div className="mb-6 md:mb-8">
+        <p className="rt-mono text-[var(--terracotta)]">Your recipe box</p>
+        <h1 className="rt-display mt-2 text-5xl sm:text-6xl lg:text-7xl">
+          What's <span className="text-[var(--terracotta)]">cooking?</span>
+        </h1>
+        <p className="rt-body mt-3 flex flex-wrap gap-x-2 gap-y-1 text-base leading-snug text-[var(--ink-2)] sm:text-lg">
+          {stats.map((stat, index) => (
+            <span key={stat} className="whitespace-nowrap">
+              {stat}
+              {index < stats.length - 1 && (
+                <span className="text-[var(--ink-3)]"> ·</span>
+              )}
+            </span>
+          ))}
+        </p>
+      </div>
+
+      <Suspense fallback={<CardGridSkeleton variant="filters" />}>
+        <RecipeList
+          recipes={recipes}
+          onDietVisibleCountChange={updateVisibleRecipeCount}
+        />
+      </Suspense>
+    </div>
+  );
+}

--- a/ui/components/recipes/recipe-card.tsx
+++ b/ui/components/recipes/recipe-card.tsx
@@ -1,8 +1,10 @@
 import { Check, ChefHat, Plus } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
+import { DietWarning } from "@/components/recipes/diet-notice";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import type { DietMatch } from "@/lib/domain/diet";
 import type { KitchenRecipeMatch } from "@/lib/domain/recipe/kitchen";
 import { cn } from "@/lib/generic/styles";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
@@ -85,6 +87,7 @@ export function RecipeMatchCard({
   highlight = false,
   footer,
   cardAction = "open-recipe",
+  dietMatch,
 }: Readonly<{
   recipe: KitchenRecipeMatch;
   inList: boolean;
@@ -93,6 +96,7 @@ export function RecipeMatchCard({
   footer?: ReactNode;
   /** What tapping the card body does: open the recipe, or toggle the list. */
   cardAction?: "open-recipe" | "toggle-list";
+  dietMatch?: DietMatch;
 }>) {
   const timeLabel = formatRecipeTime(recipe.totalTime);
   const canCook = recipe.totalCount > 0 && recipe.missingCount === 0;
@@ -175,6 +179,9 @@ export function RecipeMatchCard({
               {recipe.missingIngredients.length > 5 ? "..." : ""}
             </span>
           </p>
+        )}
+        {dietMatch && (
+          <DietWarning match={dietMatch} compact className="mt-2" />
         )}
         <button
           type="button"

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -20,6 +20,8 @@ import {
   type CookStep,
   type CookToken,
 } from "@/components/recipes/cook-mode";
+import { DietWarning } from "@/components/recipes/diet-notice";
+import { useDiet } from "@/components/recipes/diet-provider";
 import { InlineTimer } from "@/components/recipes/inline-timer";
 import { Button } from "@/components/ui/button";
 import { useScaledRecipe } from "@/hooks/use-scaled-recipe";
@@ -143,6 +145,19 @@ function buildCookUrl(open: boolean, step: number): string {
 }
 
 export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
+  const { diet, matchRecipe } = useDiet();
+  const dietMatch = useMemo(
+    () =>
+      matchRecipe({
+        ingredients: recipe.ingredientGroups.flatMap((group) =>
+          group.items.map((item) => ({
+            slug: item.ingredient,
+            name: item.name,
+          })),
+        ),
+      }),
+    [matchRecipe, recipe.ingredientGroups],
+  );
   const baseServings = Math.max(1, recipe.servings);
   const [portions, setPortions] = useState(baseServings);
   const requestedScale = portions / baseServings;
@@ -283,6 +298,8 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
         <p className="rt-body text-xl text-[var(--ink-2)] mb-4">
           {recipe.description}
         </p>
+
+        {diet.active && <DietWarning match={dietMatch} className="mb-4" />}
 
         {recipe.canonical && (
           <p className="rt-body text-sm text-[var(--ink-2)] italic mb-4 inline-flex items-center gap-2 rounded-lg border border-dashed border-[var(--line-strong)] bg-[var(--paper-warm)] px-3 py-2">

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -302,9 +302,13 @@ const RecipeCard = memo(function RecipeCard({
 
 interface RecipeListProps {
   recipes: RecipeCardView[];
+  onDietVisibleCountChange?: (count: number) => void;
 }
 
-export function RecipeList({ recipes }: RecipeListProps) {
+export function RecipeList({
+  recipes,
+  onDietVisibleCountChange,
+}: RecipeListProps) {
   const { diet, matchRecipe } = useDiet();
   const filterParams = useFilterParams({ filters: RECIPE_FILTER_PARAMS });
   const router = useRouter();
@@ -333,6 +337,9 @@ export function RecipeList({ recipes }: RecipeListProps) {
         : recipes,
     [diet.active, diet.mode, dietMatches, recipes, showHidden],
   );
+  useEffect(() => {
+    onDietVisibleCountChange?.(visibleRecipes.length);
+  }, [onDietVisibleCountChange, visibleRecipes.length]);
 
   // Derive the selected values from the raw query strings so their array
   // identities stay stable while a given filter is unchanged — this lets the

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -19,6 +19,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { DietListNotice, DietWarning } from "@/components/recipes/diet-notice";
+import { useDiet } from "@/components/recipes/diet-provider";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -34,6 +36,7 @@ import {
 } from "@/components/ui/filterable-card-grid";
 import { useFilterParams } from "@/hooks/use-filter-params";
 import type { RecipeCardView } from "@/lib/api/recipes";
+import type { DietMatch } from "@/lib/domain/diet";
 import { formatDate } from "@/lib/generic/date";
 import { cycleFilterFromCard } from "@/lib/generic/filter-cycle";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
@@ -206,6 +209,7 @@ interface RecipeCardProps {
   onToggleCuisine: (cuisine: string) => void;
   onTogglePrepTime: (rangeLabel: string) => void;
   onToggleTotalTime: (rangeLabel: string) => void;
+  dietMatch: DietMatch;
 }
 
 // Memoized so that toggling high-cardinality filters that don't affect a card's
@@ -221,6 +225,7 @@ const RecipeCard = memo(function RecipeCard({
   onToggleCuisine,
   onTogglePrepTime,
   onToggleTotalTime,
+  dietMatch,
 }: RecipeCardProps) {
   return (
     <Card className="h-full flex flex-col overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] gap-0 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]">
@@ -252,6 +257,7 @@ const RecipeCard = memo(function RecipeCard({
         <CardDescription className="rt-body line-clamp-2">
           {recipe.description}
         </CardDescription>
+        <DietWarning match={dietMatch} compact className="mt-2" />
       </CardHeader>
       <CardContent className="flex-1 flex flex-col justify-end pb-4">
         <div className="flex flex-wrap gap-2 mb-3">
@@ -299,8 +305,34 @@ interface RecipeListProps {
 }
 
 export function RecipeList({ recipes }: RecipeListProps) {
+  const { diet, matchRecipe } = useDiet();
   const filterParams = useFilterParams({ filters: RECIPE_FILTER_PARAMS });
   const router = useRouter();
+  const [showHidden, setShowHidden] = useState(false);
+  const dietMatches = useMemo(
+    () =>
+      new Map(
+        recipes.map((recipe) => [
+          recipe.slug,
+          matchRecipe({
+            ingredients: recipe.ingredientSlugs.map((slug) => ({ slug })),
+          }),
+        ]),
+      ),
+    [matchRecipe, recipes],
+  );
+  const hiddenCount = useMemo(
+    () =>
+      Array.from(dietMatches.values()).filter((match) => !match.matches).length,
+    [dietMatches],
+  );
+  const visibleRecipes = useMemo(
+    () =>
+      diet.active && diet.mode === "hide" && !showHidden
+        ? recipes.filter((recipe) => dietMatches.get(recipe.slug)?.matches)
+        : recipes,
+    [diet.active, diet.mode, dietMatches, recipes, showHidden],
+  );
 
   // Derive the selected values from the raw query strings so their array
   // identities stay stable while a given filter is unchanged — this lets the
@@ -315,9 +347,9 @@ export function RecipeList({ recipes }: RecipeListProps) {
   const searchConfig = useMemo(
     () => ({
       ...RECIPE_SEARCH_CONFIG,
-      placeholder: `Search ${recipes.length} recipes…`,
+      placeholder: `Search ${visibleRecipes.length} recipes…`,
     }),
-    [recipes.length],
+    [visibleRecipes.length],
   );
   const selectedCuisines = useMemo(
     () => (cuisineKey ? cuisineKey.split(",").filter(Boolean) : []),
@@ -403,29 +435,46 @@ export function RecipeList({ recipes }: RecipeListProps) {
   }, [searchParamQuery, searchQuery, searchParams, router]);
 
   return (
-    <FilterableCardGrid
-      items={recipes}
-      getItemKey={(recipe) => recipe.slug}
-      searchValue={searchQuery}
-      onSearchChange={setSearchQuery}
-      stackControls
-      searchConfig={searchConfig}
-      filterConfigs={RECIPE_FILTER_CONFIGS}
-      sortConfig={RECIPE_SORT_CONFIG}
-      emptyState={RECIPE_EMPTY_STATE}
-      itemName="recipes"
-      renderCard={(recipe, index) => (
-        <RecipeCard
-          recipe={recipe}
-          index={index}
-          selectedCuisines={selectedCuisines}
-          selectedPrepTimes={selectedPrepTimes}
-          selectedTotalTimes={selectedTotalTimes}
-          onToggleCuisine={onToggleCuisine}
-          onTogglePrepTime={onTogglePrepTime}
-          onToggleTotalTime={onToggleTotalTime}
+    <>
+      {diet.active && (
+        <DietListNotice
+          hiddenCount={hiddenCount}
+          labels={diet.labels}
+          mode={diet.mode}
+          showingHidden={showHidden}
+          onToggleHidden={() => setShowHidden((current) => !current)}
         />
       )}
-    />
+      <FilterableCardGrid
+        items={visibleRecipes}
+        getItemKey={(recipe) => recipe.slug}
+        searchValue={searchQuery}
+        onSearchChange={setSearchQuery}
+        stackControls
+        searchConfig={searchConfig}
+        filterConfigs={RECIPE_FILTER_CONFIGS}
+        sortConfig={RECIPE_SORT_CONFIG}
+        emptyState={RECIPE_EMPTY_STATE}
+        itemName="recipes"
+        renderCard={(recipe, index) => (
+          <RecipeCard
+            recipe={recipe}
+            index={index}
+            selectedCuisines={selectedCuisines}
+            selectedPrepTimes={selectedPrepTimes}
+            selectedTotalTimes={selectedTotalTimes}
+            onToggleCuisine={onToggleCuisine}
+            onTogglePrepTime={onTogglePrepTime}
+            onToggleTotalTime={onToggleTotalTime}
+            dietMatch={
+              dietMatches.get(recipe.slug) ?? {
+                matches: true,
+                excludedIngredients: [],
+              }
+            }
+          />
+        )}
+      />
+    </>
   );
 }

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -53,6 +53,11 @@ const TIME_RANGES = [
   { label: "Over 60 min", min: 61 },
 ] as const;
 
+const MATCHING_DIET_MATCH: DietMatch = {
+  matches: true,
+  excludedIngredients: [],
+};
+
 function getTimeRangeLabel(minutes: number): string {
   for (const range of TIME_RANGES) {
     const aboveMin = !("min" in range) || minutes >= range.min;
@@ -471,12 +476,7 @@ export function RecipeList({
             onToggleCuisine={onToggleCuisine}
             onTogglePrepTime={onTogglePrepTime}
             onToggleTotalTime={onToggleTotalTime}
-            dietMatch={
-              dietMatches.get(recipe.slug) ?? {
-                matches: true,
-                excludedIngredients: [],
-              }
-            }
+            dietMatch={dietMatches.get(recipe.slug) ?? MATCHING_DIET_MATCH}
           />
         )}
       />

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -15,6 +15,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -36,7 +37,11 @@ import {
 } from "@/components/ui/filterable-card-grid";
 import { useFilterParams } from "@/hooks/use-filter-params";
 import type { RecipeCardView } from "@/lib/api/recipes";
-import type { DietMatch } from "@/lib/domain/diet";
+import {
+  applyDietRecipeVisibility,
+  buildDietRecipeMatches,
+  type DietMatch,
+} from "@/lib/domain/diet";
 import { formatDate } from "@/lib/generic/date";
 import { cycleFilterFromCard } from "@/lib/generic/filter-cycle";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
@@ -300,10 +305,10 @@ const RecipeCard = memo(function RecipeCard({
   );
 });
 
-interface RecipeListProps {
+type RecipeListProps = Readonly<{
   recipes: RecipeCardView[];
   onDietVisibleCountChange?: (count: number) => void;
-}
+}>;
 
 export function RecipeList({
   recipes,
@@ -315,29 +320,22 @@ export function RecipeList({
   const [showHidden, setShowHidden] = useState(false);
   const dietMatches = useMemo(
     () =>
-      new Map(
-        recipes.map((recipe) => [
-          recipe.slug,
-          matchRecipe({
-            ingredients: recipe.ingredientSlugs.map((slug) => ({ slug })),
-          }),
-        ]),
-      ),
+      buildDietRecipeMatches(recipes, matchRecipe, (recipe) => ({
+        ingredients: recipe.ingredientSlugs.map((slug) => ({ slug })),
+      })),
     [matchRecipe, recipes],
   );
-  const hiddenCount = useMemo(
+  const { visibleRecipes, hiddenCount } = useMemo(
     () =>
-      Array.from(dietMatches.values()).filter((match) => !match.matches).length,
-    [dietMatches],
-  );
-  const visibleRecipes = useMemo(
-    () =>
-      diet.active && diet.mode === "hide" && !showHidden
-        ? recipes.filter((recipe) => dietMatches.get(recipe.slug)?.matches)
-        : recipes,
+      applyDietRecipeVisibility(
+        recipes,
+        dietMatches,
+        { active: diet.active, mode: diet.mode },
+        { showHidden },
+      ),
     [diet.active, diet.mode, dietMatches, recipes, showHidden],
   );
-  useEffect(() => {
+  useLayoutEffect(() => {
     onDietVisibleCountChange?.(visibleRecipes.length);
   }, [onDietVisibleCountChange, visibleRecipes.length]);
 

--- a/ui/components/recipes/settings/diet-panel.tsx
+++ b/ui/components/recipes/settings/diet-panel.tsx
@@ -254,6 +254,7 @@ function IngredientPicker({
 }>) {
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
+  const closeTimeoutRef = useRef<number | null>(null);
   const hasIngredients = ingredients.length > 0;
   const selected = useMemo(() => new Set(selectedSlugs), [selectedSlugs]);
   const matches = useMemo(() => {
@@ -269,7 +270,30 @@ function IngredientPicker({
       .slice(0, INGREDIENT_RESULT_LIMIT);
   }, [ingredients, query, selected]);
 
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current !== null) {
+        window.clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  function cancelScheduledClose() {
+    if (closeTimeoutRef.current === null) return;
+    window.clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = null;
+  }
+
+  function scheduleClose() {
+    cancelScheduledClose();
+    closeTimeoutRef.current = window.setTimeout(() => {
+      setOpen(false);
+      closeTimeoutRef.current = null;
+    }, 120);
+  }
+
   function addIngredient(ingredient: DietIngredientOption) {
+    cancelScheduledClose();
     onAdd(ingredient);
     setQuery("");
     setOpen(false);
@@ -281,12 +305,15 @@ function IngredientPicker({
       <Input
         value={query}
         disabled={!hasIngredients}
-        onBlur={() => window.setTimeout(() => setOpen(false), 120)}
+        onBlur={scheduleClose}
         onChange={(event) => {
           setQuery(event.target.value);
           setOpen(true);
         }}
-        onFocus={() => setOpen(true)}
+        onFocus={() => {
+          cancelScheduledClose();
+          setOpen(true);
+        }}
         placeholder={
           hasIngredients
             ? `Search ${ingredients.length} canonical ingredients...`

--- a/ui/components/recipes/settings/diet-panel.tsx
+++ b/ui/components/recipes/settings/diet-panel.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { DIET_PROFILE_UPDATED_EVENT } from "@/components/recipes/diet-provider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -437,6 +438,7 @@ export function DietPanel() {
       setProfile(saved);
       setSavedProfile(saved);
       setSaveState("saved");
+      globalThis.dispatchEvent(new Event(DIET_PROFILE_UPDATED_EVENT));
     } catch (saveError) {
       if (controller.signal.aborted) return;
       setSaveState("error");

--- a/ui/components/recipes/settings/diet-panel.tsx
+++ b/ui/components/recipes/settings/diet-panel.tsx
@@ -184,12 +184,14 @@ function SelectableTile({
   active,
   children,
   className,
+  disabled = false,
   label,
   onClick,
 }: Readonly<{
   active: boolean;
   children: ReactNode;
   className?: string;
+  disabled?: boolean;
   label: string;
   onClick: () => void;
 }>) {
@@ -197,12 +199,14 @@ function SelectableTile({
     <button
       type="button"
       aria-pressed={active}
+      disabled={disabled}
       onClick={onClick}
       className={cn(
         "flex items-start gap-3 rounded-lg border px-3 py-3 text-left transition-colors",
         active
           ? "border-[var(--terracotta)] bg-[var(--butter-soft)]"
           : "border-[var(--line)] bg-[var(--card)] hover:border-[var(--line-strong)]",
+        disabled && "cursor-default",
         className,
       )}
     >
@@ -529,7 +533,11 @@ export function DietPanel() {
                   return (
                     <SelectableTile
                       key={group.key}
-                      active={profile.excludedGroupKeys.includes(group.key)}
+                      active={
+                        coveredByPreset ||
+                        profile.excludedGroupKeys.includes(group.key)
+                      }
+                      disabled={coveredByPreset}
                       label={group.label}
                       onClick={() =>
                         updateProfile({

--- a/ui/components/recipes/settings/settings-view.tsx
+++ b/ui/components/recipes/settings/settings-view.tsx
@@ -24,8 +24,14 @@ export function SettingsView() {
   // A failed account link redirects back with ?error=<code>; open on the panel
   // that surfaces and clears it so the message isn't hidden behind a tab.
   useEffect(() => {
-    if (new URLSearchParams(globalThis.location.search).has("error")) {
+    const params = new URLSearchParams(globalThis.location.search);
+    if (params.has("error")) {
       setSection("signin");
+      return;
+    }
+    const requestedSection = params.get("section");
+    if (SECTIONS.some(({ id }) => id === requestedSection)) {
+      setSection(requestedSection as SectionId);
     }
   }, []);
 

--- a/ui/components/recipes/shopping/meal-planner.tsx
+++ b/ui/components/recipes/shopping/meal-planner.tsx
@@ -95,9 +95,15 @@ function PlanCell({
   );
 }
 
-type MealPlannerProps = Readonly<{ recipes: ShoppingRecipe[] }>;
+type MealPlannerProps = Readonly<{
+  recipes: ShoppingRecipe[];
+  availableRecipes?: ShoppingRecipe[];
+}>;
 
-export function MealPlanner({ recipes }: MealPlannerProps) {
+export function MealPlanner({
+  recipes,
+  availableRecipes = recipes,
+}: MealPlannerProps) {
   const state = useShoppingList();
 
   const bySlug = useMemo(() => {
@@ -107,8 +113,8 @@ export function MealPlanner({ recipes }: MealPlannerProps) {
   }, [recipes]);
 
   const sortedRecipes = useMemo(() => {
-    return [...recipes].sort((a, b) => a.title.localeCompare(b.title));
-  }, [recipes]);
+    return [...availableRecipes].sort((a, b) => a.title.localeCompare(b.title));
+  }, [availableRecipes]);
 
   const planBySlot = useMemo(() => {
     const map = new Map<string, ShoppingRecipe>();

--- a/ui/components/recipes/shopping/recipe-picker.tsx
+++ b/ui/components/recipes/shopping/recipe-picker.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { useKitchenStock } from "@/hooks/use-kitchen-stock";
 import { useShoppingList } from "@/hooks/use-shopping-list";
 import type { ShoppingRecipe } from "@/lib/api/shopping";
+import type { DietMatch } from "@/lib/domain/diet";
 import type { IngredientSlug } from "@/lib/domain/recipe/ingredient";
 import {
   getKitchenRecipeMatches,
@@ -56,7 +57,13 @@ function ServingsStepper({
   );
 }
 
-export function RecipePicker({ recipes }: { recipes: ShoppingRecipe[] }) {
+export function RecipePicker({
+  recipes,
+  dietMatches,
+}: {
+  recipes: ShoppingRecipe[];
+  dietMatches?: ReadonlyMap<string, DietMatch>;
+}) {
   const { recipes: selectedEntries } = useShoppingList();
   const stock = useKitchenStock();
   const [query, setQuery] = useState("");
@@ -162,6 +169,7 @@ export function RecipePicker({ recipes }: { recipes: ShoppingRecipe[] }) {
                 onToggleList={() => toggleRecipe(recipe.slug)}
                 highlight={selected}
                 cardAction="toggle-list"
+                dietMatch={dietMatches?.get(recipe.slug)}
                 footer={
                   selected ? (
                     <ServingsStepper slug={recipe.slug} servings={servings} />

--- a/ui/components/recipes/shopping/recipe-picker.tsx
+++ b/ui/components/recipes/shopping/recipe-picker.tsx
@@ -60,10 +60,10 @@ function ServingsStepper({
 export function RecipePicker({
   recipes,
   dietMatches,
-}: {
+}: Readonly<{
   recipes: ShoppingRecipe[];
   dietMatches?: ReadonlyMap<string, DietMatch>;
-}) {
+}>) {
   const { recipes: selectedEntries } = useShoppingList();
   const stock = useKitchenStock();
   const [query, setQuery] = useState("");

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -52,14 +52,13 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
         : recipes,
     [diet.active, diet.mode, dietMatches, recipes, showHidden],
   );
-  const pickerRecipes = useMemo(
-    () =>
-      recipes.filter(
-        (recipe) =>
-          availableRecipes.includes(recipe) || selectedSlugs.has(recipe.slug),
-      ),
-    [availableRecipes, recipes, selectedSlugs],
-  );
+  const pickerRecipes = useMemo(() => {
+    if (!diet.active || diet.mode !== "hide" || showHidden) return recipes;
+    return recipes.filter(
+      (recipe) =>
+        dietMatches.get(recipe.slug)?.matches || selectedSlugs.has(recipe.slug),
+    );
+  }, [diet.active, diet.mode, dietMatches, recipes, selectedSlugs, showHidden]);
   const count = selected.length;
   const recipeNoun = count === 1 ? "recipe" : "recipes";
   const plannedCount = plan.length;

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -43,17 +43,7 @@ export function ShoppingView({
       })),
     [matchRecipe, recipes],
   );
-  const { visibleRecipes: availableRecipes } = useMemo(
-    () =>
-      applyDietRecipeVisibility(
-        recipes,
-        dietMatches,
-        { active: diet.active, mode: diet.mode },
-        { showHidden },
-      ),
-    [diet.active, diet.mode, dietMatches, recipes, showHidden],
-  );
-  const { visibleRecipes: pickerRecipes, hiddenCount } = useMemo(
+  const { visibleRecipes: availableRecipes, hiddenCount } = useMemo(
     () =>
       applyDietRecipeVisibility(
         recipes,
@@ -66,6 +56,7 @@ export function ShoppingView({
       ),
     [diet.active, diet.mode, dietMatches, recipes, selectedSlugs, showHidden],
   );
+  const pickerRecipes = availableRecipes;
   const count = selected.length;
   const recipeNoun = count === 1 ? "recipe" : "recipes";
   const plannedCount = plan.length;

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { ArrowLeft, ArrowRight, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { DietListNotice } from "@/components/recipes/diet-notice";
+import { useDiet } from "@/components/recipes/diet-provider";
 import { MealPlanner } from "@/components/recipes/shopping/meal-planner";
 import { RecipePicker } from "@/components/recipes/shopping/recipe-picker";
 import { ShoppingList } from "@/components/recipes/shopping/shopping-list";
@@ -17,8 +19,47 @@ const STEPS: { id: Step; label: string }[] = [
 ];
 
 export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
+  const { diet, matchRecipe } = useDiet();
   const { recipes: selected, plan, extras } = useShoppingList();
   const [step, setStep] = useState<Step>("plan");
+  const [showHidden, setShowHidden] = useState(false);
+  const selectedSlugs = useMemo(
+    () => new Set(selected.map((entry) => entry.slug)),
+    [selected],
+  );
+  const dietMatches = useMemo(
+    () =>
+      new Map(
+        recipes.map((recipe) => [
+          recipe.slug,
+          matchRecipe({
+            ingredients: recipe.ingredients.map((ingredient) => ({
+              slug: ingredient.ingredient,
+              name: ingredient.name,
+            })),
+          }),
+        ]),
+      ),
+    [matchRecipe, recipes],
+  );
+  const hiddenCount = Array.from(dietMatches.values()).filter(
+    (match) => !match.matches,
+  ).length;
+  const availableRecipes = useMemo(
+    () =>
+      diet.active && diet.mode === "hide" && !showHidden
+        ? recipes.filter((recipe) => dietMatches.get(recipe.slug)?.matches)
+        : recipes,
+    [diet.active, diet.mode, dietMatches, recipes, showHidden],
+  );
+  const pickerRecipes = useMemo(
+    () =>
+      recipes.filter(
+        (recipe) =>
+          availableRecipes.includes(recipe) || selectedSlugs.has(recipe.slug),
+      ),
+    [availableRecipes, recipes, selectedSlugs],
+  );
   const count = selected.length;
   const recipeNoun = count === 1 ? "recipe" : "recipes";
   const plannedCount = plan.length;
@@ -61,6 +102,16 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
         )}
       </div>
 
+      {diet.active && (
+        <DietListNotice
+          hiddenCount={hiddenCount}
+          labels={diet.labels}
+          mode={diet.mode}
+          showingHidden={showHidden}
+          onToggleHidden={() => setShowHidden((current) => !current)}
+        />
+      )}
+
       {/* Step tabs — mirror the recipe read-view tabs so the two feel of a piece. */}
       <div className="flex items-center border-b border-[var(--line)] mb-6">
         {STEPS.map((s) => {
@@ -86,7 +137,7 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
 
       {step === "plan" ? (
         <div className="space-y-8">
-          <MealPlanner recipes={recipes} />
+          <MealPlanner recipes={recipes} availableRecipes={availableRecipes} />
           <div>
             <div className="mb-3 flex flex-wrap items-end justify-between gap-2">
               <div>
@@ -101,7 +152,7 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
                 Selected recipes appear in the plan pool and shopping list.
               </p>
             </div>
-            <RecipePicker recipes={recipes} />
+            <RecipePicker recipes={pickerRecipes} dietMatches={dietMatches} />
           </div>
           <div className="mt-6 flex justify-end">
             <button

--- a/ui/components/recipes/shopping/shopping-view.tsx
+++ b/ui/components/recipes/shopping/shopping-view.tsx
@@ -9,6 +9,10 @@ import { RecipePicker } from "@/components/recipes/shopping/recipe-picker";
 import { ShoppingList } from "@/components/recipes/shopping/shopping-list";
 import { useShoppingList } from "@/hooks/use-shopping-list";
 import type { ShoppingRecipe } from "@/lib/api/shopping";
+import {
+  applyDietRecipeVisibility,
+  buildDietRecipeMatches,
+} from "@/lib/domain/diet";
 import { clearList } from "@/lib/shopping/shoppingListStore";
 
 type Step = "plan" | "list";
@@ -18,7 +22,9 @@ const STEPS: { id: Step; label: string }[] = [
   { id: "list", label: "2 · Shopping list" },
 ];
 
-export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
+export function ShoppingView({
+  recipes,
+}: Readonly<{ recipes: ShoppingRecipe[] }>) {
   const { diet, matchRecipe } = useDiet();
   const { recipes: selected, plan, extras } = useShoppingList();
   const [step, setStep] = useState<Step>("plan");
@@ -29,36 +35,37 @@ export function ShoppingView({ recipes }: { recipes: ShoppingRecipe[] }) {
   );
   const dietMatches = useMemo(
     () =>
-      new Map(
-        recipes.map((recipe) => [
-          recipe.slug,
-          matchRecipe({
-            ingredients: recipe.ingredients.map((ingredient) => ({
-              slug: ingredient.ingredient,
-              name: ingredient.name,
-            })),
-          }),
-        ]),
-      ),
+      buildDietRecipeMatches(recipes, matchRecipe, (recipe) => ({
+        ingredients: recipe.ingredients.map((ingredient) => ({
+          slug: ingredient.ingredient,
+          name: ingredient.name,
+        })),
+      })),
     [matchRecipe, recipes],
   );
-  const hiddenCount = Array.from(dietMatches.values()).filter(
-    (match) => !match.matches,
-  ).length;
-  const availableRecipes = useMemo(
+  const { visibleRecipes: availableRecipes } = useMemo(
     () =>
-      diet.active && diet.mode === "hide" && !showHidden
-        ? recipes.filter((recipe) => dietMatches.get(recipe.slug)?.matches)
-        : recipes,
+      applyDietRecipeVisibility(
+        recipes,
+        dietMatches,
+        { active: diet.active, mode: diet.mode },
+        { showHidden },
+      ),
     [diet.active, diet.mode, dietMatches, recipes, showHidden],
   );
-  const pickerRecipes = useMemo(() => {
-    if (!diet.active || diet.mode !== "hide" || showHidden) return recipes;
-    return recipes.filter(
-      (recipe) =>
-        dietMatches.get(recipe.slug)?.matches || selectedSlugs.has(recipe.slug),
-    );
-  }, [diet.active, diet.mode, dietMatches, recipes, selectedSlugs, showHidden]);
+  const { visibleRecipes: pickerRecipes, hiddenCount } = useMemo(
+    () =>
+      applyDietRecipeVisibility(
+        recipes,
+        dietMatches,
+        { active: diet.active, mode: diet.mode },
+        {
+          showHidden,
+          alwaysVisibleSlugs: selectedSlugs,
+        },
+      ),
+    [diet.active, diet.mode, dietMatches, recipes, selectedSlugs, showHidden],
+  );
   const count = selected.length;
   const recipeNoun = count === 1 ? "recipe" : "recipes";
   const plannedCount = plan.length;

--- a/ui/content/recipes/ingredients.ts
+++ b/ui/content/recipes/ingredients.ts
@@ -1,6 +1,4 @@
-import type { IngredientContent } from "@/lib/domain/recipe/ingredient";
-
-export const ingredients: IngredientContent[] = [
+export const ingredients = [
   // Proteins
   { name: "chicken breast", category: "protein" },
   { name: "turkey mince", category: "protein" },
@@ -235,4 +233,4 @@ export const ingredients: IngredientContent[] = [
   { name: "sesame oil", category: "oil-fat" },
   { name: "chicken thigh", category: "protein" },
   { name: "frozen raspberries", category: "fruit" },
-];
+] as const;

--- a/ui/lib/domain/diet.ts
+++ b/ui/lib/domain/diet.ts
@@ -1,0 +1,104 @@
+import type {
+  DietOptions,
+  DietProfile,
+  DietRecipeMatchMode,
+} from "@/lib/api/diet";
+
+export type DietRecipe = {
+  ingredients: readonly { slug: string; name?: string }[];
+};
+
+export type DietMatch = {
+  matches: boolean;
+  excludedIngredients: { slug: string; name: string }[];
+};
+
+export type EffectiveDiet = {
+  active: boolean;
+  labels: string[];
+  mode: DietRecipeMatchMode;
+  excludedIngredientSlugs: ReadonlySet<string>;
+  ingredientNames: ReadonlyMap<string, string>;
+};
+
+function labelFromSlug(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+export function buildEffectiveDiet(
+  profile: DietProfile,
+  options: DietOptions,
+): EffectiveDiet {
+  const presetByKey = new Map(
+    options.presets.map((preset) => [preset.key, preset]),
+  );
+  const groupByKey = new Map(options.groups.map((group) => [group.key, group]));
+  const ingredientNames = new Map(
+    options.ingredients.map((ingredient) => [ingredient.slug, ingredient.name]),
+  );
+  const presetGroups = profile.presetDietKeys.flatMap(
+    (key) => presetByKey.get(key)?.excludedGroupKeys ?? [],
+  );
+  const groupKeys = new Set([...presetGroups, ...profile.excludedGroupKeys]);
+  const excludedIngredientSlugs = new Set([
+    ...profile.excludedIngredientSlugs,
+    ...profile.presetDietKeys.flatMap(
+      (key) => presetByKey.get(key)?.excludedIngredientSlugs ?? [],
+    ),
+    ...Array.from(groupKeys).flatMap(
+      (key) => groupByKey.get(key)?.ingredientSlugs ?? [],
+    ),
+  ]);
+  const labels = [
+    ...profile.presetDietKeys.map(
+      (key) => presetByKey.get(key)?.label ?? labelFromSlug(key),
+    ),
+    ...profile.excludedGroupKeys.map(
+      (key) => `no ${groupByKey.get(key)?.label ?? labelFromSlug(key)}`,
+    ),
+    ...profile.excludedIngredientSlugs.map(
+      (slug) => `no ${ingredientNames.get(slug) ?? labelFromSlug(slug)}`,
+    ),
+  ];
+
+  return {
+    active: excludedIngredientSlugs.size > 0,
+    labels: Array.from(new Set(labels)),
+    mode: profile.recipeMatchMode,
+    excludedIngredientSlugs,
+    ingredientNames,
+  };
+}
+
+export function matchRecipeToDiet(
+  recipe: DietRecipe,
+  diet: EffectiveDiet,
+): DietMatch {
+  const excludedIngredients = Array.from(
+    new Map(
+      recipe.ingredients
+        .filter((ingredient) =>
+          diet.excludedIngredientSlugs.has(ingredient.slug),
+        )
+        .map((ingredient) => [
+          ingredient.slug,
+          {
+            slug: ingredient.slug,
+            name:
+              ingredient.name ??
+              diet.ingredientNames.get(ingredient.slug) ??
+              labelFromSlug(ingredient.slug),
+          },
+        ]),
+    ).values(),
+  );
+
+  return {
+    matches: excludedIngredients.length === 0,
+    excludedIngredients,
+  };
+}

--- a/ui/lib/domain/diet.ts
+++ b/ui/lib/domain/diet.ts
@@ -23,6 +23,10 @@ export type EffectiveDiet = {
 
 export type DietVisibilityResult<T> = {
   visibleRecipes: T[];
+  /**
+   * Recipes the active hide policy would suppress. It remains the baseline
+   * count while temporarily showing hidden recipes, and is zero in warn mode.
+   */
   hiddenCount: number;
 };
 

--- a/ui/lib/domain/diet.ts
+++ b/ui/lib/domain/diet.ts
@@ -43,12 +43,19 @@ export function buildEffectiveDiet(
   const presetGroups = profile.presetDietKeys.flatMap(
     (key) => presetByKey.get(key)?.excludedGroupKeys ?? [],
   );
-  const groupKeys = new Set([...presetGroups, ...profile.excludedGroupKeys]);
-  const excludedIngredientSlugs = new Set([
-    ...profile.excludedIngredientSlugs,
+  const presetGroupKeys = new Set(presetGroups);
+  const groupKeys = new Set([...presetGroupKeys, ...profile.excludedGroupKeys]);
+  const presetExcludedIngredientSlugs = new Set([
     ...profile.presetDietKeys.flatMap(
       (key) => presetByKey.get(key)?.excludedIngredientSlugs ?? [],
     ),
+    ...Array.from(presetGroupKeys).flatMap(
+      (key) => groupByKey.get(key)?.ingredientSlugs ?? [],
+    ),
+  ]);
+  const excludedIngredientSlugs = new Set([
+    ...profile.excludedIngredientSlugs,
+    ...presetExcludedIngredientSlugs,
     ...Array.from(groupKeys).flatMap(
       (key) => groupByKey.get(key)?.ingredientSlugs ?? [],
     ),
@@ -57,12 +64,12 @@ export function buildEffectiveDiet(
     ...profile.presetDietKeys.map(
       (key) => presetByKey.get(key)?.label ?? labelFromSlug(key),
     ),
-    ...profile.excludedGroupKeys.map(
-      (key) => `no ${groupByKey.get(key)?.label ?? labelFromSlug(key)}`,
-    ),
-    ...profile.excludedIngredientSlugs.map(
-      (slug) => `no ${ingredientNames.get(slug) ?? labelFromSlug(slug)}`,
-    ),
+    ...profile.excludedGroupKeys
+      .filter((key) => !presetGroupKeys.has(key))
+      .map((key) => `no ${groupByKey.get(key)?.label ?? labelFromSlug(key)}`),
+    ...profile.excludedIngredientSlugs
+      .filter((slug) => !presetExcludedIngredientSlugs.has(slug))
+      .map((slug) => `no ${ingredientNames.get(slug) ?? labelFromSlug(slug)}`),
   ];
 
   return {

--- a/ui/lib/domain/diet.ts
+++ b/ui/lib/domain/diet.ts
@@ -21,6 +21,21 @@ export type EffectiveDiet = {
   ingredientNames: ReadonlyMap<string, string>;
 };
 
+export type DietVisibilityResult<T> = {
+  visibleRecipes: T[];
+  hiddenCount: number;
+};
+
+export function buildDietRecipeMatches<T extends { slug: string }>(
+  recipes: T[],
+  matchRecipe: (recipe: DietRecipe) => DietMatch,
+  toDietRecipe: (recipe: T) => DietRecipe,
+): Map<string, DietMatch> {
+  return new Map(
+    recipes.map((recipe) => [recipe.slug, matchRecipe(toDietRecipe(recipe))]),
+  );
+}
+
 function labelFromSlug(slug: string): string {
   return slug
     .split("-")
@@ -107,5 +122,30 @@ export function matchRecipeToDiet(
   return {
     matches: excludedIngredients.length === 0,
     excludedIngredients,
+  };
+}
+
+export function applyDietRecipeVisibility<T extends { slug: string }>(
+  recipes: T[],
+  matches: ReadonlyMap<string, DietMatch>,
+  diet: Pick<EffectiveDiet, "active" | "mode">,
+  options: Readonly<{
+    showHidden: boolean;
+    alwaysVisibleSlugs?: ReadonlySet<string>;
+  }>,
+): DietVisibilityResult<T> {
+  if (!diet.active || diet.mode !== "hide") {
+    return { visibleRecipes: recipes, hiddenCount: 0 };
+  }
+
+  const dietVisibleRecipes = recipes.filter(
+    (recipe) =>
+      matches.get(recipe.slug)?.matches === true ||
+      options.alwaysVisibleSlugs?.has(recipe.slug),
+  );
+
+  return {
+    visibleRecipes: options.showHidden ? recipes : dietVisibleRecipes,
+    hiddenCount: recipes.length - dietVisibleRecipes.length,
   };
 }

--- a/ui/lib/domain/recipe/kitchen.ts
+++ b/ui/lib/domain/recipe/kitchen.ts
@@ -73,6 +73,16 @@ export function toKitchenIngredientView(
   };
 }
 
+export function getDietRelevantKitchenIngredients(
+  ingredients: readonly KitchenIngredientView[],
+  excludedIngredientSlugs: ReadonlySet<string>,
+): KitchenIngredientView[] {
+  if (excludedIngredientSlugs.size === 0) return [...ingredients];
+  return ingredients.filter(
+    (ingredient) => !excludedIngredientSlugs.has(ingredient.slug),
+  );
+}
+
 export function getKitchenRecipeMatches(
   recipes: KitchenRecipeView[],
   availableIngredientSlugs: Iterable<IngredientSlug>,

--- a/ui/lib/domain/recipe/kitchen.ts
+++ b/ui/lib/domain/recipe/kitchen.ts
@@ -76,8 +76,11 @@ export function toKitchenIngredientView(
 export function getDietRelevantKitchenIngredients(
   ingredients: readonly KitchenIngredientView[],
   excludedIngredientSlugs: ReadonlySet<string>,
+  includeExcluded = false,
 ): KitchenIngredientView[] {
-  if (excludedIngredientSlugs.size === 0) return [...ingredients];
+  if (includeExcluded || excludedIngredientSlugs.size === 0) {
+    return [...ingredients];
+  }
   return ingredients.filter(
     (ingredient) => !excludedIngredientSlugs.has(ingredient.slug),
   );

--- a/ui/lib/domain/recipe/recipeViews.ts
+++ b/ui/lib/domain/recipe/recipeViews.ts
@@ -111,7 +111,7 @@ function extractIngredientSlugs(recipe: Recipe): IngredientSlug[] {
         group.items.map((item) => item.ingredient),
       ),
     ),
-  ).sort();
+  ).sort((first, second) => first.localeCompare(second));
 }
 
 export function toRecipeCardView(

--- a/ui/lib/domain/recipe/recipeViews.ts
+++ b/ui/lib/domain/recipe/recipeViews.ts
@@ -42,6 +42,7 @@ type BaseRecipeView = {
 
 export type RecipeCardView = BaseRecipeView & {
   ingredientNames: string[];
+  ingredientSlugs: IngredientSlug[];
   cookware: string[];
 };
 
@@ -103,6 +104,16 @@ function extractIngredientNames(
   return Array.from(names).sort();
 }
 
+function extractIngredientSlugs(recipe: Recipe): IngredientSlug[] {
+  return Array.from(
+    new Set(
+      recipe.ingredientGroups.flatMap((group) =>
+        group.items.map((item) => item.ingredient),
+      ),
+    ),
+  ).sort();
+}
+
 export function toRecipeCardView(
   recipe: Recipe,
   ingredients: Map<IngredientSlug, Ingredient>,
@@ -122,6 +133,7 @@ export function toRecipeCardView(
     imageAlt: recipe.imageAlt,
     canonical: recipe.canonical,
     ingredientNames: extractIngredientNames(recipe, ingredients),
+    ingredientSlugs: extractIngredientSlugs(recipe),
     cookware: recipe.cookware,
   };
 }

--- a/ui/tests/components/recipes/diet-notice.test.tsx
+++ b/ui/tests/components/recipes/diet-notice.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DietListNotice } from "@/components/recipes/diet-notice";
+
+describe("DietListNotice", () => {
+  it("summarises long diet label lists instead of rendering every exclusion", () => {
+    render(
+      <DietListNotice
+        hiddenCount={48}
+        labels={[
+          "Vegan",
+          "Gluten-free",
+          "Low-FODMAP review",
+          "no Chilli",
+          "no Alcohol",
+        ]}
+        mode="hide"
+        showingHidden={false}
+      />,
+    );
+
+    expect(screen.getByText(/Vegan, Gluten-free \+3 more/)).toBeInTheDocument();
+    expect(screen.queryByText(/Low-FODMAP/)).toBeNull();
+    expect(screen.getByText(/48 recipes hidden/)).toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/diet-notice.test.tsx
+++ b/ui/tests/components/recipes/diet-notice.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { DietListNotice } from "@/components/recipes/diet-notice";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DietListNotice,
+  DietLoadErrorNotice,
+  DietWarning,
+} from "@/components/recipes/diet-notice";
 
 describe("DietListNotice", () => {
   it("summarises long diet label lists instead of rendering every exclusion", () => {
@@ -22,5 +27,83 @@ describe("DietListNotice", () => {
     expect(screen.getByText(/Vegan, Gluten-free \+3 more/)).toBeInTheDocument();
     expect(screen.queryByText(/Low-FODMAP/)).toBeNull();
     expect(screen.getByText(/48 recipes hidden/)).toBeInTheDocument();
+  });
+
+  it("shows a toggle only for hidden recipes", async () => {
+    const user = userEvent.setup();
+    const onToggleHidden = vi.fn();
+    const { rerender } = render(
+      <DietListNotice
+        hiddenCount={2}
+        labels={["Vegan"]}
+        mode="hide"
+        showingHidden={false}
+        onToggleHidden={onToggleHidden}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "show anyway" }));
+    expect(onToggleHidden).toHaveBeenCalledOnce();
+
+    rerender(
+      <DietListNotice
+        hiddenCount={2}
+        labels={["Vegan"]}
+        mode="warn"
+        showingHidden={false}
+        onToggleHidden={onToggleHidden}
+      />,
+    );
+    expect(
+      screen.getByText(/Recipes that don't match are marked with a warning/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "show anyway" })).toBeNull();
+  });
+});
+
+describe("DietWarning", () => {
+  it("renders excluded ingredient names in an output", () => {
+    render(
+      <DietWarning
+        match={{
+          matches: false,
+          excludedIngredients: [
+            { slug: "bacon", name: "Bacon" },
+            { slug: "milk", name: "Milk" },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /Doesn't match your diet: Bacon, Milk/,
+    );
+  });
+
+  it("renders nothing for a match and supports compact warnings", () => {
+    const { container, rerender } = render(
+      <DietWarning match={{ matches: true, excludedIngredients: [] }} />,
+    );
+    expect(container.firstChild).toBeNull();
+
+    rerender(
+      <DietWarning
+        compact
+        match={{
+          matches: false,
+          excludedIngredients: [{ slug: "egg", name: "Egg" }],
+        }}
+      />,
+    );
+    expect(container.querySelector("output")).toHaveClass("text-xs");
+  });
+});
+
+describe("DietLoadErrorNotice", () => {
+  it("warns that filtering cannot be relied on", () => {
+    render(<DietLoadErrorNotice />);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Diet preferences are unavailable/,
+    );
   });
 });

--- a/ui/tests/components/recipes/diet-provider.test.tsx
+++ b/ui/tests/components/recipes/diet-provider.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DietProvider } from "@/components/recipes/diet-provider";
+import { DietProvider, useDiet } from "@/components/recipes/diet-provider";
 
 const apiMocks = vi.hoisted(() => ({
   getDietOptions: vi.fn(),
@@ -48,5 +48,16 @@ describe("DietProvider", () => {
       /Diet preferences are unavailable/,
     );
     expect(screen.getByText("Recipe content")).toBeInTheDocument();
+  });
+
+  it("fails fast when the hook is used outside its provider", () => {
+    function UnwrappedConsumer() {
+      useDiet();
+      return null;
+    }
+
+    expect(() => render(<UnwrappedConsumer />)).toThrow(
+      "useDiet must be used within a DietProvider.",
+    );
   });
 });

--- a/ui/tests/components/recipes/diet-provider.test.tsx
+++ b/ui/tests/components/recipes/diet-provider.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DietProvider } from "@/components/recipes/diet-provider";
+
+const apiMocks = vi.hoisted(() => ({
+  getDietOptions: vi.fn(),
+  getDietProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/api/diet", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/diet")>()),
+  ...apiMocks,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { id: "qa-user" } },
+      isPending: false,
+    }),
+  },
+}));
+
+describe("DietProvider", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces diet loading failures instead of silently disabling filters", async () => {
+    apiMocks.getDietProfile.mockRejectedValue(new Error("offline"));
+    apiMocks.getDietOptions.mockResolvedValue({
+      presets: [],
+      groups: [],
+      ingredients: [],
+    });
+
+    render(
+      <DietProvider>
+        <p>Recipe content</p>
+      </DietProvider>,
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /Diet preferences are unavailable/,
+    );
+    expect(screen.getByText("Recipe content")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/kitchen/kitchen-view.test.tsx
+++ b/ui/tests/components/recipes/kitchen/kitchen-view.test.tsx
@@ -15,7 +15,20 @@ vi.mock("@/components/recipes/diet-provider", () => ({
       ingredientNames: new Map([["bacon", "Bacon"]]),
     },
     loading: false,
-    matchRecipe: () => ({ matches: true, excludedIngredients: [] }),
+    matchRecipe: (recipe: {
+      ingredients: { slug: string; name?: string }[];
+    }) => {
+      const excludedIngredients = recipe.ingredients
+        .filter((ingredient) => ingredient.slug === "bacon")
+        .map((ingredient) => ({
+          slug: ingredient.slug,
+          name: ingredient.name ?? "Bacon",
+        }));
+      return {
+        matches: excludedIngredients.length === 0,
+        excludedIngredients,
+      };
+    },
   }),
 }));
 
@@ -43,6 +56,21 @@ const ingredients = [
   { slug: "chickpeas", name: "Chickpeas", category: "legume" as const },
 ];
 
+const recipes = [
+  {
+    slug: "bacon-pasta",
+    title: "Bacon Pasta",
+    cuisine: [],
+    ingredients: [{ slug: "bacon", name: "Bacon" }],
+  },
+  {
+    slug: "chickpea-stew",
+    title: "Chickpea Stew",
+    cuisine: [],
+    ingredients: [{ slug: "chickpeas", name: "Chickpeas" }],
+  },
+];
+
 describe("KitchenView diet ingredient catalog", () => {
   beforeEach(() => {
     dietState.mode = "hide";
@@ -68,13 +96,37 @@ describe("KitchenView diet ingredient catalog", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides mismatched recipes until the user chooses to show them", async () => {
+    const user = userEvent.setup();
+    render(<KitchenView ingredients={ingredients} recipes={recipes} />);
+
+    expect(screen.queryByText("Bacon Pasta")).toBeNull();
+    expect(screen.getByText("Chickpea Stew")).toBeInTheDocument();
+
+    const [showHiddenRecipes] = screen.getAllByRole("button", {
+      name: /show anyway/i,
+    });
+    expect(showHiddenRecipes).toBeDefined();
+    if (!showHiddenRecipes) throw new Error("Missing recipe override button.");
+    await user.click(showHiddenRecipes);
+
+    expect(screen.getByText("Bacon Pasta")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Doesn't match your diet: Bacon/),
+    ).toBeInTheDocument();
+  });
+
   it("shows excluded ingredients with warnings in warn mode", () => {
     dietState.mode = "warn";
-    render(<KitchenView ingredients={ingredients} recipes={[]} />);
+    render(<KitchenView ingredients={ingredients} recipes={recipes} />);
 
     expect(
       screen.getByRole("button", { name: /add bacon — diet warning/i }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Show anyway" })).toBeNull();
+    expect(screen.getByText("Bacon Pasta")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Doesn't match your diet: Bacon/),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/kitchen/kitchen-view.test.tsx
+++ b/ui/tests/components/recipes/kitchen/kitchen-view.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { KitchenView } from "@/components/recipes/kitchen/kitchen-view";
+
+const dietState = vi.hoisted(() => ({ mode: "hide" as "hide" | "warn" }));
+
+vi.mock("@/components/recipes/diet-provider", () => ({
+  useDiet: () => ({
+    diet: {
+      active: true,
+      labels: ["Vegan"],
+      mode: dietState.mode,
+      excludedIngredientSlugs: new Set(["bacon"]),
+      ingredientNames: new Map([["bacon", "Bacon"]]),
+    },
+    loading: false,
+    matchRecipe: () => ({ matches: true, excludedIngredients: [] }),
+  }),
+}));
+
+vi.mock("@/hooks/use-kitchen-stock", () => ({
+  useKitchenStock: () => ({}),
+}));
+
+vi.mock("@/hooks/use-shopping-list", () => ({
+  useShoppingList: () => ({ recipes: [] }),
+}));
+
+vi.mock("@/lib/kitchen/kitchenStockStore", () => ({
+  clearStock: vi.fn(),
+  removeFromStock: vi.fn(),
+  replaceStock: vi.fn(),
+  setStockLocation: vi.fn(),
+}));
+
+vi.mock("@/lib/shopping/shoppingListStore", () => ({
+  toggleRecipe: vi.fn(),
+}));
+
+const ingredients = [
+  { slug: "bacon", name: "Bacon", category: "protein" as const },
+  { slug: "chickpeas", name: "Chickpeas", category: "legume" as const },
+];
+
+describe("KitchenView diet ingredient catalog", () => {
+  beforeEach(() => {
+    dietState.mode = "hide";
+  });
+
+  it("hides excluded ingredients and supports a temporary override", async () => {
+    const user = userEvent.setup();
+    render(<KitchenView ingredients={ingredients} recipes={[]} />);
+
+    expect(screen.queryByRole("button", { name: /add bacon/i })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /add chickpeas/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show anyway" }));
+
+    expect(
+      screen.getByRole("button", { name: /add bacon — diet warning/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Diet warning")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide diet exclusions" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows excluded ingredients with warnings in warn mode", () => {
+    dietState.mode = "warn";
+    render(<KitchenView ingredients={ingredients} recipes={[]} />);
+
+    expect(
+      screen.getByRole("button", { name: /add bacon — diet warning/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show anyway" })).toBeNull();
+  });
+});

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -5,6 +5,9 @@ import { RecipeList } from "@/components/recipes/recipe-list";
 import type { RecipeCardView } from "@/lib/api/recipes";
 
 const replaceMock = vi.fn();
+const dietTestState = vi.hoisted(() => ({
+  mode: "none" as "none" | "hide" | "warn",
+}));
 
 let currentSearchParams = new URLSearchParams();
 
@@ -26,6 +29,28 @@ vi.mock("@/lib/integrations/cloudflare-images", () => ({
   getImageUrl: (image: string) => image,
 }));
 
+vi.mock("@/components/recipes/diet-provider", () => ({
+  useDiet: () => ({
+    diet: {
+      active: dietTestState.mode !== "none",
+      labels: ["Vegetarian"],
+      mode: dietTestState.mode === "warn" ? "warn" : "hide",
+    },
+    matchRecipe: (recipe: { ingredients: { slug: string }[] }) => {
+      const excludedIngredients = recipe.ingredients
+        .filter((ingredient) => ingredient.slug === "chicken-breast")
+        .map((ingredient) => ({
+          slug: ingredient.slug,
+          name: "Chicken breast",
+        }));
+      return {
+        matches: excludedIngredients.length === 0,
+        excludedIngredients,
+      };
+    },
+  }),
+}));
+
 const recipes: RecipeCardView[] = [
   {
     slug: "slow-cooker-mexican-chicken",
@@ -39,6 +64,7 @@ const recipes: RecipeCardView[] = [
     cookTime: 240,
     totalTime: 255,
     ingredientNames: ["chicken breast", "white onion"],
+    ingredientSlugs: ["chicken-breast", "white-onion"],
     cookware: ["fork", "oven", "slow cooker"],
   },
   {
@@ -53,6 +79,7 @@ const recipes: RecipeCardView[] = [
     cookTime: 30,
     totalTime: 50,
     ingredientNames: ["chicken breast", "cheddar cheese"],
+    ingredientSlugs: ["chicken-breast", "cheddar-cheese"],
     cookware: ["baking tray", "bowl", "fork", "frying pan", "oven", "spoon"],
   },
   {
@@ -67,6 +94,7 @@ const recipes: RecipeCardView[] = [
     cookTime: 30,
     totalTime: 40,
     ingredientNames: ["arborio rice", "pesto"],
+    ingredientSlugs: ["arborio-rice", "pesto"],
     cookware: ["bowl", "saucepan"],
   },
 ];
@@ -75,6 +103,33 @@ describe("RecipeList", () => {
   beforeEach(() => {
     currentSearchParams = new URLSearchParams();
     replaceMock.mockReset();
+    dietTestState.mode = "none";
+  });
+
+  it("hides diet mismatches and lets the user temporarily show them", async () => {
+    dietTestState.mode = "hide";
+    const user = userEvent.setup();
+
+    render(<RecipeList recipes={recipes} />);
+
+    expect(screen.queryByText("Chicken Quesadillas")).not.toBeInTheDocument();
+    expect(screen.getByText("Creamy Pesto Risotto")).toBeInTheDocument();
+    expect(screen.getByText(/2 recipes hidden/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /show anyway/i }));
+
+    expect(screen.getByText("Chicken Quesadillas")).toBeInTheDocument();
+    expect(screen.getAllByText(/doesn't match your diet/i)).toHaveLength(2);
+  });
+
+  it("keeps diet mismatches visible with warnings in warn mode", () => {
+    dietTestState.mode = "warn";
+
+    render(<RecipeList recipes={recipes} />);
+
+    expect(screen.getByText("Chicken Quesadillas")).toBeInTheDocument();
+    expect(screen.getAllByText(/doesn't match your diet/i)).toHaveLength(2);
+    expect(screen.getByText(/marked with a warning/i)).toBeInTheDocument();
   });
 
   it("shows an equipment filter with cookware options", async () => {

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RecipeList } from "@/components/recipes/recipe-list";
@@ -109,17 +115,29 @@ describe("RecipeList", () => {
   it("hides diet mismatches and lets the user temporarily show them", async () => {
     dietTestState.mode = "hide";
     const user = userEvent.setup();
+    const onDietVisibleCountChange = vi.fn();
 
-    render(<RecipeList recipes={recipes} />);
+    render(
+      <RecipeList
+        recipes={recipes}
+        onDietVisibleCountChange={onDietVisibleCountChange}
+      />,
+    );
 
     expect(screen.queryByText("Chicken Quesadillas")).not.toBeInTheDocument();
     expect(screen.getByText("Creamy Pesto Risotto")).toBeInTheDocument();
     expect(screen.getByText(/2 recipes hidden/i)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(onDietVisibleCountChange).toHaveBeenCalledWith(1),
+    );
 
     await user.click(screen.getByRole("button", { name: /show anyway/i }));
 
     expect(screen.getByText("Chicken Quesadillas")).toBeInTheDocument();
     expect(screen.getAllByText(/doesn't match your diet/i)).toHaveLength(2);
+    await waitFor(() =>
+      expect(onDietVisibleCountChange).toHaveBeenCalledWith(3),
+    );
   });
 
   it("keeps diet mismatches visible with warnings in warn mode", () => {

--- a/ui/tests/components/recipes/recipe-pagination.test.tsx
+++ b/ui/tests/components/recipes/recipe-pagination.test.tsx
@@ -13,6 +13,7 @@ function makeRecipe(slug: string, title: string): RecipeCardView {
     tags: [],
     servings: 4,
     ingredientNames: [],
+    ingredientSlugs: [],
     cookware: [],
   };
 }

--- a/ui/tests/components/recipes/settings/diet-panel.test.tsx
+++ b/ui/tests/components/recipes/settings/diet-panel.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DietPanel } from "@/components/recipes/settings/diet-panel";
 
 const apiMocks = vi.hoisted(() => ({
@@ -45,8 +45,13 @@ describe("DietPanel", () => {
           ingredientSlugs: ["chilli"],
         },
       ],
-      ingredients: [],
+      ingredients: [{ slug: "bacon", name: "Bacon", category: "protein" }],
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("checks groups covered by a selected preset without adding custom state", async () => {
@@ -60,5 +65,20 @@ describe("DietPanel", () => {
     expect(meat).toHaveTextContent("covered by preset");
     expect(chilli).toHaveAttribute("aria-pressed", "false");
     expect(chilli).not.toBeDisabled();
+  });
+
+  it("clears the delayed picker close when unmounted", async () => {
+    const { unmount } = render(<DietPanel />);
+    const input = await screen.findByLabelText(
+      "Search canonical ingredients to exclude",
+    );
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalledOnce();
   });
 });

--- a/ui/tests/components/recipes/settings/diet-panel.test.tsx
+++ b/ui/tests/components/recipes/settings/diet-panel.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DietPanel } from "@/components/recipes/settings/diet-panel";
+
+const apiMocks = vi.hoisted(() => ({
+  getDietOptions: vi.fn(),
+  getDietProfile: vi.fn(),
+  saveDietProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/api/diet", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/diet")>()),
+  ...apiMocks,
+}));
+
+describe("DietPanel", () => {
+  beforeEach(() => {
+    apiMocks.getDietProfile.mockResolvedValue({
+      presetDietKeys: ["vegan"],
+      excludedIngredientSlugs: [],
+      excludedGroupKeys: [],
+      recipeMatchMode: "hide",
+    });
+    apiMocks.getDietOptions.mockResolvedValue({
+      presets: [
+        {
+          key: "vegan",
+          label: "Vegan",
+          sub: "No animal products",
+          excludedGroupKeys: ["meat", "dairy"],
+          excludedIngredientSlugs: [],
+        },
+      ],
+      groups: [
+        {
+          key: "meat",
+          label: "Meat",
+          sub: "Meat ingredients",
+          ingredientSlugs: ["bacon"],
+        },
+        {
+          key: "chilli",
+          label: "Chilli",
+          sub: "Chilli ingredients",
+          ingredientSlugs: ["chilli"],
+        },
+      ],
+      ingredients: [],
+    });
+  });
+
+  it("checks groups covered by a selected preset without adding custom state", async () => {
+    render(<DietPanel />);
+
+    const meat = await screen.findByRole("button", { name: /Meat/ });
+    const chilli = screen.getByRole("button", { name: /Chilli/ });
+
+    expect(meat).toHaveAttribute("aria-pressed", "true");
+    expect(meat).toBeDisabled();
+    expect(meat).toHaveTextContent("covered by preset");
+    expect(chilli).toHaveAttribute("aria-pressed", "false");
+    expect(chilli).not.toBeDisabled();
+  });
+});

--- a/ui/tests/functions/profile-diet-proxy.test.ts
+++ b/ui/tests/functions/profile-diet-proxy.test.ts
@@ -20,6 +20,7 @@ describe("profile diet proxy", () => {
         method: "PUT",
         headers: {
           authorization: "Bearer test-token",
+          "cf-access-jwt-assertion": "access-token",
           "content-type": "application/json",
           host: "robbiepalmer.me",
         },
@@ -42,6 +43,9 @@ describe("profile diet proxy", () => {
     expect(forwarded.method).toBe("PUT");
     expect(forwarded.headers.has("host")).toBe(false);
     expect(forwarded.headers.get("authorization")).toBe("Bearer test-token");
+    expect(forwarded.headers.get("cf-access-jwt-assertion")).toBe(
+      "access-token",
+    );
     expect(await forwarded.text()).toBe(
       JSON.stringify({ recipeMatchMode: "warn" }),
     );

--- a/ui/tests/lib/domain/diet.test.ts
+++ b/ui/tests/lib/domain/diet.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { DietOptions, DietProfile } from "@/lib/api/diet";
+import { buildEffectiveDiet, matchRecipeToDiet } from "@/lib/domain/diet";
+
+const options: DietOptions = {
+  presets: [
+    {
+      key: "vegetarian",
+      label: "Vegetarian",
+      sub: "No meat or fish",
+      excludedGroupKeys: ["meat"],
+      excludedIngredientSlugs: [],
+    },
+  ],
+  groups: [
+    {
+      key: "meat",
+      label: "Meat",
+      sub: "Meat ingredients",
+      ingredientSlugs: ["chicken-breast", "beef-mince"],
+    },
+  ],
+  ingredients: [
+    { slug: "chicken-breast", name: "Chicken breast" },
+    { slug: "egg", name: "Egg" },
+  ],
+};
+
+function profile(overrides: Partial<DietProfile> = {}): DietProfile {
+  return {
+    presetDietKeys: [],
+    excludedIngredientSlugs: [],
+    excludedGroupKeys: [],
+    recipeMatchMode: "hide",
+    ...overrides,
+  };
+}
+
+describe("diet recipe matching", () => {
+  it("expands preset groups into canonical ingredient exclusions", () => {
+    const diet = buildEffectiveDiet(
+      profile({ presetDietKeys: ["vegetarian"] }),
+      options,
+    );
+
+    expect(diet.excludedIngredientSlugs).toEqual(
+      new Set(["chicken-breast", "beef-mince"]),
+    );
+    expect(
+      matchRecipeToDiet({ ingredients: [{ slug: "chicken-breast" }] }, diet),
+    ).toEqual({
+      matches: false,
+      excludedIngredients: [{ slug: "chicken-breast", name: "Chicken breast" }],
+    });
+  });
+
+  it("combines custom groups and ingredients without duplicate labels", () => {
+    const diet = buildEffectiveDiet(
+      profile({
+        excludedGroupKeys: ["meat"],
+        excludedIngredientSlugs: ["egg"],
+        recipeMatchMode: "warn",
+      }),
+      options,
+    );
+
+    expect(diet.mode).toBe("warn");
+    expect(diet.labels).toEqual(["no Meat", "no Egg"]);
+    expect(
+      matchRecipeToDiet(
+        {
+          ingredients: [
+            { slug: "egg", name: "Eggs" },
+            { slug: "tomato", name: "Tomato" },
+          ],
+        },
+        diet,
+      ).excludedIngredients,
+    ).toEqual([{ slug: "egg", name: "Eggs" }]);
+  });
+});

--- a/ui/tests/lib/domain/diet.test.ts
+++ b/ui/tests/lib/domain/diet.test.ts
@@ -123,4 +123,17 @@ describe("diet recipe matching", () => {
       ).matches,
     ).toBe(true);
   });
+
+  it("does not repeat custom exclusions already covered by a preset", () => {
+    const diet = buildEffectiveDiet(
+      profile({
+        presetDietKeys: ["vegan"],
+        excludedGroupKeys: ["meat", "dairy"],
+        excludedIngredientSlugs: ["chicken-breast", "honey", "egg"],
+      }),
+      options,
+    );
+
+    expect(diet.labels).toEqual(["Vegan", "no Egg"]);
+  });
 });

--- a/ui/tests/lib/domain/diet.test.ts
+++ b/ui/tests/lib/domain/diet.test.ts
@@ -11,6 +11,13 @@ const options: DietOptions = {
       excludedGroupKeys: ["meat"],
       excludedIngredientSlugs: [],
     },
+    {
+      key: "vegan",
+      label: "Vegan",
+      sub: "No animal products",
+      excludedGroupKeys: ["meat", "dairy", "egg"],
+      excludedIngredientSlugs: ["honey"],
+    },
   ],
   groups: [
     {
@@ -19,10 +26,25 @@ const options: DietOptions = {
       sub: "Meat ingredients",
       ingredientSlugs: ["chicken-breast", "beef-mince"],
     },
+    {
+      key: "dairy",
+      label: "Dairy",
+      sub: "Dairy ingredients",
+      ingredientSlugs: ["cheddar-cheese"],
+    },
+    {
+      key: "egg",
+      label: "Egg",
+      sub: "Egg ingredients",
+      ingredientSlugs: ["eggs"],
+    },
   ],
   ingredients: [
     { slug: "chicken-breast", name: "Chicken breast" },
     { slug: "egg", name: "Egg" },
+    { slug: "cheddar-cheese", name: "Cheddar cheese" },
+    { slug: "eggs", name: "Eggs" },
+    { slug: "honey", name: "Honey" },
   ],
 };
 
@@ -77,5 +99,28 @@ describe("diet recipe matching", () => {
         diet,
       ).excludedIngredients,
     ).toEqual([{ slug: "egg", name: "Eggs" }]);
+  });
+
+  it("filters representative recipes for a vegan profile", () => {
+    const diet = buildEffectiveDiet(
+      profile({ presetDietKeys: ["vegan"] }),
+      options,
+    );
+
+    expect(diet.active).toBe(true);
+    expect(
+      matchRecipeToDiet(
+        {
+          ingredients: [{ slug: "chicken-breast" }, { slug: "cheddar-cheese" }],
+        },
+        diet,
+      ).matches,
+    ).toBe(false);
+    expect(
+      matchRecipeToDiet(
+        { ingredients: [{ slug: "chickpeas" }, { slug: "tomato" }] },
+        diet,
+      ).matches,
+    ).toBe(true);
   });
 });

--- a/ui/tests/lib/domain/diet.test.ts
+++ b/ui/tests/lib/domain/diet.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { DietOptions, DietProfile } from "@/lib/api/diet";
-import { buildEffectiveDiet, matchRecipeToDiet } from "@/lib/domain/diet";
+import {
+  applyDietRecipeVisibility,
+  buildEffectiveDiet,
+  matchRecipeToDiet,
+} from "@/lib/domain/diet";
 
 const options: DietOptions = {
   presets: [
@@ -135,5 +139,35 @@ describe("diet recipe matching", () => {
     );
 
     expect(diet.labels).toEqual(["Vegan", "no Egg"]);
+  });
+});
+
+describe("diet recipe visibility", () => {
+  const recipes = [{ slug: "vegan" }, { slug: "bacon" }, { slug: "milk" }];
+  const matches = new Map([
+    ["vegan", { matches: true, excludedIngredients: [] }],
+    ["bacon", { matches: false, excludedIngredients: [] }],
+    ["milk", { matches: false, excludedIngredients: [] }],
+  ]);
+  const hideDiet = { active: true, mode: "hide" as const };
+
+  it("counts only recipes that are actually hidden", () => {
+    expect(
+      applyDietRecipeVisibility(recipes, matches, hideDiet, {
+        showHidden: false,
+        alwaysVisibleSlugs: new Set(["bacon"]),
+      }),
+    ).toEqual({
+      visibleRecipes: [recipes[0], recipes[1]],
+      hiddenCount: 1,
+    });
+  });
+
+  it("preserves the baseline hidden count while temporarily showing recipes", () => {
+    expect(
+      applyDietRecipeVisibility(recipes, matches, hideDiet, {
+        showHidden: true,
+      }),
+    ).toEqual({ visibleRecipes: recipes, hiddenCount: 2 });
   });
 });

--- a/ui/tests/lib/domain/recipe/kitchen.test.ts
+++ b/ui/tests/lib/domain/recipe/kitchen.test.ts
@@ -74,5 +74,13 @@ describe("kitchen helpers", () => {
         new Set(["bacon", "cheddar-cheese"]),
       ),
     ).toEqual([ingredients[2]]);
+
+    expect(
+      getDietRelevantKitchenIngredients(
+        ingredients,
+        new Set(["bacon", "cheddar-cheese"]),
+        true,
+      ),
+    ).toEqual(ingredients);
   });
 });

--- a/ui/tests/lib/domain/recipe/kitchen.test.ts
+++ b/ui/tests/lib/domain/recipe/kitchen.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getDietRelevantKitchenIngredients,
   getKitchenRecipeMatches,
   isKitchenLocation,
   KITCHEN_LOCATIONS,
@@ -54,5 +55,24 @@ describe("kitchen helpers", () => {
     expect(matches[1]?.missingIngredients).toEqual([
       { slug: "tomatoes", name: "tomatoes" },
     ]);
+  });
+
+  it("removes diet-excluded ingredients from pantry suggestions", () => {
+    const ingredients = [
+      { slug: "bacon", name: "Bacon", category: "protein" as const },
+      {
+        slug: "cheddar-cheese",
+        name: "Cheddar cheese",
+        category: "dairy" as const,
+      },
+      { slug: "chickpeas", name: "Chickpeas", category: "legume" as const },
+    ];
+
+    expect(
+      getDietRelevantKitchenIngredients(
+        ingredients,
+        new Set(["bacon", "cheddar-cheese"]),
+      ),
+    ).toEqual([ingredients[2]]);
   });
 });

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -24,6 +24,7 @@
     "hono": "^4.7.11",
     "jose": "^6.1.3",
     "postgres": "^3.4.5",
+    "recipe-domain": "workspace:*",
     "zod": "^4.2.1"
   },
   "devDependencies": {

--- a/workers/recipe-api/scripts/diet-catalog.ts
+++ b/workers/recipe-api/scripts/diet-catalog.ts
@@ -1,0 +1,169 @@
+import { resolveIngredientSlug } from "recipe-domain";
+import { ingredients } from "../../../ui/content/recipes/ingredients";
+
+export type DietGroupKey =
+  | "alcohol"
+  | "chilli"
+  | "dairy"
+  | "egg"
+  | "fish"
+  | "garlic"
+  | "gluten"
+  | "legumes"
+  | "meat"
+  | "nuts"
+  | "onion"
+  | "peanut"
+  | "poultry"
+  | "shellfish"
+  | "soy"
+  | "wheat";
+
+const EXPLICIT_GROUP_MEMBERS: Partial<
+  Record<DietGroupKey, readonly string[]>
+> = {
+  alcohol: ["white wine"],
+  chilli: [
+    "hot chilli powder",
+    "cayenne pepper",
+    "chilli",
+    "chilli flakes",
+    "red chilli powder",
+    "chilli powder",
+    "chili powder",
+    "sweet chilli sauce",
+    "chilli mayo",
+    "sriracha",
+    "red curry paste",
+  ],
+  egg: ["eggs", "mayonnaise", "chilli mayo"],
+  fish: [],
+  garlic: [
+    "garlic",
+    "garlic puree",
+    "garlic granules",
+    "garlic powder",
+    "garlic bread",
+  ],
+  gluten: [
+    "macaroni",
+    "penne pasta",
+    "large pasta shells",
+    "pasta",
+    "tortilla wrap",
+    "farfalle",
+    "plain flour",
+    "bread flour",
+    "semolina",
+    "bread",
+    "noodles",
+    "bap",
+    "garlic bread",
+    "self-raising flour",
+    "flour",
+    "naan",
+    "baps",
+    "orzo",
+    "pita",
+    "spaghetti",
+  ],
+  meat: ["chorizo", "bacon", "pork sausage"],
+  nuts: ["cashew nuts", "cashews", "ground almonds", "almond milk"],
+  onion: [
+    "white onion",
+    "red onion",
+    "onion",
+    "spring onion",
+    "shallots",
+    "onion salt",
+    "onion powder",
+  ],
+  peanut: ["peanut butter", "crunchy peanut butter"],
+  poultry: [
+    "chicken breast",
+    "turkey mince",
+    "chicken thigh",
+    "chicken stock",
+    "chicken stock pot",
+  ],
+  shellfish: ["prawn crackers"],
+  soy: ["soy sauce", "dark soy sauce", "light soy sauce"],
+  wheat: [
+    "macaroni",
+    "penne pasta",
+    "large pasta shells",
+    "pasta",
+    "tortilla wrap",
+    "farfalle",
+    "plain flour",
+    "bread flour",
+    "semolina",
+    "bread",
+    "noodles",
+    "bap",
+    "garlic bread",
+    "self-raising flour",
+    "flour",
+    "naan",
+    "baps",
+    "orzo",
+    "pita",
+    "spaghetti",
+  ],
+};
+
+export const dietCatalogIngredients = ingredients.map((ingredient) => ({
+  slug: resolveIngredientSlug(ingredient),
+  name: ingredient.name,
+  category: ingredient.category,
+}));
+
+const ingredientByName = new Map<
+  string,
+  (typeof dietCatalogIngredients)[number]
+>(
+  dietCatalogIngredients.map((ingredient) => [ingredient.name, ingredient]),
+);
+
+function slugsForNames(group: DietGroupKey, names: readonly string[]) {
+  return names.map((name) => {
+    const ingredient = ingredientByName.get(name);
+    if (!ingredient) {
+      throw new Error(`Unknown ${group} diet-group ingredient: ${name}`);
+    }
+    return ingredient.slug;
+  });
+}
+
+const categoryGroups: Partial<
+  Record<DietGroupKey, (typeof dietCatalogIngredients)[number]["category"]>
+> = {
+  dairy: "dairy",
+  legumes: "legume",
+};
+
+export const dietGroupMembers = (
+  Object.keys({
+    ...EXPLICIT_GROUP_MEMBERS,
+    ...categoryGroups,
+  }) as DietGroupKey[]
+).flatMap((groupKey) => {
+  const explicitSlugs = slugsForNames(
+    groupKey,
+    EXPLICIT_GROUP_MEMBERS[groupKey] ?? [],
+  );
+  const category = categoryGroups[groupKey];
+  const categorySlugs = category
+    ? dietCatalogIngredients
+        .filter((ingredient) => ingredient.category === category)
+        .map((ingredient) => ingredient.slug)
+    : [];
+
+  return Array.from(new Set([...explicitSlugs, ...categorySlugs])).map(
+    (ingredientSlug) => ({ groupKey, ingredientSlug }),
+  );
+});
+
+export const dietPresetIngredientExclusions = [
+  { presetKey: "vegan", ingredientSlug: resolveIngredientSlug({ name: "honey" }) },
+] as const;

--- a/workers/recipe-api/scripts/diet-catalog.ts
+++ b/workers/recipe-api/scripts/diet-catalog.ts
@@ -19,6 +19,29 @@ export type DietGroupKey =
   | "soy"
   | "wheat";
 
+const WHEAT_AND_GLUTEN_INGREDIENTS = [
+  "macaroni",
+  "penne pasta",
+  "large pasta shells",
+  "pasta",
+  "tortilla wrap",
+  "farfalle",
+  "plain flour",
+  "bread flour",
+  "semolina",
+  "bread",
+  "noodles",
+  "bap",
+  "garlic bread",
+  "self-raising flour",
+  "flour",
+  "naan",
+  "baps",
+  "orzo",
+  "pita",
+  "spaghetti",
+] as const;
+
 const EXPLICIT_GROUP_MEMBERS: Partial<
   Record<DietGroupKey, readonly string[]>
 > = {
@@ -45,28 +68,7 @@ const EXPLICIT_GROUP_MEMBERS: Partial<
     "garlic powder",
     "garlic bread",
   ],
-  gluten: [
-    "macaroni",
-    "penne pasta",
-    "large pasta shells",
-    "pasta",
-    "tortilla wrap",
-    "farfalle",
-    "plain flour",
-    "bread flour",
-    "semolina",
-    "bread",
-    "noodles",
-    "bap",
-    "garlic bread",
-    "self-raising flour",
-    "flour",
-    "naan",
-    "baps",
-    "orzo",
-    "pita",
-    "spaghetti",
-  ],
+  gluten: WHEAT_AND_GLUTEN_INGREDIENTS,
   meat: ["chorizo", "bacon", "pork sausage"],
   nuts: ["cashew nuts", "cashews", "ground almonds", "almond milk"],
   onion: [
@@ -88,28 +90,7 @@ const EXPLICIT_GROUP_MEMBERS: Partial<
   ],
   shellfish: ["prawn crackers"],
   soy: ["soy sauce", "dark soy sauce", "light soy sauce"],
-  wheat: [
-    "macaroni",
-    "penne pasta",
-    "large pasta shells",
-    "pasta",
-    "tortilla wrap",
-    "farfalle",
-    "plain flour",
-    "bread flour",
-    "semolina",
-    "bread",
-    "noodles",
-    "bap",
-    "garlic bread",
-    "self-raising flour",
-    "flour",
-    "naan",
-    "baps",
-    "orzo",
-    "pita",
-    "spaghetti",
-  ],
+  wheat: WHEAT_AND_GLUTEN_INGREDIENTS,
 };
 
 export const dietCatalogIngredients = ingredients.map((ingredient) => ({
@@ -125,13 +106,17 @@ const ingredientByName = new Map<
   dietCatalogIngredients.map((ingredient) => [ingredient.name, ingredient]),
 );
 
-function slugsForNames(group: DietGroupKey, names: readonly string[]) {
+function slugForName(context: string, name: string) {
+  const ingredient = ingredientByName.get(name);
+  if (!ingredient) {
+    throw new Error(`Unknown ${context} ingredient: ${name}`);
+  }
+  return ingredient.slug;
+}
+
+function slugsForNames(context: string, names: readonly string[]) {
   return names.map((name) => {
-    const ingredient = ingredientByName.get(name);
-    if (!ingredient) {
-      throw new Error(`Unknown ${group} diet-group ingredient: ${name}`);
-    }
-    return ingredient.slug;
+    return slugForName(context, name);
   });
 }
 
@@ -149,7 +134,7 @@ export const dietGroupMembers = (
   }) as DietGroupKey[]
 ).flatMap((groupKey) => {
   const explicitSlugs = slugsForNames(
-    groupKey,
+    `diet group "${groupKey}"`,
     EXPLICIT_GROUP_MEMBERS[groupKey] ?? [],
   );
   const category = categoryGroups[groupKey];
@@ -165,5 +150,8 @@ export const dietGroupMembers = (
 });
 
 export const dietPresetIngredientExclusions = [
-  { presetKey: "vegan", ingredientSlug: resolveIngredientSlug({ name: "honey" }) },
+  {
+    presetKey: "vegan",
+    ingredientSlug: slugForName('diet preset "vegan"', "honey"),
+  },
 ] as const;

--- a/workers/recipe-api/scripts/seed-diet-catalog.ts
+++ b/workers/recipe-api/scripts/seed-diet-catalog.ts
@@ -43,6 +43,7 @@ try {
       `;
     }
 
+    await sql`delete from "diet_preset_excluded_ingredient"`;
     for (const exclusion of dietPresetIngredientExclusions) {
       await sql`
         insert into "diet_preset_excluded_ingredient" ("preset_key", "ingredient_slug")

--- a/workers/recipe-api/scripts/seed-diet-catalog.ts
+++ b/workers/recipe-api/scripts/seed-diet-catalog.ts
@@ -2,6 +2,11 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createDb } from "../src/db";
+import {
+  dietCatalogIngredients,
+  dietGroupMembers,
+  dietPresetIngredientExclusions,
+} from "./diet-catalog";
 
 function requiredEnv(name: string): string {
   const value = process.env[name];
@@ -18,6 +23,34 @@ const statement = await readFile(seedPath, "utf8");
 
 try {
   await client.unsafe(statement);
+  await client.begin(async (sql) => {
+    for (const ingredient of dietCatalogIngredients) {
+      await sql`
+        insert into "ingredient" ("slug", "name", "category")
+        values (${ingredient.slug}, ${ingredient.name}, ${ingredient.category ?? null})
+        on conflict ("slug") do update set
+          "name" = excluded."name",
+          "category" = excluded."category",
+          "updated_at" = now()
+      `;
+    }
+
+    await sql`delete from "ingredient_group_member"`;
+    for (const member of dietGroupMembers) {
+      await sql`
+        insert into "ingredient_group_member" ("group_key", "ingredient_slug")
+        values (${member.groupKey}, ${member.ingredientSlug})
+      `;
+    }
+
+    for (const exclusion of dietPresetIngredientExclusions) {
+      await sql`
+        insert into "diet_preset_excluded_ingredient" ("preset_key", "ingredient_slug")
+        values (${exclusion.presetKey}, ${exclusion.ingredientSlug})
+        on conflict ("preset_key", "ingredient_slug") do nothing
+      `;
+    }
+  });
   console.log("Seeded diet catalog.");
 } finally {
   await client.end({ timeout: 5 });

--- a/workers/recipe-api/tests/diet-catalog.test.ts
+++ b/workers/recipe-api/tests/diet-catalog.test.ts
@@ -36,4 +36,8 @@ describe("diet catalog seed", () => {
     expect(members("garlic")).toContain("garlic-powder");
     expect(members("peanut")).toContain("crunchy-peanut-butter");
   });
+
+  it("keeps wheat and gluten exclusions aligned", () => {
+    expect(members("wheat")).toEqual(members("gluten"));
+  });
 });

--- a/workers/recipe-api/tests/diet-catalog.test.ts
+++ b/workers/recipe-api/tests/diet-catalog.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  dietCatalogIngredients,
+  dietGroupMembers,
+  dietPresetIngredientExclusions,
+} from "../scripts/diet-catalog";
+
+function members(groupKey: string) {
+  return new Set(
+    dietGroupMembers
+      .filter((member) => member.groupKey === groupKey)
+      .map((member) => member.ingredientSlug),
+  );
+}
+
+describe("diet catalog seed", () => {
+  it("seeds each canonical static ingredient exactly once", () => {
+    const slugs = dietCatalogIngredients.map((ingredient) => ingredient.slug);
+    expect(slugs.length).toBeGreaterThan(100);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("expands vegan groups to canonical animal-product ingredients", () => {
+    expect(members("poultry")).toContain("chicken-breast");
+    expect(members("dairy")).toContain("cheddar-cheese");
+    expect(members("egg")).toContain("eggs");
+    expect(members("dairy")).not.toContain("coconut-milk");
+    expect(dietPresetIngredientExclusions).toContainEqual({
+      presetKey: "vegan",
+      ingredientSlug: "honey",
+    });
+  });
+
+  it("seeds the custom trigger groups used by diet settings", () => {
+    expect(members("onion")).toContain("shallots");
+    expect(members("garlic")).toContain("garlic-powder");
+    expect(members("peanut")).toContain("crunchy-peanut-butter");
+  });
+});


### PR DESCRIPTION
## What changed

- add a shared diet provider and canonical ingredient matching layer
- hide or warn on recipes that conflict with saved diet preferences
- apply diet behavior to the recipe box, recipe details, kitchen suggestions, recipe picker, and meal planner
- preserve already-selected shopping-plan recipes so they remain editable
- refresh the active diet immediately after settings are saved
- add focused matching and recipe-list coverage

## Why

Diet preferences could be configured under profile settings, but the rest of the recipe experience did not consume them. This made the hide/warn setting ineffective outside the settings screen.

## Impact

Signed-in users now get consistent, profile-wide diet handling. Hide mode filters conflicting recipes with a temporary “show anyway” override, while warn mode leaves recipes visible with the conflicting ingredients identified.

## Validation

- `mise exec -- ./node_modules/.bin/tsc --noEmit`
- `mise exec -- ./node_modules/.bin/biome check`
- 434 non-integration UI tests passed
- focused diet and recipe-list tests passed
- Wrangler-backed Markdown negotiation integration tests passed
- production build passed with `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added diet preferences across recipe browsing, recipe details, kitchen inventory, shopping lists and meal planning.
  * Recipes can now be hidden or flagged when they conflict with dietary preferences, with new warnings and controls to reveal hidden items.
  * Recipe browsing now shows visible recipe counts and updated catalogue statistics.
* **Bug Fixes**
  * Ensured diet/auth proxy requests forward the `cf-access-jwt-assertion` header when present.
* **Tests**
  * Expanded coverage for diet matching, filtering, warnings, settings and catalogue behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->