### PR TITLE
Add recipe creation from Cooklang text

### DIFF
--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -47,9 +47,7 @@ function resolveDestinationPath(
 
   try {
     const segments = destinationPath.split("/");
-    const hasEmptyMiddleSegment = segments
-      .slice(1, -1)
-      .some((segment) => segment === "");
+    const hasEmptyMiddleSegment = segments.slice(1, -1).includes("");
     const hasUnsafeSegment = segments.some(isUnsafePathSegment);
     return hasEmptyMiddleSegment || hasUnsafeSegment ? null : destinationPath;
   } catch {

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -12,6 +12,24 @@ export type RecipeApiProxyContext = {
   env: RecipeApiProxyEnv;
 };
 
+function resolveDestinationPath(
+  pathname: string,
+  rewritePath?: (path: string) => string,
+): string | null {
+  const destinationPath = rewritePath?.(pathname) ?? pathname;
+  if (!destinationPath.startsWith("/")) return null;
+
+  try {
+    const hasUnsafeSegment = destinationPath
+      .split("/")
+      .map(decodeURIComponent)
+      .some((segment) => segment === "." || segment === "..");
+    return hasUnsafeSegment ? null : destinationPath;
+  } catch {
+    return null;
+  }
+}
+
 const FORWARDED_REQUEST_HEADERS = [
   "accept",
   "authorization",
@@ -76,17 +94,8 @@ export async function proxyRecipeApiRequest(
     );
   }
 
-  const destinationPath = rewritePath?.(url.pathname) ?? url.pathname;
-  let decodedSegments: string[];
-  try {
-    decodedSegments = destinationPath.split("/").map(decodeURIComponent);
-  } catch {
-    return Response.json({ error: "Invalid API path" }, { status: 400 });
-  }
-  if (
-    !destinationPath.startsWith("/") ||
-    decodedSegments.some((segment) => segment === "." || segment === "..")
-  ) {
+  const destinationPath = resolveDestinationPath(url.pathname, rewritePath);
+  if (!destinationPath) {
     return Response.json({ error: "Invalid API path" }, { status: 400 });
   }
 

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -12,19 +12,46 @@ export type RecipeApiProxyContext = {
   env: RecipeApiProxyEnv;
 };
 
+const MAX_PROXY_PATH_LENGTH = 2_048;
+
+function isUnsafePathSegment(segment: string): boolean {
+  let decoded = segment;
+  for (let pass = 0; pass < 10; pass += 1) {
+    const next = decodeURIComponent(decoded);
+    if (next === decoded) {
+      return (
+        decoded === "." ||
+        decoded === ".." ||
+        decoded.includes("/") ||
+        decoded.includes("\\") ||
+        decoded.includes("\0")
+      );
+    }
+    decoded = next;
+  }
+
+  // Reject path segments that remain multiply encoded after a generous limit.
+  return true;
+}
+
 function resolveDestinationPath(
   pathname: string,
   rewritePath?: (path: string) => string,
 ): string | null {
   const destinationPath = rewritePath?.(pathname) ?? pathname;
-  if (!destinationPath.startsWith("/")) return null;
+  if (
+    !destinationPath.startsWith("/") ||
+    destinationPath.length > MAX_PROXY_PATH_LENGTH
+  )
+    return null;
 
   try {
-    const hasUnsafeSegment = destinationPath
-      .split("/")
-      .map(decodeURIComponent)
-      .some((segment) => segment === "." || segment === "..");
-    return hasUnsafeSegment ? null : destinationPath;
+    const segments = destinationPath.split("/");
+    const hasEmptyMiddleSegment = segments
+      .slice(1, -1)
+      .some((segment) => segment === "");
+    const hasUnsafeSegment = segments.some(isUnsafePathSegment);
+    return hasEmptyMiddleSegment || hasUnsafeSegment ? null : destinationPath;
   } catch {
     return null;
   }

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -77,7 +77,23 @@ export async function proxyRecipeApiRequest(
   }
 
   const destinationPath = rewritePath?.(url.pathname) ?? url.pathname;
-  const destination = `${apiBase}${destinationPath}${url.search}`;
+  let decodedSegments: string[];
+  try {
+    decodedSegments = destinationPath.split("/").map(decodeURIComponent);
+  } catch {
+    return Response.json({ error: "Invalid API path" }, { status: 400 });
+  }
+  if (
+    !destinationPath.startsWith("/") ||
+    decodedSegments.some((segment) => segment === "." || segment === "..")
+  ) {
+    return Response.json({ error: "Invalid API path" }, { status: 400 });
+  }
+
+  const destinationUrl = new URL(apiBase);
+  destinationUrl.pathname = destinationPath;
+  destinationUrl.search = url.search;
+  const destination = destinationUrl.toString();
   const headers = new Headers();
   for (const name of FORWARDED_REQUEST_HEADERS) {
     const value = context.request.headers.get(name);

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -60,6 +60,7 @@ export async function proxyRecipeApiRequest(
   context: RecipeApiProxyContext,
   invalidPreviewMessage: string,
   logLabel?: string,
+  rewritePath?: (path: string) => string,
 ): Promise<Response> {
   const url = new URL(context.request.url);
   const previewBase = previewApiBase(url, context.env);
@@ -75,7 +76,8 @@ export async function proxyRecipeApiRequest(
     );
   }
 
-  const destination = `${apiBase}${url.pathname}${url.search}`;
+  const destinationPath = rewritePath?.(url.pathname) ?? url.pathname;
+  const destination = `${apiBase}${destinationPath}${url.search}`;
   const headers = new Headers();
   for (const name of FORWARDED_REQUEST_HEADERS) {
     const value = context.request.headers.get(name);
@@ -88,7 +90,7 @@ export async function proxyRecipeApiRequest(
         message: `${logLabel} proxy request`,
         method: context.request.method,
         path: url.pathname,
-        destination: `${apiBase}${url.pathname}`,
+        destination: `${apiBase}${destinationPath}`,
       }),
     );
   }

--- a/functions/api/recipes/[[path]].ts
+++ b/functions/api/recipes/[[path]].ts
@@ -1,0 +1,12 @@
+import {
+  proxyRecipeApiRequest,
+  type RecipeApiProxyContext,
+} from "../auth/routing";
+
+export const onRequest = (context: RecipeApiProxyContext): Promise<Response> =>
+  proxyRecipeApiRequest(
+    context,
+    "Recipe APIs are available on the canonical PR preview URL only",
+    "Recipes",
+    (path) => path.replace(/^\/api\/recipes/, "/recipes"),
+  );

--- a/functions/api/recipes/[[path]].ts
+++ b/functions/api/recipes/[[path]].ts
@@ -8,5 +8,8 @@ export const onRequest = (context: RecipeApiProxyContext): Promise<Response> =>
     context,
     "Recipe APIs are available on the canonical PR preview URL only",
     "Recipes",
-    (path) => path.replace(/^\/api\/recipes/, "/recipes"),
+    (path) =>
+      path === "/api/recipes" || path.startsWith("/api/recipes/")
+        ? path.replace(/^\/api\/recipes/, "/recipes")
+        : "",
   );

--- a/ui/app/recipes/add/page.tsx
+++ b/ui/app/recipes/add/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { AddRecipeView } from "@/components/recipes/add-recipe-view";
+
+export const metadata: Metadata = {
+  title: "Add Recipe",
+  description: "Add a recipe using inline Cooklang syntax.",
+  robots: { index: false, follow: false },
+};
+
+export default function AddRecipePage() {
+  return <AddRecipeView />;
+}

--- a/ui/app/recipes/saved/page.tsx
+++ b/ui/app/recipes/saved/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { SavedRecipeView } from "@/components/recipes/saved-recipe-view";
+
+export const metadata: Metadata = {
+  title: "Saved Recipe",
+  robots: { index: false, follow: false },
+};
+
+export default function SavedRecipePage() {
+  return (
+    <Suspense>
+      <SavedRecipeView />
+    </Suspense>
+  );
+}

--- a/ui/components/recipes/add-recipe-button.tsx
+++ b/ui/components/recipes/add-recipe-button.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { authClient } from "@/lib/auth-client";
+
+export function AddRecipeButton() {
+  const { data: session, isPending } = authClient.useSession();
+  if (isPending || !session) return null;
+
+  return (
+    <Button
+      asChild
+      className="rounded-full border border-[var(--terracotta-deep)] bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+    >
+      <Link href="/recipes/add">
+        <Plus /> Add recipe
+      </Link>
+    </Button>
+  );
+}

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import {
+  AlertCircle,
+  ArrowLeft,
+  FileText,
+  Loader2,
+  Save,
+  Sparkles,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useId, useMemo, useState } from "react";
+import { RecipeContent } from "@/components/recipes/recipe-content";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useCooklangRecipe } from "@/hooks/use-cooklang-recipe";
+import { authClient } from "@/lib/auth-client";
+import {
+  buildRecipeDraft,
+  normalizeRecipeSource,
+  serializeSavedRecipe,
+} from "@/lib/domain/recipe/recipeDraft";
+import { normalizeSlug } from "@/lib/generic/slugs";
+
+const EXAMPLE_RECIPE = `Bring a large #pot{} of salted water to the boil. Add @dried pasta{200%g} and cook for ~{10%minutes}.
+
+Meanwhile, warm @olive oil{2%tbsp} in a #frying pan{}. Add @garlic{2%cloves} and cook for ~{2%minutes}.
+
+Stir in @chopped tomatoes{400%g} and simmer for ~{15%minutes}. Drain the pasta, toss it through the sauce, and serve.`;
+
+function NumberField({
+  label,
+  value,
+  onChange,
+  min = 0,
+}: {
+  label: string;
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+  min?: number;
+}) {
+  const id = useId();
+  return (
+    <label htmlFor={id} className="grid gap-1.5">
+      <span className="rt-mono text-[var(--ink-3)]">{label}</span>
+      <Input
+        id={id}
+        type="number"
+        min={min}
+        value={value ?? ""}
+        onChange={(event) =>
+          onChange(event.target.value ? Number(event.target.value) : undefined)
+        }
+        className="border-[var(--line-strong)] bg-[var(--card)]"
+      />
+    </label>
+  );
+}
+
+export function AddRecipeView() {
+  const titleId = useId();
+  const descriptionId = useId();
+  const cuisineId = useId();
+  const router = useRouter();
+  const { data: session, isPending: sessionPending } = authClient.useSession();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [cuisine, setCuisine] = useState("");
+  const [servings, setServings] = useState<number | undefined>(2);
+  const [prepTime, setPrepTime] = useState<number | undefined>();
+  const [cookTime, setCookTime] = useState<number | undefined>();
+  const [source, setSource] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const cooklang = useMemo(() => normalizeRecipeSource(source), [source]);
+  const parse = useCooklangRecipe(cooklang);
+
+  const preview = useMemo(() => {
+    if (!parse.recipe || !title.trim() || !description.trim() || !servings)
+      return null;
+    try {
+      return buildRecipeDraft(
+        parse.recipe,
+        { title, description, cuisine, servings, prepTime, cookTime },
+        source,
+      );
+    } catch {
+      return null;
+    }
+  }, [
+    parse.recipe,
+    title,
+    description,
+    cuisine,
+    servings,
+    prepTime,
+    cookTime,
+    source,
+  ]);
+
+  async function saveRecipe() {
+    if (!preview) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const response = await fetch("/api/recipes", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          slug: normalizeSlug(title),
+          title: title.trim(),
+          description: description.trim(),
+          body: serializeSavedRecipe(source, preview),
+          visibility: "private",
+        }),
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(body?.error ?? "The recipe could not be saved.");
+      }
+      const saved = (await response.json()) as { slug: string };
+      router.push(`/recipes/saved?slug=${encodeURIComponent(saved.slug)}`);
+    } catch (error) {
+      setSaveError(
+        error instanceof Error
+          ? error.message
+          : "The recipe could not be saved.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (sessionPending) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <Loader2 className="animate-spin" />
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="container mx-auto max-w-2xl px-4 py-16 text-center">
+        <FileText className="mx-auto size-10 text-[var(--terracotta)]" />
+        <h1 className="rt-display mt-4 text-5xl">Sign in to save a recipe</h1>
+        <p className="rt-body mt-3 text-[var(--ink-2)]">
+          Use the sign-in button above, then come back to add recipes to your
+          private recipe box.
+        </p>
+        <Button asChild variant="outline" className="mt-6 rounded-full">
+          <Link href="/recipes">
+            <ArrowLeft /> Back to recipes
+          </Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-[1600px] px-4 py-6 md:py-10">
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <Link
+            href="/recipes"
+            className="rt-mono inline-flex items-center gap-1 text-[var(--ink-3)] hover:text-[var(--terracotta)]"
+          >
+            <ArrowLeft className="size-3.5" /> Recipe box
+          </Link>
+          <h1 className="rt-display mt-2 text-5xl sm:text-6xl">
+            Add a <span className="text-[var(--terracotta)]">recipe</span>
+          </h1>
+          <p className="rt-body mt-2 text-[var(--ink-2)]">
+            Write the recipe naturally, adding Cooklang syntax inline. The
+            preview updates as you type.
+          </p>
+        </div>
+        <Button
+          onClick={saveRecipe}
+          disabled={!preview || saving}
+          className="rounded-full bg-[var(--ink)] px-5 text-[var(--paper)] hover:bg-[var(--terracotta-deep)]"
+        >
+          {saving ? <Loader2 className="animate-spin" /> : <Save />} Save recipe
+        </Button>
+      </div>
+
+      {saveError && (
+        <div
+          role="alert"
+          className="mb-4 flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+        >
+          <AlertCircle className="size-4" />
+          {saveError}
+        </div>
+      )}
+
+      <div className="grid items-start gap-6 xl:grid-cols-[minmax(380px,0.8fr)_minmax(540px,1.2fr)]">
+        <section className="rounded-xl border-[1.25px] border-[var(--line-strong)] bg-[var(--card)] p-4 shadow-[var(--paper-shadow)] xl:sticky xl:top-24">
+          <div className="grid gap-4">
+            <label htmlFor={titleId} className="grid gap-1.5">
+              <span className="rt-mono text-[var(--ink-3)]">Recipe name</span>
+              <Input
+                id={titleId}
+                value={title}
+                maxLength={120}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Weeknight tomato pasta"
+                className="border-[var(--line-strong)] bg-[var(--paper)] text-lg"
+              />
+            </label>
+            <label htmlFor={descriptionId} className="grid gap-1.5">
+              <span className="rt-mono text-[var(--ink-3)]">
+                Short description
+              </span>
+              <Input
+                id={descriptionId}
+                value={description}
+                maxLength={500}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="A quick, cosy pasta for busy evenings"
+                className="border-[var(--line-strong)] bg-[var(--paper)]"
+              />
+            </label>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 xl:grid-cols-2">
+              <NumberField
+                label="Servings"
+                value={servings}
+                min={1}
+                onChange={setServings}
+              />
+              <NumberField
+                label="Prep minutes"
+                value={prepTime}
+                onChange={setPrepTime}
+              />
+              <NumberField
+                label="Cook minutes"
+                value={cookTime}
+                onChange={setCookTime}
+              />
+              <label htmlFor={cuisineId} className="grid gap-1.5">
+                <span className="rt-mono text-[var(--ink-3)]">Cuisine</span>
+                <Input
+                  id={cuisineId}
+                  value={cuisine}
+                  onChange={(event) => setCuisine(event.target.value)}
+                  placeholder="Italian"
+                  className="border-[var(--line-strong)] bg-[var(--card)]"
+                />
+              </label>
+            </div>
+            <div className="flex items-center justify-between gap-3 border-t border-dashed border-[var(--line-strong)] pt-3">
+              <div>
+                <p className="rt-mono text-[var(--ink-3)]">Recipe text</p>
+                <p className="text-xs text-[var(--ink-3)]">
+                  Use @ingredients, #cookware and ~timers directly in each step.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="rounded-full"
+                onClick={() => {
+                  setTitle("Weeknight tomato pasta");
+                  setDescription("A quick, cosy pasta for busy evenings.");
+                  setCuisine("Italian");
+                  setPrepTime(5);
+                  setCookTime(25);
+                  setSource(EXAMPLE_RECIPE);
+                }}
+              >
+                <Sparkles /> Try example
+              </Button>
+            </div>
+            <textarea
+              value={source}
+              onChange={(event) => setSource(event.target.value)}
+              placeholder={EXAMPLE_RECIPE}
+              spellCheck
+              className="rt-body min-h-[360px] w-full resize-y rounded-lg border border-[var(--line-strong)] bg-[var(--paper)] p-3 text-base leading-relaxed outline-none transition-shadow placeholder:text-[var(--ink-4)] focus:border-[var(--terracotta)] focus:ring-3 focus:ring-[var(--terracotta)]/15"
+            />
+          </div>
+        </section>
+
+        <section className="min-h-[600px] overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] bg-[var(--paper)]">
+          <div className="flex items-center justify-between border-b border-[var(--line)] bg-[var(--paper-warm)] px-4 py-3">
+            <p className="rt-mono text-[var(--ink-3)]">Live preview</p>
+            {parse.loading && (
+              <Loader2 className="size-4 animate-spin text-[var(--terracotta)]" />
+            )}
+          </div>
+          {preview ? (
+            <div className="px-4 py-6 md:px-8">
+              <RecipeContent recipe={preview} />
+            </div>
+          ) : (
+            <div className="flex min-h-[540px] flex-col items-center justify-center px-6 text-center">
+              <FileText className="size-12 text-[var(--terracotta)]/50" />
+              <h2 className="rt-display mt-4 text-4xl">
+                Your recipe will appear here
+              </h2>
+              <p className="rt-body mt-2 max-w-md text-[var(--ink-3)]">
+                Add a name and write your steps with inline Cooklang—or use the
+                example to see ingredients and timers come alive.
+              </p>
+              {parse.error && (
+                <p role="alert" className="mt-4 text-sm text-destructive">
+                  We couldn&apos;t read that recipe yet. Check the Cooklang
+                  syntax and try again.
+                </p>
+              )}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -130,6 +130,11 @@ export function AddRecipeView() {
         }),
       });
       if (!response.ok) {
+        if (response.status === 409) {
+          throw new Error(
+            "A recipe with this name already exists. Choose a different name.",
+          );
+        }
         const body = (await response.json().catch(() => null)) as {
           error?: string;
           details?: Array<{ message?: string }>;

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -34,12 +34,12 @@ function NumberField({
   value,
   onChange,
   min = 0,
-}: {
+}: Readonly<{
   label: string;
   value: number | undefined;
   onChange: (value: number | undefined) => void;
   min?: number;
-}) {
+}>) {
   const id = useId();
   return (
     <label htmlFor={id} className="grid gap-1.5">
@@ -118,8 +118,15 @@ export function AddRecipeView() {
       if (!response.ok) {
         const body = (await response.json().catch(() => null)) as {
           error?: string;
+          details?: Array<{ message?: string }>;
         } | null;
-        throw new Error(body?.error ?? "The recipe could not be saved.");
+        const details = body?.details
+          ?.map((detail) => detail.message)
+          .filter((message): message is string => Boolean(message))
+          .join(" ");
+        throw new Error(
+          details || body?.error || "The recipe could not be saved.",
+        );
       }
       const saved = (await response.json()) as { slug: string };
       router.push(`/recipes/saved?slug=${encodeURIComponent(saved.slug)}`);
@@ -280,6 +287,7 @@ export function AddRecipeView() {
               value={source}
               onChange={(event) => setSource(event.target.value)}
               placeholder={EXAMPLE_RECIPE}
+              maxLength={10000}
               spellCheck
               className="rt-body min-h-[360px] w-full resize-y rounded-lg border border-[var(--line-strong)] bg-[var(--paper)] p-3 text-base leading-relaxed outline-none transition-shadow placeholder:text-[var(--ink-4)] focus:border-[var(--terracotta)] focus:ring-3 focus:ring-[var(--terracotta)]/15"
             />

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useId, useMemo, useState } from "react";
+import { useId, useMemo, useRef, useState } from "react";
 import { RecipeContent } from "@/components/recipes/recipe-content";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -81,6 +81,7 @@ export function AddRecipeView() {
   const [cookTime, setCookTime] = useState<number | undefined>();
   const [source, setSource] = useState("");
   const [saving, setSaving] = useState(false);
+  const savingRef = useRef(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const cooklang = useMemo(() => normalizeRecipeSource(source), [source]);
   const parse = useCooklangRecipe(cooklang);
@@ -113,7 +114,8 @@ export function AddRecipeView() {
   const preview = previewResult.recipe;
 
   async function saveRecipe() {
-    if (!preview) return;
+    if (!preview || savingRef.current) return;
+    savingRef.current = true;
     setSaving(true);
     setSaveError(null);
     try {
@@ -156,6 +158,7 @@ export function AddRecipeView() {
           : "The recipe could not be saved.",
       );
     } finally {
+      savingRef.current = false;
       setSaving(false);
     }
   }

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -49,9 +49,18 @@ function NumberField({
         type="number"
         min={min}
         value={value ?? ""}
-        onChange={(event) =>
-          onChange(event.target.value ? Number(event.target.value) : undefined)
-        }
+        onChange={(event) => {
+          if (!event.target.value) {
+            onChange(undefined);
+            return;
+          }
+          const nextValue = Number(event.target.value);
+          onChange(
+            Number.isInteger(nextValue) && nextValue >= min
+              ? nextValue
+              : undefined,
+          );
+        }}
         className="border-[var(--line-strong)] bg-[var(--card)]"
       />
     </label>
@@ -76,17 +85,20 @@ export function AddRecipeView() {
   const cooklang = useMemo(() => normalizeRecipeSource(source), [source]);
   const parse = useCooklangRecipe(cooklang);
 
-  const preview = useMemo(() => {
+  const previewResult = useMemo(() => {
     if (!parse.recipe || !title.trim() || !description.trim() || !servings)
-      return null;
+      return { recipe: null, error: false };
     try {
-      return buildRecipeDraft(
-        parse.recipe,
-        { title, description, cuisine, servings, prepTime, cookTime },
-        source,
-      );
+      return {
+        recipe: buildRecipeDraft(
+          parse.recipe,
+          { title, description, cuisine, servings, prepTime, cookTime },
+          source,
+        ),
+        error: false,
+      };
     } catch {
-      return null;
+      return { recipe: null, error: true };
     }
   }, [
     parse.recipe,
@@ -98,6 +110,7 @@ export function AddRecipeView() {
     cookTime,
     source,
   ]);
+  const preview = previewResult.recipe;
 
   async function saveRecipe() {
     if (!preview) return;
@@ -106,6 +119,7 @@ export function AddRecipeView() {
     try {
       const response = await fetch("/api/recipes", {
         method: "POST",
+        credentials: "include",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           slug: normalizeSlug(title),
@@ -315,7 +329,7 @@ export function AddRecipeView() {
                 Add a name and write your steps with inline Cooklang—or use the
                 example to see ingredients and timers come alive.
               </p>
-              {parse.error && (
+              {(parse.error || previewResult.error) && (
                 <p role="alert" className="mt-4 text-sm text-destructive">
                   We couldn&apos;t read that recipe yet. Check the Cooklang
                   syntax and try again.

--- a/ui/components/recipes/recipe-box-view.tsx
+++ b/ui/components/recipes/recipe-box-view.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Suspense, useCallback, useState } from "react";
-import { RecipeList } from "@/components/recipes/recipe-list";
+import { AddRecipeButton } from "@/components/recipes/add-recipe-button";
+import { RecipeCollection } from "@/components/recipes/recipe-collection";
 import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
 import type { RecipeCardView } from "@/lib/api/recipes";
 
@@ -24,25 +25,28 @@ export function RecipeBoxView({
 
   return (
     <div className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-10 md:pt-7 md:pb-14">
-      <div className="mb-6 md:mb-8">
-        <p className="rt-mono text-[var(--terracotta)]">Your recipe box</p>
-        <h1 className="rt-display mt-2 text-5xl sm:text-6xl lg:text-7xl">
-          What's <span className="text-[var(--terracotta)]">cooking?</span>
-        </h1>
-        <p className="rt-body mt-3 flex flex-wrap gap-x-2 gap-y-1 text-base leading-snug text-[var(--ink-2)] sm:text-lg">
-          {stats.map((stat, index) => (
-            <span key={stat} className="whitespace-nowrap">
-              {stat}
-              {index < stats.length - 1 && (
-                <span className="text-[var(--ink-3)]"> ·</span>
-              )}
-            </span>
-          ))}
-        </p>
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-4 md:mb-8">
+        <div>
+          <p className="rt-mono text-[var(--terracotta)]">Your recipe box</p>
+          <h1 className="rt-display mt-2 text-5xl sm:text-6xl lg:text-7xl">
+            What's <span className="text-[var(--terracotta)]">cooking?</span>
+          </h1>
+          <p className="rt-body mt-3 flex flex-wrap gap-x-2 gap-y-1 text-base leading-snug text-[var(--ink-2)] sm:text-lg">
+            {stats.map((stat, index) => (
+              <span key={stat} className="whitespace-nowrap">
+                {stat}
+                {index < stats.length - 1 && (
+                  <span className="text-[var(--ink-3)]"> ·</span>
+                )}
+              </span>
+            ))}
+          </p>
+        </div>
+        <AddRecipeButton />
       </div>
 
       <Suspense fallback={<CardGridSkeleton variant="filters" />}>
-        <RecipeList
+        <RecipeCollection
           recipes={recipes}
           onDietVisibleCountChange={updateVisibleRecipeCount}
         />

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { RecipeList } from "@/components/recipes/recipe-list";
+import type { RecipeCardView } from "@/lib/api/recipes";
+import { authClient } from "@/lib/auth-client";
+import {
+  type SavedRecipeApiRecord,
+  savedRecipeCard,
+} from "@/lib/domain/recipe/recipeDraft";
+
+export function RecipeCollection({
+  recipes,
+  onDietVisibleCountChange,
+}: Readonly<{
+  recipes: RecipeCardView[];
+  onDietVisibleCountChange?: (count: number) => void;
+}>) {
+  const { isPending } = authClient.useSession();
+  const [saved, setSaved] = useState<SavedRecipeApiRecord[]>([]);
+
+  useEffect(() => {
+    if (isPending) return;
+    const controller = new AbortController();
+    void fetch("/api/recipes", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("Saved recipes unavailable");
+        return (await response.json()) as SavedRecipeApiRecord[];
+      })
+      .then(setSaved)
+      .catch((error: unknown) => {
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          console.error("Failed to load saved recipes", error);
+        }
+      });
+    return () => controller.abort();
+  }, [isPending]);
+
+  const combined = useMemo(() => {
+    const dynamic = saved.flatMap((record) => {
+      const card = savedRecipeCard(record);
+      return card ? [card] : [];
+    });
+    const dynamicSlugs = new Set(dynamic.map((recipe) => recipe.slug));
+    return [
+      ...dynamic,
+      ...recipes.filter((recipe) => !dynamicSlugs.has(recipe.slug)),
+    ];
+  }, [recipes, saved]);
+
+  return (
+    <RecipeList
+      recipes={combined}
+      onDietVisibleCountChange={onDietVisibleCountChange}
+    />
+  );
+}

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -16,12 +16,19 @@ export function RecipeCollection({
   recipes: RecipeCardView[];
   onDietVisibleCountChange?: (count: number) => void;
 }>) {
-  const { isPending } = authClient.useSession();
+  const { data: session, isPending } = authClient.useSession();
   const [saved, setSaved] = useState<SavedRecipeApiRecord[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isPending) return;
+    if (!session) {
+      setSaved([]);
+      setLoadError(null);
+      return;
+    }
     const controller = new AbortController();
+    setLoadError(null);
     void fetch("/api/recipes", { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) throw new Error("Saved recipes unavailable");
@@ -31,10 +38,13 @@ export function RecipeCollection({
       .catch((error: unknown) => {
         if (!(error instanceof DOMException && error.name === "AbortError")) {
           console.error("Failed to load saved recipes", error);
+          setLoadError(
+            "Your saved recipes could not be loaded. Static recipes are still available.",
+          );
         }
       });
     return () => controller.abort();
-  }, [isPending]);
+  }, [isPending, session]);
 
   const combined = useMemo(() => {
     const dynamic = saved.flatMap((record) => {
@@ -49,9 +59,19 @@ export function RecipeCollection({
   }, [recipes, saved]);
 
   return (
-    <RecipeList
-      recipes={combined}
-      onDietVisibleCountChange={onDietVisibleCountChange}
-    />
+    <>
+      {loadError ? (
+        <p
+          role="status"
+          className="rt-body mb-5 rounded-lg border border-[var(--terracotta)]/30 bg-[var(--terracotta)]/5 px-4 py-3 text-sm text-[var(--ink-2)]"
+        >
+          {loadError}
+        </p>
+      ) : null}
+      <RecipeList
+        recipes={combined}
+        onDietVisibleCountChange={onDietVisibleCountChange}
+      />
+    </>
   );
 }

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -61,12 +61,9 @@ export function RecipeCollection({
   return (
     <>
       {loadError ? (
-        <p
-          role="status"
-          className="rt-body mb-5 rounded-lg border border-[var(--terracotta)]/30 bg-[var(--terracotta)]/5 px-4 py-3 text-sm text-[var(--ink-2)]"
-        >
+        <output className="rt-body mb-5 block rounded-lg border border-[var(--terracotta)]/30 bg-[var(--terracotta)]/5 px-4 py-3 text-sm text-[var(--ink-2)]">
           {loadError}
-        </p>
+        </output>
       ) : null}
       <RecipeList
         recipes={combined}

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -42,6 +42,7 @@ import {
   buildDietRecipeMatches,
   type DietMatch,
 } from "@/lib/domain/diet";
+import type { RecipeGridItem } from "@/lib/domain/recipe/recipeDraft";
 import { formatDate } from "@/lib/generic/date";
 import { cycleFilterFromCard } from "@/lib/generic/filter-cycle";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
@@ -211,7 +212,7 @@ function TimeBadge({
 }
 
 interface RecipeCardProps {
-  recipe: RecipeCardView;
+  recipe: RecipeGridItem;
   index: number;
   selectedCuisines: string[];
   selectedPrepTimes: string[];
@@ -237,10 +238,11 @@ const RecipeCard = memo(function RecipeCard({
   onToggleTotalTime,
   dietMatch,
 }: RecipeCardProps) {
+  const href = recipe.href ?? `/recipes/${recipe.slug}`;
   return (
     <Card className="h-full flex flex-col overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] gap-0 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]">
       {recipe.image && (
-        <Link href={`/recipes/${recipe.slug}`} className="block">
+        <Link href={href} className="block">
           <div className="relative w-full h-48 bg-muted overflow-hidden">
             {/* biome-ignore lint/performance/noImgElement: Need native img for srcset control with SSG */}
             <img
@@ -259,11 +261,16 @@ const RecipeCard = memo(function RecipeCard({
         </Link>
       )}
       <CardHeader className="pt-4 pb-2 gap-1">
-        <Link href={`/recipes/${recipe.slug}`}>
+        <Link href={href}>
           <CardTitle className="rt-display text-2xl leading-tight hover:text-[var(--terracotta)] transition-colors">
             {recipe.title}
           </CardTitle>
         </Link>
+        {recipe.saved && (
+          <span className="rt-mono w-fit rounded-full bg-[var(--butter-soft)] px-2 py-0.5 text-[0.625rem] text-[var(--terracotta-deep)]">
+            Your recipe
+          </span>
+        )}
         <CardDescription className="rt-body line-clamp-2">
           {recipe.description}
         </CardDescription>
@@ -311,7 +318,7 @@ const RecipeCard = memo(function RecipeCard({
 });
 
 type RecipeListProps = Readonly<{
-  recipes: RecipeCardView[];
+  recipes: RecipeGridItem[];
   onDietVisibleCountChange?: (count: number) => void;
 }>;
 

--- a/ui/components/recipes/saved-recipe-view.tsx
+++ b/ui/components/recipes/saved-recipe-view.tsx
@@ -26,7 +26,11 @@ export function SavedRecipeView() {
   const [state, setState] = useState<State>({ status: "loading" });
 
   useEffect(() => {
-    if (!slug) {
+    if (
+      !slug ||
+      !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug) ||
+      slug.length > 120
+    ) {
       setState({ status: "error", message: "No saved recipe was selected." });
       return;
     }

--- a/ui/components/recipes/saved-recipe-view.tsx
+++ b/ui/components/recipes/saved-recipe-view.tsx
@@ -28,8 +28,8 @@ export function SavedRecipeView() {
   useEffect(() => {
     if (
       !slug ||
-      !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug) ||
-      slug.length > 120
+      slug.length > 120 ||
+      !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)
     ) {
       setState({ status: "error", message: "No saved recipe was selected." });
       return;
@@ -45,7 +45,11 @@ export function SavedRecipeView() {
             "That recipe was not found, or it belongs to another profile.",
           );
         if (!response.ok) throw new Error("The recipe could not be loaded.");
-        return (await response.json()) as SavedRecipeApiRecord;
+        try {
+          return (await response.json()) as SavedRecipeApiRecord;
+        } catch {
+          throw new Error("The recipe could not be loaded.");
+        }
       })
       .then((record) => {
         const recipe = parseSavedRecipe(record);

--- a/ui/components/recipes/saved-recipe-view.tsx
+++ b/ui/components/recipes/saved-recipe-view.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { ArrowLeft, Loader2, LockKeyhole } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { RecipeContent } from "@/components/recipes/recipe-content";
+import { Button } from "@/components/ui/button";
+import {
+  parseSavedRecipe,
+  type SavedRecipeApiRecord,
+} from "@/lib/domain/recipe/recipeDraft";
+import type { RecipeDetailView } from "@/lib/domain/recipe/recipeViews";
+
+type State =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | {
+      status: "ready";
+      recipe: RecipeDetailView;
+      visibility: SavedRecipeApiRecord["visibility"];
+    };
+
+export function SavedRecipeView() {
+  const slug = useSearchParams().get("slug");
+  const [state, setState] = useState<State>({ status: "loading" });
+
+  useEffect(() => {
+    if (!slug) {
+      setState({ status: "error", message: "No saved recipe was selected." });
+      return;
+    }
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    void fetch(`/api/recipes/${encodeURIComponent(slug)}`, {
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (response.status === 404)
+          throw new Error(
+            "That recipe was not found, or it belongs to another profile.",
+          );
+        if (!response.ok) throw new Error("The recipe could not be loaded.");
+        return (await response.json()) as SavedRecipeApiRecord;
+      })
+      .then((record) => {
+        const recipe = parseSavedRecipe(record);
+        if (!recipe)
+          throw new Error("The saved recipe is not in a supported format.");
+        setState({ status: "ready", recipe, visibility: record.visibility });
+      })
+      .catch((error: unknown) => {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
+        setState({
+          status: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "The recipe could not be loaded.",
+        });
+      });
+    return () => controller.abort();
+  }, [slug]);
+
+  if (state.status === "loading") {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="animate-spin text-[var(--terracotta)]" />
+      </div>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <div className="container mx-auto max-w-xl px-4 py-20 text-center">
+        <h1 className="rt-display text-5xl">Recipe not found</h1>
+        <p className="rt-body mt-3 text-[var(--ink-2)]">{state.message}</p>
+        <Button asChild variant="outline" className="mt-6 rounded-full">
+          <Link href="/recipes">
+            <ArrowLeft /> Back to recipes
+          </Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto min-h-screen max-w-5xl px-4 py-5 md:py-8">
+      <div className="mb-5 flex items-center justify-between gap-4">
+        <Link
+          href="/recipes"
+          className="rt-mono inline-flex items-center gap-1 text-[var(--ink-3)] hover:text-[var(--terracotta)]"
+        >
+          <ArrowLeft className="size-3.5" /> All recipes
+        </Link>
+        <span className="rt-mono inline-flex items-center gap-1.5 rounded-full border border-[var(--line-strong)] bg-[var(--paper-warm)] px-3 py-1 text-[var(--ink-3)]">
+          <LockKeyhole className="size-3" /> {state.visibility}
+        </span>
+      </div>
+      <RecipeContent recipe={state.recipe} />
+    </div>
+  );
+}

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -22,7 +22,7 @@ export type RecipeDraftMetadata = {
 export type SavedRecipePayload = {
   version: 1;
   source: string;
-  recipe: RecipeDetailView;
+  recipe: RecipeContent;
 };
 
 export type SavedRecipeApiRecord = {
@@ -119,7 +119,7 @@ export function serializeSavedRecipe(
   return JSON.stringify({
     version: 1,
     source,
-    recipe,
+    recipe: RecipeContentSchema.parse(recipe),
   } satisfies SavedRecipePayload);
 }
 

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -1,0 +1,172 @@
+import type { CooklangRecipe as ParsedCooklangRecipe } from "@cooklang/cooklang";
+import { buildRecipeContentFromParsed } from "@/lib/domain/recipe/cooklangTransform";
+import {
+  type RecipeContent,
+  RecipeContentSchema,
+} from "@/lib/domain/recipe/recipe";
+import type {
+  RecipeCardView,
+  RecipeDetailView,
+} from "@/lib/domain/recipe/recipeViews";
+import { normalizeSlug } from "@/lib/generic/slugs";
+
+export type RecipeDraftMetadata = {
+  title: string;
+  description: string;
+  servings: number;
+  prepTime?: number;
+  cookTime?: number;
+  cuisine?: string;
+};
+
+export type SavedRecipePayload = {
+  version: 1;
+  source: string;
+  recipe: RecipeDetailView;
+};
+
+export type SavedRecipeApiRecord = {
+  slug: string;
+  title: string;
+  description: string | null;
+  body: string | null;
+  visibility: "public" | "private" | "household";
+  createdAt: string;
+  updatedAt: string;
+};
+
+export function normalizeRecipeSource(source: string): string {
+  return source.trim();
+}
+
+function displayName(value: string): string {
+  return value
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function buildRecipeDraft(
+  parsed: ParsedCooklangRecipe,
+  metadata: RecipeDraftMetadata,
+  source: string,
+): RecipeDetailView {
+  const slug = normalizeSlug(metadata.title);
+  const cookBody = normalizeRecipeSource(source);
+  const content: RecipeContent = buildRecipeContentFromParsed(
+    parsed,
+    {
+      title: metadata.title.trim(),
+      description: metadata.description.trim(),
+      date: new Date().toISOString().slice(0, 10),
+      cuisine: metadata.cuisine?.trim() ? [metadata.cuisine.trim()] : [],
+      servings: metadata.servings,
+      prepTime: metadata.prepTime,
+      cookTime: metadata.cookTime,
+      tags: [],
+    },
+    slug,
+    cookBody,
+  );
+  return recipeContentToDetail(content, slug);
+}
+
+function recipeContentToDetail(
+  content: RecipeContent,
+  slug: string,
+): RecipeDetailView {
+  const ingredientNames = new Map<string, string>();
+  content.instructionSdk?.ingredientNames.forEach((name, index) => {
+    ingredientNames.set(
+      normalizeSlug(name),
+      content.instructionSdk?.ingredientDisplayValues[index] ?? name,
+    );
+  });
+  const totalTime =
+    content.prepTime != null && content.cookTime != null
+      ? content.prepTime + content.cookTime
+      : (content.prepTime ?? content.cookTime);
+
+  return {
+    slug,
+    title: content.title,
+    description: content.description,
+    date: content.date,
+    cuisine: content.cuisine,
+    tags: content.tags,
+    servings: content.servings,
+    prepTime: content.prepTime,
+    cookTime: content.cookTime,
+    totalTime,
+    cookBody: content.cookBody,
+    cookware: content.cookware,
+    ingredientGroups: content.ingredientGroups.map((group) => ({
+      name: group.name,
+      items: group.items.map((item) => ({
+        ...item,
+        name:
+          ingredientNames.get(item.ingredient) ?? displayName(item.ingredient),
+      })),
+    })),
+    instructions: content.instructions,
+    instructionSdk: content.instructionSdk,
+  };
+}
+
+export function serializeSavedRecipe(
+  source: string,
+  recipe: RecipeDetailView,
+): string {
+  return JSON.stringify({
+    version: 1,
+    source,
+    recipe,
+  } satisfies SavedRecipePayload);
+}
+
+export function parseSavedRecipe(
+  record: SavedRecipeApiRecord,
+): RecipeDetailView | null {
+  if (!record.body) return null;
+  try {
+    const payload = JSON.parse(record.body) as Partial<SavedRecipePayload>;
+    if (payload.version !== 1 || !payload.recipe) return null;
+    const parsed = RecipeContentSchema.safeParse(payload.recipe);
+    if (!parsed.success) return null;
+    return recipeContentToDetail(parsed.data, record.slug);
+  } catch {
+    return null;
+  }
+}
+
+export type RecipeGridItem = RecipeCardView & {
+  href?: string;
+  saved?: boolean;
+};
+
+export function savedRecipeCard(
+  record: SavedRecipeApiRecord,
+): RecipeGridItem | null {
+  const recipe = parseSavedRecipe(record);
+  if (!recipe) return null;
+  const ingredientNames = Array.from(
+    new Set(
+      recipe.ingredientGroups.flatMap((group) =>
+        group.items.map((item) => item.name),
+      ),
+    ),
+  ).sort();
+  const ingredientSlugs = Array.from(
+    new Set(
+      recipe.ingredientGroups.flatMap((group) =>
+        group.items.map((item) => item.ingredient),
+      ),
+    ),
+  ).sort();
+  return {
+    ...recipe,
+    ingredientNames,
+    ingredientSlugs,
+    href: `/recipes/saved?slug=${encodeURIComponent(record.slug)}`,
+    saved: true,
+  };
+}

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -41,7 +41,7 @@ export function normalizeRecipeSource(source: string): string {
 
 function displayName(value: string): string {
   return value
-    .replace(/-/g, " ")
+    .replaceAll("-", " ")
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
@@ -154,14 +154,14 @@ export function savedRecipeCard(
         group.items.map((item) => item.name),
       ),
     ),
-  ).sort();
+  ).sort((left, right) => left.localeCompare(right));
   const ingredientSlugs = Array.from(
     new Set(
       recipe.ingredientGroups.flatMap((group) =>
         group.items.map((item) => item.ingredient),
       ),
     ),
-  ).sort();
+  ).sort((left, right) => left.localeCompare(right));
   return {
     ...recipe,
     ingredientNames,

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -51,6 +51,10 @@ function createNextConfig(phase: string): NextConfig {
                 source: "/api/profile/diet/options",
                 destination: "http://localhost:8787/api/profile/diet/options",
               },
+              {
+                source: "/api/recipes/:path*",
+                destination: "http://localhost:8787/recipes/:path*",
+              },
             ];
           },
         }

--- a/ui/scripts/generate-agent-markdown.ts
+++ b/ui/scripts/generate-agent-markdown.ts
@@ -572,6 +572,8 @@ function buildRoutesJson(): string {
         "/api/auth/*",
         "/api/profile/diet",
         "/api/profile/diet/options",
+        "/api/recipes",
+        "/api/recipes/*",
         "/ingest/*",
         "/",
         "/experience",

--- a/ui/tests/functions/recipes-proxy.test.ts
+++ b/ui/tests/functions/recipes-proxy.test.ts
@@ -34,4 +34,24 @@ describe("recipes proxy", () => {
     );
     expect(forwarded.headers.get("cookie")).toBe("session=test");
   });
+
+  it.each([
+    "..",
+    "%2e%2e",
+    "%ZZ",
+  ])("rejects an unsafe path segment: %s", async (segment) => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const context: RecipeApiProxyContext = {
+      request: new Request(
+        `https://robbiepalmer.me/api/recipes/${segment}/private`,
+      ),
+      env: { RECIPE_API_URL: "https://recipe-api.example.test" },
+    };
+
+    const response = await onRequest(context);
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/ui/tests/functions/recipes-proxy.test.ts
+++ b/ui/tests/functions/recipes-proxy.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RecipeApiProxyContext } from "../../../functions/api/auth/routing";
+import { onRequest } from "../../../functions/api/recipes/[[path]]";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("recipes proxy", () => {
+  it("maps the Pages API path to the Worker recipe path", async () => {
+    const fetchMock = vi.fn(async (_request: Request) => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const context: RecipeApiProxyContext = {
+      request: new Request(
+        "https://robbiepalmer.me/api/recipes/my-pasta?fresh=1",
+        {
+          headers: { cookie: "session=test" },
+        },
+      ),
+      env: { RECIPE_API_URL: "https://recipe-api.example.test" },
+    };
+    const response = await onRequest(context);
+
+    expect(response.status).toBe(200);
+    const forwarded = fetchMock.mock.calls[0]?.[0];
+    expect(forwarded).toBeInstanceOf(Request);
+    if (!(forwarded instanceof Request)) throw new Error("Expected a Request");
+    expect(forwarded.url).toBe(
+      "https://recipe-api.example.test/recipes/my-pasta?fresh=1",
+    );
+    expect(forwarded.headers.get("cookie")).toBe("session=test");
+  });
+});

--- a/ui/tests/functions/recipes-proxy.test.ts
+++ b/ui/tests/functions/recipes-proxy.test.ts
@@ -38,6 +38,10 @@ describe("recipes proxy", () => {
   it.each([
     "..",
     "%2e%2e",
+    "%252e%252e",
+    "..%2Fprivate",
+    "%00",
+    "%5C",
     "%ZZ",
   ])("rejects an unsafe path segment: %s", async (segment) => {
     const fetchMock = vi.fn(async () => new Response("ok"));

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -51,7 +51,9 @@ describe("agent markdown generation", () => {
   it("generates a markdown twin for every recipe and technology page", () => {
     // Interactive, noindex app pages that intentionally have no Markdown twin.
     const nonContentPages = new Set([
+      "recipes/add.html",
       "recipes/kitchen.html",
+      "recipes/saved.html",
       "recipes/settings.html",
       "recipes/shopping.html",
     ]);
@@ -128,6 +130,8 @@ describe("agent markdown generation", () => {
     expect(routes.include).toContain("/api/auth/*");
     expect(routes.include).toContain("/api/profile/diet");
     expect(routes.include).toContain("/api/profile/diet/options");
+    expect(routes.include).toContain("/api/recipes");
+    expect(routes.include).toContain("/api/recipes/*");
     expect(routes.include).toContain("/ingest/*");
     expect(routes.include).toContain("/projects/*");
     expect(routes.exclude).toContain("/_next/*");

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -96,7 +96,9 @@ describe("agent markdown generation", () => {
 
   it("generates JSON and Cooklang exports for every recipe", () => {
     const nonRecipePages = new Set([
+      "add.html",
       "kitchen.html",
+      "saved.html",
       "settings.html",
       "shopping.html",
     ]);

--- a/ui/tests/integration/sitemap.test.ts
+++ b/ui/tests/integration/sitemap.test.ts
@@ -16,7 +16,9 @@ const STATIC_ASSET_SEGMENTS = new Set(["recipe-site-design"]);
 // Authenticated, noindex app pages (e.g. account settings) — served but kept
 // out of the sitemap on purpose.
 const NOINDEX_APP_PAGES = new Set([
+  "recipes/add",
   "recipes/kitchen",
+  "recipes/saved",
   "recipes/settings",
   "recipes/shopping",
 ]);

--- a/ui/tests/lib/domain/recipe/recipeDraft.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeDraft.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { normalizeRecipeSource } from "@/lib/domain/recipe/recipeDraft";
+
+describe("normalizeRecipeSource", () => {
+  it("preserves one continuous inline Cooklang recipe", () => {
+    const source = "  Mix @flour{200%g} in a #bowl{} for ~{2%minutes}.  ";
+    expect(normalizeRecipeSource(source)).toBe(
+      "Mix @flour{200%g} in a #bowl{} for ~{2%minutes}.",
+    );
+  });
+});

--- a/workers/recipe-api/src/db/errors.ts
+++ b/workers/recipe-api/src/db/errors.ts
@@ -8,9 +8,11 @@ export function hasPostgresErrorCode(
   while (typeof current === "object" && current !== null) {
     if (visited.has(current)) return false;
     visited.add(current);
+    const record = current as Record<string, unknown>;
 
-    if ("code" in current && current.code === expectedCode) return true;
-    current = "cause" in current ? current.cause : undefined;
+    if (Object.hasOwn(record, "code") && record.code === expectedCode)
+      return true;
+    current = Object.hasOwn(record, "cause") ? record.cause : undefined;
   }
 
   return false;

--- a/workers/recipe-api/src/db/errors.ts
+++ b/workers/recipe-api/src/db/errors.ts
@@ -1,0 +1,17 @@
+export function hasPostgresErrorCode(
+  error: unknown,
+  expectedCode: string,
+): boolean {
+  const visited = new Set<object>();
+  let current = error;
+
+  while (typeof current === "object" && current !== null) {
+    if (visited.has(current)) return false;
+    visited.add(current);
+
+    if ("code" in current && current.code === expectedCode) return true;
+    current = "cause" in current ? current.cause : undefined;
+  }
+
+  return false;
+}

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -5,6 +5,7 @@ import { createDb, schema } from "recipe-db";
 import { RecipeContentSchema } from "recipe-domain";
 import { createAuth } from "./auth";
 import { verifyCloudflareAccess } from "./cloudflare-access";
+import { hasPostgresErrorCode } from "./db/errors";
 import {
   type AuthenticatedSession,
   type AuthorizationVariables,
@@ -429,21 +430,11 @@ async function withRecipeSession(
 }
 
 function isUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "23505"
-  );
+  return hasPostgresErrorCode(error, "23505");
 }
 
 function isForeignKeyViolation(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "23503"
-  );
+  return hasPostgresErrorCode(error, "23503");
 }
 
 async function findRecipeBySlug(
@@ -1775,7 +1766,13 @@ app.post("/recipes", async (c) => {
     return c.json(recipeResponse(recipe), 201);
   } catch (e) {
     if (isUniqueViolation(e)) {
-      return c.json({ error: "Recipe slug already exists" }, 409);
+      return c.json(
+        {
+          error:
+            "A recipe with this name already exists. Choose a different name.",
+        },
+        409,
+      );
     }
     console.error("POST /recipes mutation failed", e);
     return c.json({ error: "Database mutation failed" }, 502);

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -137,10 +137,13 @@ const savedRecipeBodySchema = z
 
     const result = savedRecipePayloadSchema.safeParse(payload);
     if (!result.success) {
-      context.addIssue({
-        code: "custom",
-        message: "Recipe body must contain a valid saved recipe payload",
-      });
+      for (const issue of result.error.issues) {
+        context.addIssue({
+          code: "custom",
+          path: issue.path,
+          message: issue.message,
+        });
+      }
     }
   });
 
@@ -153,7 +156,7 @@ const createRecipeBodySchema = z.object({
   slug: recipeSlugSchema,
   title: z.string().trim().min(1).max(120),
   description: z.string().trim().min(1).max(500).optional(),
-  body: savedRecipeBodySchema.optional(),
+  body: savedRecipeBodySchema,
   visibility: recipeVisibilitySchema.default("private"),
 });
 

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -2,6 +2,7 @@ import { Hono, type Context } from "hono";
 import { and, count, desc, eq, gte, inArray, lt, or } from "drizzle-orm";
 import { z } from "zod";
 import { createDb, schema } from "recipe-db";
+import { RecipeContentSchema } from "recipe-domain";
 import { createAuth } from "./auth";
 import { verifyCloudflareAccess } from "./cloudflare-access";
 import {
@@ -100,6 +101,49 @@ const uniqueDietKeysSchema = z
   .max(80)
   .transform((values) => Array.from(new Set(values)));
 
+const MAX_RECIPE_BODY_BYTES = 100_000;
+const savedRecipePayloadSchema = z
+  .object({
+    version: z.literal(1),
+    source: z.string().trim().min(1).max(10_000),
+    recipe: RecipeContentSchema,
+  })
+  .strict();
+
+const savedRecipeBodySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(MAX_RECIPE_BODY_BYTES)
+  .superRefine((value, context) => {
+    if (new TextEncoder().encode(value).byteLength > MAX_RECIPE_BODY_BYTES) {
+      context.addIssue({
+        code: "custom",
+        message: `Recipe body must be at most ${MAX_RECIPE_BODY_BYTES} bytes`,
+      });
+      return;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(value);
+    } catch {
+      context.addIssue({
+        code: "custom",
+        message: "Recipe body must be valid JSON",
+      });
+      return;
+    }
+
+    const result = savedRecipePayloadSchema.safeParse(payload);
+    if (!result.success) {
+      context.addIssue({
+        code: "custom",
+        message: "Recipe body must contain a valid saved recipe payload",
+      });
+    }
+  });
+
 // Household invitations stay valid for 48 hours after they are created.
 const INVITATION_EXPIRY_MS = 48 * 60 * 60 * 1000;
 
@@ -109,7 +153,7 @@ const createRecipeBodySchema = z.object({
   slug: recipeSlugSchema,
   title: z.string().trim().min(1).max(120),
   description: z.string().trim().min(1).max(500).optional(),
-  body: z.string().trim().min(1).max(100_000).optional(),
+  body: savedRecipeBodySchema.optional(),
   visibility: recipeVisibilitySchema.default("private"),
 });
 
@@ -117,7 +161,7 @@ const updateRecipeBodySchema = z
   .object({
     title: z.string().trim().min(1).max(120).optional(),
     description: z.string().trim().min(1).max(500).nullable().optional(),
-    body: z.string().trim().min(1).max(100_000).nullable().optional(),
+    body: savedRecipeBodySchema.nullable().optional(),
     visibility: recipeVisibilitySchema.optional(),
   })
   .strict()

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -107,17 +107,17 @@ const HOUSEHOLD_INVITE_RATE_LIMIT = { max: 10, windowSeconds: 60 * 60 };
 
 const createRecipeBodySchema = z.object({
   slug: recipeSlugSchema,
-  title: z.string().trim().min(1),
-  description: z.string().trim().min(1).optional(),
-  body: z.string().trim().min(1).optional(),
+  title: z.string().trim().min(1).max(120),
+  description: z.string().trim().min(1).max(500).optional(),
+  body: z.string().trim().min(1).max(100_000).optional(),
   visibility: recipeVisibilitySchema.default("private"),
 });
 
 const updateRecipeBodySchema = z
   .object({
-    title: z.string().trim().min(1).optional(),
-    description: z.string().trim().min(1).nullable().optional(),
-    body: z.string().trim().min(1).nullable().optional(),
+    title: z.string().trim().min(1).max(120).optional(),
+    description: z.string().trim().min(1).max(500).nullable().optional(),
+    body: z.string().trim().min(1).max(100_000).nullable().optional(),
     visibility: recipeVisibilitySchema.optional(),
   })
   .strict()

--- a/workers/recipe-api/tests/db-errors.test.ts
+++ b/workers/recipe-api/tests/db-errors.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { hasPostgresErrorCode } from "../src/db/errors";
+
+describe("hasPostgresErrorCode", () => {
+  it("recognizes a direct PostgreSQL error", () => {
+    expect(hasPostgresErrorCode({ code: "23505" }, "23505")).toBe(true);
+  });
+
+  it("recognizes a PostgreSQL error wrapped by the database client", () => {
+    const error = new Error("Failed query", {
+      cause: new Error("Database request failed", {
+        cause: { code: "23505" },
+      }),
+    });
+
+    expect(hasPostgresErrorCode(error, "23505")).toBe(true);
+  });
+
+  it("does not loop forever on a cyclic cause chain", () => {
+    const error: Error & { cause?: unknown } = new Error("cyclic");
+    error.cause = error;
+
+    expect(hasPostgresErrorCode(error, "23505")).toBe(false);
+  });
+});

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -1062,6 +1062,32 @@ describe("POST /recipes", () => {
     expect(await res.json()).toEqual({ error: "Authentication required" });
   });
 
+  it("requires saved recipe content", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/recipes",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          slug: "private-draft",
+          title: "Private Draft",
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
   it("rejects malformed saved recipe payloads", async () => {
     authzMock.session = sessionFor({
       id: "owner-user",
@@ -1087,15 +1113,17 @@ describe("POST /recipes", () => {
     );
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
-      error: "Invalid request body",
-      details: [
-        {
-          path: ["body"],
-          message: "Recipe body must contain a valid saved recipe payload",
-        },
-      ],
-    });
+    const body = (await res.json()) as {
+      error: string;
+      details: Array<{ path: string[]; message: string }>;
+    };
+    expect(body.error).toBe("Invalid request body");
+    expect(body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: ["body", "source"] }),
+        expect.objectContaining({ path: ["body", "recipe"] }),
+      ]),
+    );
   });
 });
 

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -1061,6 +1061,42 @@ describe("POST /recipes", () => {
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "Authentication required" });
   });
+
+  it("rejects malformed saved recipe payloads", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/recipes",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          slug: "private-draft",
+          title: "Private Draft",
+          body: JSON.stringify({ version: 1 }),
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "Invalid request body",
+      details: [
+        {
+          path: ["body"],
+          message: "Recipe body must contain a valid saved recipe payload",
+        },
+      ],
+    });
+  });
 });
 
 describe("profile diet preferences", () => {


### PR DESCRIPTION
## What changed

- add an authenticated, mid-fi styled recipe editor with a live Cooklang preview
- parse ingredients, cookware, and timers directly from inline Cooklang syntax
- save user recipes privately through the existing recipe API and associate them with the signed-in profile
- merge saved recipes into the existing statically generated recipe grid and provide a runtime-backed detail view
- add Pages proxy routing, input limits, and focused proxy/parser coverage

## Why

This delivers the first end-to-end slice for adding a personal recipe without changing the existing static recipe publishing flow. Cooklang remains the canonical authoring format, so ingredients and timers are derived from the recipe prose rather than entered in separate forms.

## Validation

- `mise //ui:typecheck`
- `mise //workers/recipe-api:typecheck`
- `mise //ui:test` (453 tests)
- `mise //workers/recipe-api:test` (89 tests)
- production UI build and integration suite completed before rebasing; conflicted recipe-list integration was revalidated with typechecks and the full unit suites after rebasing onto `origin/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated recipe creation with form entry, live Cooklang preview, validation, and saving.
  - Added saved-recipe pages with loading, error, visibility, and recipe detail views.
  - Saved recipes now appear alongside existing recipes and are labelled “Your recipe”.
  - Added an “Add recipe” button for signed-in users.

- **Bug Fixes**
  - Improved recipe API routing and safely reject invalid or unsafe paths.
  - Added stronger validation for saved recipe content and clearer duplicate-name errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->