### PR TITLE
Add recipe sign-up onboarding workflow

### DIFF
--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -191,7 +191,8 @@ open or update an internal PR — the workflow runs from `main`. Confirm:
 3. Cloudflare contains `recipe-api-pr-<number>` with no Hyperdrive binding.
 4. The canonical `https://pr-<number>.<pages-host>` URL requires Access.
 5. The sign-in menu offers the empty, populated, and administrator scenarios.
-6. Closing the PR removes both the Neon branch and Worker.
+6. The onboarding sign-up button creates a new empty QA account on every use.
+7. Closing the PR removes both the Neon branch and Worker.
 
 If event-driven cleanup fails, run the **Preview Environment Cleanup** workflow
 manually with the PR number. Neon branch expiry is an additional database-only
@@ -204,6 +205,8 @@ backstop.
 - OAuth providers are disabled in preview.
 - Public email/password endpoints return `404`.
 - The scenario login exists only when `DEPLOYMENT_ENV=preview`.
+- Fresh QA sign-up exists only in previews, requires Access, and creates an
+  isolated account so onboarding can be repeated without resetting fixtures.
 - Scenario login requires a valid Access JWT and accepts only compiled-in IDs.
 - The browser never receives the generated test password.
 - Preview secrets are derived independently per PR and uploaded atomically with

--- a/functions/api/profile/recipe-box.ts
+++ b/functions/api/profile/recipe-box.ts
@@ -1,0 +1,10 @@
+import {
+  proxyRecipeApiRequest,
+  type RecipeApiProxyContext,
+} from "../auth/routing";
+
+export const onRequest = (context: RecipeApiProxyContext): Promise<Response> =>
+  proxyRecipeApiRequest(
+    context,
+    "Profile APIs are available on the canonical PR preview URL only",
+  );

