### PR TITLE
Add Cooklang recipe export option

### DIFF
--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -417,9 +417,9 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
                 href={`/recipes/${recipe.slug}.json`}
                 download={`${recipe.slug}.json`}
                 className="block rounded-md px-3 py-2 text-sm hover:bg-accent"
-                title="Download as Open Recipe JSON, importable into most recipe apps"
+                title="Download as schema.org Recipe JSON-LD, importable into most recipe apps"
               >
-                Open Recipe (.json)
+                Recipe JSON (.json)
               </a>
               <a
                 href={`/recipes/${recipe.slug}.cook`}

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -22,6 +22,11 @@ import {
 } from "@/components/recipes/cook-mode";
 import { InlineTimer } from "@/components/recipes/inline-timer";
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { useScaledRecipe } from "@/hooks/use-scaled-recipe";
 import { useUnitPreference } from "@/hooks/use-unit-preference";
 import {
@@ -396,15 +401,36 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
               <span>Total: {formatTime(recipe.totalTime)}</span>
             </div>
           )}
-          <a
-            href={`/recipes/${recipe.slug}.json`}
-            download={`${recipe.slug}.json`}
-            className="flex items-center gap-1 hover:text-foreground transition-colors"
-            title="Download as schema.org Recipe JSON, importable into most recipe apps"
-          >
-            <Download className="h-4 w-4" />
-            <span>Export</span>
-          </a>
+          <Popover>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="flex items-center gap-1 hover:text-foreground transition-colors"
+                aria-label="Choose recipe export format"
+              >
+                <Download className="h-4 w-4" />
+                <span>Export</span>
+              </button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-60 p-1.5">
+              <a
+                href={`/recipes/${recipe.slug}.json`}
+                download={`${recipe.slug}.json`}
+                className="block rounded-md px-3 py-2 text-sm hover:bg-accent"
+                title="Download as Open Recipe JSON, importable into most recipe apps"
+              >
+                Open Recipe (.json)
+              </a>
+              <a
+                href={`/recipes/${recipe.slug}.cook`}
+                download={`${recipe.slug}.cook`}
+                className="block rounded-md px-3 py-2 text-sm hover:bg-accent"
+                title="Download as a Cooklang recipe"
+              >
+                Cooklang (.cook)
+              </a>
+            </PopoverContent>
+          </Popover>
         </div>
 
         {recipe.cuisine.length > 0 && (

--- a/ui/scripts/generate-agent-markdown.ts
+++ b/ui/scripts/generate-agent-markdown.ts
@@ -46,6 +46,18 @@ import { getImageUrl } from "@/lib/integrations/cloudflare-images";
 import { buildRecipeJsonLd } from "@/lib/seo/recipe-jsonld";
 
 function formatCooklangExport(recipe: RecipeDetailView): string {
+  const ingredientAnnotations = Object.fromEntries(
+    recipe.ingredientGroups
+      .flatMap((group) => group.items)
+      .filter((item) => item.preparation || item.note)
+      .map((item) => [
+        item.ingredient,
+        {
+          ...(item.preparation ? { preparation: item.preparation } : {}),
+          ...(item.note ? { note: item.note } : {}),
+        },
+      ]),
+  );
   const frontmatter = [
     "---",
     `title: ${JSON.stringify(recipe.title)}`,
@@ -60,6 +72,9 @@ function formatCooklangExport(recipe: RecipeDetailView): string {
     ...(recipe.imageAlt ? [`imageAlt: ${JSON.stringify(recipe.imageAlt)}`] : []),
     ...(recipe.canonical
       ? [`canonical: ${JSON.stringify(recipe.canonical)}`]
+      : []),
+    ...(Object.keys(ingredientAnnotations).length > 0
+      ? [`ingredientAnnotations: ${JSON.stringify(ingredientAnnotations)}`]
       : []),
     "---",
   ];

--- a/ui/scripts/generate-agent-markdown.ts
+++ b/ui/scripts/generate-agent-markdown.ts
@@ -6,8 +6,8 @@
  * Neon's docs: append `.md` to a page URL to get plain Markdown, and fetch
  * /llms.txt for a structured index of everything available.
  *
- * Recipe pages additionally get a schema.org Recipe JSON twin (append
- * `.json` instead), the interchange format most recipe apps can import.
+ * Recipe pages additionally get schema.org Recipe JSON and Cooklang twins
+ * (append `.json` or `.cook` respectively) for portable recipe export.
  */
 
 import fs from "node:fs";
@@ -44,6 +44,28 @@ import {
 } from "@/lib/domain/technology";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
 import { buildRecipeJsonLd } from "@/lib/seo/recipe-jsonld";
+
+function formatCooklangExport(recipe: RecipeDetailView): string {
+  const frontmatter = [
+    "---",
+    `title: ${JSON.stringify(recipe.title)}`,
+    `description: ${JSON.stringify(recipe.description)}`,
+    `date: ${JSON.stringify(recipe.date)}`,
+    `cuisine: ${JSON.stringify(recipe.cuisine)}`,
+    `servings: ${recipe.servings}`,
+    ...(recipe.prepTime != null ? [`prepTime: ${recipe.prepTime}`] : []),
+    ...(recipe.cookTime != null ? [`cookTime: ${recipe.cookTime}`] : []),
+    `tags: ${JSON.stringify(recipe.tags)}`,
+    ...(recipe.image ? [`image: ${JSON.stringify(recipe.image)}`] : []),
+    ...(recipe.imageAlt ? [`imageAlt: ${JSON.stringify(recipe.imageAlt)}`] : []),
+    ...(recipe.canonical
+      ? [`canonical: ${JSON.stringify(recipe.canonical)}`]
+      : []),
+    "---",
+  ];
+
+  return `${frontmatter.join("\n")}\n${recipe.cookBody.trim()}\n`;
+}
 
 const OUT_DIR = path.join(process.cwd(), "out");
 
@@ -625,8 +647,7 @@ function main(): void {
     );
   }
 
-  // Recipe twins in schema.org Recipe JSON-LD, the interchange format most
-  // recipe apps import; same URL convention as the Markdown twins
+  // Recipe twins provide machine-readable JSON and portable Cooklang source.
   for (const recipe of recipeDetails) {
     const jsonLd = buildRecipeJsonLd(
       recipe,
@@ -637,6 +658,7 @@ function main(): void {
       `recipes/${recipe.slug}.json`,
       `${JSON.stringify(jsonLd, null, 2)}\n`,
     );
+    writeFile(`recipes/${recipe.slug}.cook`, formatCooklangExport(recipe));
   }
 
   writeFile("llms.txt", buildLlmsTxt(projects, posts, recipes, technologyPages));
@@ -652,7 +674,7 @@ function main(): void {
   writeFile("_routes.json", buildRoutesJson());
 
   console.log(
-    `Generated ${pages.length} Markdown pages, ${recipeDetails.length} recipe JSON exports, llms.txt, llms-full.txt, _headers, and _routes.json in out/`,
+    `Generated ${pages.length} Markdown pages and ${recipeDetails.length} recipe JSON/Cooklang exports, llms.txt, llms-full.txt, _headers, and _routes.json in out/`,
   );
 }
 

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -92,6 +92,29 @@ describe("agent markdown generation", () => {
     expect(recipe).not.toContain("{%"); // no leftover cooklang markup
   });
 
+  it("generates JSON and Cooklang exports for every recipe", () => {
+    const nonRecipePages = new Set([
+      "kitchen.html",
+      "settings.html",
+      "shopping.html",
+    ]);
+    const recipePages = fs
+      .readdirSync(path.join(OUT_DIR, "recipes"))
+      .filter((file) => file.endsWith(".html") && !nonRecipePages.has(file));
+
+    for (const recipePage of recipePages) {
+      const slug = recipePage.replace(/\.html$/, "");
+      expect(
+        fs.existsSync(path.join(OUT_DIR, "recipes", `${slug}.json`)),
+        `recipes/${slug}.json`,
+      ).toBe(true);
+      expect(
+        fs.existsSync(path.join(OUT_DIR, "recipes", `${slug}.cook`)),
+        `recipes/${slug}.cook`,
+      ).toBe(true);
+    }
+  });
+
   it("scopes the middleware to page routes in _routes.json", () => {
     const routes = JSON.parse(read("_routes.json"));
     expect(routes.include).toContain("/api/auth/*");

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -115,6 +115,14 @@ describe("agent markdown generation", () => {
     }
   });
 
+  it("preserves ingredient annotations in Cooklang exports", () => {
+    const recipe = read("recipes/breakfast-flatbreads.cook");
+
+    expect(recipe).toContain("ingredientAnnotations:");
+    expect(recipe).toContain('"cherry-tomato":{"preparation":"halved"}');
+    expect(recipe).toContain('"naan":{"note":"plain"}');
+  });
+
   it("scopes the middleware to page routes in _routes.json", () => {
     const routes = JSON.parse(read("_routes.json"));
     expect(routes.include).toContain("/api/auth/*");


### PR DESCRIPTION
## What changed

Recipe pages now offer an export picker with the existing Open Recipe JSON download and a new Cooklang `.cook` download.

The static export generator emits a Cooklang file for every recipe, preserving recipe metadata and Cooklang body content. Integration coverage verifies both export artifacts are produced.

## Why

Readers can now choose the recipe format that fits their preferred cooking app or workflow.

## Validation

- `mise ui:test:integration`
- `mise ui:check:static`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise ui:build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recipe export menu with options to download recipes as JSON or Cooklang files.
  * Added Cooklang export files alongside existing recipe pages and JSON exports.
  * Cooklang files preserve recipe details, including ingredient annotations, timings, tags, and metadata.

* **Tests**
  * Added coverage to verify that all recipes generate matching JSON and Cooklang exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->