### PR TITLE
Add schema.org recipe URL imports

### DIFF
--- a/packages/recipe-parsing/package.json
+++ b/packages/recipe-parsing/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@cooklang/cooklang": "^0.18.0",
+    "cheerio": "^1.2.0",
     "numeric-quantity": "^3.2.1",
     "openai": "^6.6.0",
+    "recipe-scrapers": "^1.9.0",
     "recipe-domain": "workspace:*",
     "zod": "^4.2.1"
   },

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -176,6 +176,21 @@ function instructionLines(value: unknown): string[] {
   return lines;
 }
 
+function unwrapJsonLdSource(source: string): string {
+  let cleaned = source.trim();
+  const wrappers = [
+    { prefix: "<!--", suffix: "-->" },
+    { prefix: "//<![CDATA[", suffix: "//]]>" },
+    { prefix: "<![CDATA[", suffix: "]]>" },
+  ];
+  for (const { prefix, suffix } of wrappers) {
+    if (cleaned.startsWith(prefix) && cleaned.endsWith(suffix)) {
+      cleaned = cleaned.slice(prefix.length, -suffix.length).trim();
+    }
+  }
+  return cleaned;
+}
+
 function jsonLdBlocks(html: string): unknown[] {
   const blocks: unknown[] = [];
   const lowercaseHtml = html.toLowerCase();
@@ -189,7 +204,9 @@ function jsonLdBlocks(html: string): unknown[] {
     if (closingStart === -1) break;
     const openingTag = lowercaseHtml.slice(scriptStart, openingEnd + 1);
     if (openingTag.includes("application/ld+json")) {
-      const source = html.slice(openingEnd + 1, closingStart).trim();
+      const source = unwrapJsonLdSource(
+        html.slice(openingEnd + 1, closingStart),
+      );
       try {
         blocks.push(JSON.parse(source));
       } catch {

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -1,3 +1,5 @@
+import * as cheerio from "cheerio";
+import { scrapeRecipe } from "recipe-scrapers";
 import type { ExtractionRecipe } from "../schemas/stage-artifacts.js";
 import { buildCooklangDraftFromExtraction } from "./cooklang.js";
 
@@ -11,275 +13,108 @@ export type SchemaOrgRecipeImport = {
   source: string;
 };
 
-type JsonObject = Record<string, unknown>;
-
-function isObject(value: unknown): value is JsonObject {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+function servings(value: string): string {
+  return /\d+(?:\.\d+)?/.exec(value)?.[0] ?? "1";
 }
 
-function values(value: unknown): unknown[] {
-  if (Array.isArray(value)) return value;
-  return value == null ? [] : [value];
-}
+function normalizeRecipeMarkup(html: string, url: string): string {
+  const $ = cheerio.load(html);
+  $("script[type='application/ld+json']").each((_, element) => {
+    const source = $(element)
+      .html()
+      ?.trim()
+      .replace(/^<!--|-->$/g, "")
+      .replace(/^\/\/<!\[CDATA\[|\/\/\]\]>$/g, "")
+      .trim();
+    if (!source) return;
 
-function text(value: unknown): string | undefined {
-  if (typeof value === "string") return value.trim() || undefined;
-  if (typeof value === "number") return String(value);
-  if (isObject(value)) return text(value.name ?? value.text ?? value.value);
-  return undefined;
-}
-
-function decodeHtml(value: string): string {
-  const entities: Record<string, string> = {
-    amp: "&",
-    apos: "'",
-    gt: ">",
-    lt: "<",
-    nbsp: " ",
-    quot: '"',
-  };
-  return value.replace(
-    /&(#x[\da-f]+|#\d+|[a-z]+);/gi,
-    (match, entity: string) => {
-      let codePoint: number | undefined;
-      if (entity.startsWith("#x")) {
-        codePoint = Number.parseInt(entity.slice(2), 16);
-      } else if (entity.startsWith("#")) {
-        codePoint = Number.parseInt(entity.slice(1), 10);
-      }
-      if (codePoint !== undefined) {
-        return Number.isInteger(codePoint) &&
-          codePoint >= 0 &&
-          codePoint <= 0x10ffff
-          ? String.fromCodePoint(codePoint)
-          : match;
-      }
-      return entities[entity.toLowerCase()] ?? match;
-    },
-  );
-}
-
-function plainText(value: unknown): string | undefined {
-  const raw = text(value);
-  if (!raw) return undefined;
-  let withoutTags = "";
-  let insideTag = false;
-  for (const character of raw) {
-    if (character === "<") {
-      insideTag = true;
-      withoutTags += " ";
-    } else if (character === ">") {
-      insideTag = false;
-    } else if (!insideTag) {
-      withoutTags += character;
+    try {
+      const data: unknown = JSON.parse(source);
+      const visit = (value: unknown): void => {
+        if (Array.isArray(value)) {
+          for (const entry of value) visit(entry);
+          return;
+        }
+        if (!value || typeof value !== "object") return;
+        const object = value as Record<string, unknown>;
+        const types = Array.isArray(object["@type"])
+          ? object["@type"]
+          : [object["@type"]];
+        const recipeIndex = types.findIndex(
+          (type) => typeof type === "string" && /(?:^|\/)Recipe\/?$/i.test(type),
+        );
+        if (recipeIndex >= 0) {
+          object["@type"] = [
+            "Recipe",
+            ...types.filter(
+              (type, index) => index !== recipeIndex && type !== "Recipe",
+            ),
+          ];
+          object.author ??= "Imported recipe";
+          object.description ??= `Recipe for ${String(object.name ?? "this dish")}, imported from the web.`;
+          object.image ??= url;
+          object.recipeYield ??= "1 serving";
+        }
+        for (const child of Object.values(object)) visit(child);
+      };
+      visit(data);
+      $(element).text(JSON.stringify(data));
+    } catch {
+      // recipe-scrapers can recover some malformed JSON-LD itself.
     }
-  }
-  return decodeHtml(withoutTags).replace(/\s+/g, " ").trim();
-}
-
-function isRecipeType(value: unknown): boolean {
-  return values(value).some((entry) => {
-    const type = text(entry)?.toLowerCase().replace(/\/$/, "");
-    return type === "recipe" || type?.endsWith("schema.org/recipe");
   });
+  return $.html();
 }
 
-function findRecipe(value: unknown): JsonObject | undefined {
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const recipe = findRecipe(entry);
-      if (recipe) return recipe;
-    }
-    return undefined;
-  }
-  if (!isObject(value)) return undefined;
-  if (isRecipeType(value["@type"])) return value;
-
-  for (const key of [
-    "@graph",
-    "mainEntity",
-    "mainEntityOfPage",
-    "itemListElement",
-  ]) {
-    const recipe = findRecipe(value[key]);
-    if (recipe) return recipe;
-  }
-  return undefined;
-}
-
-function isAsciiDigit(character: string | undefined): boolean {
-  return character !== undefined && character >= "0" && character <= "9";
-}
-
-function durationSectionMinutes(
-  section: string,
-  multipliers: Readonly<Record<string, number>>,
-): number | undefined {
-  if (!section) return 0;
-  let minutes = 0;
-  let cursor = 0;
-  while (cursor < section.length) {
-    const numberStart = cursor;
-    let hasDigit = false;
-    let hasDecimalPoint = false;
-    while (cursor < section.length) {
-      const character = section[cursor];
-      if (isAsciiDigit(character)) {
-        hasDigit = true;
-        cursor += 1;
-      } else if (character === "." && !hasDecimalPoint) {
-        hasDecimalPoint = true;
-        cursor += 1;
-      } else {
-        break;
-      }
-    }
-    const multiplier = multipliers[section[cursor] ?? ""];
-    if (!hasDigit || multiplier === undefined) return undefined;
-    const amount = Number(section.slice(numberStart, cursor));
-    if (!Number.isFinite(amount)) return undefined;
-    minutes += amount * multiplier;
-    cursor += 1;
-  }
-  return minutes;
-}
-
-function durationMinutes(value: unknown): number | undefined {
-  const raw = text(value)?.toUpperCase();
-  if (!raw?.startsWith("P")) return undefined;
-  const sections = raw.slice(1).split("T");
-  if (sections.length > 2) return undefined;
-  const days = durationSectionMinutes(sections[0] ?? "", { D: 1440 });
-  const time = durationSectionMinutes(sections[1] ?? "", {
-    H: 60,
-    M: 1,
-    S: 1 / 60,
-  });
-  if (days === undefined || time === undefined) return undefined;
-  const minutes = days + time;
-  return minutes > 0 ? Math.round(minutes) : undefined;
-}
-
-function servings(value: unknown): number {
-  for (const entry of values(value)) {
-    if (typeof entry === "number" && Number.isFinite(entry) && entry > 0) {
-      return Math.max(1, Math.round(entry));
-    }
-    const match = /\d+(?:\.\d+)?/.exec(text(entry) ?? "");
-    if (match) return Math.max(1, Math.round(Number(match[0])));
-  }
-  return 1;
-}
-
-function instructionLines(value: unknown): string[] {
-  const lines: string[] = [];
-  for (const entry of values(value)) {
-    if (typeof entry === "string") {
-      const line = plainText(entry);
-      if (line) lines.push(line);
-      continue;
-    }
-    if (!isObject(entry)) continue;
-    const nested = entry.itemListElement ?? entry.steps;
-    if (nested) lines.push(...instructionLines(nested));
-    else {
-      const line = plainText(entry.text ?? entry.name);
-      if (line) lines.push(line);
-    }
-  }
-  return lines;
-}
-
-function unwrapJsonLdSource(source: string): string {
-  let cleaned = source.trim();
-  const wrappers = [
-    { prefix: "<!--", suffix: "-->" },
-    { prefix: "//<![CDATA[", suffix: "//]]>" },
-    { prefix: "<![CDATA[", suffix: "]]>" },
-  ];
-  for (const { prefix, suffix } of wrappers) {
-    if (cleaned.startsWith(prefix) && cleaned.endsWith(suffix)) {
-      cleaned = cleaned.slice(prefix.length, -suffix.length).trim();
-    }
-  }
-  return cleaned;
-}
-
-function jsonLdBlocks(html: string): unknown[] {
-  const blocks: unknown[] = [];
-  const lowercaseHtml = html.toLowerCase();
-  let cursor = 0;
-  while (cursor < html.length) {
-    const scriptStart = lowercaseHtml.indexOf("<script", cursor);
-    if (scriptStart === -1) break;
-    const openingEnd = lowercaseHtml.indexOf(">", scriptStart + 7);
-    if (openingEnd === -1) break;
-    const closingStart = lowercaseHtml.indexOf("</script", openingEnd + 1);
-    if (closingStart === -1) break;
-    const openingTag = lowercaseHtml.slice(scriptStart, openingEnd + 1);
-    if (openingTag.includes("application/ld+json")) {
-      const source = unwrapJsonLdSource(
-        html.slice(openingEnd + 1, closingStart),
-      );
-      try {
-        blocks.push(JSON.parse(source));
-      } catch {
-        // Pages commonly contain unrelated malformed JSON-LD. Keep looking for
-        // a valid Recipe block before reporting that the page is unsupported.
-      }
-    }
-    cursor = closingStart + 8;
-  }
-  return blocks;
-}
-
-export function parseSchemaOrgRecipeHtml(
+/**
+ * Extract a recipe with recipe-scrapers, then convert its normalized fields to
+ * the extraction shape shared by the rest of our Cooklang import pipeline.
+ */
+export async function parseSchemaOrgRecipeHtml(
   html: string,
-): SchemaOrgRecipeImport | null {
-  let recipe: JsonObject | undefined;
-  for (const block of jsonLdBlocks(html)) {
-    recipe = findRecipe(block);
-    if (recipe) break;
-  }
-  if (!recipe) return null;
+  url = "https://example.com/recipe",
+): Promise<SchemaOrgRecipeImport | null> {
+  const result = await scrapeRecipe(normalizeRecipeMarkup(html, url), url, {
+    safeParse: true,
+  });
+  if (!result.success) return null;
 
-  const title = plainText(recipe.name)?.slice(0, 120).trim();
-  const ingredients = values(recipe.recipeIngredient ?? recipe.ingredients)
-    .map(plainText)
-    .filter((value): value is string => Boolean(value));
-  const instructions = instructionLines(recipe.recipeInstructions);
-  if (!title || ingredients.length === 0 || instructions.length === 0) {
+  const recipe = result.data;
+  const ingredientGroups = recipe.ingredients
+    .map((group) => ({
+      name: group.name ?? undefined,
+      lines: group.items.map((item) => item.value),
+    }))
+    .filter((group) => group.lines.length > 0);
+  const instructions = recipe.instructions.flatMap((group) =>
+    group.items.map((item) => item.value),
+  );
+  if (!recipe.title || ingredientGroups.length === 0 || instructions.length === 0) {
     return null;
   }
 
+  const title = recipe.title.slice(0, 120).trim();
+  const cuisine = recipe.cuisine[0] ?? "";
   const description =
-    (
-      plainText(recipe.description) ??
-      `Recipe for ${title}, imported from the web.`
-    )
-      .slice(0, 500)
-      .trim();
-  const cuisine =
-    values(recipe.recipeCuisine).map(plainText).find(Boolean) ?? "";
+    recipe.description || `Recipe for ${recipe.title}, imported from the web.`;
+  const normalizedDescription = description.slice(0, 500).trim();
   const extraction: ExtractionRecipe = {
     title,
-    description,
+    description: normalizedDescription,
     cuisine: cuisine ? [cuisine] : [],
-    servings: String(servings(recipe.recipeYield)),
-    prepTime: durationMinutes(recipe.prepTime)?.toString(),
-    cookTime: durationMinutes(recipe.cookTime)?.toString(),
-    ingredientGroups: [{ lines: ingredients }],
+    servings: servings(recipe.yields),
+    prepTime: recipe.prepTime?.toString(),
+    cookTime: recipe.cookTime?.toString(),
+    ingredientGroups,
     instructions,
-    equipment: values(recipe.tool)
-      .map(plainText)
-      .filter((value): value is string => Boolean(value)),
+    equipment: recipe.equipment,
   };
   const cooklang = buildCooklangDraftFromExtraction(extraction);
   if (!cooklang.derived) return null;
 
   return {
     title,
-    description,
+    description: normalizedDescription,
     cuisine,
     servings: cooklang.frontmatter.servings ?? 1,
     prepTime: cooklang.frontmatter.prepTime,

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -107,7 +107,9 @@ function findRecipe(value: unknown): JsonObject | undefined {
   return undefined;
 }
 
-const DURATION_PART_PATTERN = /(\d+(?:\.\d+)?)([DHMS])/gi;
+function isAsciiDigit(character: string | undefined): boolean {
+  return character !== undefined && character >= "0" && character <= "9";
+}
 
 function durationSectionMinutes(
   section: string,
@@ -116,18 +118,30 @@ function durationSectionMinutes(
   if (!section) return 0;
   let minutes = 0;
   let cursor = 0;
-  DURATION_PART_PATTERN.lastIndex = 0;
-  for (
-    let match = DURATION_PART_PATTERN.exec(section);
-    match;
-    match = DURATION_PART_PATTERN.exec(section)
-  ) {
-    const multiplier = multipliers[match[2]?.toUpperCase() ?? ""];
-    if (match.index !== cursor || multiplier === undefined) return undefined;
-    minutes += Number(match[1]) * multiplier;
-    cursor = DURATION_PART_PATTERN.lastIndex;
+  while (cursor < section.length) {
+    const numberStart = cursor;
+    let hasDigit = false;
+    let hasDecimalPoint = false;
+    while (cursor < section.length) {
+      const character = section[cursor];
+      if (isAsciiDigit(character)) {
+        hasDigit = true;
+        cursor += 1;
+      } else if (character === "." && !hasDecimalPoint) {
+        hasDecimalPoint = true;
+        cursor += 1;
+      } else {
+        break;
+      }
+    }
+    const multiplier = multipliers[section[cursor] ?? ""];
+    if (!hasDigit || multiplier === undefined) return undefined;
+    const amount = Number(section.slice(numberStart, cursor));
+    if (!Number.isFinite(amount)) return undefined;
+    minutes += amount * multiplier;
+    cursor += 1;
   }
-  return cursor === section.length ? minutes : undefined;
+  return minutes;
 }
 
 function durationMinutes(value: unknown): number | undefined {

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -17,15 +17,25 @@ function servings(value: string): string {
   return /\d+(?:\.\d+)?/.exec(value)?.[0] ?? "1";
 }
 
+function unwrapJsonLd(source: string): string {
+  let cleaned = source.trim();
+  if (cleaned.startsWith("<!--")) cleaned = cleaned.slice(4).trimStart();
+  if (cleaned.endsWith("--!>")) cleaned = cleaned.slice(0, -4).trimEnd();
+  else if (cleaned.endsWith("-->")) cleaned = cleaned.slice(0, -3).trimEnd();
+  if (cleaned.startsWith("//<![CDATA[")) {
+    cleaned = cleaned.slice("//<![CDATA[".length).trimStart();
+  }
+  if (cleaned.endsWith("//]]>")) {
+    cleaned = cleaned.slice(0, -"//]]>".length).trimEnd();
+  }
+  return cleaned;
+}
+
 function normalizeRecipeMarkup(html: string, url: string): string {
   const $ = cheerio.load(html);
   $("script[type='application/ld+json']").each((_, element) => {
-    const source = $(element)
-      .html()
-      ?.trim()
-      .replace(/^<!--|-->$/g, "")
-      .replace(/^\/\/<!\[CDATA\[|\/\/\]\]>$/g, "")
-      .trim();
+    const rawSource = $(element).html();
+    const source = rawSource ? unwrapJsonLd(rawSource) : "";
     if (!source) return;
 
     try {

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -1,0 +1,212 @@
+import type { ExtractionRecipe } from "../schemas/stage-artifacts.js";
+import { buildCooklangDraftFromExtraction } from "./cooklang.js";
+
+export type SchemaOrgRecipeImport = {
+  title: string;
+  description: string;
+  cuisine: string;
+  servings: number;
+  prepTime?: number;
+  cookTime?: number;
+  source: string;
+};
+
+type JsonObject = Record<string, unknown>;
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function values(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : value == null ? [] : [value];
+}
+
+function text(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (typeof value === "number") return String(value);
+  if (isObject(value)) return text(value.name ?? value.text ?? value.value);
+  return undefined;
+}
+
+function decodeHtml(value: string): string {
+  const entities: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  };
+  return value.replace(
+    /&(#x[\da-f]+|#\d+|[a-z]+);/gi,
+    (match, entity: string) => {
+      let codePoint: number | undefined;
+      if (entity.startsWith("#x")) {
+        codePoint = Number.parseInt(entity.slice(2), 16);
+      } else if (entity.startsWith("#")) {
+        codePoint = Number.parseInt(entity.slice(1), 10);
+      }
+      if (codePoint !== undefined) {
+        return Number.isInteger(codePoint) &&
+          codePoint >= 0 &&
+          codePoint <= 0x10ffff
+          ? String.fromCodePoint(codePoint)
+          : match;
+      }
+      return entities[entity.toLowerCase()] ?? match;
+    },
+  );
+}
+
+function plainText(value: unknown): string | undefined {
+  const raw = text(value);
+  if (!raw) return undefined;
+  return decodeHtml(raw.replace(/<[^>]*>/g, " ")).replace(/\s+/g, " ").trim();
+}
+
+function isRecipeType(value: unknown): boolean {
+  return values(value).some((entry) => {
+    const type = text(entry)?.toLowerCase().replace(/\/$/, "");
+    return type === "recipe" || type?.endsWith("schema.org/recipe");
+  });
+}
+
+function findRecipe(value: unknown): JsonObject | undefined {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const recipe = findRecipe(entry);
+      if (recipe) return recipe;
+    }
+    return undefined;
+  }
+  if (!isObject(value)) return undefined;
+  if (isRecipeType(value["@type"])) return value;
+
+  for (const key of [
+    "@graph",
+    "mainEntity",
+    "mainEntityOfPage",
+    "itemListElement",
+  ]) {
+    const recipe = findRecipe(value[key]);
+    if (recipe) return recipe;
+  }
+  return undefined;
+}
+
+function durationMinutes(value: unknown): number | undefined {
+  const raw = text(value);
+  if (!raw) return undefined;
+  const match = raw.match(
+    /^P(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/i,
+  );
+  if (!match) return undefined;
+  const minutes =
+    Number(match[1] ?? 0) * 1440 +
+    Number(match[2] ?? 0) * 60 +
+    Number(match[3] ?? 0) +
+    Number(match[4] ?? 0) / 60;
+  return minutes > 0 ? Math.round(minutes) : undefined;
+}
+
+function servings(value: unknown): number {
+  for (const entry of values(value)) {
+    if (typeof entry === "number" && Number.isFinite(entry) && entry > 0) {
+      return Math.max(1, Math.round(entry));
+    }
+    const match = text(entry)?.match(/\d+(?:\.\d+)?/);
+    if (match) return Math.max(1, Math.round(Number(match[0])));
+  }
+  return 1;
+}
+
+function instructionLines(value: unknown): string[] {
+  const lines: string[] = [];
+  for (const entry of values(value)) {
+    if (typeof entry === "string") {
+      const line = plainText(entry);
+      if (line) lines.push(line);
+      continue;
+    }
+    if (!isObject(entry)) continue;
+    const nested = entry.itemListElement ?? entry.steps;
+    if (nested) lines.push(...instructionLines(nested));
+    else {
+      const line = plainText(entry.text ?? entry.name);
+      if (line) lines.push(line);
+    }
+  }
+  return lines;
+}
+
+function jsonLdBlocks(html: string): unknown[] {
+  const blocks: unknown[] = [];
+  const pattern =
+    /<script\b[^>]*\btype\s*=\s*["']application\/ld\+json(?:\s*;[^"']*)?["'][^>]*>([\s\S]*?)<\/script\s*>/gi;
+  for (const match of html.matchAll(pattern)) {
+    const source = match[1]?.trim();
+    if (!source) continue;
+    try {
+      blocks.push(JSON.parse(source));
+    } catch {
+      // Pages commonly contain unrelated malformed JSON-LD. Keep looking for
+      // a valid Recipe block before reporting that the page is unsupported.
+    }
+  }
+  return blocks;
+}
+
+export function parseSchemaOrgRecipeHtml(
+  html: string,
+): SchemaOrgRecipeImport | null {
+  let recipe: JsonObject | undefined;
+  for (const block of jsonLdBlocks(html)) {
+    recipe = findRecipe(block);
+    if (recipe) break;
+  }
+  if (!recipe) return null;
+
+  const title = plainText(recipe.name)?.slice(0, 120).trim();
+  const ingredients = values(recipe.recipeIngredient ?? recipe.ingredients)
+    .map(plainText)
+    .filter((value): value is string => Boolean(value));
+  const instructions = instructionLines(recipe.recipeInstructions);
+  if (!title || ingredients.length === 0 || instructions.length === 0) {
+    return null;
+  }
+
+  const description =
+    (
+      plainText(recipe.description) ??
+      `Recipe for ${title}, imported from the web.`
+    )
+      .slice(0, 500)
+      .trim();
+  const cuisine =
+    values(recipe.recipeCuisine).map(plainText).find(Boolean) ?? "";
+  const extraction: ExtractionRecipe = {
+    title,
+    description,
+    cuisine: cuisine ? [cuisine] : [],
+    servings: String(servings(recipe.recipeYield)),
+    prepTime: durationMinutes(recipe.prepTime)?.toString(),
+    cookTime: durationMinutes(recipe.cookTime)?.toString(),
+    ingredientGroups: [{ lines: ingredients }],
+    instructions,
+    equipment: values(recipe.tool)
+      .map(plainText)
+      .filter((value): value is string => Boolean(value)),
+  };
+  const cooklang = buildCooklangDraftFromExtraction(extraction);
+  if (!cooklang.derived) return null;
+
+  return {
+    title,
+    description,
+    cuisine,
+    servings: cooklang.frontmatter.servings ?? 1,
+    prepTime: cooklang.frontmatter.prepTime,
+    cookTime: cooklang.frontmatter.cookTime,
+    source: cooklang.body,
+  };
+}

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -18,7 +18,8 @@ function isObject(value: unknown): value is JsonObject {
 }
 
 function values(value: unknown): unknown[] {
-  return Array.isArray(value) ? value : value == null ? [] : [value];
+  if (Array.isArray(value)) return value;
+  return value == null ? [] : [value];
 }
 
 function text(value: unknown): string | undefined {
@@ -61,7 +62,19 @@ function decodeHtml(value: string): string {
 function plainText(value: unknown): string | undefined {
   const raw = text(value);
   if (!raw) return undefined;
-  return decodeHtml(raw.replace(/<[^>]*>/g, " ")).replace(/\s+/g, " ").trim();
+  let withoutTags = "";
+  let insideTag = false;
+  for (const character of raw) {
+    if (character === "<") {
+      insideTag = true;
+      withoutTags += " ";
+    } else if (character === ">") {
+      insideTag = false;
+    } else if (!insideTag) {
+      withoutTags += character;
+    }
+  }
+  return decodeHtml(withoutTags).replace(/\s+/g, " ").trim();
 }
 
 function isRecipeType(value: unknown): boolean {
@@ -94,18 +107,42 @@ function findRecipe(value: unknown): JsonObject | undefined {
   return undefined;
 }
 
+const DURATION_PART_PATTERN = /(\d+(?:\.\d+)?)([DHMS])/gi;
+
+function durationSectionMinutes(
+  section: string,
+  multipliers: Readonly<Record<string, number>>,
+): number | undefined {
+  if (!section) return 0;
+  let minutes = 0;
+  let cursor = 0;
+  DURATION_PART_PATTERN.lastIndex = 0;
+  for (
+    let match = DURATION_PART_PATTERN.exec(section);
+    match;
+    match = DURATION_PART_PATTERN.exec(section)
+  ) {
+    const multiplier = multipliers[match[2]?.toUpperCase() ?? ""];
+    if (match.index !== cursor || multiplier === undefined) return undefined;
+    minutes += Number(match[1]) * multiplier;
+    cursor = DURATION_PART_PATTERN.lastIndex;
+  }
+  return cursor === section.length ? minutes : undefined;
+}
+
 function durationMinutes(value: unknown): number | undefined {
-  const raw = text(value);
-  if (!raw) return undefined;
-  const match = raw.match(
-    /^P(?:(\d+(?:\.\d+)?)D)?(?:T(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?)?$/i,
-  );
-  if (!match) return undefined;
-  const minutes =
-    Number(match[1] ?? 0) * 1440 +
-    Number(match[2] ?? 0) * 60 +
-    Number(match[3] ?? 0) +
-    Number(match[4] ?? 0) / 60;
+  const raw = text(value)?.toUpperCase();
+  if (!raw?.startsWith("P")) return undefined;
+  const sections = raw.slice(1).split("T");
+  if (sections.length > 2) return undefined;
+  const days = durationSectionMinutes(sections[0] ?? "", { D: 1440 });
+  const time = durationSectionMinutes(sections[1] ?? "", {
+    H: 60,
+    M: 1,
+    S: 1 / 60,
+  });
+  if (days === undefined || time === undefined) return undefined;
+  const minutes = days + time;
   return minutes > 0 ? Math.round(minutes) : undefined;
 }
 
@@ -114,7 +151,7 @@ function servings(value: unknown): number {
     if (typeof entry === "number" && Number.isFinite(entry) && entry > 0) {
       return Math.max(1, Math.round(entry));
     }
-    const match = text(entry)?.match(/\d+(?:\.\d+)?/);
+    const match = /\d+(?:\.\d+)?/.exec(text(entry) ?? "");
     if (match) return Math.max(1, Math.round(Number(match[0])));
   }
   return 1;
@@ -141,17 +178,26 @@ function instructionLines(value: unknown): string[] {
 
 function jsonLdBlocks(html: string): unknown[] {
   const blocks: unknown[] = [];
-  const pattern =
-    /<script\b[^>]*\btype\s*=\s*["']application\/ld\+json(?:\s*;[^"']*)?["'][^>]*>([\s\S]*?)<\/script\s*>/gi;
-  for (const match of html.matchAll(pattern)) {
-    const source = match[1]?.trim();
-    if (!source) continue;
-    try {
-      blocks.push(JSON.parse(source));
-    } catch {
-      // Pages commonly contain unrelated malformed JSON-LD. Keep looking for
-      // a valid Recipe block before reporting that the page is unsupported.
+  const lowercaseHtml = html.toLowerCase();
+  let cursor = 0;
+  while (cursor < html.length) {
+    const scriptStart = lowercaseHtml.indexOf("<script", cursor);
+    if (scriptStart === -1) break;
+    const openingEnd = lowercaseHtml.indexOf(">", scriptStart + 7);
+    if (openingEnd === -1) break;
+    const closingStart = lowercaseHtml.indexOf("</script", openingEnd + 1);
+    if (closingStart === -1) break;
+    const openingTag = lowercaseHtml.slice(scriptStart, openingEnd + 1);
+    if (openingTag.includes("application/ld+json")) {
+      const source = html.slice(openingEnd + 1, closingStart).trim();
+      try {
+        blocks.push(JSON.parse(source));
+      } catch {
+        // Pages commonly contain unrelated malformed JSON-LD. Keep looking for
+        // a valid Recipe block before reporting that the page is unsupported.
+      }
     }
+    cursor = closingStart + 8;
   }
   return blocks;
 }

--- a/packages/recipe-parsing/tests/lib/schema-org.test.ts
+++ b/packages/recipe-parsing/tests/lib/schema-org.test.ts
@@ -44,6 +44,18 @@ describe("parseSchemaOrgRecipeHtml", () => {
     });
   });
 
+  it.each([
+    ["HTML comments", "<!--", "-->"],
+    ["CDATA comments", "//<![CDATA[", "//]]>"],
+  ])("unwraps JSON-LD inside %s", (_name, prefix, suffix) => {
+    const html = `<script type="application/ld+json">${prefix}
+      {"@type":"Recipe","name":"Toast","recipeIngredient":["2 slices bread"],
+       "recipeInstructions":["Toast the bread."]}
+      ${suffix}</script>`;
+
+    expect(parseSchemaOrgRecipeHtml(html)).toMatchObject({ title: "Toast" });
+  });
+
   it("rejects pages without a complete Recipe", () => {
     expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Article"}</script>`)).toBeNull();
     expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Recipe","name":"Empty"}</script>`)).toBeNull();

--- a/packages/recipe-parsing/tests/lib/schema-org.test.ts
+++ b/packages/recipe-parsing/tests/lib/schema-org.test.ts
@@ -48,6 +48,7 @@ describe("parseSchemaOrgRecipeHtml", () => {
 
   it.each([
     ["HTML comments", "<!--", "-->"],
+    ["HTML comments with a bang", "<!--", "--!>"],
     ["CDATA comments", "//<![CDATA[", "//]]>"],
   ])("unwraps JSON-LD inside %s", async (_name, prefix, suffix) => {
     const html = `<script type="application/ld+json">${prefix}

--- a/packages/recipe-parsing/tests/lib/schema-org.test.ts
+++ b/packages/recipe-parsing/tests/lib/schema-org.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { parseSchemaOrgRecipeHtml } from "../../src/lib/schema-org.js";
+
+describe("parseSchemaOrgRecipeHtml", () => {
+  it("imports a Recipe from a JSON-LD graph into Cooklang source", () => {
+    const html = `<!doctype html><script type="application/ld+json">
+      {"@context":"https://schema.org","@graph":[
+        {"@type":"WebPage","name":"Dinner"},
+        {"@type":["Thing","Recipe"],"name":"Tomato &amp; Basil Pasta",
+         "description":"A <b>quick</b> supper.","recipeCuisine":["Italian"],
+         "recipeYield":"Serves 4","prepTime":"PT10M","cookTime":"PT1H5M",
+         "recipeIngredient":["200 g dried pasta","2 tbsp olive oil","400g chopped tomatoes"],
+         "recipeInstructions":[
+           {"@type":"HowToSection","name":"Cook","itemListElement":[
+             {"@type":"HowToStep","text":"Boil the pasta."},
+             {"@type":"HowToStep","text":"Stir in the tomatoes &amp; serve."}
+           ]}
+         ]}
+      ]}</script>`;
+
+    expect(parseSchemaOrgRecipeHtml(html)).toEqual({
+      title: "Tomato & Basil Pasta",
+      description: "A quick supper.",
+      cuisine: "Italian",
+      servings: 4,
+      prepTime: 10,
+      cookTime: 65,
+      source:
+        "@dried pasta{200%g}\n@olive oil{2%tbsp}\n@chopped tomatoes{400%g}\n\nBoil the pasta.\n\nStir in the tomatoes & serve.",
+    });
+  });
+
+  it("supports a top-level array and plain instruction strings", () => {
+    const html = `<script TYPE='application/ld+json'>[
+      {"@type":"BreadcrumbList"},
+      {"@type":"https://schema.org/Recipe","name":"Toast","recipeIngredient":["2 slices bread"],
+       "recipeInstructions":["Toast the bread."],"recipeYield":2}
+    ]</script>`;
+
+    expect(parseSchemaOrgRecipeHtml(html)).toMatchObject({
+      title: "Toast",
+      servings: 2,
+      source: "@bread{2%slice}\n\nToast the bread.",
+    });
+  });
+
+  it("rejects pages without a complete Recipe", () => {
+    expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Article"}</script>`)).toBeNull();
+    expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Recipe","name":"Empty"}</script>`)).toBeNull();
+  });
+});

--- a/packages/recipe-parsing/tests/lib/schema-org.test.ts
+++ b/packages/recipe-parsing/tests/lib/schema-org.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from "vitest";
 import { parseSchemaOrgRecipeHtml } from "../../src/lib/schema-org.js";
 
 describe("parseSchemaOrgRecipeHtml", () => {
-  it("imports a Recipe from a JSON-LD graph into Cooklang source", () => {
+  it("imports a Recipe from a JSON-LD graph into Cooklang source", async () => {
     const html = `<!doctype html><script type="application/ld+json">
       {"@context":"https://schema.org","@graph":[
         {"@type":"WebPage","name":"Dinner"},
-        {"@type":["Thing","Recipe"],"name":"Tomato &amp; Basil Pasta",
+        {"@type":["Thing","Recipe"],"name":"Tomato &amp; Basil Pasta","author":"Test Cook",
+         "image":"https://example.com/pasta.jpg",
          "description":"A <b>quick</b> supper.","recipeCuisine":["Italian"],
          "recipeYield":"Serves 4","prepTime":"PT10M","cookTime":"PT1H5M",
          "recipeIngredient":["200 g dried pasta","2 tbsp olive oil","400g chopped tomatoes"],
@@ -18,7 +19,7 @@ describe("parseSchemaOrgRecipeHtml", () => {
          ]}
       ]}</script>`;
 
-    expect(parseSchemaOrgRecipeHtml(html)).toEqual({
+    await expect(parseSchemaOrgRecipeHtml(html)).resolves.toEqual({
       title: "Tomato & Basil Pasta",
       description: "A quick supper.",
       cuisine: "Italian",
@@ -30,14 +31,15 @@ describe("parseSchemaOrgRecipeHtml", () => {
     });
   });
 
-  it("supports a top-level array and plain instruction strings", () => {
+  it("supports a top-level array and plain instruction strings", async () => {
     const html = `<script TYPE='application/ld+json'>[
       {"@type":"BreadcrumbList"},
-      {"@type":"https://schema.org/Recipe","name":"Toast","recipeIngredient":["2 slices bread"],
+      {"@type":"https://schema.org/Recipe","name":"Toast","author":"Test Cook",
+       "image":"https://example.com/toast.jpg","description":"Toast.","recipeIngredient":["2 slices bread"],
        "recipeInstructions":["Toast the bread."],"recipeYield":2}
     ]</script>`;
 
-    expect(parseSchemaOrgRecipeHtml(html)).toMatchObject({
+    await expect(parseSchemaOrgRecipeHtml(html)).resolves.toMatchObject({
       title: "Toast",
       servings: 2,
       source: "@bread{2%slice}\n\nToast the bread.",
@@ -47,17 +49,18 @@ describe("parseSchemaOrgRecipeHtml", () => {
   it.each([
     ["HTML comments", "<!--", "-->"],
     ["CDATA comments", "//<![CDATA[", "//]]>"],
-  ])("unwraps JSON-LD inside %s", (_name, prefix, suffix) => {
+  ])("unwraps JSON-LD inside %s", async (_name, prefix, suffix) => {
     const html = `<script type="application/ld+json">${prefix}
-      {"@type":"Recipe","name":"Toast","recipeIngredient":["2 slices bread"],
+      {"@type":"Recipe","name":"Toast","author":"Test Cook",
+       "image":"https://example.com/toast.jpg","description":"Toast.","recipeIngredient":["2 slices bread"],
        "recipeInstructions":["Toast the bread."]}
       ${suffix}</script>`;
 
-    expect(parseSchemaOrgRecipeHtml(html)).toMatchObject({ title: "Toast" });
+    await expect(parseSchemaOrgRecipeHtml(html)).resolves.toMatchObject({ title: "Toast" });
   });
 
-  it("rejects pages without a complete Recipe", () => {
-    expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Article"}</script>`)).toBeNull();
-    expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Recipe","name":"Empty"}</script>`)).toBeNull();
+  it("rejects pages without a complete Recipe", async () => {
+    await expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Article"}</script>`)).resolves.toBeNull();
+    await expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Recipe","name":"Empty"}</script>`)).resolves.toBeNull();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@cooklang/cooklang':
         specifier: ^0.18.0
         version: 0.18.7(patch_hash=85b684e1c0e18dedb7ebd9e043c0c937dc04446f8417852c7f5af27b4b423ec7)
+      cheerio:
+        specifier: ^1.2.0
+        version: 1.2.0
       numeric-quantity:
         specifier: ^3.2.1
         version: 3.2.2
@@ -178,6 +181,9 @@ importers:
       recipe-domain:
         specifier: workspace:*
         version: link:../recipe-domain
+      recipe-scrapers:
+        specifier: ^1.9.0
+        version: 1.9.0(cheerio@1.2.0)(zod@4.4.3)
       zod:
         specifier: ^4.2.1
         version: 4.4.3
@@ -465,6 +471,9 @@ importers:
       hono:
         specifier: ^4.7.11
         version: 4.12.30
+      ipaddr.js:
+        specifier: ^2.4.0
+        version: 2.4.0
       jose:
         specifier: ^6.1.3
         version: 6.2.3
@@ -3178,6 +3187,9 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   boxen@7.0.0:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
@@ -3257,6 +3269,13 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -3414,9 +3433,16 @@ packages:
   css-mediaquery@0.1.2:
     resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -3669,8 +3695,21 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dot-prop@9.0.0:
     resolution: {integrity: sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==}
@@ -3813,6 +3852,9 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -3827,6 +3869,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   entities@8.0.0:
@@ -4170,6 +4216,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   http-link-header@1.1.3:
     resolution: {integrity: sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==}
     engines: {node: '>=6.0.0'}
@@ -4247,6 +4296,10 @@ packages:
 
   intl-messageformat@10.7.18:
     resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -4328,6 +4381,9 @@ packages:
   isexe@3.1.5:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
+
+  iso8601-duration@2.1.4:
+    resolution: {integrity: sha512-2TuWcuR6W0OhFZQDAY+jDUp9FC2fVTDgxTtbN0nFBfwmUA6HTqXc0wx2tIBVd/FhRp4CnJbDgCv3sCeTPMQbew==}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -4990,6 +5046,9 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   numeric-quantity@3.2.2:
     resolution: {integrity: sha512-qHc6mhIySaoqFYCM+foWY0DYYIT0ick1fI+MB9530gJ8XAPDExwXT8eyl3J+PWLIlZy0MCxSLobBjrggN9Z8EQ==}
     engines: {node: '>=16'}
@@ -5053,12 +5112,22 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse-ingredient@2.2.0:
+    resolution: {integrity: sha512-0nC1B3AJxZHAXM4zu/57XlZbaXuK6vpZDQcHpwBALU7KRxw5f1O/Tr0x0Srz3vxpn4+AP0NqCLKqnNdkIx9GVQ==}
+    engines: {node: '>=10'}
+
   parse-json@7.1.1:
     resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
     engines: {node: '>=16'}
 
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -5324,6 +5393,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  recipe-scrapers@1.9.0:
+    resolution: {integrity: sha512-Lz4MaEMHo2tV27LBxRiAdstFMA3CmQ3yGb0vCgPAVE+UoQVBc9hiQSAJQsBRqc78KjB54OoUhfZPIEODQ1V5sQ==}
+    peerDependencies:
+      cheerio: ^1
+      zod: ^4
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -6156,6 +6231,15 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -8732,6 +8816,8 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
+  boolbase@1.0.0: {}
+
   boxen@7.0.0:
     dependencies:
       ansi-align: 3.0.1
@@ -8807,6 +8893,29 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.28.0
+      whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
     dependencies:
@@ -8990,10 +9099,20 @@ snapshots:
 
   css-mediaquery@0.1.2: {}
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
 
@@ -9246,9 +9365,27 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dot-prop@9.0.0:
     dependencies:
@@ -9303,6 +9440,11 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
@@ -9316,6 +9458,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -9773,6 +9917,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-link-header@1.1.3: {}
 
   human-signals@2.1.0: {}
@@ -9831,6 +9982,8 @@ snapshots:
       '@formatjs/icu-messageformat-parser': 2.11.4
       tslib: 2.8.1
 
+  ipaddr.js@2.4.0: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -9887,6 +10040,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
+
+  iso8601-duration@2.1.4: {}
 
   jackspeak@3.4.3:
     dependencies:
@@ -10881,6 +11036,10 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   numeric-quantity@3.2.2: {}
 
   object-assign@4.1.1: {}
@@ -10930,6 +11089,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse-ingredient@2.2.0:
+    dependencies:
+      numeric-quantity: 3.2.2
+
   parse-json@7.1.1:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -10939,6 +11102,15 @@ snapshots:
       type-fest: 3.13.1
 
   parse-numeric-range@1.3.0: {}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
 
   parse5@7.3.0:
     dependencies:
@@ -11204,6 +11376,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - redux
+
+  recipe-scrapers@1.9.0(cheerio@1.2.0)(zod@4.4.3):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      cheerio: 1.2.0
+      iso8601-duration: 2.1.4
+      parse-ingredient: 2.2.0
+      zod: 4.4.3
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -12287,6 +12468,12 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   whatwg-mimetype@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       recipe-domain:
         specifier: workspace:*
         version: link:../../packages/recipe-domain
+      recipe-parsing:
+        specifier: workspace:*
+        version: link:../../packages/recipe-parsing
       zod:
         specifier: ^4.2.1
         version: 4.4.3

--- a/ui/app/recipes/add/page.tsx
+++ b/ui/app/recipes/add/page.tsx
@@ -3,7 +3,7 @@ import { AddRecipeView } from "@/components/recipes/add-recipe-view";
 
 export const metadata: Metadata = {
   title: "Add Recipe",
-  description: "Add a recipe using inline Cooklang syntax.",
+  description: "Add a recipe using Cooklang or import schema.org Recipe data.",
   robots: { index: false, follow: false },
 };
 

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -361,9 +361,9 @@ export function AddRecipeView() {
                       className="bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
                     >
                       {importing ? (
-                        <Loader2 className="animate-spin" />
+                        <Loader2 className="size-4 animate-spin" />
                       ) : (
-                        <Globe2 />
+                        <Globe2 className="size-4" />
                       )}
                       {importing ? "Importing…" : "Import recipe"}
                     </Button>

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -383,9 +383,9 @@ export function AddRecipeView() {
                   </p>
                 )}
                 {importedUrl && !importError && (
-                  <p role="status" className="text-sm text-[var(--sage)]">
+                  <output className="text-sm text-[var(--sage)]">
                     Imported successfully. You can edit any field before saving.
-                  </p>
+                  </output>
                 )}
               </div>
             )}

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -305,7 +305,10 @@ export function AddRecipeView() {
             >
               <button
                 type="button"
-                onClick={() => setMethod("write")}
+                onClick={() => {
+                  setMethod("write");
+                  setImportedUrl(null);
+                }}
                 aria-pressed={method === "write"}
                 className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
                   method === "write"

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -4,7 +4,9 @@ import {
   AlertCircle,
   ArrowLeft,
   FileText,
+  Globe2,
   Loader2,
+  PenLine,
   Save,
   Sparkles,
 } from "lucide-react";
@@ -28,6 +30,19 @@ const EXAMPLE_RECIPE = `Bring a large #pot{} of salted water to the boil. Add @d
 Meanwhile, warm @olive oil{2%tbsp} in a #frying pan{}. Add @garlic{2%cloves} and cook for ~{2%minutes}.
 
 Stir in @chopped tomatoes{400%g} and simmer for ~{15%minutes}. Drain the pasta, toss it through the sauce, and serve.`;
+
+type AddMethod = "write" | "url";
+
+type ImportedRecipe = {
+  title: string;
+  description: string;
+  cuisine: string;
+  servings: number;
+  prepTime?: number;
+  cookTime?: number;
+  source: string;
+  url: string;
+};
 
 function NumberField({
   label,
@@ -73,6 +88,11 @@ export function AddRecipeView() {
   const cuisineId = useId();
   const router = useRouter();
   const { data: session, isPending: sessionPending } = authClient.useSession();
+  const [method, setMethod] = useState<AddMethod>("write");
+  const [recipeUrl, setRecipeUrl] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importedUrl, setImportedUrl] = useState<string | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [cuisine, setCuisine] = useState("");
@@ -93,7 +113,15 @@ export function AddRecipeView() {
       return {
         recipe: buildRecipeDraft(
           parse.recipe,
-          { title, description, cuisine, servings, prepTime, cookTime },
+          {
+            title,
+            description,
+            cuisine,
+            servings,
+            prepTime,
+            cookTime,
+            canonical: importedUrl ?? undefined,
+          },
           source,
         ),
         error: false,
@@ -109,9 +137,51 @@ export function AddRecipeView() {
     servings,
     prepTime,
     cookTime,
+    importedUrl,
     source,
   ]);
   const preview = previewResult.recipe;
+
+  async function importRecipeUrl() {
+    if (!recipeUrl.trim() || importing) return;
+    setImporting(true);
+    setImportError(null);
+    try {
+      const response = await fetch("/api/recipes/import-url", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: recipeUrl.trim() }),
+      });
+      const body = (await response.json().catch(() => null)) as
+        | ImportedRecipe
+        | { error?: string }
+        | null;
+      if (!response.ok || !body || !("source" in body)) {
+        throw new Error(
+          (body && "error" in body && body.error) ||
+            "The recipe could not be imported.",
+        );
+      }
+      setTitle(body.title);
+      setDescription(body.description);
+      setCuisine(body.cuisine);
+      setServings(body.servings);
+      setPrepTime(body.prepTime);
+      setCookTime(body.cookTime);
+      setSource(body.source);
+      setRecipeUrl(body.url);
+      setImportedUrl(body.url);
+    } catch (error) {
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : "The recipe could not be imported.",
+      );
+    } finally {
+      setImporting(false);
+    }
+  }
 
   async function saveRecipe() {
     if (!preview || savingRef.current) return;
@@ -203,8 +273,8 @@ export function AddRecipeView() {
             Add a <span className="text-[var(--terracotta)]">recipe</span>
           </h1>
           <p className="rt-body mt-2 text-[var(--ink-2)]">
-            Write the recipe naturally, adding Cooklang syntax inline. The
-            preview updates as you type.
+            Write a recipe with Cooklang or import one from a webpage. Both
+            methods feed the same editable preview.
           </p>
         </div>
         <Button
@@ -229,6 +299,97 @@ export function AddRecipeView() {
       <div className="grid items-start gap-6 xl:grid-cols-[minmax(380px,0.8fr)_minmax(540px,1.2fr)]">
         <section className="rounded-xl border-[1.25px] border-[var(--line-strong)] bg-[var(--card)] p-4 shadow-[var(--paper-shadow)] xl:sticky xl:top-24">
           <div className="grid gap-4">
+            <fieldset
+              className="grid grid-cols-2 rounded-lg border border-[var(--line-strong)] bg-[var(--paper-warm)] p-1"
+              aria-label="Choose how to add a recipe"
+            >
+              <button
+                type="button"
+                onClick={() => setMethod("write")}
+                aria-pressed={method === "write"}
+                className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
+                  method === "write"
+                    ? "bg-[var(--card)] text-[var(--ink)] shadow-sm"
+                    : "text-[var(--ink-3)] hover:text-[var(--ink)]"
+                }`}
+              >
+                <PenLine className="size-4" /> Write with Cooklang
+              </button>
+              <button
+                type="button"
+                onClick={() => setMethod("url")}
+                aria-pressed={method === "url"}
+                className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
+                  method === "url"
+                    ? "bg-[var(--card)] text-[var(--ink)] shadow-sm"
+                    : "text-[var(--ink-3)] hover:text-[var(--ink)]"
+                }`}
+              >
+                <Globe2 className="size-4" /> Import from URL
+              </button>
+            </fieldset>
+
+            {method === "url" && (
+              <div className="grid gap-2 rounded-lg border border-dashed border-[var(--line-strong)] bg-[var(--paper-warm)] p-3">
+                <label htmlFor="recipe-import-url" className="grid gap-1.5">
+                  <span className="rt-mono text-[var(--ink-3)]">
+                    Recipe webpage URL
+                  </span>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Input
+                      id="recipe-import-url"
+                      type="url"
+                      value={recipeUrl}
+                      onChange={(event) => {
+                        setRecipeUrl(event.target.value);
+                        setImportError(null);
+                        setImportedUrl(null);
+                      }}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter") {
+                          event.preventDefault();
+                          void importRecipeUrl();
+                        }
+                      }}
+                      placeholder="https://example.com/recipes/tomato-pasta"
+                      className="min-w-0 flex-1 border-[var(--line-strong)] bg-[var(--paper)]"
+                    />
+                    <Button
+                      type="button"
+                      onClick={() => void importRecipeUrl()}
+                      disabled={!recipeUrl.trim() || importing}
+                      className="bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+                    >
+                      {importing ? (
+                        <Loader2 className="animate-spin" />
+                      ) : (
+                        <Globe2 />
+                      )}
+                      {importing ? "Importing…" : "Import recipe"}
+                    </Button>
+                  </div>
+                </label>
+                <p className="text-xs text-[var(--ink-3)]">
+                  The page must publish schema.org Recipe data with a name,
+                  ingredients and instructions.
+                </p>
+                {importError && (
+                  <p
+                    role="alert"
+                    className="flex items-start gap-1.5 text-sm text-destructive"
+                  >
+                    <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                    {importError}
+                  </p>
+                )}
+                {importedUrl && !importError && (
+                  <p role="status" className="text-sm text-[var(--sage)]">
+                    Imported successfully. You can edit any field before saving.
+                  </p>
+                )}
+              </div>
+            )}
+
             <label htmlFor={titleId} className="grid gap-1.5">
               <span className="rt-mono text-[var(--ink-3)]">Recipe name</span>
               <Input
@@ -285,7 +446,9 @@ export function AddRecipeView() {
               <div>
                 <p className="rt-mono text-[var(--ink-3)]">Recipe text</p>
                 <p className="text-xs text-[var(--ink-3)]">
-                  Use @ingredients, #cookware and ~timers directly in each step.
+                  {method === "url"
+                    ? "Imported as editable Cooklang. Adjust anything before saving."
+                    : "Use @ingredients, #cookware and ~timers directly in each step."}
                 </p>
               </div>
               <Button
@@ -300,6 +463,7 @@ export function AddRecipeView() {
                   setPrepTime(5);
                   setCookTime(25);
                   setSource(EXAMPLE_RECIPE);
+                  setImportedUrl(null);
                 }}
               >
                 <Sparkles /> Try example
@@ -335,7 +499,8 @@ export function AddRecipeView() {
               </h2>
               <p className="rt-body mt-2 max-w-md text-[var(--ink-3)]">
                 Add a name and write your steps with inline Cooklang—or use the
-                example to see ingredients and timers come alive.
+                example or URL importer to see ingredients and timers come
+                alive.
               </p>
               {(parse.error || previewResult.error) && (
                 <p role="alert" className="mt-4 text-sm text-destructive">

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -102,6 +102,11 @@ export function AddRecipeView() {
   const [source, setSource] = useState("");
   const [saving, setSaving] = useState(false);
   const savingRef = useRef(false);
+  const importRequestRef = useRef<{
+    id: number;
+    controller: AbortController;
+  } | null>(null);
+  const nextImportRequestIdRef = useRef(0);
   const [saveError, setSaveError] = useState<string | null>(null);
   const cooklang = useMemo(() => normalizeRecipeSource(source), [source]);
   const parse = useCooklangRecipe(cooklang);
@@ -144,6 +149,12 @@ export function AddRecipeView() {
 
   async function importRecipeUrl() {
     if (!recipeUrl.trim() || importing) return;
+    importRequestRef.current?.controller.abort();
+    const request = {
+      id: ++nextImportRequestIdRef.current,
+      controller: new AbortController(),
+    };
+    importRequestRef.current = request;
     setImporting(true);
     setImportError(null);
     try {
@@ -152,6 +163,7 @@ export function AddRecipeView() {
         credentials: "include",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ url: recipeUrl.trim() }),
+        signal: request.controller.signal,
       });
       const body = (await response.json().catch(() => null)) as
         | ImportedRecipe
@@ -163,6 +175,7 @@ export function AddRecipeView() {
             "The recipe could not be imported.",
         );
       }
+      if (importRequestRef.current?.id !== request.id) return;
       setTitle(body.title);
       setDescription(body.description);
       setCuisine(body.cuisine);
@@ -173,14 +186,29 @@ export function AddRecipeView() {
       setRecipeUrl(body.url);
       setImportedUrl(body.url);
     } catch (error) {
+      if (
+        request.controller.signal.aborted ||
+        importRequestRef.current?.id !== request.id
+      ) {
+        return;
+      }
       setImportError(
         error instanceof Error
           ? error.message
           : "The recipe could not be imported.",
       );
     } finally {
-      setImporting(false);
+      if (importRequestRef.current?.id === request.id) {
+        importRequestRef.current = null;
+        setImporting(false);
+      }
     }
+  }
+
+  function invalidateImportRequest() {
+    importRequestRef.current?.controller.abort();
+    importRequestRef.current = null;
+    setImporting(false);
   }
 
   async function saveRecipe() {
@@ -306,8 +334,8 @@ export function AddRecipeView() {
               <button
                 type="button"
                 onClick={() => {
+                  invalidateImportRequest();
                   setMethod("write");
-                  setImportedUrl(null);
                 }}
                 aria-pressed={method === "write"}
                 className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
@@ -344,9 +372,9 @@ export function AddRecipeView() {
                       type="url"
                       value={recipeUrl}
                       onChange={(event) => {
+                        invalidateImportRequest();
                         setRecipeUrl(event.target.value);
                         setImportError(null);
-                        setImportedUrl(null);
                       }}
                       onKeyDown={(event) => {
                         if (event.key === "Enter") {
@@ -460,6 +488,7 @@ export function AddRecipeView() {
                 size="sm"
                 className="rounded-full"
                 onClick={() => {
+                  invalidateImportRequest();
                   setTitle("Weeknight tomato pasta");
                   setDescription("A quick, cosy pasta for busy evenings.");
                   setCuisine("Italian");

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -17,6 +17,7 @@ export type RecipeDraftMetadata = {
   prepTime?: number;
   cookTime?: number;
   cuisine?: string;
+  canonical?: string;
 };
 
 export type SavedRecipePayload = {
@@ -62,6 +63,7 @@ export function buildRecipeDraft(
       servings: metadata.servings,
       prepTime: metadata.prepTime,
       cookTime: metadata.cookTime,
+      canonical: metadata.canonical,
       tags: [],
     },
     slug,

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -26,6 +26,7 @@
     "postgres": "^3.4.5",
     "recipe-db": "workspace:*",
     "recipe-domain": "workspace:*",
+    "recipe-parsing": "workspace:*",
     "zod": "^4.2.1"
   },
   "devDependencies": {

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -22,6 +22,7 @@
     "better-auth-cloudflare": "^0.3.0",
     "drizzle-orm": "^0.45.0",
     "hono": "^4.7.11",
+    "ipaddr.js": "^2.4.0",
     "jose": "^6.1.3",
     "postgres": "^3.4.5",
     "recipe-db": "workspace:*",

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -3,6 +3,7 @@ import { and, count, desc, eq, gte, inArray, lt, or } from "drizzle-orm";
 import { z } from "zod";
 import { createDb, schema } from "recipe-db";
 import { RecipeContentSchema } from "recipe-domain";
+import { parseSchemaOrgRecipeHtml } from "recipe-parsing/schema-org";
 import { createAuth } from "./auth";
 import { verifyCloudflareAccess } from "./cloudflare-access";
 import { hasPostgresErrorCode } from "./db/errors";
@@ -20,6 +21,10 @@ import {
 import { enforceRateLimit, rateLimitedResponse } from "./http/rate-limit";
 import { validateCsrf } from "./http/security";
 import { parseJsonBody } from "./http/validation";
+import {
+  fetchRecipePage,
+  RecipeUrlImportError,
+} from "./recipe-url-import";
 import {
   findPreviewScenario,
   previewScenarios,
@@ -152,6 +157,7 @@ const savedRecipeBodySchema = z
 const INVITATION_EXPIRY_MS = 48 * 60 * 60 * 1000;
 
 const HOUSEHOLD_INVITE_RATE_LIMIT = { max: 10, windowSeconds: 60 * 60 };
+const RECIPE_URL_IMPORT_RATE_LIMIT = { max: 20, windowSeconds: 60 * 60 };
 
 const createRecipeBodySchema = z.object({
   slug: recipeSlugSchema,
@@ -160,6 +166,10 @@ const createRecipeBodySchema = z.object({
   body: savedRecipeBodySchema,
   visibility: recipeVisibilitySchema.default("private"),
 });
+
+const importRecipeUrlBodySchema = z
+  .object({ url: z.string().trim().min(1).max(2_048) })
+  .strict();
 
 const updateRecipeBodySchema = z
   .object({
@@ -1674,6 +1684,69 @@ app.get("/recipes", async (c) => {
   } catch (e) {
     console.error("GET /recipes query failed", e);
     return c.json({ error: "Database query failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.post("/recipes/import-url", async (c) => {
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const session = await requireRecipeSession(c, connection.db);
+    if (!session.success) return session.response;
+
+    const body = await parseJsonBody(c, importRecipeUrlBodySchema);
+    if (!body.success) return body.response;
+
+    const importLimit = await enforceRateLimit(
+      connection.db,
+      `recipe-url-import:${session.session.user.id}`,
+      RECIPE_URL_IMPORT_RATE_LIMIT,
+    );
+    if (!importLimit.allowed) {
+      return rateLimitedResponse(c, importLimit.retryAfter);
+    }
+
+    const page = await fetchRecipePage(body.data.url);
+    const recipe = parseSchemaOrgRecipeHtml(page.html);
+    if (!recipe) {
+      return c.json(
+        {
+          error:
+            "No complete schema.org Recipe was found on that page. It must include a name, ingredients, and instructions.",
+        },
+        422,
+      );
+    }
+    if (recipe.source.length > 10_000) {
+      return c.json(
+        {
+          error:
+            "That recipe is too long to import. The Cooklang draft exceeds 10,000 characters.",
+        },
+        422,
+      );
+    }
+    return c.json({ ...recipe, url: page.url });
+  } catch (error) {
+    if (error instanceof RecipeUrlImportError) {
+      return c.json({ error: error.message }, error.status);
+    }
+    console.error("POST /recipes/import-url failed", error);
+    return c.json({ error: "The recipe could not be imported" }, 502);
   } finally {
     await closeDbClient(client);
   }

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -1721,7 +1721,7 @@ app.post("/recipes/import-url", async (c) => {
     }
 
     const page = await fetchRecipePage(body.data.url);
-    const recipe = parseSchemaOrgRecipeHtml(page.html);
+    const recipe = await parseSchemaOrgRecipeHtml(page.html, page.url);
     if (!recipe) {
       return c.json(
         {

--- a/workers/recipe-api/src/recipe-url-import.ts
+++ b/workers/recipe-api/src/recipe-url-import.ts
@@ -1,3 +1,5 @@
+import ipaddr from "ipaddr.js";
+
 const MAX_RECIPE_PAGE_BYTES = 2 * 1024 * 1024;
 const MAX_REDIRECTS = 3;
 const FETCH_TIMEOUT_MS = 10_000;
@@ -12,105 +14,9 @@ export class RecipeUrlImportError extends Error {
   }
 }
 
-function isPrivateIpv4(hostname: string): boolean {
-  const octets = hostname.split(".").map(Number);
-  if (
-    octets.length !== 4 ||
-    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
-  ) {
-    return false;
-  }
-  const [first, second] = octets as [number, number, number, number];
-  return (
-    first === 0 ||
-    first === 10 ||
-    first === 127 ||
-    (first === 100 && second >= 64 && second <= 127) ||
-    (first === 169 && second === 254) ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && (second === 0 || second === 168)) ||
-    (first === 198 && (second === 18 || second === 19)) ||
-    first >= 224
-  );
-}
-
-function ipv4Groups(value: string): [number, number] | undefined {
-  const octets = value.split(".").map(Number);
-  if (
-    octets.length !== 4 ||
-    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
-  ) {
-    return undefined;
-  }
-  const [first, second, third, fourth] = octets as [
-    number,
-    number,
-    number,
-    number,
-  ];
-  return [(first << 8) | second, (third << 8) | fourth];
-}
-
-function ipv6SideGroups(value: string): number[] | undefined {
-  if (!value) return [];
-  const parts = value.split(":");
-  const groups: number[] = [];
-  for (const [index, part] of parts.entries()) {
-    if (part.includes(".")) {
-      if (index !== parts.length - 1) return undefined;
-      const tail = ipv4Groups(part);
-      if (!tail) return undefined;
-      groups.push(...tail);
-      continue;
-    }
-    if (!/^[0-9a-f]{1,4}$/i.test(part)) return undefined;
-    groups.push(Number.parseInt(part, 16));
-  }
-  return groups;
-}
-
-function ipv6Groups(hostname: string): number[] | undefined {
-  const sides = hostname.split("::");
-  if (sides.length > 2) return undefined;
-  const left = ipv6SideGroups(sides[0] ?? "");
-  const right = ipv6SideGroups(sides[1] ?? "");
-  if (!left || !right) return undefined;
-  if (sides.length === 1) return left.length === 8 ? left : undefined;
-  const omitted = 8 - left.length - right.length;
-  if (omitted < 1) return undefined;
-  return [...left, ...new Array<number>(omitted).fill(0), ...right];
-}
-
-function isPrivateIpv6(hostname: string): boolean {
-  const groups = ipv6Groups(hostname);
-  if (!groups) return true;
-  const [first, , , , , sixth, seventh, eighth] = groups as [
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-    number,
-  ];
-  const isUnspecifiedOrCompatible = groups
-    .slice(0, 6)
-    .every((group) => group === 0);
-  const isIpv4Mapped =
-    groups.slice(0, 5).every((group) => group === 0) && sixth === 0xffff;
-  const mappedIpv4 = `${seventh >> 8}.${seventh & 0xff}.${eighth >> 8}.${
-    eighth & 0xff
-  }`;
-  return (
-    isUnspecifiedOrCompatible ||
-    (isIpv4Mapped && isPrivateIpv4(mappedIpv4)) ||
-    (first & 0xfe00) === 0xfc00 ||
-    (first & 0xffc0) === 0xfe80 ||
-    (first & 0xffc0) === 0xfec0 ||
-    (first & 0xff00) === 0xff00 ||
-    (first === 0x2001 && groups[1] === 0x0db8)
-  );
+function isNonPublicIp(hostname: string): boolean {
+  if (!ipaddr.isValid(hostname)) return false;
+  return ipaddr.process(hostname).range() !== "unicast";
 }
 
 export function validateRecipeUrl(value: string | URL): URL {
@@ -141,8 +47,7 @@ export function validateRecipeUrl(value: string | URL): URL {
     hostname.endsWith(".localhost") ||
     hostname.endsWith(".local") ||
     hostname.endsWith(".internal") ||
-    (hostname.includes(":") && isPrivateIpv6(hostname)) ||
-    isPrivateIpv4(hostname)
+    isNonPublicIp(hostname)
   ) {
     throw new RecipeUrlImportError("That recipe URL cannot be accessed", 400);
   }

--- a/workers/recipe-api/src/recipe-url-import.ts
+++ b/workers/recipe-api/src/recipe-url-import.ts
@@ -113,11 +113,14 @@ function validateRecipePageResponse(response: Response): void {
   if (!response.ok) {
     throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
   }
-  const contentType = response.headers.get("content-type")?.toLowerCase();
+  const contentType = response.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
   if (
-    contentType &&
-    !contentType.includes("text/html") &&
-    !contentType.includes("application/xhtml+xml")
+    contentType !== "text/html" &&
+    contentType !== "application/xhtml+xml"
   ) {
     throw new RecipeUrlImportError(
       "The URL does not point to an HTML page",

--- a/workers/recipe-api/src/recipe-url-import.ts
+++ b/workers/recipe-api/src/recipe-url-import.ts
@@ -1,0 +1,160 @@
+const MAX_RECIPE_PAGE_BYTES = 2 * 1024 * 1024;
+const MAX_REDIRECTS = 3;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export class RecipeUrlImportError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 413 | 415 | 422 | 502 | 504,
+  ) {
+    super(message);
+    this.name = "RecipeUrlImportError";
+  }
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split(".").map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return false;
+  }
+  const [first, second] = octets as [number, number, number, number];
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && (second === 0 || second === 168)) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    first >= 224
+  );
+}
+
+export function validateRecipeUrl(value: string | URL): URL {
+  let url: URL;
+  try {
+    url = value instanceof URL ? value : new URL(value);
+  } catch {
+    throw new RecipeUrlImportError("Enter a valid recipe page URL", 400);
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new RecipeUrlImportError("Recipe URLs must use http or https", 400);
+  }
+  if (url.username || url.password) {
+    throw new RecipeUrlImportError("Recipe URLs must not contain credentials", 400);
+  }
+  if (
+    (url.protocol === "http:" && url.port && url.port !== "80") ||
+    (url.protocol === "https:" && url.port && url.port !== "443")
+  ) {
+    throw new RecipeUrlImportError("Recipe URLs must use a standard web port", 400);
+  }
+
+  const hostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    !hostname ||
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    hostname.endsWith(".internal") ||
+    hostname.includes(":") ||
+    isPrivateIpv4(hostname)
+  ) {
+    throw new RecipeUrlImportError("That recipe URL cannot be accessed", 400);
+  }
+  return url;
+}
+
+async function readLimitedText(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (
+    Number.isFinite(declaredLength) &&
+    declaredLength > MAX_RECIPE_PAGE_BYTES
+  ) {
+    throw new RecipeUrlImportError("The recipe page is too large to import", 413);
+  }
+  if (!response.body) return "";
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    size += value.byteLength;
+    if (size > MAX_RECIPE_PAGE_BYTES) {
+      await reader.cancel();
+      throw new RecipeUrlImportError("The recipe page is too large to import", 413);
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export async function fetchRecipePage(
+  rawUrl: string,
+  fetcher: typeof fetch = fetch,
+): Promise<{ html: string; url: string }> {
+  let url = validateRecipeUrl(rawUrl);
+  const signal = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+
+  try {
+    for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+      const response = await fetcher(url, {
+        headers: {
+          accept: "text/html,application/xhtml+xml",
+          "user-agent": "RecipeImporter/1.0 (+https://robbiepalmer.me/recipes)",
+        },
+        redirect: "manual",
+        signal,
+      });
+
+      if (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location || redirect === MAX_REDIRECTS) {
+          throw new RecipeUrlImportError(
+            "The recipe page redirected too many times",
+            502,
+          );
+        }
+        url = validateRecipeUrl(new URL(location, url));
+        continue;
+      }
+      if (!response.ok) {
+        throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
+      }
+      const contentType = response.headers.get("content-type")?.toLowerCase();
+      if (
+        contentType &&
+        !contentType.includes("text/html") &&
+        !contentType.includes("application/xhtml+xml")
+      ) {
+        throw new RecipeUrlImportError(
+          "The URL does not point to an HTML page",
+          415,
+        );
+      }
+      return { html: await readLimitedText(response), url: url.toString() };
+    }
+  } catch (error) {
+    if (error instanceof RecipeUrlImportError) throw error;
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new RecipeUrlImportError("The recipe page took too long to respond", 504);
+    }
+    throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
+  }
+
+  throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
+}

--- a/workers/recipe-api/src/recipe-url-import.ts
+++ b/workers/recipe-api/src/recipe-url-import.ts
@@ -103,6 +103,50 @@ async function readLimitedText(response: Response): Promise<string> {
   return new TextDecoder().decode(bytes);
 }
 
+function redirectUrl(
+  response: Response,
+  currentUrl: URL,
+  redirectCount: number,
+): URL | undefined {
+  if (response.status < 300 || response.status >= 400) return undefined;
+  const location = response.headers.get("location");
+  if (!location || redirectCount === MAX_REDIRECTS) {
+    throw new RecipeUrlImportError(
+      "The recipe page redirected too many times",
+      502,
+    );
+  }
+  return validateRecipeUrl(new URL(location, currentUrl));
+}
+
+function validateRecipePageResponse(response: Response): void {
+  if (!response.ok) {
+    throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
+  }
+  const contentType = response.headers.get("content-type")?.toLowerCase();
+  if (
+    contentType &&
+    !contentType.includes("text/html") &&
+    !contentType.includes("application/xhtml+xml")
+  ) {
+    throw new RecipeUrlImportError(
+      "The URL does not point to an HTML page",
+      415,
+    );
+  }
+}
+
+function rethrowFetchError(error: unknown): never {
+  if (error instanceof RecipeUrlImportError) throw error;
+  if (error instanceof Error && error.name === "TimeoutError") {
+    throw new RecipeUrlImportError(
+      "The recipe page took too long to respond",
+      504,
+    );
+  }
+  throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
+}
+
 export async function fetchRecipePage(
   rawUrl: string,
   fetcher: typeof fetch = fetch,
@@ -120,40 +164,16 @@ export async function fetchRecipePage(
         redirect: "manual",
         signal,
       });
-
-      if (response.status >= 300 && response.status < 400) {
-        const location = response.headers.get("location");
-        if (!location || redirect === MAX_REDIRECTS) {
-          throw new RecipeUrlImportError(
-            "The recipe page redirected too many times",
-            502,
-          );
-        }
-        url = validateRecipeUrl(new URL(location, url));
+      const nextUrl = redirectUrl(response, url, redirect);
+      if (nextUrl) {
+        url = nextUrl;
         continue;
       }
-      if (!response.ok) {
-        throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
-      }
-      const contentType = response.headers.get("content-type")?.toLowerCase();
-      if (
-        contentType &&
-        !contentType.includes("text/html") &&
-        !contentType.includes("application/xhtml+xml")
-      ) {
-        throw new RecipeUrlImportError(
-          "The URL does not point to an HTML page",
-          415,
-        );
-      }
+      validateRecipePageResponse(response);
       return { html: await readLimitedText(response), url: url.toString() };
     }
   } catch (error) {
-    if (error instanceof RecipeUrlImportError) throw error;
-    if (error instanceof Error && error.name === "TimeoutError") {
-      throw new RecipeUrlImportError("The recipe page took too long to respond", 504);
-    }
-    throw new RecipeUrlImportError("The recipe page could not be fetched", 502);
+    rethrowFetchError(error);
   }
 
   throw new RecipeUrlImportError("The recipe page could not be fetched", 502);

--- a/workers/recipe-api/src/recipe-url-import.ts
+++ b/workers/recipe-api/src/recipe-url-import.ts
@@ -78,7 +78,7 @@ function ipv6Groups(hostname: string): number[] | undefined {
   if (sides.length === 1) return left.length === 8 ? left : undefined;
   const omitted = 8 - left.length - right.length;
   if (omitted < 1) return undefined;
-  return [...left, ...Array<number>(omitted).fill(0), ...right];
+  return [...left, ...new Array<number>(omitted).fill(0), ...right];
 }
 
 function isPrivateIpv6(hostname: string): boolean {

--- a/workers/recipe-api/src/recipe-url-import.ts
+++ b/workers/recipe-api/src/recipe-url-import.ts
@@ -34,6 +34,85 @@ function isPrivateIpv4(hostname: string): boolean {
   );
 }
 
+function ipv4Groups(value: string): [number, number] | undefined {
+  const octets = value.split(".").map(Number);
+  if (
+    octets.length !== 4 ||
+    octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return undefined;
+  }
+  const [first, second, third, fourth] = octets as [
+    number,
+    number,
+    number,
+    number,
+  ];
+  return [(first << 8) | second, (third << 8) | fourth];
+}
+
+function ipv6SideGroups(value: string): number[] | undefined {
+  if (!value) return [];
+  const parts = value.split(":");
+  const groups: number[] = [];
+  for (const [index, part] of parts.entries()) {
+    if (part.includes(".")) {
+      if (index !== parts.length - 1) return undefined;
+      const tail = ipv4Groups(part);
+      if (!tail) return undefined;
+      groups.push(...tail);
+      continue;
+    }
+    if (!/^[0-9a-f]{1,4}$/i.test(part)) return undefined;
+    groups.push(Number.parseInt(part, 16));
+  }
+  return groups;
+}
+
+function ipv6Groups(hostname: string): number[] | undefined {
+  const sides = hostname.split("::");
+  if (sides.length > 2) return undefined;
+  const left = ipv6SideGroups(sides[0] ?? "");
+  const right = ipv6SideGroups(sides[1] ?? "");
+  if (!left || !right) return undefined;
+  if (sides.length === 1) return left.length === 8 ? left : undefined;
+  const omitted = 8 - left.length - right.length;
+  if (omitted < 1) return undefined;
+  return [...left, ...Array<number>(omitted).fill(0), ...right];
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const groups = ipv6Groups(hostname);
+  if (!groups) return true;
+  const [first, , , , , sixth, seventh, eighth] = groups as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ];
+  const isUnspecifiedOrCompatible = groups
+    .slice(0, 6)
+    .every((group) => group === 0);
+  const isIpv4Mapped =
+    groups.slice(0, 5).every((group) => group === 0) && sixth === 0xffff;
+  const mappedIpv4 = `${seventh >> 8}.${seventh & 0xff}.${eighth >> 8}.${
+    eighth & 0xff
+  }`;
+  return (
+    isUnspecifiedOrCompatible ||
+    (isIpv4Mapped && isPrivateIpv4(mappedIpv4)) ||
+    (first & 0xfe00) === 0xfc00 ||
+    (first & 0xffc0) === 0xfe80 ||
+    (first & 0xffc0) === 0xfec0 ||
+    (first & 0xff00) === 0xff00 ||
+    (first === 0x2001 && groups[1] === 0x0db8)
+  );
+}
+
 export function validateRecipeUrl(value: string | URL): URL {
   let url: URL;
   try {
@@ -62,7 +141,7 @@ export function validateRecipeUrl(value: string | URL): URL {
     hostname.endsWith(".localhost") ||
     hostname.endsWith(".local") ||
     hostname.endsWith(".internal") ||
-    hostname.includes(":") ||
+    (hostname.includes(":") && isPrivateIpv6(hostname)) ||
     isPrivateIpv4(hostname)
   ) {
     throw new RecipeUrlImportError("That recipe URL cannot be accessed", 400);
@@ -110,7 +189,13 @@ function redirectUrl(
 ): URL | undefined {
   if (response.status < 300 || response.status >= 400) return undefined;
   const location = response.headers.get("location");
-  if (!location || redirectCount === MAX_REDIRECTS) {
+  if (!location) {
+    throw new RecipeUrlImportError(
+      "The recipe page returned a redirect without a destination",
+      502,
+    );
+  }
+  if (redirectCount === MAX_REDIRECTS) {
     throw new RecipeUrlImportError(
       "The recipe page redirected too many times",
       502,
@@ -156,6 +241,9 @@ export async function fetchRecipePage(
 
   try {
     for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect++) {
+      // Cloudflare owns DNS resolution and egress enforcement for Workers fetch.
+      // Literal and redirect targets are checked here; protection from a hostname
+      // resolving to a private address relies on Cloudflare's network boundary.
       const response = await fetcher(url, {
         headers: {
           accept: "text/html,application/xhtml+xml",

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -1127,6 +1127,112 @@ describe("POST /recipes", () => {
   });
 });
 
+describe("POST /recipes/import-url", () => {
+  it("requires authentication before fetching the page", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await app.request(
+      "/recipes/import-url",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ url: "https://recipes.example.test/pasta" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("returns an editable Cooklang draft from schema.org Recipe data", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        `<script type="application/ld+json">${JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "Recipe",
+          name: "Tomato pasta",
+          description: "A quick dinner.",
+          recipeYield: "2 servings",
+          prepTime: "PT5M",
+          cookTime: "PT20M",
+          recipeIngredient: ["200 g pasta", "400 g tomatoes"],
+          recipeInstructions: [
+            { "@type": "HowToStep", text: "Boil the pasta." },
+            { "@type": "HowToStep", text: "Add the tomatoes." },
+          ],
+        })}</script>`,
+        { headers: { "content-type": "text/html" } },
+      ),
+    );
+
+    const res = await app.request(
+      "/recipes/import-url",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ url: "https://recipes.example.test/pasta" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      title: "Tomato pasta",
+      description: "A quick dinner.",
+      servings: 2,
+      prepTime: 5,
+      cookTime: 20,
+      url: "https://recipes.example.test/pasta",
+      source:
+        "@pasta{200%g}\n@tomatoes{400%g}\n\nBoil the pasta.\n\nAdd the tomatoes.",
+    });
+    fetchSpy.mockRestore();
+  });
+
+  it("reports pages without complete Recipe markup", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        '<script type="application/ld+json">{"@type":"Article"}</script>',
+        { headers: { "content-type": "text/html" } },
+      ),
+    );
+
+    const res = await app.request(
+      "/recipes/import-url",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ url: "https://recipes.example.test/article" }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toMatchObject({ error: expect.any(String) });
+    fetchSpy.mockRestore();
+  });
+});
+
 describe("profile diet preferences", () => {
   it("requires authentication before returning a diet profile", async () => {
     const res = await app.request("/api/profile/diet", {}, env);

--- a/workers/recipe-api/tests/recipe-url-import.test.ts
+++ b/workers/recipe-api/tests/recipe-url-import.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchRecipePage,
+  RecipeUrlImportError,
+  validateRecipeUrl,
+} from "../src/recipe-url-import";
+
+describe("validateRecipeUrl", () => {
+  it.each([
+    "file:///etc/passwd",
+    "http://localhost/recipe",
+    "http://127.0.0.1/recipe",
+    "http://10.1.2.3/recipe",
+    "http://[::1]/recipe",
+    "https://example.com:8443/recipe",
+    "https://user:secret@example.com/recipe",
+  ])("rejects unsafe URL %s", (url) => {
+    expect(() => validateRecipeUrl(url)).toThrow(RecipeUrlImportError);
+  });
+
+  it("allows a public HTTP URL", () => {
+    expect(validateRecipeUrl("https://recipes.example.com/pasta").toString()).toBe(
+      "https://recipes.example.com/pasta",
+    );
+  });
+});
+
+describe("fetchRecipePage", () => {
+  it("follows validated redirects and returns HTML", async () => {
+    const fetcher = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, { status: 302, headers: { location: "/final" } }),
+      )
+      .mockResolvedValueOnce(
+        new Response("<html>recipe</html>", {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        }),
+      );
+
+    await expect(
+      fetchRecipePage("https://recipes.example.com/start", fetcher),
+    ).resolves.toEqual({
+      html: "<html>recipe</html>",
+      url: "https://recipes.example.com/final",
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a redirect to a private address", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1/private" },
+      }),
+    );
+
+    await expect(
+      fetchRecipePage("https://recipes.example.com/start", fetcher),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("rejects non-HTML and oversized responses", async () => {
+    await expect(
+      fetchRecipePage(
+        "https://recipes.example.com/file",
+        vi.fn<typeof fetch>().mockResolvedValue(
+          new Response("{}", { headers: { "content-type": "application/json" } }),
+        ),
+      ),
+    ).rejects.toMatchObject({ status: 415 });
+
+    await expect(
+      fetchRecipePage(
+        "https://recipes.example.com/huge",
+        vi.fn<typeof fetch>().mockResolvedValue(
+          new Response("small", {
+            headers: {
+              "content-length": "3000000",
+              "content-type": "text/html",
+            },
+          }),
+        ),
+      ),
+    ).rejects.toMatchObject({ status: 413 });
+  });
+});

--- a/workers/recipe-api/tests/recipe-url-import.test.ts
+++ b/workers/recipe-api/tests/recipe-url-import.test.ts
@@ -113,4 +113,16 @@ describe("fetchRecipePage", () => {
       ),
     ).rejects.toMatchObject({ status: 413 });
   });
+
+  it.each([
+    ["a missing content type", {}],
+    ["a deceptive HTML content type", { "content-type": "text/html-malicious" }],
+  ])("rejects %s", async (_name, headers) => {
+    await expect(
+      fetchRecipePage(
+        "https://recipes.example.com/file",
+        vi.fn<typeof fetch>().mockResolvedValue(new Response("recipe", { headers })),
+      ),
+    ).rejects.toMatchObject({ status: 415 });
+  });
 });

--- a/workers/recipe-api/tests/recipe-url-import.test.ts
+++ b/workers/recipe-api/tests/recipe-url-import.test.ts
@@ -12,6 +12,9 @@ describe("validateRecipeUrl", () => {
     "http://127.0.0.1/recipe",
     "http://10.1.2.3/recipe",
     "http://[::1]/recipe",
+    "http://[fc00::1]/recipe",
+    "http://[fe80::1]/recipe",
+    "http://[::ffff:127.0.0.1]/recipe",
     "https://example.com:8443/recipe",
     "https://user:secret@example.com/recipe",
   ])("rejects unsafe URL %s", (url) => {
@@ -22,6 +25,12 @@ describe("validateRecipeUrl", () => {
     expect(validateRecipeUrl("https://recipes.example.com/pasta").toString()).toBe(
       "https://recipes.example.com/pasta",
     );
+  });
+
+  it("allows a public IPv6 URL", () => {
+    expect(
+      validateRecipeUrl("https://[2606:4700:4700::1111]/recipe").toString(),
+    ).toBe("https://[2606:4700:4700::1111]/recipe");
   });
 });
 
@@ -58,6 +67,26 @@ describe("fetchRecipePage", () => {
     await expect(
       fetchRecipePage("https://recipes.example.com/start", fetcher),
     ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("distinguishes malformed redirects from redirect loops", async () => {
+    await expect(
+      fetchRecipePage(
+        "https://recipes.example.com/start",
+        vi.fn<typeof fetch>().mockResolvedValue(
+          new Response(null, { status: 302 }),
+        ),
+      ),
+    ).rejects.toThrow("redirect without a destination");
+
+    await expect(
+      fetchRecipePage(
+        "https://recipes.example.com/start",
+        vi.fn<typeof fetch>().mockResolvedValue(
+          new Response(null, { status: 302, headers: { location: "/again" } }),
+        ),
+      ),
+    ).rejects.toThrow("redirected too many times");
   });
 
   it("rejects non-HTML and oversized responses", async () => {


### PR DESCRIPTION
## What changed

- add an authenticated “Import from URL” method to the recipe authoring screen
- fetch recipe pages server-side with redirect, timeout, size, content-type, private-network, and rate-limit protections
- parse schema.org Recipe JSON-LD into editable Cooklang and feed the existing live preview/save flow
- preserve the resolved source URL as canonical attribution
- cover JSON-LD variants, endpoint behavior, and URL-fetch safety with tests

## Why

Recipe creation currently supports manually entered Cooklang only. Many recipe sites already publish portable schema.org Recipe data, so importing that data avoids retyping while preserving the same editable preview and save experience.

## Validation

- `mise //packages/recipe-parsing:check`
- `mise //workers/recipe-api:check`
- `mise //ui:test` (460 tests)
- `mise //ui:typecheck`
- `mise //:lint`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recipe importing from public URLs using Schema.org recipe data.
  - Added URL validation, safe redirects, size limits, and clear import errors.
  - Imported recipes can be reviewed and edited as Cooklang drafts, with source URL preserved.
  - Added a choice between writing with Cooklang and importing from a URL.

- **Bug Fixes**
  - Improved handling of varied Schema.org formats, including arrays, graphs, comments, and HTML entities.

- **Tests**
  - Added coverage for successful imports, invalid pages, unsafe URLs, redirects, oversized responses, and authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->