### PR TITLE
Custom cooking timers

### DIFF
--- a/ui/components/recipes/add-timer-popover.tsx
+++ b/ui/components/recipes/add-timer-popover.tsx
@@ -92,7 +92,11 @@ export function AddTimerPopover({
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent align={align} className="w-64">
+      {/* Above the cook-mode dialog (z-60) and the floating dock (z-80): this
+          popover is opened from inside both, and the shared PopoverContent's
+          default z-50 would otherwise render it behind the opaque cook-mode
+          overlay — i.e. "nothing happens" when you tap add-timer while cooking. */}
+      <PopoverContent align={align} className="z-[90] w-64">
         <form
           onSubmit={(event) => {
             event.preventDefault();

--- a/ui/components/recipes/add-timer-popover.tsx
+++ b/ui/components/recipes/add-timer-popover.tsx
@@ -12,7 +12,6 @@ import {
 import { startCustomTimer } from "@/lib/cooking/timerStore";
 import { cn } from "@/lib/generic/styles";
 
-/** Minute presets for the one-tap chips — the common "package instructions" spans. */
 const QUICK_MINUTES = [1, 3, 5, 10, 15] as const;
 
 function clampInt(value: string, max: number): number {
@@ -21,17 +20,6 @@ function clampInt(value: string, max: number): number {
   return Math.min(parsed, max);
 }
 
-/**
- * A tap-to-open popover for starting an ad-hoc timer the user types in
- * themselves — for the many recipes that say "cook according to package
- * instructions" with no inline duration to kick off. The started timer lands
- * in the same global store as parsed recipe timers, so it shows up in cook
- * mode and the floating dock and survives navigation.
- *
- * `trigger` is the visible control (rendered via Radix `asChild`, so it must be
- * a single focusable element). Recipe context is optional: pass it when adding
- * from within a recipe so the dock can deep-link back to the step.
- */
 export function AddTimerPopover({
   trigger,
   defaultLabel = "",
@@ -64,8 +52,6 @@ export function AddTimerPopover({
 
   const durationSeconds = clampInt(minutes, 999) * 60 + clampInt(seconds, 59);
 
-  // Reset the form each time the popover opens so a previous entry doesn't
-  // linger, and re-seed from the (possibly step-specific) defaults.
   const handleOpenChange = (next: boolean) => {
     if (next) {
       setMinutes(String(defaultMinutes));

--- a/ui/components/recipes/add-timer-popover.tsx
+++ b/ui/components/recipes/add-timer-popover.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { Timer } from "lucide-react";
+import { type ReactNode, useId, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { startCustomTimer } from "@/lib/cooking/timerStore";
+import { cn } from "@/lib/generic/styles";
+
+/** Minute presets for the one-tap chips — the common "package instructions" spans. */
+const QUICK_MINUTES = [1, 3, 5, 10, 15] as const;
+
+function clampInt(value: string, max: number): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.min(parsed, max);
+}
+
+/**
+ * A tap-to-open popover for starting an ad-hoc timer the user types in
+ * themselves — for the many recipes that say "cook according to package
+ * instructions" with no inline duration to kick off. The started timer lands
+ * in the same global store as parsed recipe timers, so it shows up in cook
+ * mode and the floating dock and survives navigation.
+ *
+ * `trigger` is the visible control (rendered via Radix `asChild`, so it must be
+ * a single focusable element). Recipe context is optional: pass it when adding
+ * from within a recipe so the dock can deep-link back to the step.
+ */
+export function AddTimerPopover({
+  trigger,
+  defaultLabel = "",
+  defaultMinutes = 5,
+  recipeSlug,
+  recipeTitle,
+  stepIndex,
+  stepText,
+  align = "center",
+  onStarted,
+}: Readonly<{
+  trigger: ReactNode;
+  defaultLabel?: string;
+  defaultMinutes?: number;
+  recipeSlug?: string;
+  recipeTitle?: string;
+  stepIndex?: number;
+  stepText?: string;
+  align?: "start" | "center" | "end";
+  onStarted?: (id: string) => void;
+}>) {
+  const [open, setOpen] = useState(false);
+  const [minutes, setMinutes] = useState(String(defaultMinutes));
+  const [seconds, setSeconds] = useState("0");
+  const [label, setLabel] = useState(defaultLabel);
+  const labelId = useId();
+  const minutesId = useId();
+  const secondsId = useId();
+
+  const durationSeconds = clampInt(minutes, 999) * 60 + clampInt(seconds, 59);
+
+  // Reset the form each time the popover opens so a previous entry doesn't
+  // linger, and re-seed from the (possibly step-specific) defaults.
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setMinutes(String(defaultMinutes));
+      setSeconds("0");
+      setLabel(defaultLabel);
+    }
+    setOpen(next);
+  };
+
+  const start = () => {
+    if (durationSeconds <= 0) return;
+    const id = startCustomTimer({
+      label: label.trim() || "Timer",
+      durationSeconds,
+      recipeSlug,
+      recipeTitle,
+      stepIndex,
+      stepText,
+    });
+    onStarted?.(id);
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align={align} className="w-64">
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            start();
+          }}
+          className="flex flex-col gap-3"
+        >
+          <div className="rt-mono flex items-center gap-1.5 text-[var(--terracotta)]">
+            <Timer className="size-3.5" />
+            add a timer
+          </div>
+
+          <div className="flex items-end gap-2">
+            <label className="flex flex-1 flex-col gap-1" htmlFor={minutesId}>
+              <span className="rt-mono text-[10px] text-[var(--ink-3)]">
+                min
+              </span>
+              <Input
+                id={minutesId}
+                type="number"
+                inputMode="numeric"
+                min={0}
+                max={999}
+                value={minutes}
+                onChange={(event) => setMinutes(event.target.value)}
+                className="tabular-nums"
+              />
+            </label>
+            <span className="pb-2 text-[var(--ink-3)]">:</span>
+            <label className="flex flex-1 flex-col gap-1" htmlFor={secondsId}>
+              <span className="rt-mono text-[10px] text-[var(--ink-3)]">
+                sec
+              </span>
+              <Input
+                id={secondsId}
+                type="number"
+                inputMode="numeric"
+                min={0}
+                max={59}
+                value={seconds}
+                onChange={(event) => setSeconds(event.target.value)}
+                className="tabular-nums"
+              />
+            </label>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5">
+            {QUICK_MINUTES.map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => {
+                  setMinutes(String(m));
+                  setSeconds("0");
+                }}
+                className={cn(
+                  "rt-mono rounded-full border border-[var(--line-strong)] px-2 py-0.5 text-[11px] transition-colors hover:bg-[var(--butter-soft)]",
+                  clampInt(minutes, 999) === m &&
+                    clampInt(seconds, 59) === 0 &&
+                    "bg-[var(--butter-soft)] font-semibold",
+                )}
+              >
+                {m}m
+              </button>
+            ))}
+          </div>
+
+          <label className="flex flex-col gap-1" htmlFor={labelId}>
+            <span className="rt-mono text-[10px] text-[var(--ink-3)]">
+              label (optional)
+            </span>
+            <Input
+              id={labelId}
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="e.g. pasta"
+              maxLength={40}
+            />
+          </label>
+
+          <Button
+            type="submit"
+            size="sm"
+            disabled={durationSeconds <= 0}
+            className="bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+          >
+            Start timer
+          </Button>
+        </form>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/components/recipes/add-timer-popover.tsx
+++ b/ui/components/recipes/add-timer-popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Timer } from "lucide-react";
-import { type ReactNode, useId, useState } from "react";
+import { type ReactElement, useId, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -43,7 +43,8 @@ export function AddTimerPopover({
   align = "center",
   onStarted,
 }: Readonly<{
-  trigger: ReactNode;
+  /** Radix `asChild` requires a single focusable element, so ReactElement (not ReactNode). */
+  trigger: ReactElement;
   defaultLabel?: string;
   defaultMinutes?: number;
   recipeSlug?: string;
@@ -117,6 +118,9 @@ export function AddTimerPopover({
                 max={999}
                 value={minutes}
                 onChange={(event) => setMinutes(event.target.value)}
+                // Snap the field to the value actually used, so a typed 1000
+                // doesn't read as 1000 while the timer starts at 999.
+                onBlur={() => setMinutes(String(clampInt(minutes, 999)))}
                 className="tabular-nums"
               />
             </label>
@@ -133,6 +137,7 @@ export function AddTimerPopover({
                 max={59}
                 value={seconds}
                 onChange={(event) => setSeconds(event.target.value)}
+                onBlur={() => setSeconds(String(clampInt(seconds, 59)))}
                 className="tabular-nums"
               />
             </label>

--- a/ui/components/recipes/cook-mode.tsx
+++ b/ui/components/recipes/cook-mode.tsx
@@ -194,6 +194,11 @@ export function CookMode({
   // trapped inside the dialog.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      // An add-timer popover (portalled to <body>, outside the dialog) is open:
+      // let it own the keyboard. Otherwise our focus trap yanks Tab back into
+      // the dialog — leaving the popover's fields unreachable — and Escape would
+      // exit cook mode instead of closing the popover.
+      if (document.querySelector('[data-slot="popover-content"]')) return;
       if (event.key === "Tab") {
         trapFocus(event, containerRef.current);
         return;

--- a/ui/components/recipes/cook-mode.tsx
+++ b/ui/components/recipes/cook-mode.tsx
@@ -271,13 +271,16 @@ export function CookMode({
       token.durationSeconds !== null,
   );
 
-  // Author-marked timers with no duration (e.g. `~pasta{}` for "cook to package
-  // instructions") — surfaced as prompts so the cook can set their own time
-  // without leaving cook mode.
+  // Timer tokens with no resolved duration render as "set a timer" prompts.
   const currentPrompts = (current.tokens ?? []).filter(
     (token): token is CookToken & { type: "timer" } =>
       token.type === "timer" && token.durationSeconds === null,
   );
+
+  // Offer the generic add-timer only when the step has no timer of its own, so
+  // it never doubles up with a timer control or a prompt.
+  const showAddTimer =
+    currentTimers.length === 0 && currentPrompts.length === 0;
 
   const isLastStep = clampedStep === steps.length - 1;
 
@@ -387,13 +390,34 @@ export function CookMode({
               />
             ))}
 
-            <div className="mt-7 flex flex-wrap items-center gap-2">
-              {currentPrompts.map((token, index) => {
-                const promptLabel = token.value.trim();
-                return (
+            {(currentPrompts.length > 0 || showAddTimer) && (
+              <div className="mt-7 flex flex-wrap items-center gap-2">
+                {currentPrompts.map((token, index) => {
+                  const promptLabel = token.value.trim();
+                  return (
+                    <AddTimerPopover
+                      key={`prompt-${index}:${token.value}`}
+                      defaultLabel={promptLabel}
+                      recipeSlug={recipeSlug}
+                      recipeTitle={recipeTitle}
+                      stepIndex={clampedStep}
+                      stepText={current.text}
+                      trigger={
+                        <Button
+                          size="sm"
+                          className="bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+                        >
+                          <Timer className="size-4" />
+                          {promptLabel
+                            ? `Set ${promptLabel} timer`
+                            : "Set timer"}
+                        </Button>
+                      }
+                    />
+                  );
+                })}
+                {showAddTimer && (
                   <AddTimerPopover
-                    key={`prompt-${index}:${token.value}`}
-                    defaultLabel={promptLabel}
                     recipeSlug={recipeSlug}
                     recipeTitle={recipeTitle}
                     stepIndex={clampedStep}
@@ -401,32 +425,17 @@ export function CookMode({
                     trigger={
                       <Button
                         size="sm"
-                        className="bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+                        variant="outline"
+                        className="text-[var(--ink-2)]"
                       >
-                        <Timer className="size-4" />
-                        {promptLabel ? `Set ${promptLabel} timer` : "Set timer"}
+                        <Plus className="size-4" />
+                        Add timer
                       </Button>
                     }
                   />
-                );
-              })}
-              <AddTimerPopover
-                recipeSlug={recipeSlug}
-                recipeTitle={recipeTitle}
-                stepIndex={clampedStep}
-                stepText={current.text}
-                trigger={
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="text-[var(--ink-2)]"
-                  >
-                    <Plus className="size-4" />
-                    Add timer
-                  </Button>
-                }
-              />
-            </div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* nav */}

--- a/ui/components/recipes/cook-mode.tsx
+++ b/ui/components/recipes/cook-mode.tsx
@@ -8,10 +8,13 @@ import {
   ListChecks,
   Pause,
   Play,
+  Plus,
   RotateCcw,
+  Timer,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
 import { Button } from "@/components/ui/button";
 import { useCookingTimer } from "@/hooks/use-cooking-timers";
 import {
@@ -263,6 +266,14 @@ export function CookMode({
       token.durationSeconds !== null,
   );
 
+  // Author-marked timers with no duration (e.g. `~pasta{}` for "cook to package
+  // instructions") — surfaced as prompts so the cook can set their own time
+  // without leaving cook mode.
+  const currentPrompts = (current.tokens ?? []).filter(
+    (token): token is CookToken & { type: "timer" } =>
+      token.type === "timer" && token.durationSeconds === null,
+  );
+
   const isLastStep = clampedStep === steps.length - 1;
 
   const ingredientPanel = (
@@ -370,6 +381,47 @@ export function CookMode({
                 stepText={current.text}
               />
             ))}
+
+            <div className="mt-7 flex flex-wrap items-center gap-2">
+              {currentPrompts.map((token, index) => {
+                const promptLabel = token.value.trim();
+                return (
+                  <AddTimerPopover
+                    key={`prompt-${index}:${token.value}`}
+                    defaultLabel={promptLabel}
+                    recipeSlug={recipeSlug}
+                    recipeTitle={recipeTitle}
+                    stepIndex={clampedStep}
+                    stepText={current.text}
+                    trigger={
+                      <Button
+                        size="sm"
+                        className="bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+                      >
+                        <Timer className="size-4" />
+                        {promptLabel ? `Set ${promptLabel} timer` : "Set timer"}
+                      </Button>
+                    }
+                  />
+                );
+              })}
+              <AddTimerPopover
+                recipeSlug={recipeSlug}
+                recipeTitle={recipeTitle}
+                stepIndex={clampedStep}
+                stepText={current.text}
+                trigger={
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="text-[var(--ink-2)]"
+                  >
+                    <Plus className="size-4" />
+                    Add timer
+                  </Button>
+                }
+              />
+            </div>
           </div>
 
           {/* nav */}

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -75,10 +75,8 @@ export function InlineTimer({
     label,
   ]);
 
-  // A timer the author marked without a resolvable duration (e.g. a
-  // "cook to package instructions" step). Rather than a dead badge, invite the
-  // cook to set their own time — the started timer joins the global store. The
-  // label can be empty for free-text markers, so fall back to a generic prompt.
+  // No resolved duration: offer to set a custom time. The label can be empty
+  // for free-text markers, so fall back to a generic prompt.
   if (durationSeconds === null) {
     const promptLabel = label.trim() || "set timer";
     return (

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -2,6 +2,7 @@
 
 import { Pause, RotateCcw, Timer, X } from "lucide-react";
 import { useCallback } from "react";
+import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
 import { badgeVariants } from "@/components/ui/badge";
 import { useCookingTimer } from "@/hooks/use-cooking-timers";
 import {
@@ -74,15 +75,37 @@ export function InlineTimer({
     label,
   ]);
 
+  // A timer the author marked without a resolvable duration (e.g. a
+  // "cook to package instructions" step). Rather than a dead badge, invite the
+  // cook to set their own time — the started timer joins the global store. The
+  // label can be empty for free-text markers, so fall back to a generic prompt.
   if (durationSeconds === null) {
+    const promptLabel = label.trim() || "set timer";
     return (
-      <span
-        data-recipe-pill
-        className={cn(badgeVariants({ variant: "outline" }), "align-baseline")}
-      >
-        <Timer className="size-3" />
-        {label}
-      </span>
+      <AddTimerPopover
+        defaultLabel={label.trim()}
+        recipeSlug={recipeSlug}
+        recipeTitle={recipeTitle}
+        stepIndex={stepIndex}
+        stepText={stepText}
+        trigger={
+          <button
+            type="button"
+            data-recipe-pill
+            className={cn(
+              badgeVariants({ variant: "outline", interactive: true }),
+              "align-baseline text-[0.8125rem] font-semibold",
+              "bg-[var(--butter-soft)] text-[var(--ink)]",
+            )}
+            aria-label={
+              label.trim() ? `Set a ${label.trim()} timer` : "Set a timer"
+            }
+          >
+            <Timer className="size-3" />
+            {promptLabel}
+          </button>
+        }
+      />
     );
   }
 

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -537,27 +537,34 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
                           )}
                         </span>
                       ))
-                    : step.text}{" "}
-                  <AddTimerPopover
-                    align="start"
-                    recipeSlug={recipe.slug}
-                    recipeTitle={recipe.title}
-                    stepIndex={stepIndex}
-                    stepText={step.text}
-                    trigger={
-                      <button
-                        type="button"
-                        // Low-emphasis so it never competes with the method
-                        // text, but always there for the "package instructions"
-                        // steps that carry no inline timer of their own.
-                        className="ml-0.5 inline-flex translate-y-[1px] items-center gap-0.5 align-baseline text-[0.6875rem] text-[var(--ink-4)] opacity-70 transition-opacity hover:opacity-100 hover:text-[var(--terracotta)]"
-                        aria-label="Add a timer for this step"
-                      >
-                        <Timer className="size-3" />
-                        timer
-                      </button>
-                    }
-                  />
+                    : step.text}
+                  {/* Only offer the generic add-timer on steps that have no
+                      timer of their own, so it never doubles up with a timer
+                      pill or a "set a timer" prompt already in the step. */}
+                  {step.tokens?.some(
+                    (token) => token.type === "timer",
+                  ) ? null : (
+                    <>
+                      {" "}
+                      <AddTimerPopover
+                        align="start"
+                        recipeSlug={recipe.slug}
+                        recipeTitle={recipe.title}
+                        stepIndex={stepIndex}
+                        stepText={step.text}
+                        trigger={
+                          <button
+                            type="button"
+                            className="ml-0.5 inline-flex translate-y-[1px] items-center gap-0.5 align-baseline text-[0.6875rem] text-[var(--ink-4)] opacity-70 transition-opacity hover:opacity-100 hover:text-[var(--terracotta)]"
+                            aria-label="Add a timer for this step"
+                          >
+                            <Timer className="size-3" />
+                            timer
+                          </button>
+                        }
+                      />
+                    </>
+                  )}
                 </div>
               </div>
             </li>

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
 import {
   CookMode,
   type CookStep,
@@ -536,7 +537,27 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
                           )}
                         </span>
                       ))
-                    : step.text}
+                    : step.text}{" "}
+                  <AddTimerPopover
+                    align="start"
+                    recipeSlug={recipe.slug}
+                    recipeTitle={recipe.title}
+                    stepIndex={stepIndex}
+                    stepText={step.text}
+                    trigger={
+                      <button
+                        type="button"
+                        // Low-emphasis so it never competes with the method
+                        // text, but always there for the "package instructions"
+                        // steps that carry no inline timer of their own.
+                        className="ml-0.5 inline-flex translate-y-[1px] items-center gap-0.5 align-baseline text-[0.6875rem] text-[var(--ink-4)] opacity-70 transition-opacity hover:opacity-100 hover:text-[var(--terracotta)]"
+                        aria-label="Add a timer for this step"
+                      >
+                        <Timer className="size-3" />
+                        timer
+                      </button>
+                    }
+                  />
                 </div>
               </div>
             </li>

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -6,6 +6,7 @@ import {
   GripVertical,
   Pause,
   Play,
+  Plus,
   X,
 } from "lucide-react";
 import {
@@ -16,6 +17,7 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
+import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
 import { useCookingTimers } from "@/hooks/use-cooking-timers";
 import {
   type CookingTimer,
@@ -89,9 +91,11 @@ function dotColor(timer: CookingTimer): string {
 /**
  * Link back to the timer's recipe, deep-linking straight into cook mode at the
  * step that started it when we know which step that was. Slug is encoded as
- * defense-in-depth even though recipe slugs are build-time safe.
+ * defense-in-depth even though recipe slugs are build-time safe. Null for
+ * free-standing custom timers, which have no recipe to return to.
  */
-function timerHref(timer: CookingTimer): string {
+function timerHref(timer: CookingTimer): string | null {
+  if (timer.recipeSlug === undefined) return null;
   const base = `/recipes/${encodeURIComponent(timer.recipeSlug)}`;
   return timer.stepIndex === undefined
     ? base
@@ -243,11 +247,13 @@ export function TimerDock() {
     [],
   );
 
-  if (!mounted || timers.length === 0) return null;
+  // Keep the dock out of the way on non-cooking pages, but while cook mode is
+  // open surface it even with no timers yet so "add a timer" is always one tap
+  // away — the whole point for recipes that say "cook to package instructions".
+  if (!mounted || (timers.length === 0 && !cookModeOpen)) return null;
 
   const sorted = [...timers].sort(byUrgency);
   const primary = sorted[0];
-  if (!primary) return null;
 
   // Positioning: default anchor comes from CSS classes; a dragged position is
   // applied inline. While cook mode is open, raise the bottom to clear its
@@ -262,6 +268,40 @@ export function TimerDock() {
     };
   } else if (cookModeOpen) {
     style = { bottom: cookModeFooterClearance() };
+  }
+
+  const addTimerControl = (
+    <AddTimerPopover
+      align="end"
+      trigger={
+        <button
+          type="button"
+          aria-label="Add a custom timer"
+          className="flex items-center gap-1.5 rounded-full px-2 py-1.5 text-[var(--paper)]/85 transition-colors hover:bg-[var(--paper)]/15 hover:text-[var(--paper)]"
+        >
+          <Plus className="size-4" />
+          <span className="rt-mono text-[11px]">add timer</span>
+        </button>
+      }
+    />
+  );
+
+  // Cook mode is open but nothing is running yet: show just the add-timer
+  // entry point so the user never has to leave the site for a stray timer.
+  if (!primary) {
+    return createPortal(
+      <section
+        ref={dockRef}
+        aria-label="Cooking timers"
+        className="rt-timer-dock fixed right-3 bottom-3 z-[80] sm:right-4 sm:bottom-4"
+        style={style}
+      >
+        <div className="flex items-center rounded-full bg-[var(--ink)] px-1 py-1 text-[var(--paper)] shadow-lg">
+          {addTimerControl}
+        </div>
+      </section>,
+      document.body,
+    );
   }
 
   const grip = (
@@ -314,6 +354,9 @@ export function TimerDock() {
               <DockRow key={timer.id} timer={timer} />
             ))}
           </div>
+          <div className="mt-1 border-t border-[var(--paper)]/10 pt-1">
+            {addTimerControl}
+          </div>
         </div>
       ) : (
         <div className="flex items-center rounded-full bg-[var(--ink)] py-1 pr-2.5 pl-1.5 text-[var(--paper)] shadow-lg">
@@ -360,6 +403,18 @@ export function TimerDock() {
             )}
             <ChevronUp className="size-3.5 opacity-60" />
           </button>
+          <AddTimerPopover
+            align="end"
+            trigger={
+              <button
+                type="button"
+                aria-label="Add a custom timer"
+                className="ml-1 rounded-full p-1.5 text-[var(--paper)]/80 transition-colors hover:bg-[var(--paper)]/15 hover:text-[var(--paper)]"
+              >
+                <Plus className="size-4" />
+              </button>
+            }
+          />
         </div>
       )}
     </section>,
@@ -371,6 +426,8 @@ function DockRow({ timer }: Readonly<{ timer: CookingTimer }>) {
   const completed = timer.state === "completed";
   const paused = timer.state === "paused";
   const tag = stepTag(timer);
+  const href = timerHref(timer);
+  const subtitle = timer.stepText || timer.recipeTitle || "custom timer";
   const tooltip = [
     timer.recipeTitle,
     tag && `${tag} of ${timer.recipeTitle}`,
@@ -379,39 +436,49 @@ function DockRow({ timer }: Readonly<{ timer: CookingTimer }>) {
     .filter(Boolean)
     .join(" — ");
 
+  const detailClassName = [
+    "flex min-w-0 flex-1 flex-col leading-tight",
+    completed ? "animate-pulse" : "",
+  ].join(" ");
+  const detail = (
+    <>
+      <span
+        className="rt-mono max-w-40 truncate text-[9px]"
+        style={{ color: dotColor(timer) }}
+      >
+        ● {timer.label}
+        {tag && <span className="text-[var(--ink-4)]"> · {tag}</span>}
+      </span>
+      <span className="max-w-40 truncate font-[family-name:var(--font-kalam)] text-[10px] text-[var(--ink-4)]">
+        {subtitle}
+      </span>
+      <span
+        className={[
+          "rt-display text-lg leading-none tabular-nums",
+          paused ? "opacity-60" : "",
+        ].join(" ")}
+      >
+        {completed ? "done!" : formatCountdown(timer.remainingSeconds)}
+      </span>
+    </>
+  );
+
   return (
     <div className="flex items-center gap-1.5 rounded-lg px-1 py-0.5">
       {/* A plain <a> (full navigation), not next/link: deep-linking into cook
           mode relies on RecipeContent reading ?cook=1&step=N on mount, which a
           client-side transition to the same recipe route wouldn't retrigger.
-          Timers persist across the reload, so the dock survives. */}
-      <a
-        href={timerHref(timer)}
-        className={[
-          "flex min-w-0 flex-1 flex-col leading-tight",
-          completed ? "animate-pulse" : "",
-        ].join(" ")}
-        title={tooltip}
-      >
-        <span
-          className="rt-mono max-w-40 truncate text-[9px]"
-          style={{ color: dotColor(timer) }}
-        >
-          ● {timer.label}
-          {tag && <span className="text-[var(--ink-4)]"> · {tag}</span>}
-        </span>
-        <span className="max-w-40 truncate font-[family-name:var(--font-kalam)] text-[10px] text-[var(--ink-4)]">
-          {timer.stepText || timer.recipeTitle}
-        </span>
-        <span
-          className={[
-            "rt-display text-lg leading-none tabular-nums",
-            paused ? "opacity-60" : "",
-          ].join(" ")}
-        >
-          {completed ? "done!" : formatCountdown(timer.remainingSeconds)}
-        </span>
-      </a>
+          Timers persist across the reload, so the dock survives. Custom timers
+          have no recipe to return to, so they render as a plain block. */}
+      {href === null ? (
+        <div className={detailClassName} title={tooltip || undefined}>
+          {detail}
+        </div>
+      ) : (
+        <a href={href} className={detailClassName} title={tooltip}>
+          {detail}
+        </a>
+      )}
       {!completed && (
         <button
           type="button"

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -95,11 +95,31 @@ function dotColor(timer: CookingTimer): string {
  * free-standing custom timers, which have no recipe to return to.
  */
 function timerHref(timer: CookingTimer): string | null {
-  if (timer.recipeSlug === undefined) return null;
+  if (!timer.recipeSlug) return null;
   const base = `/recipes/${encodeURIComponent(timer.recipeSlug)}`;
   return timer.stepIndex === undefined
     ? base
     : `${base}?cook=1&step=${timer.stepIndex + 1}`;
+}
+
+/**
+ * Inline positioning for a dragged dock. Default anchor comes from CSS classes,
+ * so this returns undefined until the user has moved it; while cook mode is open
+ * the bottom is raised to clear its footer without mutating the stored position.
+ */
+function dockStyle(
+  position: DockPosition | null,
+  cookModeOpen: boolean,
+): React.CSSProperties | undefined {
+  if (position) {
+    return {
+      right: position.right,
+      bottom: cookModeOpen
+        ? Math.max(position.bottom, cookModeFooterClearance())
+        : position.bottom,
+    };
+  }
+  return cookModeOpen ? { bottom: cookModeFooterClearance() } : undefined;
 }
 
 /** Short "step N" tag when the originating step is known. */
@@ -254,21 +274,7 @@ export function TimerDock() {
 
   const sorted = [...timers].sort(byUrgency);
   const primary = sorted[0];
-
-  // Positioning: default anchor comes from CSS classes; a dragged position is
-  // applied inline. While cook mode is open, raise the bottom to clear its
-  // footer without mutating the stored position.
-  let style: React.CSSProperties | undefined;
-  if (position) {
-    style = {
-      right: position.right,
-      bottom: cookModeOpen
-        ? Math.max(position.bottom, cookModeFooterClearance())
-        : position.bottom,
-    };
-  } else if (cookModeOpen) {
-    style = { bottom: cookModeFooterClearance() };
-  }
+  const style = dockStyle(position, cookModeOpen);
 
   const addTimerControl = (
     <AddTimerPopover

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -267,9 +267,8 @@ export function TimerDock() {
     [],
   );
 
-  // Keep the dock out of the way on non-cooking pages, but while cook mode is
-  // open surface it even with no timers yet so "add a timer" is always one tap
-  // away — the whole point for recipes that say "cook to package instructions".
+  // Hide the dock when idle, but keep it while cook mode is open (even with no
+  // timers) so add-timer stays one tap away.
   if (!mounted || (timers.length === 0 && !cookModeOpen)) return null;
 
   const sorted = [...timers].sort(byUrgency);
@@ -292,8 +291,7 @@ export function TimerDock() {
     />
   );
 
-  // Cook mode is open but nothing is running yet: show just the add-timer
-  // entry point so the user never has to leave the site for a stray timer.
+  // Cook mode open with no timers yet: show just the add-timer entry point.
   if (!primary) {
     return createPortal(
       <section

--- a/ui/content/recipes/cajun-sausage-pasta.cook
+++ b/ui/content/recipes/cajun-sausage-pasta.cook
@@ -24,7 +24,7 @@ ingredientAnnotations:
     note: "for frying"
 ---
 
-Cook the @pasta{320%g} according to package instructions in a #saucepan{}, ensuring you save a few ladles of pasta water before draining.
+Cook the @pasta{320%g} according to ~{package instructions} in a #saucepan{}, ensuring you save a few ladles of pasta water before draining.
 
 While the pasta is cooking, heat @olive oil{} in a separate #frying pan{} over a medium heat.
 

--- a/ui/content/recipes/creamy-cajun-orzo.cook
+++ b/ui/content/recipes/creamy-cajun-orzo.cook
@@ -22,7 +22,7 @@ Stir in the @light cream cheese{240%g} and allow it to melt.
 
 Add the remaining @cajun powder{1%tbsp}, @paprika{1%tbsp}, and @garlic powder{1%tsp}.
 
-Cook the @orzo{} in a #saucepan{} according to package directions.
+Cook the @orzo{} in a #saucepan{} according to ~{package directions}.
 
 Simmer the sauce for approximately ~{10%minutes}, slowly whisking in the @plain flour{1%tbsp} during that time to thicken.
 

--- a/ui/content/recipes/marry-me-chicken-pasta.cook
+++ b/ui/content/recipes/marry-me-chicken-pasta.cook
@@ -35,7 +35,7 @@ Add @tomato puree{1%tbsp} and mix through.
 
 Add the @chicken stock{300%ml}, @single cream{100%ml}, @sun-dried tomato|sun-dried tomatoes{75%g}, and @basil{1%handful} and bring to the boil.
 
-In a separate #pot{}, cook the @pasta{300%g} according to package instructions.
+In a separate #pot{}, cook the @pasta{300%g} according to ~{package instructions}.
 
 Add the chicken back into the #frying pan{} and simmer with the #lid{} on for ~{10%minutes}.
 

--- a/ui/lib/cooking/timerStore.ts
+++ b/ui/lib/cooking/timerStore.ts
@@ -239,14 +239,10 @@ export function startTimer(input: StartTimerInput): void {
 
 let customTimerSeq = 0;
 
-/**
- * Start an ad-hoc timer the user typed in themselves (not parsed from a
- * recipe). A fresh id is minted each call so repeated "add timer" taps stack
- * rather than replacing one another, and it's returned for the caller to track.
- * The fallback uses a monotonic counter (not Math.random) so ids stay unique
- * even for rapid taps in the same millisecond.
- */
+/** Start an ad-hoc timer under a freshly minted id, which is returned. */
 export function startCustomTimer(input: CustomTimerInput): string {
+  // Monotonic counter (not Math.random) so the fallback stays collision-free
+  // for rapid taps within the same millisecond.
   customTimerSeq += 1;
   const unique =
     globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${customTimerSeq}`;

--- a/ui/lib/cooking/timerStore.ts
+++ b/ui/lib/cooking/timerStore.ts
@@ -16,8 +16,9 @@ export type CookingTimerState = "running" | "paused" | "completed";
 
 export type CookingTimer = {
   id: string;
-  recipeSlug: string;
-  recipeTitle: string;
+  /** Recipe the timer belongs to; absent for free-standing custom timers. */
+  recipeSlug?: string;
+  recipeTitle?: string;
   label: string;
   /** Zero-based method step the timer belongs to, when known. */
   stepIndex?: number;
@@ -33,13 +34,16 @@ export type CookingTimer = {
 
 export type StartTimerInput = {
   id: string;
-  recipeSlug: string;
-  recipeTitle: string;
+  recipeSlug?: string;
+  recipeTitle?: string;
   label: string;
   stepIndex?: number;
   stepText?: string;
   durationSeconds: number;
 };
+
+/** A custom timer with no parsed-recipe origin; recipe context is optional. */
+export type CustomTimerInput = Omit<StartTimerInput, "id">;
 
 const STORAGE_KEY = "cooking-timers:v1";
 const WAKE_LOCK_KEY = "cooking-timers";
@@ -71,8 +75,8 @@ function isStoredTimer(value: unknown): value is CookingTimer {
   const t = value as Record<string, unknown>;
   return (
     typeof t.id === "string" &&
-    typeof t.recipeSlug === "string" &&
-    typeof t.recipeTitle === "string" &&
+    (t.recipeSlug === undefined || typeof t.recipeSlug === "string") &&
+    (t.recipeTitle === undefined || typeof t.recipeTitle === "string") &&
     typeof t.label === "string" &&
     typeof t.durationSeconds === "number" &&
     typeof t.remainingSeconds === "number" &&
@@ -231,6 +235,19 @@ export function startTimer(input: StartTimerInput): void {
     endTimeMs: Date.now() + input.durationSeconds * 1000,
   };
   commit([...timers.filter((t) => t.id !== input.id), timer]);
+}
+
+/**
+ * Start an ad-hoc timer the user typed in themselves (not parsed from a
+ * recipe). A fresh id is minted each call so repeated "add timer" taps stack
+ * rather than replacing one another, and it's returned for the caller to track.
+ */
+export function startCustomTimer(input: CustomTimerInput): string {
+  const id = `custom:${
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`
+  }`;
+  startTimer({ ...input, id });
+  return id;
 }
 
 export function pauseTimer(id: string): void {

--- a/ui/lib/cooking/timerStore.ts
+++ b/ui/lib/cooking/timerStore.ts
@@ -237,15 +237,20 @@ export function startTimer(input: StartTimerInput): void {
   commit([...timers.filter((t) => t.id !== input.id), timer]);
 }
 
+let customTimerSeq = 0;
+
 /**
  * Start an ad-hoc timer the user typed in themselves (not parsed from a
  * recipe). A fresh id is minted each call so repeated "add timer" taps stack
  * rather than replacing one another, and it's returned for the caller to track.
+ * The fallback uses a monotonic counter (not Math.random) so ids stay unique
+ * even for rapid taps in the same millisecond.
  */
 export function startCustomTimer(input: CustomTimerInput): string {
-  const id = `custom:${
-    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`
-  }`;
+  customTimerSeq += 1;
+  const unique =
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${customTimerSeq}`;
+  const id = `custom:${unique}`;
   startTimer({ ...input, id });
   return id;
 }

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -146,7 +146,27 @@ function isIngredientOnlyStep(step: Step): boolean {
   return hasIngredient;
 }
 
+/**
+ * A timer whose quantity is free text rather than a number, e.g.
+ * `~{package instructions}`. The cooklang parser keeps the phrase as a text
+ * quantity; we surface it verbatim so it both reads naturally in the step
+ * ("cook the pasta according to package instructions") and gives the
+ * duration-less "set a timer" prompt a meaningful label.
+ */
+function timerQuantityText(timer: Timer): string | null {
+  const value = (timer.quantity as { value?: unknown } | null)?.value;
+  if (value && typeof value === "object" && "type" in value) {
+    const inner = value as { type: string; value?: unknown };
+    if (inner.type === "text" && typeof inner.value === "string") {
+      return inner.value.trim();
+    }
+  }
+  return null;
+}
+
 function formatTimerDisplay(timer: Timer): string {
+  const text = timerQuantityText(timer);
+  if (text !== null) return text;
   const qty = resolveQuantityValue(timer.quantity);
   const unit = getQuantityUnit(timer.quantity);
   return [qty !== undefined ? String(qty) : null, unit]

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -158,7 +158,9 @@ function timerQuantityText(timer: Timer): string | null {
   if (value && typeof value === "object" && "type" in value) {
     const inner = value as { type: string; value?: unknown };
     if (inner.type === "text" && typeof inner.value === "string") {
-      return inner.value.trim();
+      // Empty text falls through to the numeric path rather than blanking the
+      // display (defensive — the parser rejects `~{}` before we get here).
+      return inner.value.trim() || null;
     }
   }
   return null;

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -147,11 +147,8 @@ function isIngredientOnlyStep(step: Step): boolean {
 }
 
 /**
- * A timer whose quantity is free text rather than a number, e.g.
- * `~{package instructions}`. The cooklang parser keeps the phrase as a text
- * quantity; we surface it verbatim so it both reads naturally in the step
- * ("cook the pasta according to package instructions") and gives the
- * duration-less "set a timer" prompt a meaningful label.
+ * The free-text form of a timer quantity (e.g. `~{package instructions}`),
+ * which the cooklang parser keeps as a text value; null for numeric timers.
  */
 function timerQuantityText(timer: Timer): string | null {
   const value = (timer.quantity as { value?: unknown } | null)?.value;

--- a/ui/tests/components/recipes/add-timer-popover.test.tsx
+++ b/ui/tests/components/recipes/add-timer-popover.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
+
+describe("AddTimerPopover", () => {
+  it("renders its content above the cook-mode dialog (z-60) when opened", async () => {
+    const user = userEvent.setup();
+    render(
+      <AddTimerPopover
+        trigger={
+          <button type="button" aria-label="add timer">
+            add
+          </button>
+        }
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "add timer" }));
+
+    // The popover portals to <body> as a sibling of the full-screen opaque
+    // cook-mode dialog (z-[60]); without a higher z-index it renders behind it
+    // and tapping add-timer while cooking appears to do nothing.
+    const content = document.querySelector('[data-slot="popover-content"]');
+    expect(content).not.toBeNull();
+    expect(content?.className).toContain("z-[90]");
+  });
+});

--- a/ui/tests/lib/cooking/timer-store.test.ts
+++ b/ui/tests/lib/cooking/timer-store.test.ts
@@ -7,6 +7,7 @@ import {
   getTimersSnapshot,
   pauseTimer,
   resumeTimer,
+  startCustomTimer,
   startTimer,
   subscribeTimers,
 } from "@/lib/cooking/timerStore";
@@ -166,6 +167,42 @@ describe("timerStore", () => {
     expect(listener).toHaveBeenCalledTimes(4);
 
     unsubscribe();
+  });
+
+  it("starts a custom timer with a minted id and no recipe context", () => {
+    const id = startCustomTimer({ label: "Pasta", durationSeconds: 300 });
+    expect(id).toMatch(/^custom:/);
+    const timer = firstTimer();
+    expect(timer).toMatchObject({
+      id,
+      label: "Pasta",
+      state: "running",
+      remainingSeconds: 300,
+    });
+    expect(timer.recipeSlug).toBeUndefined();
+    expect(timer.recipeTitle).toBeUndefined();
+  });
+
+  it("mints a distinct id for each custom timer so they stack", () => {
+    const first = startCustomTimer({ label: "One", durationSeconds: 60 });
+    const second = startCustomTimer({ label: "Two", durationSeconds: 120 });
+    expect(first).not.toBe(second);
+    expect(getTimersSnapshot()).toHaveLength(2);
+  });
+
+  it("persists and restores custom timers with no recipe fields", () => {
+    startCustomTimer({ label: "Rice", durationSeconds: 600 });
+    vi.advanceTimersByTime(60_000);
+
+    __resetTimerStoreForTests();
+    const timers = getTimersSnapshot();
+    expect(timers).toHaveLength(1);
+    expect(timers[0]).toMatchObject({
+      label: "Rice",
+      state: "running",
+      remainingSeconds: 540,
+    });
+    expect(timers[0]?.recipeSlug).toBeUndefined();
   });
 
   it("formats countdowns", () => {

--- a/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
+++ b/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
@@ -39,6 +39,31 @@ describe("buildScaledRecipeParts", () => {
     ]);
   });
 
+  it("renders a free-text timer as its phrase with no resolved duration", () => {
+    const parts = buildScaledRecipeParts(
+      parsedAt(
+        `Cook the @pasta{100%g} according to ~{package instructions}.\n`,
+      ),
+    );
+
+    // The phrase reads naturally in the step text...
+    expect(parts.instructions).toEqual([
+      "Cook the 100g of pasta according to package instructions.",
+    ]);
+    // ...and is carried as the timer's display value with no duration, which is
+    // what turns it into a tap-to-set "custom timer" prompt in the UI.
+    expect(parts.instructionSdk.timerDisplayValues).toEqual([
+      "package instructions",
+    ]);
+    expect(parts.instructionSdk.timerDurationSeconds).toEqual([null]);
+  });
+
+  it("still resolves numeric timers to a duration", () => {
+    const parts = buildScaledRecipeParts(parsedAt(`Bake for ~{12%minutes}.\n`));
+    expect(parts.instructionSdk.timerDisplayValues).toEqual(["12 minutes"]);
+    expect(parts.instructionSdk.timerDurationSeconds).toEqual([720]);
+  });
+
   it("honours the = fixed-quantity prefix when scaling", () => {
     const parts = buildScaledRecipeParts(
       parsedAt(`Mix @flour{200%g} with @salt{=1%tsp}.\n`, 3),


### PR DESCRIPTION
## Why

Recipes constantly say *"cook according to package instructions"* with no inline duration to start — so cook mode can't help, and you leave the site for a separate timer app, breaking the whole stay-in-the-flow purpose. There was also no way to start an ad-hoc timer of your own.

## What

**Free-standing custom timers** (`AddTimerPopover`): minutes/seconds + one-tap presets + optional label, feeding the existing global timer store — so persistence, the floating dock, wake lock, cross-tab sync and the alert tone are all reused for free. Entry points:
- the timer **dock** (an "add timer" row, plus a minimal add-pill while cook mode is open with no timers running),
- a subtle **per-step** affordance in the method list,
- **per-step** controls in cook mode.

**Author-marked prompts.** Duration-less timers now render a tappable *"set a timer"* prompt instead of a dead badge, in both the method list and cook mode.

**Layer-2 parsing.** The cooklang parser keeps a timer's free-text quantity (`~{package instructions}`) as a text value, but we were dropping it — the phrase vanished from the step and the prompt had no label. We now surface it verbatim, so it reads naturally in the method *and* labels the prompt. This is the author-facing marker syntax, layered on cooklang with no spec change. Applied to three real recipes as live examples.

## Notes on the parser

Worth knowing for future work: empty-brace timers (`~{}`, `~pasta{}`) **crash** the parser (`RuntimeError: unreachable`), and a timer's name is not used as its display label. So a non-empty free-text quantity is the workable way to author a duration-less prompt. A genuine upstream suggestion would be first-class open-ended timers that don't crash and surface the name.

## Testing

- New unit tests: custom-timer store path (optional recipe context, id minting, persistence) and free-text-timer parsing (natural prose + null duration).
- Full suite (435) green; typecheck + Biome clean.
- Verified in the **built static export**: `recipes/cajun-sausage-pasta.html` renders the prompt pill (`aria-label="Set a package instructions timer"`) and the prose reads "…according to package instructions…"; the `.md` twin matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add custom timers with minutes, seconds, presets and optional labels.
  * Start timers directly from recipe steps, cook mode and the timer dock.
* **Improvements**
  * Timer prompts now support text-based durations (e.g., “package instructions”).
  * Custom timers are clearly distinguished from recipe-linked timers, including correct handling of “no duration” steps.
  * Cook mode no longer conflicts with timer popover interactions.
* **Content**
  * Updated several recipe instructions with clearer timer annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->