### PR TITLE
Expand Trivy IaC coverage to the full workspace

### DIFF
--- a/.github/workflows/trivy-security.yml
+++ b/.github/workflows/trivy-security.yml
@@ -3,14 +3,12 @@ name: Trivy Security Scan
 on:
   pull_request:
     paths:
-      # Terraform roots (and any future *.tf / *.tfvars anywhere)
+      # IaC / config-shaped paths (keep broad enough that new roots are not
+      # silently skipped on PRs; weekly schedule is the full-tree backstop)
       - "infra/**"
       - "infra-bootstrap/**"
       - "**/*.tf"
       - "**/*.tfvars"
-      # Other config types Trivy config mode understands — keep path filters
-      # ahead of first use so new Docker/Helm/K8s configs are not silently
-      # skipped on PRs (scheduled scan still covers the full tree weekly)
       - "**/Dockerfile"
       - "**/Dockerfile.*"
       - "**/docker-compose*.yml"
@@ -48,10 +46,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # Scan the whole workspace so every Terraform root (infra/, infra-bootstrap/,
-      # and any future roots) and other supported config types are covered. Do not
-      # pin scan-ref to a single directory — that omission previously left
-      # infra-bootstrap unscanned.
+      # Whole workspace: never pin to a single Terraform root.
       - name: Run Trivy IaC scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -61,8 +56,6 @@ jobs:
           output: "trivy-iac-results.sarif"
           severity: "CRITICAL,HIGH"
           timeout: "10m"
-          # Avoid noise from dependency trees if present on the runner; config
-          # mode only needs IaC-like files, not installed packages.
           skip-dirs: "node_modules,.pnpm-store,.terraform"
 
       - name: Upload Trivy results to GitHub Security

--- a/.github/workflows/trivy-security.yml
+++ b/.github/workflows/trivy-security.yml
@@ -3,7 +3,27 @@ name: Trivy Security Scan
 on:
   pull_request:
     paths:
+      # Terraform roots (and any future *.tf / *.tfvars anywhere)
       - "infra/**"
+      - "infra-bootstrap/**"
+      - "**/*.tf"
+      - "**/*.tfvars"
+      # Other config types Trivy config mode understands — keep path filters
+      # ahead of first use so new Docker/Helm/K8s configs are not silently
+      # skipped on PRs (scheduled scan still covers the full tree weekly)
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+      - "**/docker-compose*.yml"
+      - "**/docker-compose*.yaml"
+      - "**/compose.yml"
+      - "**/compose.yaml"
+      - "**/Chart.yaml"
+      - "**/values.yml"
+      - "**/values.yaml"
+      - "**/kubernetes/**"
+      - "**/k8s/**"
+      - "**/helm/**"
+      # Dependencies
       - "**/pnpm-lock.yaml"
       - "**/package.json"
       - ".github/workflows/trivy-security.yml"
@@ -28,15 +48,22 @@ jobs:
         with:
           persist-credentials: false
 
+      # Scan the whole workspace so every Terraform root (infra/, infra-bootstrap/,
+      # and any future roots) and other supported config types are covered. Do not
+      # pin scan-ref to a single directory — that omission previously left
+      # infra-bootstrap unscanned.
       - name: Run Trivy IaC scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: "config"
-          scan-ref: "./infra"
+          scan-ref: "."
           format: "sarif"
           output: "trivy-iac-results.sarif"
           severity: "CRITICAL,HIGH"
           timeout: "10m"
+          # Avoid noise from dependency trees if present on the runner; config
+          # mode only needs IaC-like files, not installed packages.
+          skip-dirs: "node_modules,.pnpm-store,.terraform"
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/ui/content/projects/personal-site/adrs/047-trivy.mdx
+++ b/ui/content/projects/personal-site/adrs/047-trivy.mdx
@@ -28,8 +28,8 @@ Use **Trivy** for security scanning, covering IaC (Terraform) and dependency vul
 
 Trivy runs two scan jobs in CI via GitHub Actions:
 
