### PR TITLE
Add household user profile page

### DIFF
--- a/ui/app/recipes/profile/page.tsx
+++ b/ui/app/recipes/profile/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { ProfileView } from "@/components/recipes/profile/profile-view";
+import { authClient } from "@/lib/auth-client";
+
+function SelectedProfile() {
+  const searchParams = useSearchParams();
+  const { data: session } = authClient.useSession();
+  const userId = searchParams.get("user") ?? session?.user.id ?? "";
+
+  return <ProfileView userId={userId} />;
+}
+
+export default function ProfilePage() {
+  return (
+    <Suspense fallback={null}>
+      <SelectedProfile />
+    </Suspense>
+  );
+}

--- a/ui/app/recipes/profile/page.tsx
+++ b/ui/app/recipes/profile/page.tsx
@@ -1,15 +1,12 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
+import type { Metadata } from "next";
 import { Suspense } from "react";
-import { ProfileView } from "@/components/recipes/profile/profile-view";
+import { SelectedProfile } from "@/components/recipes/profile/selected-profile";
 
-function SelectedProfile() {
-  const searchParams = useSearchParams();
-  const userId = searchParams.get("user") ?? undefined;
-
-  return <ProfileView userId={userId} />;
-}
+export const metadata: Metadata = {
+  title: "Profile",
+  description: "See who you share a household and kitchen with.",
+  robots: { index: false, follow: false },
+};
 
 export default function ProfilePage() {
   return (

--- a/ui/app/recipes/profile/page.tsx
+++ b/ui/app/recipes/profile/page.tsx
@@ -3,12 +3,10 @@
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { ProfileView } from "@/components/recipes/profile/profile-view";
-import { authClient } from "@/lib/auth-client";
 
 function SelectedProfile() {
   const searchParams = useSearchParams();
-  const { data: session } = authClient.useSession();
-  const userId = searchParams.get("user") ?? session?.user.id ?? "";
+  const userId = searchParams.get("user") ?? undefined;
 
   return <ProfileView userId={userId} />;
 }

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -9,6 +9,7 @@ import {
   LogOut,
   Settings,
   UserPlus,
+  UserRound,
 } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -259,6 +260,17 @@ export function AuthButton({
             </div>
 
             <div className="p-1.5">
+              <Button
+                variant="ghost"
+                className="w-full justify-start"
+                asChild
+                onClick={() => setOpen(false)}
+              >
+                <Link href="/recipes/profile">
+                  <UserRound />
+                  Profile
+                </Link>
+              </Button>
               <Button
                 variant="ghost"
                 className="w-full justify-start"

--- a/ui/components/recipes/profile/profile-view.tsx
+++ b/ui/components/recipes/profile/profile-view.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { ArrowRight, Home, Settings, Users } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
+import { Button } from "@/components/ui/button";
+import {
+  getHouseholdMembers,
+  getHouseholds,
+  type Household,
+  type HouseholdMember,
+} from "@/lib/api/households";
+import { authClient } from "@/lib/auth-client";
+
+type ProfileData = {
+  household: Household;
+  members: HouseholdMember[];
+  profile: HouseholdMember;
+};
+
+function loadErrorMessage(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : "We couldn't load this profile.";
+}
+
+export function ProfileView({ userId }: Readonly<{ userId: string }>) {
+  const { data: session, isPending: sessionPending } = authClient.useSession();
+  const [data, setData] = useState<ProfileData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (sessionPending) return;
+    if (!session) {
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    void getHouseholds(controller.signal)
+      .then(async (households) => {
+        const household = households[0];
+        if (!household)
+          throw new Error("This account isn't in a household yet.");
+        const members = await getHouseholdMembers(
+          household.id,
+          controller.signal,
+        );
+        const selectedUserId = userId || session.user.id;
+        const profile = members.find(
+          (member) => member.user.id === selectedUserId,
+        );
+        if (!profile) {
+          throw new Error("This profile isn't part of your household.");
+        }
+        setData({ household, members, profile });
+      })
+      .catch((loadError: unknown) => {
+        if (!controller.signal.aborted) setError(loadErrorMessage(loadError));
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [session, sessionPending, userId]);
+
+  if (sessionPending || loading) {
+    return (
+      <div className="container mx-auto flex max-w-5xl flex-1 items-center justify-center px-4 py-20">
+        <p className="rt-mono text-[var(--ink-3)]">Loading kitchen profile…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="container mx-auto max-w-xl flex-1 px-4 py-20 text-center">
+        <p className="rt-mono text-[var(--terracotta)]">Profile</p>
+        <h1 className="rt-display mt-3 text-5xl">
+          Log in to meet your household.
+        </h1>
+        <p className="rt-body mt-4 text-[var(--ink-2)]">
+          Household profiles are shared only with the people you cook with.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data || error) {
+    return (
+      <div className="container mx-auto max-w-xl flex-1 px-4 py-20 text-center">
+        <p className="rt-mono text-[var(--terracotta)]">Profile unavailable</p>
+        <h1 className="rt-display mt-3 text-5xl">Nothing cooking here yet.</h1>
+        <p className="rt-body mt-4 text-[var(--ink-2)]">{error}</p>
+        <Button asChild variant="outline" className="mt-6">
+          <Link href="/recipes/settings?section=household">
+            Household settings
+          </Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const { household, members, profile } = data;
+  const isSelf = profile.user.id === session.user.id;
+  const firstName = profile.user.name.trim().split(/\s+/)[0] || "Their";
+
+  return (
+    <div className="container mx-auto w-full max-w-5xl flex-1 px-4 py-8 md:py-12">
+      <header className="flex flex-col gap-5 border-b border-dashed border-[var(--line-strong)] pb-8 sm:flex-row sm:items-center">
+        <RecipeAvatar
+          name={profile.user.name}
+          email={profile.user.email}
+          image={profile.user.image}
+          size={88}
+          className="shadow-[var(--paper-shadow)]"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="rt-mono text-[var(--terracotta)]">
+            {isSelf ? "Your profile" : "Household profile"} · {profile.role}
+          </p>
+          <h1 className="rt-display mt-2 text-5xl sm:text-6xl">
+            {firstName}&apos;s{" "}
+            <span className="text-[var(--terracotta)]">kitchen.</span>
+          </h1>
+          <p className="rt-body mt-2 text-sm text-[var(--ink-2)]">
+            {isSelf
+              ? "Your home for the recipes and people you cook with."
+              : `You and ${firstName} share ${household.name}.`}
+          </p>
+        </div>
+        {isSelf && (
+          <Button asChild variant="outline">
+            <Link href="/recipes/settings">
+              <Settings /> Settings
+            </Link>
+          </Button>
+        )}
+      </header>
+
+      <section className="mt-8 rounded-xl border border-[var(--line-strong)] bg-[var(--card)] p-5 shadow-[var(--paper-shadow)] sm:p-6">
+        <div className="flex items-start gap-3">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--paper-warm)] text-[var(--terracotta-deep)]">
+            <Home aria-hidden="true" className="size-5" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="rt-mono text-[var(--terracotta)]">Household</p>
+            <h2 className="rt-display mt-1 text-3xl">{household.name}</h2>
+            <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
+              {members.length} {members.length === 1 ? "person" : "people"}{" "}
+              sharing a kitchen
+            </p>
+          </div>
+          <Users aria-hidden="true" className="size-5 text-[var(--ink-3)]" />
+        </div>
+
+        <div className="mt-5 divide-y divide-dashed divide-[var(--line)] border-t border-dashed border-[var(--line)]">
+          {members.map((member) => {
+            const memberIsSelf = member.user.id === session.user.id;
+            const active = member.user.id === profile.user.id;
+            return (
+              <Link
+                key={member.id}
+                href={`/recipes/profile?user=${encodeURIComponent(member.user.id)}`}
+                aria-current={active ? "page" : undefined}
+                className="group flex items-center gap-3 rounded-lg px-2 py-4 transition-colors hover:bg-[var(--paper-warm)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--terracotta)]"
+              >
+                <RecipeAvatar
+                  name={member.user.name}
+                  email={member.user.email}
+                  image={member.user.image}
+                  size={44}
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="rt-body truncate font-semibold text-[var(--ink)]">
+                    {member.user.name}
+                    {memberIsSelf ? " · you" : ""}
+                  </p>
+                  <p className="rt-mono text-[var(--ink-3)]">{member.role}</p>
+                </div>
+                {active ? (
+                  <span className="rt-mono rounded-full bg-[var(--sage)] px-2 py-1 text-white">
+                    Viewing
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-1 text-sm text-[var(--ink-3)] group-hover:text-[var(--terracotta-deep)]">
+                    View profile{" "}
+                    <ArrowRight aria-hidden="true" className="size-4" />
+                  </span>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/ui/components/recipes/profile/profile-view.tsx
+++ b/ui/components/recipes/profile/profile-view.tsx
@@ -14,9 +14,10 @@ import {
 import { authClient } from "@/lib/auth-client";
 
 type ProfileData = {
-  household: Household;
+  household: Household | null;
   members: HouseholdMember[];
-  profile: HouseholdMember;
+  profile: HouseholdMember["user"];
+  role: HouseholdMember["role"] | null;
 };
 
 function loadErrorMessage(error: unknown) {
@@ -46,21 +47,43 @@ export function ProfileView({ userId }: Readonly<{ userId?: string | null }>) {
     void getHouseholds(controller.signal)
       .then(async (households) => {
         const household = households[0];
-        if (!household)
-          throw new Error("This account isn't in a household yet.");
+        const selectedUserId = userId || currentUserId;
+        if (!household) {
+          if (selectedUserId !== currentUserId) {
+            throw new Error("This profile isn't part of your household.");
+          }
+          if (!controller.signal.aborted) {
+            setData({
+              household: null,
+              members: [],
+              profile: {
+                id: session.user.id,
+                email: session.user.email,
+                name: session.user.name,
+                image: session.user.image ?? null,
+              },
+              role: null,
+            });
+          }
+          return;
+        }
         const members = await getHouseholdMembers(
           household.id,
           controller.signal,
         );
-        const selectedUserId = userId || currentUserId;
-        const profile = members.find(
+        const membership = members.find(
           (member) => member.user.id === selectedUserId,
         );
-        if (!profile) {
+        if (!membership) {
           throw new Error("This profile isn't part of your household.");
         }
         if (!controller.signal.aborted) {
-          setData({ household, members, profile });
+          setData({
+            household,
+            members,
+            profile: membership.user,
+            role: membership.role,
+          });
         }
       })
       .catch((loadError: unknown) => {
@@ -110,24 +133,25 @@ export function ProfileView({ userId }: Readonly<{ userId?: string | null }>) {
     );
   }
 
-  const { household, members, profile } = data;
+  const { household, members, profile, role } = data;
   const currentUserId = session.user.id;
-  const isSelf = profile.user.id === currentUserId;
-  const firstName = profile.user.name.trim().split(/\s+/)[0] || "Chef";
+  const isSelf = profile.id === currentUserId;
+  const firstName = profile.name.trim().split(/\s+/)[0] || "Chef";
 
   return (
     <div className="container mx-auto w-full max-w-5xl flex-1 px-4 py-8 md:py-12">
       <header className="flex flex-col gap-5 border-b border-dashed border-[var(--line-strong)] pb-8 sm:flex-row sm:items-center">
         <RecipeAvatar
-          name={profile.user.name}
-          email={profile.user.email}
-          image={profile.user.image}
+          name={profile.name}
+          email={profile.email}
+          image={profile.image}
           size={88}
           className="shadow-[var(--paper-shadow)]"
         />
         <div className="min-w-0 flex-1">
           <p className="rt-mono text-[var(--terracotta)]">
-            {isSelf ? "Your profile" : "Household profile"} · {profile.role}
+            {isSelf ? "Your profile" : "Household profile"}
+            {role ? ` · ${role}` : ""}
           </p>
           <h1 className="rt-display mt-2 text-5xl sm:text-6xl">
             {firstName}&apos;s{" "}
@@ -136,7 +160,7 @@ export function ProfileView({ userId }: Readonly<{ userId?: string | null }>) {
           <p className="rt-body mt-2 text-sm text-[var(--ink-2)]">
             {isSelf
               ? "Your home for the recipes and people you cook with."
-              : `You and ${firstName} share ${household.name}.`}
+              : `You and ${firstName} share ${household?.name}.`}
           </p>
         </div>
         {isSelf && (
@@ -148,61 +172,63 @@ export function ProfileView({ userId }: Readonly<{ userId?: string | null }>) {
         )}
       </header>
 
-      <section className="mt-8 rounded-xl border border-[var(--line-strong)] bg-[var(--card)] p-5 shadow-[var(--paper-shadow)] sm:p-6">
-        <div className="flex items-start gap-3">
-          <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--paper-warm)] text-[var(--terracotta-deep)]">
-            <Home aria-hidden="true" className="size-5" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <p className="rt-mono text-[var(--terracotta)]">Household</p>
-            <h2 className="rt-display mt-1 text-3xl">{household.name}</h2>
-            <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
-              {members.length} {members.length === 1 ? "person" : "people"}{" "}
-              sharing a kitchen
-            </p>
+      {household && (
+        <section className="mt-8 rounded-xl border border-[var(--line-strong)] bg-[var(--card)] p-5 shadow-[var(--paper-shadow)] sm:p-6">
+          <div className="flex items-start gap-3">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--paper-warm)] text-[var(--terracotta-deep)]">
+              <Home aria-hidden="true" className="size-5" />
+            </span>
+            <div className="min-w-0 flex-1">
+              <p className="rt-mono text-[var(--terracotta)]">Household</p>
+              <h2 className="rt-display mt-1 text-3xl">{household.name}</h2>
+              <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
+                {members.length} {members.length === 1 ? "person" : "people"}{" "}
+                sharing a kitchen
+              </p>
+            </div>
+            <Users aria-hidden="true" className="size-5 text-[var(--ink-3)]" />
           </div>
-          <Users aria-hidden="true" className="size-5 text-[var(--ink-3)]" />
-        </div>
 
-        <div className="mt-5 divide-y divide-dashed divide-[var(--line)] border-t border-dashed border-[var(--line)]">
-          {members.map((member) => {
-            const memberIsSelf = member.user.id === currentUserId;
-            const active = member.user.id === profile.user.id;
-            return (
-              <Link
-                key={member.id}
-                href={`/recipes/profile?user=${encodeURIComponent(member.user.id)}`}
-                aria-current={active ? "page" : undefined}
-                className="group flex items-center gap-3 rounded-lg px-2 py-4 transition-colors hover:bg-[var(--paper-warm)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--terracotta)]"
-              >
-                <RecipeAvatar
-                  name={member.user.name}
-                  email={member.user.email}
-                  image={member.user.image}
-                  size={44}
-                />
-                <div className="min-w-0 flex-1">
-                  <p className="rt-body truncate font-semibold text-[var(--ink)]">
-                    {member.user.name}
-                    {memberIsSelf ? " · you" : ""}
-                  </p>
-                  <p className="rt-mono text-[var(--ink-3)]">{member.role}</p>
-                </div>
-                {active ? (
-                  <span className="rt-mono rounded-full bg-[var(--sage)] px-2 py-1 text-white">
-                    Viewing
-                  </span>
-                ) : (
-                  <span className="flex items-center gap-1 text-sm text-[var(--ink-3)] group-hover:text-[var(--terracotta-deep)]">
-                    View profile{" "}
-                    <ArrowRight aria-hidden="true" className="size-4" />
-                  </span>
-                )}
-              </Link>
-            );
-          })}
-        </div>
-      </section>
+          <div className="mt-5 divide-y divide-dashed divide-[var(--line)] border-t border-dashed border-[var(--line)]">
+            {members.map((member) => {
+              const memberIsSelf = member.user.id === currentUserId;
+              const active = member.user.id === profile.id;
+              return (
+                <Link
+                  key={member.id}
+                  href={`/recipes/profile?user=${encodeURIComponent(member.user.id)}`}
+                  aria-current={active ? "page" : undefined}
+                  className="group flex items-center gap-3 rounded-lg px-2 py-4 transition-colors hover:bg-[var(--paper-warm)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--terracotta)]"
+                >
+                  <RecipeAvatar
+                    name={member.user.name}
+                    email={member.user.email}
+                    image={member.user.image}
+                    size={44}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="rt-body truncate font-semibold text-[var(--ink)]">
+                      {member.user.name}
+                      {memberIsSelf ? " · you" : ""}
+                    </p>
+                    <p className="rt-mono text-[var(--ink-3)]">{member.role}</p>
+                  </div>
+                  {active ? (
+                    <span className="rt-mono rounded-full bg-[var(--sage)] px-2 py-1 text-white">
+                      Viewing
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 text-sm text-[var(--ink-3)] group-hover:text-[var(--terracotta-deep)]">
+                      View profile{" "}
+                      <ArrowRight aria-hidden="true" className="size-4" />
+                    </span>
+                  )}
+                </Link>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/ui/components/recipes/profile/profile-view.tsx
+++ b/ui/components/recipes/profile/profile-view.tsx
@@ -25,7 +25,7 @@ function loadErrorMessage(error: unknown) {
     : "We couldn't load this profile.";
 }
 
-export function ProfileView({ userId }: Readonly<{ userId: string }>) {
+export function ProfileView({ userId }: Readonly<{ userId?: string | null }>) {
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const [data, setData] = useState<ProfileData | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -41,6 +41,7 @@ export function ProfileView({ userId }: Readonly<{ userId: string }>) {
     const controller = new AbortController();
     setLoading(true);
     setError(null);
+    const currentUserId = session.user.id;
 
     void getHouseholds(controller.signal)
       .then(async (households) => {
@@ -51,7 +52,7 @@ export function ProfileView({ userId }: Readonly<{ userId: string }>) {
           household.id,
           controller.signal,
         );
-        const selectedUserId = userId || session.user.id;
+        const selectedUserId = userId || currentUserId;
         const profile = members.find(
           (member) => member.user.id === selectedUserId,
         );
@@ -108,8 +109,9 @@ export function ProfileView({ userId }: Readonly<{ userId: string }>) {
   }
 
   const { household, members, profile } = data;
-  const isSelf = profile.user.id === session.user.id;
-  const firstName = profile.user.name.trim().split(/\s+/)[0] || "Their";
+  const currentUserId = session.user.id;
+  const isSelf = profile.user.id === currentUserId;
+  const firstName = profile.user.name.trim().split(/\s+/)[0] || "Chef";
 
   return (
     <div className="container mx-auto w-full max-w-5xl flex-1 px-4 py-8 md:py-12">
@@ -162,7 +164,7 @@ export function ProfileView({ userId }: Readonly<{ userId: string }>) {
 
         <div className="mt-5 divide-y divide-dashed divide-[var(--line)] border-t border-dashed border-[var(--line)]">
           {members.map((member) => {
-            const memberIsSelf = member.user.id === session.user.id;
+            const memberIsSelf = member.user.id === currentUserId;
             const active = member.user.id === profile.user.id;
             return (
               <Link

--- a/ui/components/recipes/profile/profile-view.tsx
+++ b/ui/components/recipes/profile/profile-view.tsx
@@ -59,7 +59,9 @@ export function ProfileView({ userId }: Readonly<{ userId?: string | null }>) {
         if (!profile) {
           throw new Error("This profile isn't part of your household.");
         }
-        setData({ household, members, profile });
+        if (!controller.signal.aborted) {
+          setData({ household, members, profile });
+        }
       })
       .catch((loadError: unknown) => {
         if (!controller.signal.aborted) setError(loadErrorMessage(loadError));

--- a/ui/components/recipes/profile/selected-profile.tsx
+++ b/ui/components/recipes/profile/selected-profile.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { ProfileView } from "@/components/recipes/profile/profile-view";
+
+export function SelectedProfile() {
+  const searchParams = useSearchParams();
+  const userId = searchParams.get("user") ?? undefined;
+
+  return <ProfileView userId={userId} />;
+}

--- a/ui/tests/components/recipes/profile/profile-view.test.tsx
+++ b/ui/tests/components/recipes/profile/profile-view.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -125,5 +125,30 @@ describe("ProfileView", () => {
     expect(
       await screen.findByRole("heading", { name: /Chef's kitchen/i }),
     ).toBeInTheDocument();
+  });
+
+  it("ignores a stale response after navigating to another profile", async () => {
+    let resolveFirstMembers: ((value: typeof members) => void) | undefined;
+    const firstMembers = new Promise<typeof members>((resolve) => {
+      resolveFirstMembers = resolve;
+    });
+    mocks.getHouseholdMembers
+      .mockReturnValueOnce(firstMembers)
+      .mockResolvedValueOnce(members);
+
+    const { rerender } = render(<ProfileView userId="user-1" />);
+    await waitFor(() =>
+      expect(mocks.getHouseholdMembers).toHaveBeenCalledOnce(),
+    );
+
+    rerender(<ProfileView userId="user-2" />);
+    expect(
+      await screen.findByRole("heading", { name: /Ellie's kitchen/i }),
+    ).toBeInTheDocument();
+
+    await act(async () => resolveFirstMembers?.(members));
+    expect(
+      screen.queryByRole("heading", { name: /Robbie's kitchen/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/profile/profile-view.test.tsx
+++ b/ui/tests/components/recipes/profile/profile-view.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+  getHouseholds: vi.fn(),
+  getHouseholdMembers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: mocks.useSession },
+}));
+
+vi.mock("@/lib/api/households", () => ({
+  getHouseholds: mocks.getHouseholds,
+  getHouseholdMembers: mocks.getHouseholdMembers,
+}));
+
+import { ProfileView } from "@/components/recipes/profile/profile-view";
+
+const household = {
+  id: "household-1",
+  name: "Park Road kitchen",
+  slug: "park-road",
+  logo: null,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  membership: { id: "member-1", role: "owner" },
+};
+
+const members = [
+  {
+    id: "member-1",
+    role: "owner",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    user: {
+      id: "user-1",
+      name: "Robbie Palmer",
+      email: "robbie@example.com",
+      image: null,
+    },
+  },
+  {
+    id: "member-2",
+    role: "member",
+    createdAt: "2026-01-02T00:00:00.000Z",
+    user: {
+      id: "user-2",
+      name: "Ellie Example",
+      email: "ellie@example.com",
+      image: null,
+    },
+  },
+];
+
+describe("ProfileView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useSession.mockReturnValue({
+      data: {
+        user: {
+          id: "user-1",
+          name: "Robbie Palmer",
+          email: "robbie@example.com",
+          image: null,
+        },
+      },
+      isPending: false,
+    });
+    mocks.getHouseholds.mockResolvedValue([household]);
+    mocks.getHouseholdMembers.mockResolvedValue(members);
+  });
+
+  it("shows the selected member and links every household member profile", async () => {
+    render(<ProfileView userId="user-2" />);
+
+    expect(
+      await screen.findByRole("heading", { name: /Ellie's kitchen/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Park Road kitchen")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Robbie Palmer/ })).toHaveAttribute(
+      "href",
+      "/recipes/profile?user=user-1",
+    );
+    expect(screen.getByRole("link", { name: /Ellie Example/ })).toHaveAttribute(
+      "href",
+      "/recipes/profile?user=user-2",
+    );
+    expect(screen.queryByText("robbie@example.com")).not.toBeInTheDocument();
+  });
+
+  it("shows profile settings only on the signed-in user's page", async () => {
+    const { rerender } = render(<ProfileView userId="user-1" />);
+
+    expect(
+      await screen.findByRole("link", { name: /settings/i }),
+    ).toHaveAttribute("href", "/recipes/settings");
+
+    rerender(<ProfileView userId="user-2" />);
+    await screen.findByRole("heading", { name: /Ellie's kitchen/i });
+    expect(
+      screen.queryByRole("link", { name: /^settings$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not expose profiles outside the current household", async () => {
+    render(<ProfileView userId="unknown-user" />);
+
+    expect(await screen.findByText("Profile unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText("This profile isn't part of your household."),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/profile/profile-view.test.tsx
+++ b/ui/tests/components/recipes/profile/profile-view.test.tsx
@@ -103,6 +103,22 @@ describe("ProfileView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows the signed-in user's profile without a household", async () => {
+    mocks.getHouseholds.mockResolvedValue([]);
+
+    render(<ProfileView />);
+
+    expect(
+      await screen.findByRole("heading", { name: /Robbie's kitchen/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /settings/i })).toHaveAttribute(
+      "href",
+      "/recipes/settings",
+    );
+    expect(screen.queryByText("Household")).not.toBeInTheDocument();
+    expect(mocks.getHouseholdMembers).not.toHaveBeenCalled();
+  });
+
   it("does not expose profiles outside the current household", async () => {
     render(<ProfileView userId="unknown-user" />);
 

--- a/ui/tests/components/recipes/profile/profile-view.test.tsx
+++ b/ui/tests/components/recipes/profile/profile-view.test.tsx
@@ -111,4 +111,19 @@ describe("ProfileView", () => {
       screen.getByText("This profile isn't part of your household."),
     ).toBeInTheDocument();
   });
+
+  it("uses a grammatical fallback when a member has no display name", async () => {
+    mocks.getHouseholdMembers.mockResolvedValue([
+      {
+        ...members[1],
+        user: { ...members[1]?.user, name: "" },
+      },
+    ]);
+
+    render(<ProfileView userId="user-2" />);
+
+    expect(
+      await screen.findByRole("heading", { name: /Chef's kitchen/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -54,6 +54,7 @@ describe("agent markdown generation", () => {
       "recipes/add.html",
       "recipes/kitchen.html",
       "recipes/onboarding.html",
+      "recipes/profile.html",
       "recipes/saved.html",
       "recipes/settings.html",
       "recipes/shopping.html",
@@ -85,6 +86,8 @@ describe("agent markdown generation", () => {
     expect(read("llms-full.txt")).not.toContain("/recipes/settings");
     expect(read("llms.txt")).not.toContain("/recipes/onboarding");
     expect(read("llms-full.txt")).not.toContain("/recipes/onboarding");
+    expect(read("llms.txt")).not.toContain("/recipes/profile");
+    expect(read("llms-full.txt")).not.toContain("/recipes/profile");
   });
 
   it("renders recipe ingredients and instructions as markdown", () => {
@@ -102,6 +105,7 @@ describe("agent markdown generation", () => {
       "add.html",
       "kitchen.html",
       "onboarding.html",
+      "profile.html",
       "saved.html",
       "settings.html",
       "shopping.html",

--- a/ui/tests/integration/sitemap.test.ts
+++ b/ui/tests/integration/sitemap.test.ts
@@ -19,6 +19,7 @@ const NOINDEX_APP_PAGES = new Set([
   "recipes/add",
   "recipes/kitchen",
   "recipes/onboarding",
+  "recipes/profile",
   "recipes/saved",
   "recipes/settings",
   "recipes/shopping",


### PR DESCRIPTION
## What changed

- add an authenticated recipe profile page inspired by the mid-fi profile designs
- show the current household and link each member to their profile
- add a Profile entry to the signed-in account menu
- handle logged-out, missing-household, and unavailable-profile states
- add focused component coverage for profile navigation and access boundaries

## Why

The current household functionality exposes membership data but had no profile surface. This adds the relevant profile experience supported by today’s functionality, while keeping profiles scoped to members of the signed-in user’s household.

Because the frontend is statically exported, household member navigation uses `/recipes/profile?user=<id>` rather than an unbounded dynamic route.

## Validation

- `mise //ui:typecheck`
- `mise //ui:test -- tests/components/recipes/profile/profile-view.test.tsx tests/components/recipes/auth-button.test.tsx`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`
- `mise //ui:lint` (passes with existing repository warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a profile page for viewing personal and household member kitchen profiles.
  - Added profile navigation to the authenticated user menu.
  - Added household member links, profile status indicators, and profile-specific settings access.
  - Added loading, sign-in, and unavailable-profile states.

- **Bug Fixes**
  - Improved handling of profile loading errors and cancelled requests.

- **Tests**
  - Added coverage for profile navigation, permissions, missing names, unavailable profiles, and asynchronous updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->