--- a/packages/recipe-db/src/schema.ts
+++ b/packages/recipe-db/src/schema.ts
@@ -368,10 +368,7 @@ export const userRecipeBoxItem = pgTable(
     recipeSlug: text().notNull(),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [
-    primaryKey({ columns: [table.userId, table.recipeSlug] }),
-    index("user_recipe_box_item_user_id_idx").on(table.userId),
-  ],
+  (table) => [primaryKey({ columns: [table.userId, table.recipeSlug] })],
 );
 
 export const appRateLimit = pgTable("app_rate_limit", {

--- a/packages/recipe-db/src/schema.ts
+++ b/packages/recipe-db/src/schema.ts
@@ -343,6 +343,37 @@ export const userDietExcludedIngredient = pgTable(
   ],
 );
 
+/**
+ * The static recipes a user has chosen for their personal recipe box. The
+ * recipe content remains in the versioned Cooklang catalog; this table only
+ * stores the user's selection so the same recipe can be used by many people.
+ */
+export const userRecipeBox = pgTable("user_recipe_box", {
+  userId: text()
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+  completedAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp({ withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export const userRecipeBoxItem = pgTable(
+  "user_recipe_box_item",
+  {
+    userId: text()
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    recipeSlug: text().notNull(),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.recipeSlug] }),
+    index("user_recipe_box_item_user_id_idx").on(table.userId),
+  ],
+);
+
 export const appRateLimit = pgTable("app_rate_limit", {
   key: text().primaryKey(),
   count: integer().notNull().default(0),

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -58,14 +58,14 @@ export default function RecipesLayout({
           <nav className="container mx-auto px-4 py-3 max-w-7xl flex flex-wrap items-center gap-x-4 gap-y-2">
             <Link
               href="/recipes"
-              className="order-1 w-full shrink-0 rt-display text-3xl leading-none text-foreground sm:w-auto"
+              className="order-1 min-w-0 shrink whitespace-nowrap rt-display text-2xl leading-none text-foreground min-[360px]:text-3xl"
             >
               <span>Robbie's</span>{" "}
               <span className="rt-logo-accent">recipes</span>
             </Link>
-            <div className="order-2 flex w-full items-center justify-end gap-2 sm:order-3 sm:ms-auto sm:w-auto">
-              <AuthButton intent="signup" />
-              <AuthButton />
+            <div className="order-2 ms-auto flex shrink-0 items-center gap-2 sm:order-3">
+              <AuthButton intent="signup" compactOnMobile />
+              <AuthButton compactOnMobile />
             </div>
             <div className="order-3 w-full sm:order-2 sm:w-auto">
               <RecipeNavTabs />

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -58,12 +58,12 @@ export default function RecipesLayout({
           <nav className="container mx-auto px-4 py-3 max-w-7xl flex flex-wrap items-center gap-x-4 gap-y-2">
             <Link
               href="/recipes"
-              className="order-1 shrink-0 rt-display text-3xl leading-none text-foreground"
+              className="order-1 w-full shrink-0 rt-display text-3xl leading-none text-foreground sm:w-auto"
             >
               <span>Robbie's</span>{" "}
               <span className="rt-logo-accent">recipes</span>
             </Link>
-            <div className="order-2 ms-auto flex items-center gap-2 sm:order-3">
+            <div className="order-2 flex w-full items-center justify-end gap-2 sm:order-3 sm:ms-auto sm:w-auto">
               <AuthButton intent="signup" />
               <AuthButton />
             </div>

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -63,7 +63,8 @@ export default function RecipesLayout({
               <span>Robbie's</span>{" "}
               <span className="rt-logo-accent">recipes</span>
             </Link>
-            <div className="order-2 ms-auto sm:order-3">
+            <div className="order-2 ms-auto flex items-center gap-2 sm:order-3">
+              <AuthButton intent="signup" />
               <AuthButton />
             </div>
             <div className="order-3 w-full sm:order-2 sm:w-auto">

--- a/ui/app/recipes/onboarding/page.tsx
+++ b/ui/app/recipes/onboarding/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { RecipeOnboarding } from "@/components/recipes/onboarding/recipe-onboarding";
+import { getAllRecipes } from "@/lib/api/recipes";
+
+export const metadata: Metadata = {
+  title: "Set up your recipe box",
+  description: "Choose your diet and add a few recipes to your box.",
+  robots: { index: false, follow: false },
+};
+
+export default function RecipeOnboardingPage() {
+  return <RecipeOnboarding recipes={getAllRecipes()} />;
+}

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -21,6 +21,7 @@ import {
   normalizeRecipeSource,
   serializeSavedRecipe,
 } from "@/lib/domain/recipe/recipeDraft";
+import { safeRecipeReturnPath } from "@/lib/generic/safe-return-path";
 import { normalizeSlug } from "@/lib/generic/slugs";
 
 const EXAMPLE_RECIPE = `Bring a large #pot{} of salted water to the boil. Add @dried pasta{200%g} and cook for ~{10%minutes}.
@@ -153,9 +154,13 @@ export function AddRecipeView() {
       const returnTo = new URLSearchParams(window.location.search).get(
         "returnTo",
       );
+      const safeReturnTo = safeRecipeReturnPath(
+        returnTo,
+        window.location.origin,
+      );
       router.push(
-        returnTo?.startsWith("/recipes/")
-          ? returnTo
+        safeReturnTo
+          ? safeReturnTo
           : `/recipes/saved?slug=${encodeURIComponent(saved.slug)}`,
       );
     } catch (error) {

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -21,7 +21,7 @@ import {
   normalizeRecipeSource,
   serializeSavedRecipe,
 } from "@/lib/domain/recipe/recipeDraft";
-import { safeRecipeReturnPath } from "@/lib/generic/safe-return-path";
+import { recipeSaveReturnPath } from "@/lib/generic/safe-return-path";
 import { normalizeSlug } from "@/lib/generic/slugs";
 
 const EXAMPLE_RECIPE = `Bring a large #pot{} of salted water to the boil. Add @dried pasta{200%g} and cook for ~{10%minutes}.
@@ -154,8 +154,9 @@ export function AddRecipeView() {
       const returnTo = new URLSearchParams(window.location.search).get(
         "returnTo",
       );
-      const safeReturnTo = safeRecipeReturnPath(
+      const safeReturnTo = recipeSaveReturnPath(
         returnTo,
+        saved.slug,
         window.location.origin,
       );
       router.push(

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -150,7 +150,14 @@ export function AddRecipeView() {
         );
       }
       const saved = (await response.json()) as { slug: string };
-      router.push(`/recipes/saved?slug=${encodeURIComponent(saved.slug)}`);
+      const returnTo = new URLSearchParams(window.location.search).get(
+        "returnTo",
+      );
+      router.push(
+        returnTo?.startsWith("/recipes/")
+          ? returnTo
+          : `/recipes/saved?slug=${encodeURIComponent(saved.slug)}`,
+      );
     } catch (error) {
       setSaveError(
         error instanceof Error
@@ -175,9 +182,9 @@ export function AddRecipeView() {
     return (
       <div className="container mx-auto max-w-2xl px-4 py-16 text-center">
         <FileText className="mx-auto size-10 text-[var(--terracotta)]" />
-        <h1 className="rt-display mt-4 text-5xl">Sign in to save a recipe</h1>
+        <h1 className="rt-display mt-4 text-5xl">Log in to save a recipe</h1>
         <p className="rt-body mt-3 text-[var(--ink-2)]">
-          Use the sign-in button above, then come back to add recipes to your
+          Use the log-in button above, then come back to add recipes to your
           private recipe box.
         </p>
         <Button asChild variant="outline" className="mt-6 rounded-full">

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -330,13 +330,18 @@ export function AddRecipeView() {
         <section className="min-h-[600px] overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] bg-[var(--paper)]">
           <div className="flex items-center justify-between border-b border-[var(--line)] bg-[var(--paper-warm)] px-4 py-3">
             <p className="rt-mono text-[var(--ink-3)]">Live preview</p>
-            {parse.loading && (
-              <Loader2 className="size-4 animate-spin text-[var(--terracotta)]" />
-            )}
+            <div className="flex items-center gap-2">
+              <span className="rt-mono text-[var(--ink-4)]">
+                Timers activate after saving
+              </span>
+              {parse.loading && (
+                <Loader2 className="size-4 animate-spin text-[var(--terracotta)]" />
+              )}
+            </div>
           </div>
           {preview ? (
             <div className="px-4 py-6 md:px-8">
-              <RecipeContent recipe={preview} />
+              <RecipeContent recipe={preview} timersEnabled={false} />
             </div>
           ) : (
             <div className="flex min-h-[540px] flex-col items-center justify-center px-6 text-center">

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -159,9 +159,7 @@ export function AddRecipeView() {
         window.location.origin,
       );
       router.push(
-        safeReturnTo
-          ? safeReturnTo
-          : `/recipes/saved?slug=${encodeURIComponent(saved.slug)}`,
+        safeReturnTo ?? `/recipes/saved?slug=${encodeURIComponent(saved.slug)}`,
       );
     } catch (error) {
       setSaveError(

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -37,7 +37,9 @@ function authPrompt(
   if (isPreview) {
     return previewBackendDisabled
       ? "Sign-in unavailable"
-      : "Choose a preview scenario";
+      : intent === "signup"
+        ? "Start a fresh preview account"
+        : "Choose a preview scenario";
   }
   return intent === "signup"
     ? "Create your recipe box"
@@ -79,6 +81,8 @@ export function AuthButton({
       return;
     }
 
+    if (intent === "signup") return;
+
     void fetch("/api/auth/preview/scenarios")
       .then(async (response) => {
         if (!response.ok) throw new Error("Preview scenarios unavailable");
@@ -86,7 +90,7 @@ export function AuthButton({
       })
       .then(setPreviewScenarios)
       .catch(() => setError("Preview sign-in is not configured."));
-  }, [previewBackendDisabled]);
+  }, [intent, previewBackendDisabled]);
 
   async function signOut() {
     setError(null);
@@ -248,6 +252,28 @@ export function AuthButton({
     }
   }
 
+  async function previewSignUp() {
+    setPendingSignIn("fresh-signup");
+    setError(null);
+    try {
+      const response = await fetch("/api/auth/preview/sign-up", {
+        method: "POST",
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        setError(body?.error ?? "Preview sign-up failed.");
+        return;
+      }
+      window.location.assign("/recipes/onboarding");
+    } catch {
+      setError("Preview sign-up failed.");
+    } finally {
+      setPendingSignIn(null);
+    }
+  }
+
   return (
     <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
       <PopoverPrimitive.Trigger asChild>
@@ -257,26 +283,49 @@ export function AuthButton({
           aria-expanded={open}
           className={cn(
             intent === "signup" &&
-              "rounded-full bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]",
+              "max-w-full rounded-full bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]",
           )}
         >
           {intent === "signup" ? <UserPlus /> : <LogIn />}
-          <span>{intent === "signup" ? "Sign up — free" : "Log in"}</span>
-          <ChevronDown className="size-3.5 opacity-60" />
+          <span className="min-w-0 truncate">
+            {intent === "signup" ? "Sign up — free" : "Log in"}
+          </span>
+          <ChevronDown className="size-3.5 shrink-0 opacity-60" />
         </Button>
       </PopoverPrimitive.Trigger>
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Content
           align="end"
           sideOffset={6}
-          className="bg-popover text-popover-foreground z-50 w-56 rounded-md border p-2 shadow-md outline-none"
+          collisionPadding={16}
+          className="bg-popover text-popover-foreground z-50 w-[calc(100vw-2rem)] max-w-56 rounded-md border p-2 shadow-md outline-none"
         >
           <p className="px-2 pb-2 text-xs font-medium text-muted-foreground">
             {authPrompt(isPreview, previewBackendDisabled, intent)}
           </p>
           <div className="flex flex-col gap-1">
-            {isPreview
-              ? previewScenarios?.map((scenario) => (
+            {isPreview ? (
+              intent === "signup" ? (
+                <Button
+                  variant="ghost"
+                  className="h-auto w-full justify-start py-2"
+                  disabled={pendingSignIn !== null}
+                  onClick={previewSignUp}
+                >
+                  {pendingSignIn === "fresh-signup" ? (
+                    <LoaderCircle className="animate-spin" />
+                  ) : (
+                    <FlaskConical />
+                  )}
+                  <span className="min-w-0 text-left">
+                    <span className="block">Start fresh</span>
+                    <span className="block whitespace-normal text-xs font-normal text-muted-foreground">
+                      Create a new empty QA account
+                    </span>
+                  </span>
+                </Button>
+              ) : (
+                previewScenarios?.map((scenario) => (
                   <Button
                     key={scenario.id}
                     variant="ghost"
@@ -297,33 +346,39 @@ export function AuthButton({
                     </span>
                   </Button>
                 ))
-              : providers.map((provider) => (
-                  <Button
-                    key={provider.id}
-                    variant="ghost"
-                    className="w-full justify-start"
-                    disabled={pendingSignIn !== null}
-                    onClick={() => signIn(provider.id)}
-                  >
-                    {pendingSignIn === provider.id ? (
-                      <LoaderCircle className="animate-spin" />
-                    ) : (
-                      <ProviderIcon path={provider.iconPath} />
-                    )}
-                    Continue with {provider.name}
-                    {lastUsedProvider === provider.id && (
-                      <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
-                        Last used
-                      </span>
-                    )}
-                  </Button>
-                ))}
-            {isPreview && previewScenarios === null && !error && (
-              <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
-                <LoaderCircle className="animate-spin" />
-                Loading scenarios…
-              </div>
+              )
+            ) : (
+              providers.map((provider) => (
+                <Button
+                  key={provider.id}
+                  variant="ghost"
+                  className="w-full justify-start"
+                  disabled={pendingSignIn !== null}
+                  onClick={() => signIn(provider.id)}
+                >
+                  {pendingSignIn === provider.id ? (
+                    <LoaderCircle className="animate-spin" />
+                  ) : (
+                    <ProviderIcon path={provider.iconPath} />
+                  )}
+                  Continue with {provider.name}
+                  {lastUsedProvider === provider.id && (
+                    <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
+                      Last used
+                    </span>
+                  )}
+                </Button>
+              ))
             )}
+            {isPreview &&
+              intent === "signin" &&
+              previewScenarios === null &&
+              !error && (
+                <div className="flex items-center gap-2 px-2 py-2 text-xs text-muted-foreground">
+                  <LoaderCircle className="animate-spin" />
+                  Loading scenarios…
+                </div>
+              )}
           </div>
           {error && (
             <p role="alert" className="px-2 pt-2 text-xs text-destructive">

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -288,7 +288,7 @@ export function AuthButton({
         >
           {intent === "signup" ? <UserPlus /> : <LogIn />}
           <span className="min-w-0 truncate">
-            {intent === "signup" ? "Sign up — free" : "Log in"}
+            {intent === "signup" ? "Sign up" : "Log in"}
           </span>
           <ChevronDown className="size-3.5 shrink-0 opacity-60" />
         </Button>

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -136,11 +136,16 @@ function AuthOptions({
 }
 
 export function AuthButton({
+  compactOnMobile = false,
   intent = "signin",
-}: Readonly<{ intent?: "signin" | "signup" }>) {
+}: Readonly<{
+  compactOnMobile?: boolean;
+  intent?: "signin" | "signup";
+}>) {
   const previewBackendDisabled =
     process.env.NEXT_PUBLIC_PREVIEW_BACKEND === "false";
   const { data: session, isPending } = authClient.useSession();
+  const triggerLabel = intent === "signup" ? "Sign up" : "Log in";
   const [open, setOpen] = useState(false);
   const [pendingSignIn, setPendingSignIn] = useState<string | null>(null);
   const [isPreview, setIsPreview] = useState(false);
@@ -369,6 +374,7 @@ export function AuthButton({
         <Button
           variant={intent === "signup" ? "default" : "outline"}
           size="sm"
+          aria-label={compactOnMobile ? triggerLabel : undefined}
           aria-expanded={open}
           className={cn(
             intent === "signup" &&
@@ -376,10 +382,20 @@ export function AuthButton({
           )}
         >
           {intent === "signup" ? <UserPlus /> : <LogIn />}
-          <span className="min-w-0 truncate">
-            {intent === "signup" ? "Sign up" : "Log in"}
+          <span
+            className={cn(
+              "min-w-0 truncate",
+              compactOnMobile && "hidden min-[480px]:inline",
+            )}
+          >
+            {triggerLabel}
           </span>
-          <ChevronDown className="size-3.5 shrink-0 opacity-60" />
+          <ChevronDown
+            className={cn(
+              "size-3.5 shrink-0 opacity-60",
+              compactOnMobile && "hidden min-[480px]:block",
+            )}
+          />
         </Button>
       </PopoverPrimitive.Trigger>
       <PopoverPrimitive.Portal>

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -35,15 +35,104 @@ function authPrompt(
   intent: "signin" | "signup",
 ): string {
   if (isPreview) {
-    return previewBackendDisabled
-      ? "Sign-in unavailable"
-      : intent === "signup"
-        ? "Start a fresh preview account"
-        : "Choose a preview scenario";
+    if (previewBackendDisabled) return "Sign-in unavailable";
+    if (intent === "signup") return "Start a fresh preview account";
+    return "Choose a preview scenario";
   }
   return intent === "signup"
     ? "Create your recipe box"
     : "Log in to your recipes";
+}
+
+type AuthOptionsProps = {
+  isPreview: boolean;
+  intent: "signin" | "signup";
+  pendingSignIn: string | null;
+  previewScenarios: PreviewScenario[] | null;
+  lastUsedProvider: Provider | null;
+  previewSignUp: () => Promise<void>;
+  previewSignIn: (scenario: PreviewScenario) => Promise<void>;
+  signIn: (provider: Provider) => Promise<void>;
+};
+
+function AuthOptions({
+  isPreview,
+  intent,
+  pendingSignIn,
+  previewScenarios,
+  lastUsedProvider,
+  previewSignUp,
+  previewSignIn,
+  signIn,
+}: Readonly<AuthOptionsProps>) {
+  if (isPreview && intent === "signup") {
+    return (
+      <Button
+        variant="ghost"
+        className="h-auto w-full justify-start py-2"
+        disabled={pendingSignIn !== null}
+        onClick={previewSignUp}
+      >
+        {pendingSignIn === "fresh-signup" ? (
+          <LoaderCircle className="animate-spin" />
+        ) : (
+          <FlaskConical />
+        )}
+        <span className="min-w-0 text-left">
+          <span className="block">Start fresh</span>
+          <span className="block whitespace-normal text-xs font-normal text-muted-foreground">
+            Create a new empty QA account
+          </span>
+        </span>
+      </Button>
+    );
+  }
+
+  if (isPreview) {
+    return previewScenarios?.map((scenario) => (
+      <Button
+        key={scenario.id}
+        variant="ghost"
+        className="h-auto w-full justify-start py-2"
+        disabled={pendingSignIn !== null}
+        onClick={() => previewSignIn(scenario)}
+      >
+        {pendingSignIn === scenario.id ? (
+          <LoaderCircle className="animate-spin" />
+        ) : (
+          <FlaskConical />
+        )}
+        <span className="min-w-0 text-left">
+          <span className="block">{scenario.name}</span>
+          <span className="block truncate text-xs font-normal text-muted-foreground">
+            {scenario.description}
+          </span>
+        </span>
+      </Button>
+    ));
+  }
+
+  return providers.map((provider) => (
+    <Button
+      key={provider.id}
+      variant="ghost"
+      className="w-full justify-start"
+      disabled={pendingSignIn !== null}
+      onClick={() => signIn(provider.id)}
+    >
+      {pendingSignIn === provider.id ? (
+        <LoaderCircle className="animate-spin" />
+      ) : (
+        <ProviderIcon path={provider.iconPath} />
+      )}
+      Continue with {provider.name}
+      {lastUsedProvider === provider.id && (
+        <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
+          Last used
+        </span>
+      )}
+    </Button>
+  ));
 }
 
 export function AuthButton({
@@ -304,72 +393,16 @@ export function AuthButton({
             {authPrompt(isPreview, previewBackendDisabled, intent)}
           </p>
           <div className="flex flex-col gap-1">
-            {isPreview ? (
-              intent === "signup" ? (
-                <Button
-                  variant="ghost"
-                  className="h-auto w-full justify-start py-2"
-                  disabled={pendingSignIn !== null}
-                  onClick={previewSignUp}
-                >
-                  {pendingSignIn === "fresh-signup" ? (
-                    <LoaderCircle className="animate-spin" />
-                  ) : (
-                    <FlaskConical />
-                  )}
-                  <span className="min-w-0 text-left">
-                    <span className="block">Start fresh</span>
-                    <span className="block whitespace-normal text-xs font-normal text-muted-foreground">
-                      Create a new empty QA account
-                    </span>
-                  </span>
-                </Button>
-              ) : (
-                previewScenarios?.map((scenario) => (
-                  <Button
-                    key={scenario.id}
-                    variant="ghost"
-                    className="h-auto w-full justify-start py-2"
-                    disabled={pendingSignIn !== null}
-                    onClick={() => previewSignIn(scenario)}
-                  >
-                    {pendingSignIn === scenario.id ? (
-                      <LoaderCircle className="animate-spin" />
-                    ) : (
-                      <FlaskConical />
-                    )}
-                    <span className="min-w-0 text-left">
-                      <span className="block">{scenario.name}</span>
-                      <span className="block truncate text-xs font-normal text-muted-foreground">
-                        {scenario.description}
-                      </span>
-                    </span>
-                  </Button>
-                ))
-              )
-            ) : (
-              providers.map((provider) => (
-                <Button
-                  key={provider.id}
-                  variant="ghost"
-                  className="w-full justify-start"
-                  disabled={pendingSignIn !== null}
-                  onClick={() => signIn(provider.id)}
-                >
-                  {pendingSignIn === provider.id ? (
-                    <LoaderCircle className="animate-spin" />
-                  ) : (
-                    <ProviderIcon path={provider.iconPath} />
-                  )}
-                  Continue with {provider.name}
-                  {lastUsedProvider === provider.id && (
-                    <span className="ml-auto rounded bg-muted px-1.5 py-0.5 text-xs font-normal text-muted-foreground">
-                      Last used
-                    </span>
-                  )}
-                </Button>
-              ))
-            )}
+            <AuthOptions
+              isPreview={isPreview}
+              intent={intent}
+              pendingSignIn={pendingSignIn}
+              previewScenarios={previewScenarios}
+              lastUsedProvider={lastUsedProvider}
+              previewSignUp={previewSignUp}
+              previewSignIn={previewSignIn}
+              signIn={signIn}
+            />
             {isPreview &&
               intent === "signin" &&
               previewScenarios === null &&

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -29,6 +29,21 @@ type PreviewScenario = {
   description: string;
 };
 
+function authPrompt(
+  isPreview: boolean,
+  previewBackendDisabled: boolean,
+  intent: "signin" | "signup",
+): string {
+  if (isPreview) {
+    return previewBackendDisabled
+      ? "Sign-in unavailable"
+      : "Choose a preview scenario";
+  }
+  return intent === "signup"
+    ? "Create your recipe box"
+    : "Log in to your recipes";
+}
+
 export function AuthButton({
   intent = "signin",
 }: Readonly<{ intent?: "signin" | "signup" }>) {
@@ -257,13 +272,7 @@ export function AuthButton({
           className="bg-popover text-popover-foreground z-50 w-56 rounded-md border p-2 shadow-md outline-none"
         >
           <p className="px-2 pb-2 text-xs font-medium text-muted-foreground">
-            {isPreview
-              ? previewBackendDisabled
-                ? "Sign-in unavailable"
-                : "Choose a preview scenario"
-              : intent === "signup"
-                ? "Create your recipe box"
-                : "Log in to your recipes"}
+            {authPrompt(isPreview, previewBackendDisabled, intent)}
           </p>
           <div className="flex flex-col gap-1">
             {isPreview

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -8,6 +8,7 @@ import {
   LogIn,
   LogOut,
   Settings,
+  UserPlus,
 } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -19,6 +20,7 @@ import {
 import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/generic/styles";
 import { isPreviewDeployment } from "@/lib/preview-environment";
 
 type PreviewScenario = {
@@ -27,7 +29,9 @@ type PreviewScenario = {
   description: string;
 };
 
-export function AuthButton() {
+export function AuthButton({
+  intent = "signin",
+}: Readonly<{ intent?: "signin" | "signup" }>) {
   const previewBackendDisabled =
     process.env.NEXT_PUBLIC_PREVIEW_BACKEND === "false";
   const { data: session, isPending } = authClient.useSession();
@@ -84,13 +88,16 @@ export function AuthButton() {
   }
 
   if (isPending) {
+    if (intent === "signup") return null;
     return (
       <Button variant="outline" size="sm" disabled aria-label="Loading session">
         <LoaderCircle className="animate-spin" />
-        <span className="hidden sm:inline">Sign in</span>
+        <span className="hidden sm:inline">Log in</span>
       </Button>
     );
   }
+
+  if (session && intent === "signup") return null;
 
   if (session) {
     return (
@@ -178,7 +185,10 @@ export function AuthButton() {
     setPendingSignIn(provider);
     setError(null);
 
-    const currentURL = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const currentURL =
+      intent === "signup"
+        ? "/recipes/onboarding"
+        : `${window.location.pathname}${window.location.search}${window.location.hash}`;
     try {
       const result = await authClient.signIn.social({
         provider,
@@ -211,7 +221,11 @@ export function AuthButton() {
         setError(body?.error ?? "Preview sign-in failed.");
         return;
       }
-      window.location.reload();
+      if (intent === "signup") {
+        window.location.assign("/recipes/onboarding");
+      } else {
+        window.location.reload();
+      }
     } catch {
       setError("Preview sign-in failed.");
     } finally {
@@ -222,9 +236,17 @@ export function AuthButton() {
   return (
     <PopoverPrimitive.Root open={open} onOpenChange={setOpen}>
       <PopoverPrimitive.Trigger asChild>
-        <Button variant="outline" size="sm" aria-expanded={open}>
-          <LogIn />
-          <span className="hidden sm:inline">Sign in</span>
+        <Button
+          variant={intent === "signup" ? "default" : "outline"}
+          size="sm"
+          aria-expanded={open}
+          className={cn(
+            intent === "signup" &&
+              "rounded-full bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]",
+          )}
+        >
+          {intent === "signup" ? <UserPlus /> : <LogIn />}
+          <span>{intent === "signup" ? "Sign up — free" : "Log in"}</span>
           <ChevronDown className="size-3.5 opacity-60" />
         </Button>
       </PopoverPrimitive.Trigger>
@@ -239,7 +261,9 @@ export function AuthButton() {
               ? previewBackendDisabled
                 ? "Sign-in unavailable"
                 : "Choose a preview scenario"
-              : "Sign in to your recipes"}
+              : intent === "signup"
+                ? "Create your recipe box"
+                : "Log in to your recipes"}
           </p>
           <div className="flex flex-col gap-1">
             {isPreview

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -17,6 +17,7 @@ import { RecipeThumb, recipeMetaLabel } from "@/components/recipes/recipe-card";
 import { Button } from "@/components/ui/button";
 import {
   type DietOptions,
+  type DietPresetOption,
   type DietProfile,
   emptyDietOptions,
   emptyDietProfile,
@@ -108,6 +109,105 @@ function Intro() {
   );
 }
 
+async function fetchAuthoredRecipes(signal: AbortSignal) {
+  const response = await fetch("/api/recipes", { signal });
+  if (!response.ok) {
+    throw new Error("Your authored recipes could not be loaded.");
+  }
+  return (await response.json()) as SavedRecipeApiRecord[];
+}
+
+function toggleValue(values: string[], value: string): string[] {
+  return values.includes(value)
+    ? values.filter((current) => current !== value)
+    : [...values, value];
+}
+
+function DietPresetTile({
+  active,
+  onToggle,
+  preset,
+}: Readonly<{
+  active: boolean;
+  onToggle: (key: string) => void;
+  preset: DietPresetOption;
+}>) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={() => onToggle(preset.key)}
+      className={cn(
+        "flex items-start gap-3 rounded-xl border p-4 text-left transition-colors",
+        active
+          ? "border-[var(--terracotta)] bg-[var(--butter-soft)]"
+          : "border-[var(--line-strong)] bg-[var(--card)] hover:border-[var(--terracotta)]",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border",
+          active
+            ? "border-[var(--terracotta)] bg-[var(--terracotta)] text-white"
+            : "border-[var(--line-strong)]",
+        )}
+      >
+        <Check className="size-3.5" />
+      </span>
+      <span>
+        <span className="rt-body block font-bold">{preset.label}</span>
+        <span className="rt-mono mt-1 block text-[var(--ink-3)]">
+          {preset.sub}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function StarterRecipeTile({
+  onToggle,
+  recipe,
+  selected,
+}: Readonly<{
+  onToggle: (slug: string) => void;
+  recipe: RecipeCardView;
+  selected: boolean;
+}>) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={() => onToggle(recipe.slug)}
+      className={cn(
+        "flex items-center gap-3 rounded-xl border p-3 text-left transition-all",
+        selected
+          ? "border-[var(--terracotta)] bg-[var(--butter-soft)] ring-1 ring-[var(--terracotta)]"
+          : "border-[var(--line-strong)] bg-[var(--card)] hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]",
+      )}
+    >
+      <RecipeThumb recipe={recipe} size={54} />
+      <span className="min-w-0 flex-1">
+        <span className="rt-display block text-xl leading-none">
+          {recipe.title}
+        </span>
+        <span className="rt-mono mt-1 block truncate text-[var(--ink-3)]">
+          {recipeMetaLabel(recipe)}
+        </span>
+      </span>
+      <span
+        className={cn(
+          "flex size-7 shrink-0 items-center justify-center rounded-full border",
+          selected
+            ? "border-[var(--ink)] bg-[var(--ink)] text-[var(--butter)]"
+            : "border-[var(--line-strong)]",
+        )}
+      >
+        {selected ? <Check className="size-4" /> : "+"}
+      </span>
+    </button>
+  );
+}
+
 export function RecipeOnboarding({
   recipes,
 }: Readonly<{ recipes: RecipeCardView[] }>) {
@@ -135,13 +235,7 @@ export function RecipeOnboarding({
       getDietProfile(controller.signal),
       getDietOptions(controller.signal),
       getRecipeBoxProfile(controller.signal),
-      fetch("/api/recipes", { signal: controller.signal }).then(
-        async (response) => {
-          if (!response.ok)
-            throw new Error("Your authored recipes could not be loaded.");
-          return (await response.json()) as SavedRecipeApiRecord[];
-        },
-      ),
+      fetchAuthoredRecipes(controller.signal),
     ])
       .then(([profile, options, box, saved]) => {
         setDiet(profile);
@@ -149,11 +243,11 @@ export function RecipeOnboarding({
         setSelectedSlugs(box.staticRecipeSlugs);
         setAuthoredRecipes(saved.filter((record) => savedRecipeCard(record)));
       })
-      .catch((caught: unknown) => {
-        if (!(caught instanceof DOMException && caught.name === "AbortError")) {
+      .catch((error_: unknown) => {
+        if (!(error_ instanceof DOMException && error_.name === "AbortError")) {
           setError(
-            caught instanceof Error
-              ? caught.message
+            error_ instanceof Error
+              ? error_.message
               : "Setup could not be loaded.",
           );
         }
@@ -184,16 +278,27 @@ export function RecipeOnboarding({
   const selectedSet = useMemo(() => new Set(selectedSlugs), [selectedSlugs]);
   const boxCount = selectedSlugs.length + authoredRecipes.length;
 
+  function toggleDietPreset(key: string) {
+    setDiet((current) => ({
+      ...current,
+      presetDietKeys: toggleValue(current.presetDietKeys, key),
+    }));
+  }
+
+  function toggleSelectedRecipe(slug: string) {
+    setSelectedSlugs((current) => toggleValue(current, slug));
+  }
+
   async function continueFromDiet() {
     setSaving(true);
     setError(null);
     try {
       setDiet(await saveDietProfile(diet));
       setStep(2);
-    } catch (caught) {
+    } catch (error_) {
       setError(
-        caught instanceof Error
-          ? caught.message
+        error_ instanceof Error
+          ? error_.message
           : "Your diet could not be saved.",
       );
     } finally {
@@ -207,10 +312,10 @@ export function RecipeOnboarding({
     try {
       await saveRecipeBoxProfile(selectedSlugs);
       setStep(3);
-    } catch (caught) {
+    } catch (error_) {
       setError(
-        caught instanceof Error
-          ? caught.message
+        error_ instanceof Error
+          ? error_.message
           : "Your recipe box could not be saved.",
       );
     } finally {
@@ -256,51 +361,14 @@ export function RecipeOnboarding({
             change how matches are shown later in settings.
           </p>
           <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {dietOptions.presets.map((preset) => {
-              const active = diet.presetDietKeys.includes(preset.key);
-              return (
-                <button
-                  key={preset.key}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() =>
-                    setDiet((current) => ({
-                      ...current,
-                      presetDietKeys: active
-                        ? current.presetDietKeys.filter(
-                            (key) => key !== preset.key,
-                          )
-                        : [...current.presetDietKeys, preset.key],
-                    }))
-                  }
-                  className={cn(
-                    "flex items-start gap-3 rounded-xl border p-4 text-left transition-colors",
-                    active
-                      ? "border-[var(--terracotta)] bg-[var(--butter-soft)]"
-                      : "border-[var(--line-strong)] bg-[var(--card)] hover:border-[var(--terracotta)]",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border",
-                      active
-                        ? "border-[var(--terracotta)] bg-[var(--terracotta)] text-white"
-                        : "border-[var(--line-strong)]",
-                    )}
-                  >
-                    <Check className="size-3.5" />
-                  </span>
-                  <span>
-                    <span className="rt-body block font-bold">
-                      {preset.label}
-                    </span>
-                    <span className="rt-mono mt-1 block text-[var(--ink-3)]">
-                      {preset.sub}
-                    </span>
-                  </span>
-                </button>
-              );
-            })}
+            {dietOptions.presets.map((preset) => (
+              <DietPresetTile
+                key={preset.key}
+                preset={preset}
+                active={diet.presetDietKeys.includes(preset.key)}
+                onToggle={toggleDietPreset}
+              />
+            ))}
           </div>
           {dietOptions.presets.length === 0 && (
             <p className="rt-body mt-7 rounded-xl border border-dashed p-4 text-[var(--ink-3)]">
@@ -345,49 +413,14 @@ export function RecipeOnboarding({
             </div>
           )}
           <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {compatibleRecipes.map((recipe) => {
-              const selected = selectedSet.has(recipe.slug);
-              return (
-                <button
-                  key={recipe.slug}
-                  type="button"
-                  aria-pressed={selected}
-                  onClick={() =>
-                    setSelectedSlugs((current) =>
-                      selected
-                        ? current.filter((slug) => slug !== recipe.slug)
-                        : [...current, recipe.slug],
-                    )
-                  }
-                  className={cn(
-                    "flex items-center gap-3 rounded-xl border p-3 text-left transition-all",
-                    selected
-                      ? "border-[var(--terracotta)] bg-[var(--butter-soft)] ring-1 ring-[var(--terracotta)]"
-                      : "border-[var(--line-strong)] bg-[var(--card)] hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]",
-                  )}
-                >
-                  <RecipeThumb recipe={recipe} size={54} />
-                  <span className="min-w-0 flex-1">
-                    <span className="rt-display block text-xl leading-none">
-                      {recipe.title}
-                    </span>
-                    <span className="rt-mono mt-1 block truncate text-[var(--ink-3)]">
-                      {recipeMetaLabel(recipe)}
-                    </span>
-                  </span>
-                  <span
-                    className={cn(
-                      "flex size-7 shrink-0 items-center justify-center rounded-full border",
-                      selected
-                        ? "border-[var(--ink)] bg-[var(--ink)] text-[var(--butter)]"
-                        : "border-[var(--line-strong)]",
-                    )}
-                  >
-                    {selected ? <Check className="size-4" /> : "+"}
-                  </span>
-                </button>
-              );
-            })}
+            {compatibleRecipes.map((recipe) => (
+              <StarterRecipeTile
+                key={recipe.slug}
+                recipe={recipe}
+                selected={selectedSet.has(recipe.slug)}
+                onToggle={toggleSelectedRecipe}
+              />
+            ))}
           </div>
         </section>
       )}

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -1,0 +1,464 @@
+"use client";
+
+import {
+  ArrowLeft,
+  ArrowRight,
+  BookOpen,
+  Check,
+  ChefHat,
+  Loader2,
+  PenLine,
+  Sparkles,
+} from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { AuthButton } from "@/components/recipes/auth-button";
+import { RecipeThumb, recipeMetaLabel } from "@/components/recipes/recipe-card";
+import { Button } from "@/components/ui/button";
+import {
+  type DietOptions,
+  type DietProfile,
+  emptyDietOptions,
+  emptyDietProfile,
+  getDietOptions,
+  getDietProfile,
+  saveDietProfile,
+} from "@/lib/api/diet";
+import {
+  getRecipeBoxProfile,
+  saveRecipeBoxProfile,
+} from "@/lib/api/recipe-box";
+import type { RecipeCardView } from "@/lib/api/recipes";
+import { authClient } from "@/lib/auth-client";
+import { buildEffectiveDiet, matchRecipeToDiet } from "@/lib/domain/diet";
+import {
+  type SavedRecipeApiRecord,
+  savedRecipeCard,
+} from "@/lib/domain/recipe/recipeDraft";
+import { cn } from "@/lib/generic/styles";
+
+const STEPS = ["sign up", "your diet", "fill your box", "ready"];
+
+function StepRail({ step }: Readonly<{ step: number }>) {
+  return (
+    <ol aria-label="Onboarding progress" className="flex items-center gap-2">
+      {STEPS.map((label, index) => (
+        <li key={label} className="flex items-center gap-2">
+          {index > 0 && (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "hidden h-px w-5 sm:block",
+                index <= step ? "bg-[var(--ink)]" : "bg-[var(--line-strong)]",
+              )}
+            />
+          )}
+          <span className="flex items-center gap-1.5">
+            <span
+              className={cn(
+                "rt-mono flex size-6 items-center justify-center rounded-full border text-[0.65rem]",
+                index < step &&
+                  "border-[var(--ink)] bg-[var(--ink)] text-[var(--butter)]",
+                index === step && "border-[var(--ink)] bg-[var(--butter)]",
+                index > step &&
+                  "border-[var(--line-strong)] text-[var(--ink-3)]",
+              )}
+            >
+              {index < step ? <Check className="size-3.5" /> : index + 1}
+            </span>
+            <span
+              className={cn(
+                "rt-body hidden text-sm md:inline",
+                index === step
+                  ? "font-bold text-[var(--ink)]"
+                  : "text-[var(--ink-3)]",
+              )}
+            >
+              {label}
+            </span>
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function Intro() {
+  return (
+    <div className="mx-auto flex max-w-xl flex-1 flex-col items-center justify-center py-12 text-center">
+      <ChefHat className="size-12 text-[var(--terracotta)]" />
+      <p className="rt-mono mt-5 text-[var(--terracotta)]">
+        Welcome — let&apos;s set up your box
+      </p>
+      <h1 className="rt-display mt-3 text-5xl leading-[0.95] sm:text-7xl">
+        A few minutes to a box that{" "}
+        <span className="text-[var(--terracotta)]">feels yours.</span>
+      </h1>
+      <p className="rt-body mt-5 max-w-lg text-lg text-[var(--ink-2)]">
+        Create a free account, set your diet, then choose a few recipes or write
+        one of your own with Cooklang.
+      </p>
+      <div className="mt-7">
+        <AuthButton intent="signup" />
+      </div>
+      <p className="rt-mono mt-4 text-[var(--ink-4)]">
+        Google or GitHub · your recipes stay yours
+      </p>
+    </div>
+  );
+}
+
+export function RecipeOnboarding({
+  recipes,
+}: Readonly<{ recipes: RecipeCardView[] }>) {
+  const { data: session, isPending: sessionPending } = authClient.useSession();
+  const [step, setStep] = useState(0);
+  const [diet, setDiet] = useState<DietProfile>(emptyDietProfile);
+  const [dietOptions, setDietOptions] = useState<DietOptions>(emptyDietOptions);
+  const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
+  const [authoredRecipes, setAuthoredRecipes] = useState<
+    SavedRecipeApiRecord[]
+  >([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (sessionPending || !session) return;
+    const requestedBoxStep =
+      new URLSearchParams(window.location.search).get("step") === "box";
+    setStep(requestedBoxStep ? 2 : 1);
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    void Promise.all([
+      getDietProfile(controller.signal),
+      getDietOptions(controller.signal),
+      getRecipeBoxProfile(controller.signal),
+      fetch("/api/recipes", { signal: controller.signal }).then(
+        async (response) => {
+          if (!response.ok)
+            throw new Error("Your authored recipes could not be loaded.");
+          return (await response.json()) as SavedRecipeApiRecord[];
+        },
+      ),
+    ])
+      .then(([profile, options, box, saved]) => {
+        setDiet(profile);
+        setDietOptions(options);
+        setSelectedSlugs(box.staticRecipeSlugs);
+        setAuthoredRecipes(saved.filter((record) => savedRecipeCard(record)));
+      })
+      .catch((caught: unknown) => {
+        if (!(caught instanceof DOMException && caught.name === "AbortError")) {
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : "Setup could not be loaded.",
+          );
+        }
+      })
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [session, sessionPending]);
+
+  const effectiveDiet = useMemo(
+    () => buildEffectiveDiet(diet, dietOptions),
+    [diet, dietOptions],
+  );
+  const compatibleRecipes = useMemo(() => {
+    const matching = recipes.filter(
+      (recipe) =>
+        matchRecipeToDiet(
+          {
+            ingredients: recipe.ingredientSlugs.map((slug, index) => ({
+              slug,
+              name: recipe.ingredientNames[index],
+            })),
+          },
+          effectiveDiet,
+        ).matches,
+    );
+    return (matching.length >= 6 ? matching : recipes).slice(0, 12);
+  }, [effectiveDiet, recipes]);
+  const selectedSet = useMemo(() => new Set(selectedSlugs), [selectedSlugs]);
+  const boxCount = selectedSlugs.length + authoredRecipes.length;
+
+  async function continueFromDiet() {
+    setSaving(true);
+    setError(null);
+    try {
+      setDiet(await saveDietProfile(diet));
+      setStep(2);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Your diet could not be saved.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function finishBox() {
+    setSaving(true);
+    setError(null);
+    try {
+      await saveRecipeBoxProfile(selectedSlugs);
+      setStep(3);
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : "Your recipe box could not be saved.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (sessionPending) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <Loader2 className="animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto flex min-h-[calc(100vh-10rem)] max-w-6xl flex-col px-4 py-5 md:py-8">
+      <div className="flex items-center justify-between gap-4 border-b border-[var(--line)] pb-4">
+        <Link href="/recipes" className="rt-display text-2xl">
+          Your recipe box
+        </Link>
+        <StepRail step={step} />
+      </div>
+
+      {!session && <Intro />}
+
+      {session && loading && (
+        <div className="flex flex-1 items-center justify-center">
+          <Loader2 className="animate-spin text-[var(--terracotta)]" />
+        </div>
+      )}
+
+      {session && !loading && step === 1 && (
+        <section className="flex-1 py-8">
+          <p className="rt-mono text-[var(--terracotta)]">
+            Step 2 · filters every recipe list
+          </p>
+          <h1 className="rt-display mt-2 text-5xl sm:text-6xl">
+            Anything you don&apos;t eat?
+          </h1>
+          <p className="rt-body mt-3 max-w-2xl text-[var(--ink-2)]">
+            Choose any presets that fit. You can fine-tune ingredients and
+            change how matches are shown later in settings.
+          </p>
+          <div className="mt-7 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {dietOptions.presets.map((preset) => {
+              const active = diet.presetDietKeys.includes(preset.key);
+              return (
+                <button
+                  key={preset.key}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() =>
+                    setDiet((current) => ({
+                      ...current,
+                      presetDietKeys: active
+                        ? current.presetDietKeys.filter(
+                            (key) => key !== preset.key,
+                          )
+                        : [...current.presetDietKeys, preset.key],
+                    }))
+                  }
+                  className={cn(
+                    "flex items-start gap-3 rounded-xl border p-4 text-left transition-colors",
+                    active
+                      ? "border-[var(--terracotta)] bg-[var(--butter-soft)]"
+                      : "border-[var(--line-strong)] bg-[var(--card)] hover:border-[var(--terracotta)]",
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border",
+                      active
+                        ? "border-[var(--terracotta)] bg-[var(--terracotta)] text-white"
+                        : "border-[var(--line-strong)]",
+                    )}
+                  >
+                    <Check className="size-3.5" />
+                  </span>
+                  <span>
+                    <span className="rt-body block font-bold">
+                      {preset.label}
+                    </span>
+                    <span className="rt-mono mt-1 block text-[var(--ink-3)]">
+                      {preset.sub}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          {dietOptions.presets.length === 0 && (
+            <p className="rt-body mt-7 rounded-xl border border-dashed p-4 text-[var(--ink-3)]">
+              No diet presets are available yet. You can continue and configure
+              exclusions later.
+            </p>
+          )}
+        </section>
+      )}
+
+      {session && !loading && step === 2 && (
+        <section className="flex-1 py-8">
+          <p className="rt-mono text-[var(--terracotta)]">
+            Step 3 · make it yours
+          </p>
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h1 className="rt-display mt-2 text-5xl sm:text-6xl">
+                Put a few recipes in.
+              </h1>
+              <p className="rt-body mt-3 text-[var(--ink-2)]">
+                Pick from the current collection, or author your own recipe as
+                Cooklang text.
+              </p>
+            </div>
+            <Button asChild variant="outline" className="rounded-full">
+              <Link href="/recipes/add?returnTo=%2Frecipes%2Fonboarding%3Fstep%3Dbox">
+                <PenLine /> Write your own
+              </Link>
+            </Button>
+          </div>
+          {authoredRecipes.length > 0 && (
+            <div className="mt-6 flex items-center gap-3 rounded-xl border border-[var(--sage)]/50 bg-[var(--sage)]/10 px-4 py-3">
+              <PenLine className="size-5 text-[var(--sage)]" />
+              <p className="rt-body">
+                <b>
+                  {authoredRecipes.length} authored{" "}
+                  {authoredRecipes.length === 1 ? "recipe" : "recipes"}
+                </b>{" "}
+                already in your box.
+              </p>
+            </div>
+          )}
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {compatibleRecipes.map((recipe) => {
+              const selected = selectedSet.has(recipe.slug);
+              return (
+                <button
+                  key={recipe.slug}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() =>
+                    setSelectedSlugs((current) =>
+                      selected
+                        ? current.filter((slug) => slug !== recipe.slug)
+                        : [...current, recipe.slug],
+                    )
+                  }
+                  className={cn(
+                    "flex items-center gap-3 rounded-xl border p-3 text-left transition-all",
+                    selected
+                      ? "border-[var(--terracotta)] bg-[var(--butter-soft)] ring-1 ring-[var(--terracotta)]"
+                      : "border-[var(--line-strong)] bg-[var(--card)] hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]",
+                  )}
+                >
+                  <RecipeThumb recipe={recipe} size={54} />
+                  <span className="min-w-0 flex-1">
+                    <span className="rt-display block text-xl leading-none">
+                      {recipe.title}
+                    </span>
+                    <span className="rt-mono mt-1 block truncate text-[var(--ink-3)]">
+                      {recipeMetaLabel(recipe)}
+                    </span>
+                  </span>
+                  <span
+                    className={cn(
+                      "flex size-7 shrink-0 items-center justify-center rounded-full border",
+                      selected
+                        ? "border-[var(--ink)] bg-[var(--ink)] text-[var(--butter)]"
+                        : "border-[var(--line-strong)]",
+                    )}
+                  >
+                    {selected ? <Check className="size-4" /> : "+"}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {session && !loading && step === 3 && (
+        <section className="mx-auto flex max-w-xl flex-1 flex-col items-center justify-center py-12 text-center">
+          <Sparkles className="size-12 text-[var(--terracotta)]" />
+          <p className="rt-mono mt-5 text-[var(--terracotta)]">
+            You&apos;re all set
+          </p>
+          <h1 className="rt-display mt-3 text-6xl leading-none">
+            Your box has {boxCount} {boxCount === 1 ? "recipe" : "recipes"}.
+          </h1>
+          <p className="rt-body mt-4 text-lg text-[var(--ink-2)]">
+            Your diet will filter the collection, and you can keep writing
+            recipes in Cooklang whenever inspiration strikes.
+          </p>
+          <Button
+            asChild
+            className="mt-7 rounded-full bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+          >
+            <Link href="/recipes">
+              <BookOpen /> Open my recipe box <ArrowRight />
+            </Link>
+          </Button>
+        </section>
+      )}
+
+      {session && !loading && step > 0 && step < 3 && (
+        <footer className="sticky bottom-0 -mx-4 mt-auto flex flex-wrap items-center gap-3 border-t border-[var(--line)] bg-[var(--paper)]/95 px-4 py-4 backdrop-blur">
+          <div className="rt-body mr-auto text-[var(--ink-3)]">
+            {step === 1 ? (
+              "You can skip this and set it later."
+            ) : (
+              <>
+                <b className="text-[var(--ink)]">{boxCount}</b>{" "}
+                {boxCount === 1 ? "recipe" : "recipes"} in your box
+              </>
+            )}
+          </div>
+          {step === 2 && (
+            <Button variant="ghost" onClick={() => setStep(1)}>
+              <ArrowLeft /> Back
+            </Button>
+          )}
+          {step === 1 && (
+            <Button variant="outline" onClick={() => setStep(2)}>
+              Skip
+            </Button>
+          )}
+          {step === 1 ? (
+            <Button onClick={continueFromDiet} disabled={saving}>
+              {saving && <Loader2 className="animate-spin" />} Continue{" "}
+              <ArrowRight />
+            </Button>
+          ) : (
+            <Button onClick={finishBox} disabled={saving || boxCount === 0}>
+              {saving && <Loader2 className="animate-spin" />} Finish setup{" "}
+              <ArrowRight />
+            </Button>
+          )}
+        </footer>
+      )}
+      {error && (
+        <p
+          role="alert"
+          className="rt-body mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-destructive"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -33,6 +33,10 @@ import type { RecipeCardView } from "@/lib/api/recipes";
 import { authClient } from "@/lib/auth-client";
 import { buildEffectiveDiet, filterRecipesForDiet } from "@/lib/domain/diet";
 import {
+  buildRecipeAuthoringHref,
+  resolveOnboardingRecipeSelection,
+} from "@/lib/domain/recipe/onboarding";
+import {
   type SavedRecipeApiRecord,
   savedRecipeCard,
 } from "@/lib/domain/recipe/recipeDraft";
@@ -42,7 +46,10 @@ const STEPS = ["sign up", "your diet", "fill your box", "ready"];
 
 function StepRail({ step }: Readonly<{ step: number }>) {
   return (
-    <ol aria-label="Onboarding progress" className="flex items-center gap-2">
+    <ol
+      aria-label="Onboarding progress"
+      className="flex shrink-0 items-center gap-2"
+    >
       {STEPS.map((label, index) => (
         <li key={label} className="flex items-center gap-2">
           {index > 0 && (
@@ -86,7 +93,7 @@ function StepRail({ step }: Readonly<{ step: number }>) {
 
 function Intro() {
   return (
-    <div className="mx-auto flex max-w-xl flex-1 flex-col items-center justify-center py-12 text-center">
+    <div className="mx-auto flex max-w-full flex-1 flex-col items-center justify-center py-12 text-center sm:max-w-xl">
       <ChefHat className="size-12 text-[var(--terracotta)]" />
       <p className="rt-mono mt-5 text-[var(--terracotta)]">
         Welcome — let&apos;s set up your box
@@ -99,7 +106,7 @@ function Intro() {
         Create a free account, set your diet, then choose a few recipes or write
         one of your own with Cooklang.
       </p>
-      <div className="mt-7">
+      <div className="mt-7 max-w-full">
         <AuthButton intent="signup" />
       </div>
       <p className="rt-mono mt-4 text-[var(--ink-4)]">
@@ -254,7 +261,13 @@ export function RecipeOnboarding({
         setStep(authenticatedOnboardingStep(box.completed, requestedBoxStep));
         setDiet(profile);
         setDietOptions(options);
-        setSelectedSlugs(box.staticRecipeSlugs);
+        setSelectedSlugs(
+          resolveOnboardingRecipeSelection(
+            window.location.search,
+            box.staticRecipeSlugs,
+            new Set(recipes.map((recipe) => recipe.slug)),
+          ),
+        );
         const authoredSlugs = saved.flatMap((record) =>
           savedRecipeCard(record) ? [record.slug] : [],
         );
@@ -281,7 +294,7 @@ export function RecipeOnboarding({
       })
       .finally(() => setLoading(false));
     return () => controller.abort();
-  }, [loadAttempt, userId]);
+  }, [loadAttempt, recipes, userId]);
 
   const effectiveDiet = useMemo(
     () => buildEffectiveDiet(diet, dietOptions),
@@ -311,6 +324,7 @@ export function RecipeOnboarding({
     [compatibleSelectedSlugs],
   );
   const boxCount = compatibleSelectedSlugs.length + authoredRecipeSlugs.length;
+  const authorRecipeHref = buildRecipeAuthoringHref(compatibleSelectedSlugs);
 
   function toggleDietPreset(key: string) {
     setDiet((current) => ({
@@ -367,8 +381,8 @@ export function RecipeOnboarding({
 
   return (
     <div className="container mx-auto flex min-h-[calc(100vh-10rem)] max-w-6xl flex-col px-4 py-5 md:py-8">
-      <div className="flex items-center justify-between gap-4 border-b border-[var(--line)] pb-4">
-        <Link href="/recipes" className="rt-display text-2xl">
+      <div className="flex min-w-0 items-center justify-between gap-4 border-b border-[var(--line)] pb-4">
+        <Link href="/recipes" className="rt-display min-w-0 truncate text-2xl">
           Your recipe box
         </Link>
         <StepRail step={step} />
@@ -429,7 +443,7 @@ export function RecipeOnboarding({
               </p>
             </div>
             <Button asChild variant="outline" className="rounded-full">
-              <Link href="/recipes/add?returnTo=%2Frecipes%2Fonboarding%3Fstep%3Dbox">
+              <Link href={authorRecipeHref}>
                 <PenLine /> Write your own
               </Link>
             </Button>
@@ -478,14 +492,19 @@ export function RecipeOnboarding({
             Your diet will filter the collection, and you can keep writing
             recipes in Cooklang whenever inspiration strikes.
           </p>
-          <Button
-            asChild
-            className="mt-7 rounded-full bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
-          >
-            <Link href="/recipes">
-              <BookOpen /> Open my recipe box <ArrowRight />
-            </Link>
-          </Button>
+          <div className="mt-7 flex flex-wrap justify-center gap-3">
+            <Button variant="outline" onClick={() => setStep(2)}>
+              <ArrowLeft /> Back to choices
+            </Button>
+            <Button
+              asChild
+              className="rounded-full bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+            >
+              <Link href="/recipes">
+                <BookOpen /> Open my recipe box <ArrowRight />
+              </Link>
+            </Button>
+          </div>
         </section>
       )}
 
@@ -512,7 +531,7 @@ export function RecipeOnboarding({
         <footer className="sticky bottom-0 -mx-4 mt-auto flex flex-wrap items-center gap-3 border-t border-[var(--line)] bg-[var(--paper)]/95 px-4 py-4 backdrop-blur">
           <div className="rt-body mr-auto text-[var(--ink-3)]">
             {step === 1 ? (
-              "You can skip this and set it later."
+              "Select any that apply, or continue with none."
             ) : (
               <>
                 <b className="text-[var(--ink)]">{boxCount}</b>{" "}
@@ -523,11 +542,6 @@ export function RecipeOnboarding({
           {step === 2 && (
             <Button variant="ghost" onClick={() => setStep(1)}>
               <ArrowLeft /> Back
-            </Button>
-          )}
-          {step === 1 && (
-            <Button variant="outline" onClick={() => setStep(2)}>
-              Skip
             </Button>
           )}
           {step === 1 ? (

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -123,6 +123,15 @@ function toggleValue(values: string[], value: string): string[] {
     : [...values, value];
 }
 
+function authenticatedOnboardingStep(
+  completed: boolean,
+  requestedBoxStep: boolean,
+): number {
+  if (completed) return 3;
+  if (requestedBoxStep) return 2;
+  return 1;
+}
+
 function DietPresetTile({
   active,
   onToggle,
@@ -237,7 +246,7 @@ export function RecipeOnboarding({
       fetchAuthoredRecipes(controller.signal),
     ])
       .then(([profile, options, box, saved]) => {
-        setStep(box.completed ? 3 : requestedBoxStep ? 2 : 1);
+        setStep(authenticatedOnboardingStep(box.completed, requestedBoxStep));
         setDiet(profile);
         setDietOptions(options);
         setSelectedSlugs(box.staticRecipeSlugs);

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/lib/api/recipe-box";
 import type { RecipeCardView } from "@/lib/api/recipes";
 import { authClient } from "@/lib/auth-client";
-import { buildEffectiveDiet, matchRecipeToDiet } from "@/lib/domain/diet";
+import { buildEffectiveDiet, filterRecipesForDiet } from "@/lib/domain/diet";
 import {
   type SavedRecipeApiRecord,
   savedRecipeCard,
@@ -110,7 +110,11 @@ function Intro() {
 }
 
 async function fetchAuthoredRecipes(signal: AbortSignal) {
-  const response = await fetch("/api/recipes", { signal });
+  const response = await fetch("/api/recipes?scope=owned", {
+    cache: "no-store",
+    credentials: "include",
+    signal,
+  });
   if (!response.ok) {
     throw new Error("Your authored recipes could not be loaded.");
   }
@@ -226,9 +230,7 @@ export function RecipeOnboarding({
   const [diet, setDiet] = useState<DietProfile>(emptyDietProfile);
   const [dietOptions, setDietOptions] = useState<DietOptions>(emptyDietOptions);
   const [selectedSlugs, setSelectedSlugs] = useState<string[]>([]);
-  const [authoredRecipes, setAuthoredRecipes] = useState<
-    SavedRecipeApiRecord[]
-  >([]);
+  const [authoredRecipeSlugs, setAuthoredRecipeSlugs] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -236,8 +238,9 @@ export function RecipeOnboarding({
 
   useEffect(() => {
     if (!userId) return;
-    const requestedBoxStep =
-      new URLSearchParams(window.location.search).get("step") === "box";
+    const searchParams = new URLSearchParams(window.location.search);
+    const requestedBoxStep = searchParams.get("step") === "box";
+    const returnedAuthoredSlug = searchParams.get("authored");
     const controller = new AbortController();
     setLoading(true);
     setError(null);
@@ -252,7 +255,16 @@ export function RecipeOnboarding({
         setDiet(profile);
         setDietOptions(options);
         setSelectedSlugs(box.staticRecipeSlugs);
-        setAuthoredRecipes(saved.filter((record) => savedRecipeCard(record)));
+        const authoredSlugs = saved.flatMap((record) =>
+          savedRecipeCard(record) ? [record.slug] : [],
+        );
+        if (
+          returnedAuthoredSlug &&
+          /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(returnedAuthoredSlug)
+        ) {
+          authoredSlugs.push(returnedAuthoredSlug);
+        }
+        setAuthoredRecipeSlugs(Array.from(new Set(authoredSlugs)));
       })
       .catch((error_: unknown) => {
         if (!(error_ instanceof DOMException && error_.name === "AbortError")) {
@@ -275,23 +287,30 @@ export function RecipeOnboarding({
     () => buildEffectiveDiet(diet, dietOptions),
     [diet, dietOptions],
   );
-  const compatibleRecipes = useMemo(() => {
-    const matching = recipes.filter(
-      (recipe) =>
-        matchRecipeToDiet(
-          {
-            ingredients: recipe.ingredientSlugs.map((slug, index) => ({
-              slug,
-              name: recipe.ingredientNames[index],
-            })),
-          },
-          effectiveDiet,
-        ).matches,
-    );
-    return (matching.length >= 6 ? matching : recipes).slice(0, 12);
-  }, [effectiveDiet, recipes]);
-  const selectedSet = useMemo(() => new Set(selectedSlugs), [selectedSlugs]);
-  const boxCount = selectedSlugs.length + authoredRecipes.length;
+  const allCompatibleRecipes = useMemo(
+    () =>
+      filterRecipesForDiet(recipes, effectiveDiet, (recipe) => ({
+        ingredients: recipe.ingredientSlugs.map((slug, index) => ({
+          slug,
+          name: recipe.ingredientNames[index],
+        })),
+      })),
+    [effectiveDiet, recipes],
+  );
+  const compatibleRecipes = allCompatibleRecipes.slice(0, 12);
+  const compatibleRecipeSlugs = useMemo(
+    () => new Set(allCompatibleRecipes.map((recipe) => recipe.slug)),
+    [allCompatibleRecipes],
+  );
+  const compatibleSelectedSlugs = useMemo(
+    () => selectedSlugs.filter((slug) => compatibleRecipeSlugs.has(slug)),
+    [compatibleRecipeSlugs, selectedSlugs],
+  );
+  const selectedSet = useMemo(
+    () => new Set(compatibleSelectedSlugs),
+    [compatibleSelectedSlugs],
+  );
+  const boxCount = compatibleSelectedSlugs.length + authoredRecipeSlugs.length;
 
   function toggleDietPreset(key: string) {
     setDiet((current) => ({
@@ -325,7 +344,7 @@ export function RecipeOnboarding({
     setSaving(true);
     setError(null);
     try {
-      await saveRecipeBoxProfile(selectedSlugs);
+      await saveRecipeBoxProfile(compatibleSelectedSlugs);
       setStep(3);
     } catch (error_) {
       setError(
@@ -415,13 +434,13 @@ export function RecipeOnboarding({
               </Link>
             </Button>
           </div>
-          {authoredRecipes.length > 0 && (
+          {authoredRecipeSlugs.length > 0 && (
             <div className="mt-6 flex items-center gap-3 rounded-xl border border-[var(--sage)]/50 bg-[var(--sage)]/10 px-4 py-3">
               <PenLine className="size-5 text-[var(--sage)]" />
               <p className="rt-body">
                 <b>
-                  {authoredRecipes.length} authored{" "}
-                  {authoredRecipes.length === 1 ? "recipe" : "recipes"}
+                  {authoredRecipeSlugs.length} authored{" "}
+                  {authoredRecipeSlugs.length === 1 ? "recipe" : "recipes"}
                 </b>{" "}
                 already in your box.
               </p>
@@ -437,6 +456,12 @@ export function RecipeOnboarding({
               />
             ))}
           </div>
+          {compatibleRecipes.length === 0 && (
+            <p className="rt-body mt-6 rounded-xl border border-dashed border-[var(--line-strong)] p-4 text-[var(--ink-3)]">
+              No recipes in the current collection match your diet yet. You can
+              still write one of your own with Cooklang.
+            </p>
+          )}
         </section>
       )}
 

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -44,24 +44,23 @@ import { cn } from "@/lib/generic/styles";
 
 const STEPS = ["sign up", "your diet", "fill your box", "ready"];
 
-function StepRail({ step }: Readonly<{ step: number }>) {
+function StepRail({
+  disabled,
+  onStepChange,
+  step,
+}: Readonly<{
+  disabled: boolean;
+  onStepChange: (step: number) => void;
+  step: number;
+}>) {
   return (
     <ol
       aria-label="Onboarding progress"
       className="flex shrink-0 items-center gap-2"
     >
-      {STEPS.map((label, index) => (
-        <li key={label} className="flex items-center gap-2">
-          {index > 0 && (
-            <span
-              aria-hidden="true"
-              className={cn(
-                "hidden h-px w-5 sm:block",
-                index <= step ? "bg-[var(--ink)]" : "bg-[var(--line-strong)]",
-              )}
-            />
-          )}
-          <span className="flex items-center gap-1.5">
+      {STEPS.map((label, index) => {
+        const marker = (
+          <>
             <span
               className={cn(
                 "rt-mono flex size-6 items-center justify-center rounded-full border text-[0.65rem]",
@@ -84,9 +83,40 @@ function StepRail({ step }: Readonly<{ step: number }>) {
             >
               {label}
             </span>
-          </span>
-        </li>
-      ))}
+          </>
+        );
+        const canGoBack = index > 0 && index < step && !disabled;
+        return (
+          <li key={label} className="flex items-center gap-2">
+            {index > 0 && (
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "hidden h-px w-5 sm:block",
+                  index <= step ? "bg-[var(--ink)]" : "bg-[var(--line-strong)]",
+                )}
+              />
+            )}
+            {canGoBack ? (
+              <button
+                type="button"
+                aria-label={`Go back to ${label}`}
+                onClick={() => onStepChange(index)}
+                className="flex items-center gap-1.5 rounded-full outline-none transition-opacity hover:opacity-70 focus-visible:ring-2 focus-visible:ring-[var(--terracotta)] focus-visible:ring-offset-2"
+              >
+                {marker}
+              </button>
+            ) : (
+              <span
+                aria-current={index === step ? "step" : undefined}
+                className="flex items-center gap-1.5"
+              >
+                {marker}
+              </span>
+            )}
+          </li>
+        );
+      })}
     </ol>
   );
 }
@@ -337,6 +367,12 @@ export function RecipeOnboarding({
     setSelectedSlugs((current) => toggleValue(current, slug));
   }
 
+  function goBackToStep(nextStep: number) {
+    if (nextStep <= 0 || nextStep >= step || loading || saving) return;
+    setError(null);
+    setStep(nextStep);
+  }
+
   async function continueFromDiet() {
     setSaving(true);
     setError(null);
@@ -385,7 +421,11 @@ export function RecipeOnboarding({
         <Link href="/recipes" className="rt-display min-w-0 truncate text-2xl">
           Your recipe box
         </Link>
-        <StepRail step={step} />
+        <StepRail
+          step={step}
+          disabled={loading || saving}
+          onStepChange={goBackToStep}
+        />
       </div>
 
       {!session && <Intro />}

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -221,6 +221,7 @@ export function RecipeOnboarding({
   recipes,
 }: Readonly<{ recipes: RecipeCardView[] }>) {
   const { data: session, isPending: sessionPending } = authClient.useSession();
+  const userId = session?.user.id;
   const [step, setStep] = useState(0);
   const [diet, setDiet] = useState<DietProfile>(emptyDietProfile);
   const [dietOptions, setDietOptions] = useState<DietOptions>(emptyDietOptions);
@@ -231,9 +232,10 @@ export function RecipeOnboarding({
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [loadAttempt, setLoadAttempt] = useState(0);
 
   useEffect(() => {
-    if (sessionPending || !session) return;
+    if (!userId) return;
     const requestedBoxStep =
       new URLSearchParams(window.location.search).get("step") === "box";
     const controller = new AbortController();
@@ -254,6 +256,10 @@ export function RecipeOnboarding({
       })
       .catch((error_: unknown) => {
         if (!(error_ instanceof DOMException && error_.name === "AbortError")) {
+          console.error(
+            `Recipe onboarding load attempt ${loadAttempt + 1} failed`,
+            error_,
+          );
           setError(
             error_ instanceof Error
               ? error_.message
@@ -263,7 +269,7 @@ export function RecipeOnboarding({
       })
       .finally(() => setLoading(false));
     return () => controller.abort();
-  }, [session, sessionPending]);
+  }, [loadAttempt, userId]);
 
   const effectiveDiet = useMemo(
     () => buildEffectiveDiet(diet, dietOptions),
@@ -459,12 +465,22 @@ export function RecipeOnboarding({
       )}
 
       {error && (
-        <p
+        <div
           role="alert"
-          className="rt-body mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-destructive"
+          className="rt-body mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-destructive"
         >
-          {error}
-        </p>
+          <span>{error}</span>
+          {userId && step === 0 && !loading && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => setLoadAttempt((current) => current + 1)}
+            >
+              Try again
+            </Button>
+          )}
+        </div>
       )}
 
       {session && !loading && step > 0 && step < 3 && (

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -227,7 +227,6 @@ export function RecipeOnboarding({
     if (sessionPending || !session) return;
     const requestedBoxStep =
       new URLSearchParams(window.location.search).get("step") === "box";
-    setStep(requestedBoxStep ? 2 : 1);
     const controller = new AbortController();
     setLoading(true);
     setError(null);
@@ -238,6 +237,7 @@ export function RecipeOnboarding({
       fetchAuthoredRecipes(controller.signal),
     ])
       .then(([profile, options, box, saved]) => {
+        setStep(box.completed ? 3 : requestedBoxStep ? 2 : 1);
         setDiet(profile);
         setDietOptions(options);
         setSelectedSlugs(box.staticRecipeSlugs);

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -449,6 +449,15 @@ export function RecipeOnboarding({
         </section>
       )}
 
+      {error && (
+        <p
+          role="alert"
+          className="rt-body mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-destructive"
+        >
+          {error}
+        </p>
+      )}
+
       {session && !loading && step > 0 && step < 3 && (
         <footer className="sticky bottom-0 -mx-4 mt-auto flex flex-wrap items-center gap-3 border-t border-[var(--line)] bg-[var(--paper)]/95 px-4 py-4 backdrop-blur">
           <div className="rt-body mr-auto text-[var(--ink-3)]">
@@ -483,14 +492,6 @@ export function RecipeOnboarding({
             </Button>
           )}
         </footer>
-      )}
-      {error && (
-        <p
-          role="alert"
-          className="rt-body mb-4 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-destructive"
-        >
-          {error}
-        </p>
       )}
     </div>
   );

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -36,7 +36,7 @@ export function RecipeCollection({
     }
     const controller = new AbortController();
     setLoadError(null);
-    void Promise.all([
+    void Promise.allSettled([
       fetch("/api/recipes", { signal: controller.signal }).then(
         async (response) => {
           if (!response.ok) throw new Error("Saved recipes unavailable");
@@ -44,19 +44,28 @@ export function RecipeCollection({
         },
       ),
       getRecipeBoxProfile(controller.signal),
-    ])
-      .then(([records, profile]) => {
-        setSaved(records);
-        setBox(profile);
-      })
-      .catch((error: unknown) => {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          console.error("Failed to load saved recipes", error);
-          setLoadError(
-            "Your saved recipes could not be loaded. Static recipes are still available.",
-          );
-        }
-      });
+    ]).then(([savedResult, boxResult]) => {
+      if (savedResult.status === "fulfilled") {
+        setSaved(savedResult.value);
+      }
+      if (boxResult.status === "fulfilled") {
+        setBox(boxResult.value);
+      }
+
+      const errors = [savedResult, boxResult].flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      const nonAbortErrors = errors.filter(
+        (error) =>
+          !(error instanceof DOMException && error.name === "AbortError"),
+      );
+      if (nonAbortErrors.length > 0) {
+        console.error("Failed to load some recipe box data", nonAbortErrors);
+        setLoadError(
+          "Some recipe box data could not be loaded. Available recipes are still shown.",
+        );
+      }
+    });
     return () => controller.abort();
   }, [isPending, session]);
 

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -1,7 +1,12 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { RecipeList } from "@/components/recipes/recipe-list";
+import {
+  getRecipeBoxProfile,
+  type RecipeBoxProfile,
+} from "@/lib/api/recipe-box";
 import type { RecipeCardView } from "@/lib/api/recipes";
 import { authClient } from "@/lib/auth-client";
 import {
@@ -18,23 +23,32 @@ export function RecipeCollection({
 }>) {
   const { data: session, isPending } = authClient.useSession();
   const [saved, setSaved] = useState<SavedRecipeApiRecord[]>([]);
+  const [box, setBox] = useState<RecipeBoxProfile | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isPending) return;
     if (!session) {
       setSaved([]);
+      setBox(null);
       setLoadError(null);
       return;
     }
     const controller = new AbortController();
     setLoadError(null);
-    void fetch("/api/recipes", { signal: controller.signal })
-      .then(async (response) => {
-        if (!response.ok) throw new Error("Saved recipes unavailable");
-        return (await response.json()) as SavedRecipeApiRecord[];
+    void Promise.all([
+      fetch("/api/recipes", { signal: controller.signal }).then(
+        async (response) => {
+          if (!response.ok) throw new Error("Saved recipes unavailable");
+          return (await response.json()) as SavedRecipeApiRecord[];
+        },
+      ),
+      getRecipeBoxProfile(controller.signal),
+    ])
+      .then(([records, profile]) => {
+        setSaved(records);
+        setBox(profile);
       })
-      .then(setSaved)
       .catch((error: unknown) => {
         if (!(error instanceof DOMException && error.name === "AbortError")) {
           console.error("Failed to load saved recipes", error);
@@ -52,11 +66,18 @@ export function RecipeCollection({
       return card ? [card] : [];
     });
     const dynamicSlugs = new Set(dynamic.map((recipe) => recipe.slug));
+    const selectedStaticSlugs = box?.completed
+      ? new Set(box.staticRecipeSlugs)
+      : null;
     return [
       ...dynamic,
-      ...recipes.filter((recipe) => !dynamicSlugs.has(recipe.slug)),
+      ...recipes.filter(
+        (recipe) =>
+          !dynamicSlugs.has(recipe.slug) &&
+          (!selectedStaticSlugs || selectedStaticSlugs.has(recipe.slug)),
+      ),
     ];
-  }, [recipes, saved]);
+  }, [box, recipes, saved]);
 
   return (
     <>
@@ -64,6 +85,19 @@ export function RecipeCollection({
         <output className="rt-body mb-5 block rounded-lg border border-[var(--terracotta)]/30 bg-[var(--terracotta)]/5 px-4 py-3 text-sm text-[var(--ink-2)]">
           {loadError}
         </output>
+      ) : null}
+      {session && box && !box.completed ? (
+        <div className="rt-body mb-5 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--terracotta)]/30 bg-[var(--butter-soft)] px-4 py-3 text-sm text-[var(--ink-2)]">
+          <span>
+            Make this box yours with a diet and a few starter recipes.
+          </span>
+          <Link
+            href="/recipes/onboarding"
+            className="font-bold text-[var(--terracotta-deep)] hover:underline"
+          >
+            Set up my box →
+          </Link>
+        </div>
       ) : null}
       <RecipeList
         recipes={combined}

--- a/ui/components/recipes/recipe-content.tsx
+++ b/ui/components/recipes/recipe-content.tsx
@@ -149,7 +149,62 @@ function buildCookUrl(open: boolean, step: number): string {
   return url.toString();
 }
 
-export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
+function MethodToken({
+  recipeSlug,
+  recipeTitle,
+  scale,
+  stepIndex,
+  stepText,
+  system,
+  timersEnabled,
+  token,
+}: Readonly<{
+  recipeSlug: string;
+  recipeTitle: string;
+  scale: number;
+  stepIndex: number;
+  stepText: string;
+  system: MeasurementSystem;
+  timersEnabled: boolean;
+  token: CookToken;
+}>) {
+  if (token.type === "timer") {
+    if (timersEnabled && token.timerId) {
+      return (
+        <InlineTimer
+          timerId={token.timerId}
+          recipeSlug={recipeSlug}
+          recipeTitle={recipeTitle}
+          stepIndex={stepIndex}
+          stepText={stepText}
+          durationSeconds={token.durationSeconds}
+          label={token.value}
+        />
+      );
+    }
+    return (
+      <button
+        type="button"
+        disabled
+        data-recipe-pill
+        title="Timers are available after saving the recipe"
+        className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-[var(--line-strong)] px-2 py-0.5 align-baseline text-[0.8125rem] font-semibold text-[var(--ink-2)] opacity-70"
+      >
+        <Timer className="size-3" />
+        {token.value}
+      </button>
+    );
+  }
+  if (token.type === "ingredient") {
+    return formatInstructionIngredientToken(token, scale, system);
+  }
+  return token.value;
+}
+
+export function RecipeContent({
+  recipe,
+  timersEnabled = true,
+}: Readonly<{ recipe: RecipeDetailView; timersEnabled?: boolean }>) {
   const { diet, matchRecipe } = useDiet();
   const dietMatch = useMemo(
     () =>
@@ -234,7 +289,7 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
         // Step index keeps the key unique even when two steps read identically.
         key: `${stepIndex}:${tokens.map((token) => token.value).join("|")}`,
         tokens: tokens.map((token, tokenIndex): CookToken => {
-          if (token.type !== "timer") return token;
+          if (token.type !== "timer" || !timersEnabled) return token;
           return {
             ...token,
             timerId: `${recipe.slug}:s${stepIndex}:t${tokenIndex}`,
@@ -248,7 +303,12 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
       tokens: null,
       text: step,
     }));
-  }, [instructionTokenization, effectiveRecipe.instructions, recipe.slug]);
+  }, [
+    instructionTokenization,
+    effectiveRecipe.instructions,
+    recipe.slug,
+    timersEnabled,
+  ]);
 
   // Cook mode open/step state is mirrored into the URL (?cook=1&step=N) via
   // the history API: entering pushes an entry so the back button exits, step
@@ -558,25 +618,16 @@ export function RecipeContent({ recipe }: { recipe: RecipeDetailView }) {
                         <span
                           key={`${tokenIndex}:${token.type}:${token.value}`}
                         >
-                          {token.type === "timer" && token.timerId ? (
-                            <InlineTimer
-                              timerId={token.timerId}
-                              recipeSlug={recipe.slug}
-                              recipeTitle={recipe.title}
-                              stepIndex={stepIndex}
-                              stepText={step.text}
-                              durationSeconds={token.durationSeconds}
-                              label={token.value}
-                            />
-                          ) : token.type === "ingredient" ? (
-                            formatInstructionIngredientToken(
-                              token,
-                              scale,
-                              unitSystem,
-                            )
-                          ) : (
-                            token.value
-                          )}
+                          <MethodToken
+                            token={token}
+                            recipeSlug={recipe.slug}
+                            recipeTitle={recipe.title}
+                            stepIndex={stepIndex}
+                            stepText={step.text}
+                            scale={scale}
+                            system={unitSystem}
+                            timersEnabled={timersEnabled}
+                          />
                         </span>
                       ))
                     : step.text}

--- a/ui/components/recipes/settings/settings-view.tsx
+++ b/ui/components/recipes/settings/settings-view.tsx
@@ -50,9 +50,9 @@ export function SettingsView() {
           <span className="mx-auto mb-4 flex size-12 items-center justify-center rounded-full border border-[var(--line)] bg-[var(--paper-warm)]">
             <Lock className="size-5 text-[var(--terracotta)]" />
           </span>
-          <h1 className="rt-display text-3xl">Sign in to open settings.</h1>
+          <h1 className="rt-display text-3xl">Log in to open settings.</h1>
           <p className="rt-body mt-2 text-[var(--ink-2)]">
-            Use the account menu in the top-right to sign in with Google or
+            Use the account menu in the top-right to log in with Google or
             GitHub, then manage your account here.
           </p>
           <Button

--- a/ui/lib/api/recipe-box.ts
+++ b/ui/lib/api/recipe-box.ts
@@ -1,0 +1,34 @@
+export type RecipeBoxProfile = {
+  completed: boolean;
+  staticRecipeSlugs: string[];
+};
+
+async function parseRecipeBoxResponse(response: Response) {
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(body?.error ?? "Recipe box request failed.");
+  }
+  return response.json() as Promise<RecipeBoxProfile>;
+}
+
+export async function getRecipeBoxProfile(signal?: AbortSignal) {
+  return parseRecipeBoxResponse(
+    await fetch("/api/profile/recipe-box", {
+      credentials: "same-origin",
+      signal,
+    }),
+  );
+}
+
+export async function saveRecipeBoxProfile(staticRecipeSlugs: string[]) {
+  return parseRecipeBoxResponse(
+    await fetch("/api/profile/recipe-box", {
+      method: "PUT",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ staticRecipeSlugs }),
+    }),
+  );
+}

--- a/ui/lib/domain/diet.ts
+++ b/ui/lib/domain/diet.ts
@@ -129,6 +129,16 @@ export function matchRecipeToDiet(
   };
 }
 
+export function filterRecipesForDiet<T>(
+  recipes: T[],
+  diet: EffectiveDiet,
+  toDietRecipe: (recipe: T) => DietRecipe,
+): T[] {
+  return recipes.filter(
+    (recipe) => matchRecipeToDiet(toDietRecipe(recipe), diet).matches,
+  );
+}
+
 export function applyDietRecipeVisibility<T extends { slug: string }>(
   recipes: T[],
   matches: ReadonlyMap<string, DietMatch>,

--- a/ui/lib/domain/recipe/onboarding.ts
+++ b/ui/lib/domain/recipe/onboarding.ts
@@ -1,0 +1,22 @@
+export function buildRecipeAuthoringHref(selectedSlugs: string[]): string {
+  const returnParams = new URLSearchParams({ step: "box", draft: "1" });
+  for (const slug of new Set(selectedSlugs)) {
+    returnParams.append("selected", slug);
+  }
+
+  return `/recipes/add?returnTo=${encodeURIComponent(
+    `/recipes/onboarding?${returnParams.toString()}`,
+  )}`;
+}
+
+export function resolveOnboardingRecipeSelection(
+  search: string,
+  persistedSlugs: string[],
+  availableSlugs: ReadonlySet<string>,
+): string[] {
+  const params = new URLSearchParams(search);
+  const source =
+    params.get("draft") === "1" ? params.getAll("selected") : persistedSlugs;
+
+  return Array.from(new Set(source.filter((slug) => availableSlugs.has(slug))));
+}

--- a/ui/lib/generic/safe-return-path.ts
+++ b/ui/lib/generic/safe-return-path.ts
@@ -18,3 +18,18 @@ export function safeRecipeReturnPath(
     return null;
   }
 }
+
+export function recipeSaveReturnPath(
+  value: string | null,
+  savedSlug: string,
+  origin: string,
+): string | null {
+  const safePath = safeRecipeReturnPath(value, origin);
+  if (!safePath) return null;
+
+  const url = new URL(safePath, origin);
+  if (url.pathname === "/recipes/onboarding") {
+    url.searchParams.set("authored", savedSlug);
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/ui/lib/generic/safe-return-path.ts
+++ b/ui/lib/generic/safe-return-path.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve an untrusted return target to a same-origin recipe route. URL
+ * resolution also normalizes dot segments before the pathname is checked.
+ */
+export function safeRecipeReturnPath(
+  value: string | null,
+  origin: string,
+): string | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value, origin);
+    if (url.origin !== origin || !url.pathname.startsWith("/recipes/")) {
+      return null;
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -52,6 +52,10 @@ function createNextConfig(phase: string): NextConfig {
                 destination: "http://localhost:8787/api/profile/diet/options",
               },
               {
+                source: "/api/profile/recipe-box",
+                destination: "http://localhost:8787/api/profile/recipe-box",
+              },
+              {
                 source: "/api/recipes/:path*",
                 destination: "http://localhost:8787/recipes/:path*",
               },

--- a/ui/scripts/generate-agent-markdown.ts
+++ b/ui/scripts/generate-agent-markdown.ts
@@ -570,8 +570,7 @@ function buildRoutesJson(): string {
       version: 1,
       include: [
         "/api/auth/*",
-        "/api/profile/diet",
-        "/api/profile/diet/options",
+        "/api/profile/*",
         "/api/recipes",
         "/api/recipes/*",
         "/ingest/*",

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -149,6 +149,49 @@ describe("AuthButton", () => {
     );
   });
 
+  it("starts each preview sign-up with a fresh QA account", async () => {
+    const user = userEvent.setup();
+    mocks.isPreviewDeployment.mockReturnValue(true);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: "Preview sign-up failed" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<AuthButton intent="signup" />);
+
+    await user.click(screen.getByRole("button", { name: /sign up/i }));
+    expect(
+      screen.getByText("Start a fresh preview account"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Choose a preview scenario"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /start fresh/i }));
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/preview/sign-up", {
+      method: "POST",
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Preview sign-up failed",
+    );
+  });
+
+  it("constrains the sign-up control and menu to a mobile viewport", async () => {
+    const user = userEvent.setup();
+    render(<AuthButton intent="signup" />);
+
+    const trigger = screen.getByRole("button", { name: /sign up/i });
+    expect(trigger).toHaveClass("max-w-full");
+    await user.click(trigger);
+
+    expect(screen.getByRole("dialog")).toHaveClass(
+      "w-[calc(100vw-2rem)]",
+      "max-w-56",
+    );
+  });
+
   it("disables sign-in on a frontend-only preview", async () => {
     const user = userEvent.setup();
     mocks.isPreviewDeployment.mockReturnValue(true);

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -44,7 +44,7 @@ describe("AuthButton", () => {
     const user = userEvent.setup();
     render(<AuthButton />);
 
-    await user.click(screen.getByRole("button", { name: /sign in/i }));
+    await user.click(screen.getByRole("button", { name: /log in/i }));
 
     expect(
       screen.getByRole("button", { name: "Continue with Google" }),
@@ -59,7 +59,7 @@ describe("AuthButton", () => {
     mocks.getLastUsedLoginMethod.mockReturnValue("google");
     render(<AuthButton />);
 
-    await user.click(screen.getByRole("button", { name: /sign in/i }));
+    await user.click(screen.getByRole("button", { name: /log in/i }));
 
     expect(
       screen.getByRole("button", { name: /Continue with Google/ }),
@@ -74,7 +74,7 @@ describe("AuthButton", () => {
     window.history.replaceState({}, "", "/recipes/pasta?servings=4#method");
     render(<AuthButton />);
 
-    await user.click(screen.getByRole("button", { name: /sign in/i }));
+    await user.click(screen.getByRole("button", { name: /log in/i }));
     await user.click(
       screen.getByRole("button", { name: "Continue with GitHub" }),
     );
@@ -83,6 +83,22 @@ describe("AuthButton", () => {
       provider: "github",
       callbackURL: "/recipes/pasta?servings=4#method",
       errorCallbackURL: "/recipes/pasta?servings=4#method",
+    });
+  });
+
+  it("starts sign-up providers with onboarding as the callback", async () => {
+    const user = userEvent.setup();
+    render(<AuthButton intent="signup" />);
+
+    await user.click(screen.getByRole("button", { name: /sign up/i }));
+    await user.click(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    );
+
+    expect(mocks.signInSocial).toHaveBeenCalledWith({
+      provider: "google",
+      callbackURL: "/recipes/onboarding",
+      errorCallbackURL: "/recipes/onboarding",
     });
   });
 
@@ -109,7 +125,7 @@ describe("AuthButton", () => {
     vi.stubGlobal("fetch", fetchMock);
     render(<AuthButton />);
 
-    await user.click(screen.getByRole("button", { name: /sign in/i }));
+    await user.click(screen.getByRole("button", { name: /log in/i }));
     const scenarioButton = await screen.findByRole("button", {
       name: /Empty account/,
     });
@@ -141,7 +157,7 @@ describe("AuthButton", () => {
     vi.stubGlobal("fetch", fetchMock);
     render(<AuthButton />);
 
-    await user.click(screen.getByRole("button", { name: /sign in/i }));
+    await user.click(screen.getByRole("button", { name: /log in/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Sign-in is disabled on this frontend-only preview.",

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -192,6 +192,17 @@ describe("AuthButton", () => {
     );
   });
 
+  it("can hide header auth text on narrow mobile screens", () => {
+    render(<AuthButton intent="signup" compactOnMobile />);
+
+    const trigger = screen.getByRole("button", { name: "Sign up" });
+    expect(trigger).toHaveAccessibleName("Sign up");
+    expect(screen.getByText("Sign up")).toHaveClass(
+      "hidden",
+      "min-[480px]:inline",
+    );
+  });
+
   it("disables sign-in on a frontend-only preview", async () => {
     const user = userEvent.setup();
     mocks.isPreviewDeployment.mockReturnValue(true);

--- a/ui/tests/components/recipes/onboarding/recipe-onboarding.test.tsx
+++ b/ui/tests/components/recipes/onboarding/recipe-onboarding.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RecipeCardView } from "@/lib/api/recipes";
+
+const mocks = vi.hoisted(() => ({
+  getDietOptions: vi.fn(),
+  getDietProfile: vi.fn(),
+  getRecipeBoxProfile: vi.fn(),
+  saveDietProfile: vi.fn(),
+  saveRecipeBoxProfile: vi.fn(),
+  useSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: mocks.useSession },
+}));
+
+vi.mock("@/lib/api/diet", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/diet")>()),
+  getDietOptions: mocks.getDietOptions,
+  getDietProfile: mocks.getDietProfile,
+  saveDietProfile: mocks.saveDietProfile,
+}));
+
+vi.mock("@/lib/api/recipe-box", () => ({
+  getRecipeBoxProfile: mocks.getRecipeBoxProfile,
+  saveRecipeBoxProfile: mocks.saveRecipeBoxProfile,
+}));
+
+vi.mock("@/components/recipes/recipe-card", () => ({
+  RecipeThumb: () => null,
+  recipeMetaLabel: () => "",
+}));
+
+import { RecipeOnboarding } from "@/components/recipes/onboarding/recipe-onboarding";
+
+const emptyDiet = {
+  presetDietKeys: [],
+  excludedIngredientSlugs: [],
+  excludedGroupKeys: [],
+  recipeMatchMode: "hide" as const,
+};
+
+const recipe = {
+  slug: "vegan-soup",
+  title: "Vegan Soup",
+  ingredientSlugs: ["lentils"],
+  ingredientNames: ["Lentils"],
+} as RecipeCardView;
+
+describe("RecipeOnboarding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, "", "/recipes/onboarding");
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "qa-user" } },
+      isPending: false,
+    });
+    mocks.getDietProfile.mockResolvedValue(emptyDiet);
+    mocks.getDietOptions.mockResolvedValue({
+      presets: [],
+      groups: [],
+      ingredients: [],
+    });
+    mocks.getRecipeBoxProfile.mockResolvedValue({
+      completed: false,
+      staticRecipeSlugs: [],
+    });
+    mocks.saveDietProfile.mockResolvedValue(emptyDiet);
+    mocks.saveRecipeBoxProfile.mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      }),
+    );
+  });
+
+  it("continues with no diet selections without a redundant skip action", async () => {
+    render(<RecipeOnboarding recipes={[recipe]} />);
+
+    expect(
+      await screen.findByRole("heading", { name: /anything you don't eat/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /skip/i }),
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(mocks.saveDietProfile).toHaveBeenCalledWith(emptyDiet);
+    expect(
+      await screen.findByRole("heading", { name: /put a few recipes in/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("preserves selected starters in the author-recipe return URL", async () => {
+    const user = userEvent.setup();
+    render(<RecipeOnboarding recipes={[recipe]} />);
+    await screen.findByRole("heading", { name: /anything you don't eat/i });
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    await user.click(screen.getByRole("button", { name: /vegan soup/i }));
+
+    const href = screen.getByRole("link", { name: /write your own/i });
+    const addURL = new URL(
+      href.getAttribute("href") ?? "",
+      "https://recipes.example.test",
+    );
+
+    expect(addURL.searchParams.get("returnTo")).toContain(
+      "selected=vegan-soup",
+    );
+  });
+
+  it("lets the user return from completion to correct recipe choices", async () => {
+    const user = userEvent.setup();
+    render(<RecipeOnboarding recipes={[recipe]} />);
+    await screen.findByRole("heading", { name: /anything you don't eat/i });
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    await user.click(screen.getByRole("button", { name: /vegan soup/i }));
+    await user.click(screen.getByRole("button", { name: /finish setup/i }));
+
+    await waitFor(() =>
+      expect(mocks.saveRecipeBoxProfile).toHaveBeenCalledWith(["vegan-soup"]),
+    );
+    await user.click(screen.getByRole("button", { name: /back to choices/i }));
+
+    expect(
+      screen.getByRole("heading", { name: /put a few recipes in/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /vegan soup/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+});

--- a/ui/tests/components/recipes/onboarding/recipe-onboarding.test.tsx
+++ b/ui/tests/components/recipes/onboarding/recipe-onboarding.test.tsx
@@ -135,4 +135,35 @@ describe("RecipeOnboarding", () => {
       "true",
     );
   });
+
+  it("uses completed progress steps as back navigation", async () => {
+    const user = userEvent.setup();
+    render(<RecipeOnboarding recipes={[recipe]} />);
+    await screen.findByRole("heading", { name: /anything you don't eat/i });
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await user.click(
+      screen.getByRole("button", { name: /go back to your diet/i }),
+    );
+    expect(
+      screen.getByRole("heading", { name: /anything you don't eat/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+    await user.click(screen.getByRole("button", { name: /vegan soup/i }));
+    await user.click(screen.getByRole("button", { name: /finish setup/i }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: /go back to fill your box/i,
+      }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /put a few recipes in/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /vegan soup/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
 });

--- a/ui/tests/components/recipes/recipe-content.test.tsx
+++ b/ui/tests/components/recipes/recipe-content.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RecipeDetailView } from "@/lib/domain/recipe/recipeViews";
+
+const mocks = vi.hoisted(() => ({
+  tokenizeInstructionSdk: vi.fn(),
+}));
+
+vi.mock("@/components/recipes/diet-provider", () => ({
+  useDiet: () => ({
+    diet: { active: false },
+    matchRecipe: () => ({ matches: true, excludedIngredients: [] }),
+  }),
+}));
+
+vi.mock("@/hooks/use-scaled-recipe", () => ({
+  useScaledRecipe: (recipe: RecipeDetailView) => ({
+    view: recipe,
+    scaleMultiplier: 1,
+    isScaling: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/hooks/use-unit-preference", () => ({
+  useUnitPreference: () => ["metric", vi.fn()],
+}));
+
+vi.mock("@/lib/domain/recipe/instructionTokens", () => ({
+  tokenizeInstructionSdk: mocks.tokenizeInstructionSdk,
+}));
+
+import { RecipeContent } from "@/components/recipes/recipe-content";
+
+const recipe: RecipeDetailView = {
+  slug: "weeknight",
+  title: "Weeknight pasta",
+  description: "A quick test recipe.",
+  date: "2026-07-14",
+  cuisine: [],
+  tags: [],
+  servings: 2,
+  cookBody: "Cook for ~{10%minutes}.",
+  cookware: [],
+  ingredientGroups: [],
+  instructions: ["Cook for 10 minutes."],
+  instructionSdk: {} as NonNullable<RecipeDetailView["instructionSdk"]>,
+};
+
+describe("RecipeContent", () => {
+  beforeEach(() => {
+    mocks.tokenizeInstructionSdk.mockReturnValue({
+      ok: true,
+      steps: [
+        [
+          { type: "text", value: "Cook for " },
+          { type: "timer", value: "10 minutes", durationSeconds: 600 },
+          { type: "text", value: "." },
+        ],
+      ],
+    });
+  });
+
+  it("renders timers as disabled in an unsaved recipe preview", () => {
+    render(<RecipeContent recipe={recipe} timersEnabled={false} />);
+
+    expect(screen.getByRole("button", { name: "10 minutes" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /start 10 minutes timer/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/settings/settings-view.test.tsx
+++ b/ui/tests/components/recipes/settings/settings-view.test.tsx
@@ -64,7 +64,7 @@ describe("SettingsView", () => {
     mocks.useSession.mockReturnValue({ data: null, isPending: false });
     renderSettingsView();
 
-    expect(screen.getByText("Sign in to open settings.")).toBeInTheDocument();
+    expect(screen.getByText("Log in to open settings.")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /back to recipes/i }),
     ).toHaveAttribute("href", "/recipes");

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -53,6 +53,7 @@ describe("agent markdown generation", () => {
     const nonContentPages = new Set([
       "recipes/add.html",
       "recipes/kitchen.html",
+      "recipes/onboarding.html",
       "recipes/saved.html",
       "recipes/settings.html",
       "recipes/shopping.html",
@@ -82,6 +83,8 @@ describe("agent markdown generation", () => {
     );
     expect(read("llms.txt")).not.toContain("/recipes/settings");
     expect(read("llms-full.txt")).not.toContain("/recipes/settings");
+    expect(read("llms.txt")).not.toContain("/recipes/onboarding");
+    expect(read("llms-full.txt")).not.toContain("/recipes/onboarding");
   });
 
   it("renders recipe ingredients and instructions as markdown", () => {
@@ -98,6 +101,7 @@ describe("agent markdown generation", () => {
     const nonRecipePages = new Set([
       "add.html",
       "kitchen.html",
+      "onboarding.html",
       "saved.html",
       "settings.html",
       "shopping.html",

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -134,8 +134,7 @@ describe("agent markdown generation", () => {
   it("scopes the middleware to page routes in _routes.json", () => {
     const routes = JSON.parse(read("_routes.json"));
     expect(routes.include).toContain("/api/auth/*");
-    expect(routes.include).toContain("/api/profile/diet");
-    expect(routes.include).toContain("/api/profile/diet/options");
+    expect(routes.include).toContain("/api/profile/*");
     expect(routes.include).toContain("/api/recipes");
     expect(routes.include).toContain("/api/recipes/*");
     expect(routes.include).toContain("/ingest/*");

--- a/ui/tests/integration/sitemap.test.ts
+++ b/ui/tests/integration/sitemap.test.ts
@@ -18,6 +18,7 @@ const STATIC_ASSET_SEGMENTS = new Set(["recipe-site-design"]);
 const NOINDEX_APP_PAGES = new Set([
   "recipes/add",
   "recipes/kitchen",
+  "recipes/onboarding",
   "recipes/saved",
   "recipes/settings",
   "recipes/shopping",

--- a/ui/tests/lib/domain/diet.test.ts
+++ b/ui/tests/lib/domain/diet.test.ts
@@ -3,6 +3,7 @@ import type { DietOptions, DietProfile } from "@/lib/api/diet";
 import {
   applyDietRecipeVisibility,
   buildEffectiveDiet,
+  filterRecipesForDiet,
   matchRecipeToDiet,
 } from "@/lib/domain/diet";
 
@@ -126,6 +127,22 @@ describe("diet recipe matching", () => {
         diet,
       ).matches,
     ).toBe(true);
+  });
+
+  it("keeps a small starter list diet-compatible instead of filling it with excluded recipes", () => {
+    const diet = buildEffectiveDiet(
+      profile({ presetDietKeys: ["vegan"] }),
+      options,
+    );
+    const recipes = [
+      { slug: "chickpea-stew", ingredients: [{ slug: "chickpeas" }] },
+      { slug: "chicken-pie", ingredients: [{ slug: "chicken-breast" }] },
+      { slug: "cheese-toast", ingredients: [{ slug: "cheddar-cheese" }] },
+    ];
+
+    expect(filterRecipesForDiet(recipes, diet, (recipe) => recipe)).toEqual([
+      recipes[0],
+    ]);
   });
 
   it("does not repeat custom exclusions already covered by a preset", () => {

--- a/ui/tests/lib/domain/recipe/onboarding.test.ts
+++ b/ui/tests/lib/domain/recipe/onboarding.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRecipeAuthoringHref,
+  resolveOnboardingRecipeSelection,
+} from "@/lib/domain/recipe/onboarding";
+
+describe("recipe onboarding navigation", () => {
+  const available = new Set(["lentil-soup", "chickpea-stew", "pasta"]);
+
+  it("carries the current starter choices through recipe authoring", () => {
+    const href = buildRecipeAuthoringHref([
+      "lentil-soup",
+      "chickpea-stew",
+      "lentil-soup",
+    ]);
+    const addURL = new URL(href, "https://recipes.example.test");
+    const returnTo = addURL.searchParams.get("returnTo");
+
+    expect(returnTo).toBe(
+      "/recipes/onboarding?step=box&draft=1&selected=lentil-soup&selected=chickpea-stew",
+    );
+    expect(
+      resolveOnboardingRecipeSelection(returnTo ?? "", [], available),
+    ).toEqual(["lentil-soup", "chickpea-stew"]);
+  });
+
+  it("restores an intentionally empty draft instead of persisted choices", () => {
+    expect(
+      resolveOnboardingRecipeSelection(
+        "/recipes/onboarding?step=box&draft=1",
+        ["pasta"],
+        available,
+      ),
+    ).toEqual([]);
+  });
+
+  it("uses persisted choices without a returned draft and rejects unknown slugs", () => {
+    expect(
+      resolveOnboardingRecipeSelection(
+        "?step=box",
+        ["pasta", "not-in-the-static-catalog"],
+        available,
+      ),
+    ).toEqual(["pasta"]);
+  });
+});

--- a/ui/tests/lib/generic/safe-return-path.test.ts
+++ b/ui/tests/lib/generic/safe-return-path.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { safeRecipeReturnPath } from "@/lib/generic/safe-return-path";
+
+const ORIGIN = "https://recipes.example.test";
+
+describe("safeRecipeReturnPath", () => {
+  it("keeps same-origin recipe paths, queries, and fragments", () => {
+    expect(
+      safeRecipeReturnPath("/recipes/onboarding?step=box#choices", ORIGIN),
+    ).toBe("/recipes/onboarding?step=box#choices");
+  });
+
+  it.each([
+    null,
+    "https://attacker.example/recipes/onboarding",
+    "//attacker.example/recipes/onboarding",
+    "/recipes/../attacker.example",
+    "/recipes/..//attacker.example",
+    "/projects/recipe-site",
+  ])("rejects unsafe return target %s", (value) => {
+    expect(safeRecipeReturnPath(value, ORIGIN)).toBeNull();
+  });
+});

--- a/ui/tests/lib/generic/safe-return-path.test.ts
+++ b/ui/tests/lib/generic/safe-return-path.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { safeRecipeReturnPath } from "@/lib/generic/safe-return-path";
+import {
+  recipeSaveReturnPath,
+  safeRecipeReturnPath,
+} from "@/lib/generic/safe-return-path";
 
 const ORIGIN = "https://recipes.example.test";
 
@@ -19,5 +22,33 @@ describe("safeRecipeReturnPath", () => {
     "/projects/recipe-site",
   ])("rejects unsafe return target %s", (value) => {
     expect(safeRecipeReturnPath(value, ORIGIN)).toBeNull();
+  });
+});
+
+describe("recipeSaveReturnPath", () => {
+  it("adds the saved recipe to an onboarding return while preserving state", () => {
+    expect(
+      recipeSaveReturnPath(
+        "/recipes/onboarding?step=box#choices",
+        "lentil-soup",
+        ORIGIN,
+      ),
+    ).toBe("/recipes/onboarding?step=box&authored=lentil-soup#choices");
+  });
+
+  it("leaves other safe recipe returns unchanged", () => {
+    expect(
+      recipeSaveReturnPath("/recipes/kitchen?tab=mine", "lentil-soup", ORIGIN),
+    ).toBe("/recipes/kitchen?tab=mine");
+  });
+
+  it("rejects unsafe return targets", () => {
+    expect(
+      recipeSaveReturnPath(
+        "https://attacker.example/recipes/onboarding",
+        "lentil-soup",
+        ORIGIN,
+      ),
+    ).toBeNull();
   });
 });

--- a/workers/recipe-api/src/auth.ts
+++ b/workers/recipe-api/src/auth.ts
@@ -25,6 +25,7 @@ type AuthEnv = {
 
 type CreateAuthOptions = {
   allowPreviewSignUp?: boolean;
+  autoSignInPreviewSignUp?: boolean;
 };
 
 function rateLimitStorage(db: Db) {
@@ -105,7 +106,7 @@ export function createAuth(
         emailAndPassword: {
           enabled: isPreview,
           disableSignUp: !options.allowPreviewSignUp,
-          autoSignIn: false,
+          autoSignIn: options.autoSignInPreviewSignUp ?? false,
         },
         socialProviders,
         account: {

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -531,6 +531,16 @@ async function findReadableRecipes(
     );
 }
 
+async function findOwnedRecipes(
+  db: ReturnType<typeof createDb>["db"],
+  userId: string,
+): Promise<Recipe[]> {
+  return db
+    .select()
+    .from(schema.recipe)
+    .where(eq(schema.recipe.userId, userId));
+}
+
 async function findOwnedRecipeBySlug(
   db: ReturnType<typeof createDb>["db"],
   slug: string,
@@ -1943,6 +1953,11 @@ app.post("/households/:householdId/leave", async (c) => {
 });
 
 app.get("/recipes", async (c) => {
+  const scope = c.req.query("scope");
+  if (scope && scope !== "owned") {
+    return c.json({ error: "Invalid recipe scope" }, 400);
+  }
+
   const connectionString = databaseConnection(c.env);
   if (!connectionString) {
     return c.json(
@@ -1955,8 +1970,15 @@ app.get("/recipes", async (c) => {
     const connection = createDb(connectionString);
     client = connection.client;
     const { db } = connection;
-    const session = await loadOptionalRecipeSession(c, db);
-    const recipes = await findReadableRecipes(db, session?.user.id);
+    let recipes: Recipe[];
+    if (scope === "owned") {
+      const session = await requireRecipeSession(c, db);
+      if (!session.success) return session.response;
+      recipes = await findOwnedRecipes(db, session.session.user.id);
+    } else {
+      const session = await loadOptionalRecipeSession(c, db);
+      recipes = await findReadableRecipes(db, session?.user.id);
+    }
     return c.json(recipes.map(recipeResponse));
   } catch (e) {
     console.error("GET /recipes query failed", e);

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -952,6 +952,52 @@ app.get("/api/auth/preview/scenarios", async (c) => {
   );
 });
 
+app.post("/api/auth/preview/sign-up", async (c) => {
+  if (c.env.DEPLOYMENT_ENV !== "preview") return c.notFound();
+  if (!hasAuthConfiguration(c.env)) {
+    return c.json({ error: "Preview auth configuration is incomplete" }, 503);
+  }
+  if (!(await hasPreviewAccess(c.req.raw, c.env))) {
+    return c.json({ error: "Cloudflare Access authorization required" }, 403);
+  }
+
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json({ error: "No database connection configured" }, 503);
+  }
+
+  const { db, client } = createDb(connectionString);
+  const suffix = crypto.randomUUID();
+  const credentials = {
+    email: `qa-${suffix}@preview.invalid`,
+    name: `Fresh QA account ${suffix.slice(0, 8)}`,
+    password: c.env.PREVIEW_AUTH_PASSWORD!,
+  };
+  try {
+    const auth = createAuth(db, c.env, {
+      allowPreviewSignUp: true,
+      autoSignInPreviewSignUp: true,
+    });
+    return await auth.api.signUpEmail({
+      body: credentials,
+      headers: c.req.raw.headers,
+      asResponse: true,
+    });
+  } catch (error) {
+    console.error("Preview sign-up failed", error);
+    return c.json({ error: "Preview sign-up failed" }, 502);
+  } finally {
+    try {
+      await client.end({ timeout: 5 });
+    } catch (error) {
+      console.error("client.end() cleanup failed", error);
+    }
+  }
+});
+
 app.post("/api/auth/preview/sign-in", async (c) => {
   if (c.env.DEPLOYMENT_ENV !== "preview") return c.notFound();
   if (!hasAuthConfiguration(c.env)) {

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -102,6 +102,15 @@ const uniqueDietKeysSchema = z
   .max(80)
   .transform((values) => Array.from(new Set(values)));
 
+const recipeBoxBodySchema = z
+  .object({
+    staticRecipeSlugs: z
+      .array(recipeSlugSchema)
+      .max(100)
+      .transform((values) => Array.from(new Set(values))),
+  })
+  .strict();
+
 const MAX_RECIPE_BODY_BYTES = 100_000;
 const savedRecipePayloadSchema = z
   .object({
@@ -221,6 +230,27 @@ async function closeDbClient(client: DbClient | undefined) {
 function recipeResponse(recipe: Recipe) {
   const { userId: _userId, ...response } = recipe;
   return response;
+}
+
+async function recipeBoxResponse(db: Db, userId: string) {
+  const [profile, items] = await Promise.all([
+    db
+      .select({ completedAt: schema.userRecipeBox.completedAt })
+      .from(schema.userRecipeBox)
+      .where(eq(schema.userRecipeBox.userId, userId))
+      .limit(1),
+    db
+      .select({ recipeSlug: schema.userRecipeBoxItem.recipeSlug })
+      .from(schema.userRecipeBoxItem)
+      .where(eq(schema.userRecipeBoxItem.userId, userId)),
+  ]);
+
+  return {
+    completed: Boolean(profile[0]),
+    staticRecipeSlugs: items
+      .map((item) => item.recipeSlug)
+      .sort((first, second) => first.localeCompare(second)),
+  };
 }
 
 function householdResponse(household: Household) {
@@ -1056,6 +1086,53 @@ app.put("/api/profile/diet", async (c) => {
         }
         throw error;
       }
+    },
+  );
+});
+
+app.get("/api/profile/recipe-box", async (c) => {
+  return withRecipeSession(
+    c,
+    "query",
+    "GET /api/profile/recipe-box query failed",
+    async ({ db, session }) => c.json(await recipeBoxResponse(db, session.user.id)),
+  );
+});
+
+app.put("/api/profile/recipe-box", async (c) => {
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  return withRecipeSession(
+    c,
+    "mutation",
+    "PUT /api/profile/recipe-box mutation failed",
+    async ({ db, session }) => {
+      const body = await parseJsonBody(c, recipeBoxBodySchema);
+      if (!body.success) return body.response;
+
+      await db.transaction(async (tx) => {
+        await tx
+          .insert(schema.userRecipeBox)
+          .values({ userId: session.user.id, completedAt: new Date() })
+          .onConflictDoUpdate({
+            target: schema.userRecipeBox.userId,
+            set: { updatedAt: new Date() },
+          });
+        await tx
+          .delete(schema.userRecipeBoxItem)
+          .where(eq(schema.userRecipeBoxItem.userId, session.user.id));
+        if (body.data.staticRecipeSlugs.length > 0) {
+          await tx.insert(schema.userRecipeBoxItem).values(
+            body.data.staticRecipeSlugs.map((recipeSlug) => ({
+              userId: session.user.id,
+              recipeSlug,
+            })),
+          );
+        }
+      });
+
+      return c.json(await recipeBoxResponse(db, session.user.id));
     },
   );
 });

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -696,8 +696,8 @@ const dbMock = vi.hoisted(() => {
 
     if (
       query.includes('from "recipe"') &&
-      query.includes('"recipe"."slug"') &&
-      query.includes('"recipe"."user_id"')
+      query.includes('"recipe"."slug" =') &&
+      query.includes('"recipe"."user_id" =')
     ) {
       const slug = params[0] as string;
       const userId = params[1] as string;
@@ -706,7 +706,20 @@ const dbMock = vi.hoisted(() => {
         .map(recipeRow);
     }
 
-    if (query.includes('from "recipe"') && query.includes('"recipe"."slug"')) {
+    if (
+      query.includes('from "recipe"') &&
+      query.includes('"recipe"."user_id" =')
+    ) {
+      const userId = params[0] as string;
+      return state.recipes
+        .filter((recipe) => recipe.userId === userId)
+        .map(recipeRow);
+    }
+
+    if (
+      query.includes('from "recipe"') &&
+      query.includes('"recipe"."slug" =')
+    ) {
       const slug = params[0] as string;
       return state.recipes
         .filter((recipe) => recipe.slug === slug)
@@ -1107,6 +1120,62 @@ describe("GET /recipes", () => {
     expect(await res.json()).toEqual({
       error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)",
     });
+  });
+
+  it("requires authentication for the owned scope", async () => {
+    const res = await app.request("/recipes?scope=owned", {}, env);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+
+  it("returns only recipes authored by the signed-in user", async () => {
+    dbMock.state.recipes.push(
+      {
+        id: "recipe-owned",
+        slug: "my-lentil-soup",
+        title: "My Lentil Soup",
+        description: null,
+        body: null,
+        userId: "owner-user",
+        visibility: "private",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+      {
+        id: "recipe-public",
+        slug: "someone-elses-soup",
+        title: "Someone Else's Soup",
+        description: null,
+        body: null,
+        userId: "other-user",
+        visibility: "public",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+    );
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request("/recipes?scope=owned", {}, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      expect.objectContaining({
+        slug: "my-lentil-soup",
+        title: "My Lentil Soup",
+      }),
+    ]);
+  });
+
+  it("rejects an unknown recipe scope", async () => {
+    const res = await app.request("/recipes?scope=household", {}, env);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid recipe scope" });
   });
 
   it("returns 502 when database query fails", async () => {

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -2993,6 +2993,15 @@ describe("preview authentication", () => {
     expect(res.status).toBe(404);
   });
 
+  it("does not expose fresh QA sign-up outside preview deployments", async () => {
+    const res = await app.request(
+      "/api/auth/preview/sign-up",
+      { method: "POST" },
+      env,
+    );
+    expect(res.status).toBe(404);
+  });
+
   it("requires complete preview configuration", async () => {
     const res = await app.request(
       "/api/auth/preview/scenarios",
@@ -3009,6 +3018,40 @@ describe("preview authentication", () => {
       previewEnv,
     );
     expect(res.status).toBe(403);
+  });
+
+  it("protects fresh QA sign-up with Cloudflare Access", async () => {
+    const res = await app.request(
+      "/api/auth/preview/sign-up",
+      {
+        method: "POST",
+        headers: { origin: previewEnv.BETTER_AUTH_URL },
+      },
+      previewEnv,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects fresh QA sign-up without a trusted CSRF signal", async () => {
+    const res = await app.request(
+      "/api/auth/preview/sign-up",
+      {
+        method: "POST",
+        headers: { "cf-access-jwt-assertion": "test-assertion" },
+      },
+      previewEnv,
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({
+      error: "CSRF validation failed",
+      details: [
+        {
+          path: [],
+          message: "Unsafe browser mutations must come from a trusted origin",
+        },
+      ],
+    });
   });
 
   it("returns the allowlisted scenarios after Access authorization", async () => {

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -110,6 +110,8 @@ const dbMock = vi.hoisted(() => {
       ingredientSlug: string;
     }[],
     userDietExcludedGroups: [] as { userId: string; groupKey: string }[],
+    recipeBoxes: [] as { userId: string; completedAt: Date; updatedAt: Date }[],
+    recipeBoxItems: [] as { userId: string; recipeSlug: string }[],
     rateLimitCounts: new Map<string, number>(),
     rateLimitSweeps: 0,
   };
@@ -174,6 +176,8 @@ const dbMock = vi.hoisted(() => {
     state.userDietPresets = [];
     state.userDietExcludedIngredients = [];
     state.userDietExcludedGroups = [];
+    state.recipeBoxes = [];
+    state.recipeBoxItems = [];
     state.rateLimitCounts.clear();
     state.rateLimitSweeps = 0;
   }
@@ -249,6 +253,27 @@ const dbMock = vi.hoisted(() => {
       };
       state.dietProfiles.push(profile);
       return [dietProfileRow(profile)];
+    }
+
+    if (query.startsWith('insert into "user_recipe_box"')) {
+      const userId = params[0] as string;
+      const existing = state.recipeBoxes.find((box) => box.userId === userId);
+      if (existing) {
+        existing.updatedAt = date;
+      } else {
+        state.recipeBoxes.push({ userId, completedAt: date, updatedAt: date });
+      }
+      return [];
+    }
+
+    if (query.startsWith('insert into "user_recipe_box_item"')) {
+      for (let index = 0; index < params.length; index += 2) {
+        state.recipeBoxItems.push({
+          userId: params[index] as string,
+          recipeSlug: params[index + 1] as string,
+        });
+      }
+      return [];
     }
 
     if (query.startsWith('insert into "user_diet_preset"')) {
@@ -336,6 +361,14 @@ const dbMock = vi.hoisted(() => {
       const userId = params[0] as string;
       state.userDietExcludedGroups = state.userDietExcludedGroups.filter(
         (selection) => selection.userId !== userId,
+      );
+      return [];
+    }
+
+    if (query.startsWith('delete from "user_recipe_box_item"')) {
+      const userId = params[0] as string;
+      state.recipeBoxItems = state.recipeBoxItems.filter(
+        (item) => item.userId !== userId,
       );
       return [];
     }
@@ -638,6 +671,20 @@ const dbMock = vi.hoisted(() => {
       return state.dietProfiles
         .filter((profile) => profile.userId === userId)
         .map(dietProfileRow);
+    }
+
+    if (query.includes('from "user_recipe_box_item"')) {
+      const userId = params[0] as string;
+      return state.recipeBoxItems
+        .filter((item) => item.userId === userId)
+        .map((item) => [item.recipeSlug]);
+    }
+
+    if (query.includes('from "user_recipe_box"')) {
+      const userId = params[0] as string;
+      return state.recipeBoxes
+        .filter((box) => box.userId === userId)
+        .map((box) => [box.completedAt]);
     }
 
     if (query.startsWith('insert into "verification"')) {
@@ -1395,6 +1442,91 @@ describe("profile diet preferences", () => {
         expect.objectContaining({ path: ["recipeMatchMode"] }),
       ]),
     });
+  });
+});
+
+describe("profile recipe box", () => {
+  it("requires authentication", async () => {
+    const res = await app.request("/api/profile/recipe-box", {}, env);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+
+  it("distinguishes an unfinished setup from an intentionally empty box", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const initial = await app.request("/api/profile/recipe-box", {}, env);
+    expect(await initial.json()).toEqual({
+      completed: false,
+      staticRecipeSlugs: [],
+    });
+
+    const saved = await app.request(
+      "/api/profile/recipe-box",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ staticRecipeSlugs: [] }),
+      },
+      env,
+    );
+
+    expect(saved.status).toBe(200);
+    expect(await saved.json()).toEqual({
+      completed: true,
+      staticRecipeSlugs: [],
+    });
+  });
+
+  it("deduplicates and replaces selected static recipes", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    await app.request(
+      "/api/profile/recipe-box",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          staticRecipeSlugs: ["lentil-soup", "overnight-pizza", "lentil-soup"],
+        }),
+      },
+      env,
+    );
+    const updated = await app.request(
+      "/api/profile/recipe-box",
+      {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ staticRecipeSlugs: ["breakfast-flatbreads"] }),
+      },
+      env,
+    );
+
+    expect(await updated.json()).toEqual({
+      completed: true,
+      staticRecipeSlugs: ["breakfast-flatbreads"],
+    });
+    expect(dbMock.state.recipeBoxItems).toEqual([
+      { userId: "owner-user", recipeSlug: "breakfast-flatbreads" },
+    ]);
   });
 });
 


### PR DESCRIPTION
## What changed

- add an explicit **Sign up — free** path alongside **Log in**
- add a four-step, mid-fi-inspired recipe onboarding flow for social sign-up, diet selection, starter recipe selection, and completion
- persist each user's selected static recipes without copying the canonical Cooklang content
- personalize the recipe collection after onboarding while preserving the legacy catalog for accounts that have not completed setup
- let users author a Cooklang recipe during onboarding and return to finish their box
- add profile API coverage, auth callback coverage, and settings copy updates

## Why

New users could authenticate, configure diet preferences, and author private recipes, but those capabilities were disconnected. They landed in the full static catalog without a guided way to make the recipe box their own.

This joins the capabilities already in production into a focused first-run workflow and deliberately omits mid-fi features that are not implemented yet.

## Impact

New users can create an account, populate their diet and recipe box from the current static catalog, or add an original recipe using inline Cooklang syntax. Existing accounts retain the full catalog until they intentionally complete onboarding.

## Validation

- `mise //ui:typecheck`
- `mise //ui:test` — 460 tests
- `mise //workers/recipe-api:check` — 97 API tests plus typecheck
- `mise //packages/recipe-db:typecheck`
- `mise //:lint`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`
- local `/recipes` and `/recipes/onboarding` routes returned HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided recipe onboarding for diet presets and starter recipe selection, including step-based progress and “return to” handling.
  * Introduced recipe box support with saved selections and setup-completion status.
  * Added a dedicated recipes onboarding page for sign-up flow.
* **Improvements**
  * Auth prompts/navigation now support clear sign-in vs sign-up behaviour.
  * Recipe previews can disable timer activation.
  * Recipe pages now use safer, same-origin return redirects.
* **Bug Fixes**
  * Prevented unsafe redirect targets after saving recipes.
* **Tests**
  * Expanded coverage for onboarding, recipe box, preview sign-up, and return-path safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->