-1. **IaC scan** (`config` mode): Scans the whole workspace for misconfigurations in supported config types (Terraform, Dockerfiles, Helm, Kubernetes manifests, etc.). That includes every Terraform root today (`infra/`, `infra-bootstrap/`) and any future roots without needing a new path pin. Triggered on changes to Terraform roots, `*.tf` / `*.tfvars`, Docker/Helm/K8s-related paths, and the workflow file itself.
-2. **Dependency scan** (`fs` mode): Scans lockfiles (`pnpm-lock.yaml`) for known CVEs in direct and transitive dependencies. Triggered on changes to dependency files (`pnpm-lock.yaml`, `package.json`).
+1. **IaC scan** (`config` mode): Scans the whole workspace for misconfigurations in formats Trivy understands. Do not pin `scan-ref` to a single directory—new Terraform roots and other supported config must be covered automatically. PR path filters should include the kinds of paths that introduce those configs (plus the workflow file itself); the weekly schedule remains a full-tree backstop.
+2. **Dependency scan** (`fs` mode): Scans the workspace filesystem for known CVEs in dependencies (lockfiles and package manifests). Triggered on changes to dependency files.
 
 Both jobs run on:
 

--- a/ui/content/projects/personal-site/adrs/047-trivy.mdx
+++ b/ui/content/projects/personal-site/adrs/047-trivy.mdx
@@ -28,7 +28,7 @@ Use **Trivy** for security scanning, covering IaC (Terraform) and dependency vul
 
 Trivy runs two scan jobs in CI via GitHub Actions:
 
-1. **IaC scan** (`config` mode): Scans Terraform configurations for misconfigurations. Triggered on changes to `infra/**`.
+1. **IaC scan** (`config` mode): Scans the whole workspace for misconfigurations in supported config types (Terraform, Dockerfiles, Helm, Kubernetes manifests, etc.). That includes every Terraform root today (`infra/`, `infra-bootstrap/`) and any future roots without needing a new path pin. Triggered on changes to Terraform roots, `*.tf` / `*.tfvars`, Docker/Helm/K8s-related paths, and the workflow file itself.
 2. **Dependency scan** (`fs` mode): Scans lockfiles (`pnpm-lock.yaml`) for known CVEs in direct and transitive dependencies. Triggered on changes to dependency files (`pnpm-lock.yaml`, `package.json`).
 
 Both jobs run on:

--- a/ui/content/projects/recipe-site/adrs/044-trivy.mdx
+++ b/ui/content/projects/recipe-site/adrs/044-trivy.mdx
@@ -4,7 +4,7 @@ inherits_from: "personal-site:047-trivy"
 
 # Additional Context for Recipe Site
 
-The recipe site extends the Trivy security scanning baseline to cover Neon Postgres infrastructure in addition to Cloudflare.
+The recipe site extends the Trivy security scanning baseline to cover Neon Postgres infrastructure in addition to Cloudflare. GCP bootstrap IAM (`infra-bootstrap/`) is covered by the same monorepo-wide IaC scan (see [personal-site ADR 047](/projects/personal-site/adrs/047-trivy)).
 
 ## Neon-Specific IaC Scanning
 

--- a/ui/content/projects/recipe-site/adrs/044-trivy.mdx
+++ b/ui/content/projects/recipe-site/adrs/044-trivy.mdx
@@ -4,7 +4,7 @@ inherits_from: "personal-site:047-trivy"
 
 # Additional Context for Recipe Site
 
-The recipe site extends the Trivy security scanning baseline to cover Neon Postgres infrastructure in addition to Cloudflare. GCP bootstrap IAM (`infra-bootstrap/`) is covered by the same monorepo-wide IaC scan (see [personal-site ADR 047](/projects/personal-site/adrs/047-trivy)).
+The recipe site extends the Trivy security scanning baseline to cover Neon Postgres infrastructure in addition to Cloudflare. Additional Terraform roots in the monorepo are covered by the same workspace-wide IaC scan (see [personal-site ADR 047](/projects/personal-site/adrs/047-trivy)).
 
 ## Neon-Specific IaC Scanning
 


### PR DESCRIPTION
## Summary

- Fix Trivy IaC scanning so it covers the whole workspace instead of a single Terraform root (that pin was a mistake and left bootstrap infra unscanned).
- Broaden PR path filters so config-relevant changes trigger the scan; weekly schedule remains the full-tree backstop.
- Align Trivy ADRs with monorepo-wide config scanning rather than a pinned directory.

## Testing

- Not run (workflow/config + docs only).
- Diff review: `scan-ref: "."`, broader path filters, `skip-dirs` for install/cache noise.