### PR TITLE
Add logged-out recipe landing page

### DIFF
--- a/ui/app/recipes/cooks/page.tsx
+++ b/ui/app/recipes/cooks/page.tsx
@@ -5,6 +5,10 @@ import { PublicCooksView } from "@/components/recipes/public-cooks-view";
 export const metadata: Metadata = {
   title: "Cooks",
   description: "Meet home cooks through the public recipes they share.",
+  robots: {
+    index: false,
+    follow: true,
+  },
 };
 
 export default function CooksPage() {

--- a/ui/app/recipes/cooks/page.tsx
+++ b/ui/app/recipes/cooks/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { PublicCooksView } from "@/components/recipes/public-cooks-view";
+
+export const metadata: Metadata = {
+  title: "Cooks",
+  description: "Meet home cooks through the public recipes they share.",
+};
+
+export default function CooksPage() {
+  return (
+    <Suspense fallback={null}>
+      <PublicCooksView />
+    </Suspense>
+  );
+}

--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { AuthButton } from "@/components/recipes/auth-button";
 import { DietProvider } from "@/components/recipes/diet-provider";
 import { NotificationBell } from "@/components/recipes/notifications/notification-bell";
-import { RecipeNavTabs } from "@/components/recipes/recipe-nav-tabs";
+import { RecipeSiteNav } from "@/components/recipes/recipe-site-nav";
 import { RecipeThemeBody } from "@/components/recipes/recipe-theme-body";
 import { TimerDock } from "@/components/recipes/timer-dock";
 import { siteConfig } from "@/lib/config/site-config";
@@ -70,7 +70,7 @@ export default function RecipesLayout({
               <AuthButton compactOnMobile />
             </div>
             <div className="order-3 w-full sm:order-2 sm:w-auto">
-              <RecipeNavTabs />
+              <RecipeSiteNav />
             </div>
           </nav>
         </header>

--- a/ui/app/recipes/page.tsx
+++ b/ui/app/recipes/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from "next";
-import { RecipeBoxView } from "@/components/recipes/recipe-box-view";
+import { RecipeHome } from "@/components/recipes/recipe-home";
 import { JsonLdScript } from "@/components/seo/json-ld-script";
 import { getAllRecipes } from "@/lib/api/recipes";
 import { siteConfig } from "@/lib/config/site-config";
 import { buildRecipeListJsonLd } from "@/lib/seo/recipe-jsonld";
 
 export const metadata: Metadata = {
-  title: "All Recipes",
-  description: "Browse all of my favorite recipes",
+  title: "Recipes for real life",
+  description:
+    "Discover what home cooks are making and keep the recipes you want to cook again.",
 };
 
 export default function RecipesPage() {
@@ -31,7 +32,7 @@ export default function RecipesPage() {
   return (
     <>
       <JsonLdScript data={jsonLd} />
-      <RecipeBoxView recipes={recipes} catalogStats={catalogStats} />
+      <RecipeHome recipes={recipes} catalogStats={catalogStats} />
     </>
   );
 }

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -204,13 +204,19 @@ export function AuthButton({
   }
 
   if (isPending) {
-    if (intent === "signup") return null;
-    return (
-      <Button variant="outline" size="sm" disabled aria-label="Loading session">
-        <LoaderCircle className="animate-spin" />
-        <span className="hidden sm:inline">Log in</span>
-      </Button>
-    );
+    if (intent === "signin") {
+      return (
+        <Button
+          variant="outline"
+          size="sm"
+          disabled
+          aria-label="Loading session"
+        >
+          <LoaderCircle className="animate-spin" />
+          <span className="hidden sm:inline">Log in</span>
+        </Button>
+      );
+    }
   }
 
   if (session && intent === "signup") return null;

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -137,9 +137,11 @@ function AuthOptions({
 }
 
 export function AuthButton({
+  className,
   compactOnMobile = false,
   intent = "signin",
 }: Readonly<{
+  className?: string;
   compactOnMobile?: boolean;
   intent?: "signin" | "signup";
 }>) {
@@ -391,6 +393,7 @@ export function AuthButton({
           className={cn(
             intent === "signup" &&
               "max-w-full rounded-full bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]",
+            className,
           )}
         >
           {intent === "signup" ? <UserPlus /> : <LogIn />}

--- a/ui/components/recipes/logged-out-landing.tsx
+++ b/ui/components/recipes/logged-out-landing.tsx
@@ -1,0 +1,183 @@
+import {
+  ArrowRight,
+  BookHeart,
+  House,
+  Sparkles,
+  UtensilsCrossed,
+} from "lucide-react";
+import Link from "next/link";
+import { AuthButton } from "@/components/recipes/auth-button";
+import { RecipeThumb, recipeMetaLabel } from "@/components/recipes/recipe-card";
+import type { RecipeCardView } from "@/lib/api/recipes";
+
+const steps = [
+  {
+    number: "01",
+    title: "See what’s cooking",
+    description:
+      "Browse public recipe activity and meet the cooks behind the dishes.",
+    icon: Sparkles,
+  },
+  {
+    number: "02",
+    title: "Keep the good ones",
+    description:
+      "Create a recipe box for the dishes you want to make, tweak and return to.",
+    icon: BookHeart,
+  },
+  {
+    number: "03",
+    title: "Cook as a household",
+    description:
+      "Share the practical bits—your kitchen, meal plan and shopping list—with the people you cook with.",
+    icon: House,
+  },
+] as const;
+
+export function LoggedOutLanding({
+  recipes,
+}: Readonly<{ recipes: RecipeCardView[] }>) {
+  const previewRecipes = recipes.slice(0, 3);
+
+  return (
+    <div className="overflow-hidden">
+      <section className="container mx-auto grid min-h-[calc(100svh-9rem)] max-w-7xl items-center gap-12 px-4 py-14 lg:grid-cols-[1.08fr_0.92fr] lg:gap-16 lg:py-20">
+        <div className="max-w-3xl">
+          <p className="rt-mono text-[var(--terracotta)]">
+            A recipe box built for real life
+          </p>
+          <h1 className="rt-display mt-4 text-[clamp(4.25rem,10vw,7.75rem)] leading-[0.78] tracking-[-0.035em]">
+            Find something worth cooking.{" "}
+            <span className="text-[var(--terracotta)]">
+              Keep what you love.
+            </span>
+          </h1>
+          <p className="rt-body mt-7 max-w-2xl text-lg leading-relaxed text-[var(--ink-2)] sm:text-xl">
+            Follow recipe activity from home cooks, collect the dishes that earn
+            a repeat, and turn scattered links into a recipe box that works in
+            your kitchen.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <AuthButton
+              intent="signup"
+              className="h-11 px-5 text-base shadow-[var(--paper-shadow)]"
+            />
+            <Link
+              href="/recipes/discover"
+              className="rt-body inline-flex h-11 items-center gap-2 rounded-full border border-[var(--line-strong)] bg-[var(--card)] px-5 font-bold text-[var(--ink)] transition-colors hover:border-[var(--terracotta)] hover:text-[var(--terracotta-deep)]"
+            >
+              Browse activity <ArrowRight className="size-4" />
+            </Link>
+          </div>
+          <p className="rt-mono mt-5 text-[var(--ink-3)]">
+            Browse freely · make an account when you’re ready to save
+          </p>
+        </div>
+
+        <div className="relative mx-auto w-full max-w-xl lg:mx-0">
+          <div className="absolute -top-12 -right-16 size-56 rounded-full bg-[var(--butter)]/30 blur-3xl" />
+          <div className="absolute -bottom-12 -left-16 size-56 rounded-full bg-[var(--sage)]/20 blur-3xl" />
+          <div className="relative rotate-[0.6deg] rounded-[2rem] border border-[var(--line-strong)] bg-[var(--card)] p-5 shadow-[0_24px_70px_rgba(31,26,20,0.14)] sm:p-7">
+            <div className="flex items-center justify-between border-b border-dashed border-[var(--line-strong)] pb-4">
+              <div>
+                <p className="rt-mono text-[var(--terracotta)]">
+                  Your future recipe box
+                </p>
+                <p className="rt-display mt-1 text-3xl">Worth making again</p>
+              </div>
+              <span className="flex size-11 items-center justify-center rounded-full bg-[var(--butter-soft)] text-[var(--terracotta-deep)]">
+                <UtensilsCrossed className="size-5" />
+              </span>
+            </div>
+            <div className="mt-2 divide-y divide-dashed divide-[var(--line)]">
+              {previewRecipes.map((recipe, index) => (
+                <Link
+                  key={recipe.slug}
+                  href={`/recipes/${recipe.slug}`}
+                  className="group flex items-center gap-4 py-4"
+                >
+                  <RecipeThumb recipe={recipe} size={72} />
+                  <div className="min-w-0 flex-1">
+                    <p className="rt-mono text-[var(--ink-3)]">
+                      {index === 0
+                        ? "Save it"
+                        : index === 1
+                          ? "Cook it"
+                          : "Make it yours"}
+                    </p>
+                    <h2 className="rt-display mt-1 truncate text-2xl transition-colors group-hover:text-[var(--terracotta)] sm:text-3xl">
+                      {recipe.title}
+                    </h2>
+                    <p className="rt-body mt-1 truncate text-xs text-[var(--ink-3)]">
+                      {recipeMetaLabel(recipe)}
+                    </p>
+                  </div>
+                  <ArrowRight className="size-4 shrink-0 text-[var(--ink-3)] transition-transform group-hover:translate-x-1 group-hover:text-[var(--terracotta)]" />
+                </Link>
+              ))}
+            </div>
+            <Link
+              href="/recipes/discover"
+              className="rt-body mt-3 flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--paper-warm)] px-4 py-3 font-bold text-[var(--ink-2)] transition-colors hover:text-[var(--terracotta-deep)]"
+            >
+              See what other cooks are adding <ArrowRight className="size-4" />
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="how-it-works"
+        className="scroll-mt-32 border-y border-[var(--line)] bg-[var(--paper-warm)]/65"
+      >
+        <div className="container mx-auto max-w-7xl px-4 py-16 sm:py-20">
+          <div className="max-w-2xl">
+            <p className="rt-mono text-[var(--terracotta)]">How it works</p>
+            <h2 className="rt-display mt-3 text-5xl sm:text-6xl">
+              From “that looks good” to dinner.
+            </h2>
+          </div>
+          <div className="mt-10 grid gap-4 md:grid-cols-3">
+            {steps.map((step) => {
+              const Icon = step.icon;
+              return (
+                <article
+                  key={step.number}
+                  className="rounded-2xl border border-[var(--line-strong)] bg-[var(--card)] p-6 shadow-[var(--paper-shadow)]"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="rt-mono text-[var(--terracotta)]">
+                      {step.number}
+                    </span>
+                    <Icon className="size-5 text-[var(--terracotta)]" />
+                  </div>
+                  <h3 className="rt-display mt-8 text-3xl">{step.title}</h3>
+                  <p className="rt-body mt-3 text-sm text-[var(--ink-2)]">
+                    {step.description}
+                  </p>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="container mx-auto max-w-7xl px-4 py-16 sm:py-20">
+        <div className="flex flex-col items-start justify-between gap-8 rounded-[2rem] border border-[var(--terracotta)] bg-[var(--butter-soft)] p-7 sm:p-10 lg:flex-row lg:items-center">
+          <div className="max-w-2xl">
+            <p className="rt-mono text-[var(--terracotta-deep)]">
+              Ready when you are
+            </p>
+            <h2 className="rt-display mt-3 text-4xl sm:text-5xl">
+              Give the recipes you love somewhere useful to live.
+            </h2>
+          </div>
+          <AuthButton
+            intent="signup"
+            className="h-11 shrink-0 px-5 text-base shadow-[var(--paper-shadow)]"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/ui/components/recipes/logged-out-landing.tsx
+++ b/ui/components/recipes/logged-out-landing.tsx
@@ -41,7 +41,7 @@ export function LoggedOutLanding({
 
   return (
     <div className="w-full max-w-full overflow-x-clip">
-      <section className="container mx-auto grid min-w-0 max-w-7xl items-center gap-12 overflow-x-clip px-4 py-14 lg:min-h-[calc(100svh-9rem)] lg:grid-cols-[1.08fr_0.92fr] lg:gap-16 lg:py-20">
+      <section className="container mx-auto grid min-w-0 max-w-7xl items-center gap-12 overflow-x-clip px-4 pt-8 pb-10 sm:pt-10 sm:pb-12 lg:grid-cols-[1.08fr_0.92fr] lg:gap-16 lg:py-8">
         <div className="min-w-0 max-w-3xl">
           <p className="rt-mono text-[var(--terracotta)]">
             A recipe box built for real life
@@ -130,7 +130,7 @@ export function LoggedOutLanding({
         id="how-it-works"
         className="scroll-mt-32 border-y border-[var(--line)] bg-[var(--paper-warm)]/65"
       >
-        <div className="container mx-auto max-w-7xl px-4 py-16 sm:py-20">
+        <div className="container mx-auto max-w-7xl px-4 py-10 sm:py-12 lg:py-10">
           <div className="max-w-2xl">
             <p className="rt-mono text-[var(--terracotta)]">How it works</p>
             <h2 className="rt-display mt-3 text-5xl sm:text-6xl">
@@ -162,7 +162,7 @@ export function LoggedOutLanding({
         </div>
       </section>
 
-      <section className="container mx-auto max-w-7xl px-4 py-16 sm:py-20">
+      <section className="container mx-auto max-w-7xl px-4 py-10 sm:py-12 lg:py-10">
         <div className="flex flex-col items-start justify-between gap-8 rounded-[2rem] border border-[var(--terracotta)] bg-[var(--butter-soft)] p-7 sm:p-10 lg:flex-row lg:items-center">
           <div className="max-w-2xl">
             <p className="rt-mono text-[var(--terracotta-deep)]">

--- a/ui/components/recipes/logged-out-landing.tsx
+++ b/ui/components/recipes/logged-out-landing.tsx
@@ -40,13 +40,13 @@ export function LoggedOutLanding({
   const previewRecipes = recipes.slice(0, 3);
 
   return (
-    <div className="overflow-hidden">
-      <section className="container mx-auto grid min-h-[calc(100svh-9rem)] max-w-7xl items-center gap-12 px-4 py-14 lg:grid-cols-[1.08fr_0.92fr] lg:gap-16 lg:py-20">
-        <div className="max-w-3xl">
+    <div className="w-full max-w-full overflow-x-clip">
+      <section className="container mx-auto grid min-w-0 max-w-7xl items-center gap-12 overflow-x-clip px-4 py-14 lg:min-h-[calc(100svh-9rem)] lg:grid-cols-[1.08fr_0.92fr] lg:gap-16 lg:py-20">
+        <div className="min-w-0 max-w-3xl">
           <p className="rt-mono text-[var(--terracotta)]">
             A recipe box built for real life
           </p>
-          <h1 className="rt-display mt-4 text-[clamp(4.25rem,10vw,7.75rem)] leading-[0.78] tracking-[-0.035em]">
+          <h1 className="rt-display mt-4 break-words text-6xl leading-[0.82] tracking-[-0.035em] min-[380px]:text-[4.25rem] sm:text-[clamp(4.25rem,10vw,7.75rem)] sm:leading-[0.78]">
             Find something worth cooking.{" "}
             <span className="text-[var(--terracotta)]">
               Keep what you love.
@@ -74,10 +74,10 @@ export function LoggedOutLanding({
           </p>
         </div>
 
-        <div className="relative mx-auto w-full max-w-xl lg:mx-0">
-          <div className="absolute -top-12 -right-16 size-56 rounded-full bg-[var(--butter)]/30 blur-3xl" />
-          <div className="absolute -bottom-12 -left-16 size-56 rounded-full bg-[var(--sage)]/20 blur-3xl" />
-          <div className="relative rotate-[0.6deg] rounded-[2rem] border border-[var(--line-strong)] bg-[var(--card)] p-5 shadow-[0_24px_70px_rgba(31,26,20,0.14)] sm:p-7">
+        <div className="relative mx-auto min-w-0 w-full max-w-xl lg:mx-0">
+          <div className="absolute -top-12 -right-16 hidden size-56 rounded-full bg-[var(--butter)]/30 blur-3xl sm:block" />
+          <div className="absolute -bottom-12 -left-16 hidden size-56 rounded-full bg-[var(--sage)]/20 blur-3xl sm:block" />
+          <div className="relative max-w-full rounded-[2rem] border border-[var(--line-strong)] bg-[var(--card)] p-5 shadow-[0_24px_70px_rgba(31,26,20,0.14)] sm:rotate-[0.6deg] sm:p-7">
             <div className="flex items-center justify-between border-b border-dashed border-[var(--line-strong)] pb-4">
               <div>
                 <p className="rt-mono text-[var(--terracotta)]">

--- a/ui/components/recipes/logged-out-landing.tsx
+++ b/ui/components/recipes/logged-out-landing.tsx
@@ -34,6 +34,12 @@ const steps = [
   },
 ] as const;
 
+function previewActionLabel(index: number) {
+  if (index === 0) return "Save it";
+  if (index === 1) return "Cook it";
+  return "Make it yours";
+}
+
 export function LoggedOutLanding({
   recipes,
 }: Readonly<{ recipes: RecipeCardView[] }>) {
@@ -99,11 +105,7 @@ export function LoggedOutLanding({
                   <RecipeThumb recipe={recipe} size={72} />
                   <div className="min-w-0 flex-1">
                     <p className="rt-mono text-[var(--ink-3)]">
-                      {index === 0
-                        ? "Save it"
-                        : index === 1
-                          ? "Cook it"
-                          : "Make it yours"}
+                      {previewActionLabel(index)}
                     </p>
                     <h2 className="rt-display mt-1 truncate text-2xl transition-colors group-hover:text-[var(--terracotta)] sm:text-3xl">
                       {recipe.title}

--- a/ui/components/recipes/public-cooks-view.tsx
+++ b/ui/components/recipes/public-cooks-view.tsx
@@ -20,6 +20,32 @@ type PublicCook = {
   activity: DiscoverFeedItem[];
 };
 
+const COOKS_FEED_PAGE_SIZE = 30;
+
+async function loadPublicActivity(signal: AbortSignal) {
+  const items: DiscoverFeedItem[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | null = null;
+
+  do {
+    const page = await getDiscoverFeedPage(
+      "public",
+      cursor,
+      signal,
+      COOKS_FEED_PAGE_SIZE,
+    );
+    items.push(...page.items);
+    if (!page.nextCursor) return items;
+    if (seenCursors.has(page.nextCursor)) {
+      throw new Error("The cooks directory returned a repeated page.");
+    }
+    seenCursors.add(page.nextCursor);
+    cursor = page.nextCursor;
+  } while (!signal.aborted);
+
+  throw new DOMException("The request was aborted.", "AbortError");
+}
+
 function groupCooks(items: DiscoverFeedItem[]): PublicCook[] {
   const cooks = new Map<string, PublicCook>();
   for (const item of items) {
@@ -132,10 +158,9 @@ function CookProfile({ cook }: Readonly<{ cook: PublicCook }>) {
 function CookNotFound() {
   return (
     <div className="rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
-      <p className="rt-display text-3xl">No recent activity found.</p>
+      <p className="rt-display text-3xl">Cook not found.</p>
       <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
-        Profiles are built from the 30 most recent public recipe additions, so
-        this cook may be outside the current activity window.
+        This cook has no public recipe activity.
       </p>
       <Button asChild variant="outline" className="mt-5">
         <Link href="/recipes/cooks">Browse all cooks</Link>
@@ -144,19 +169,7 @@ function CookNotFound() {
   );
 }
 
-function CookDirectoryResults({
-  cooks,
-  error,
-}: Readonly<{ cooks: PublicCook[]; error: string | null }>) {
-  if (error) {
-    return (
-      <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
-        <p className="rt-display text-3xl">The kitchen is quiet.</p>
-        <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">{error}</p>
-      </div>
-    );
-  }
-
+function CookDirectoryResults({ cooks }: Readonly<{ cooks: PublicCook[] }>) {
   if (cooks.length === 0) {
     return (
       <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
@@ -178,10 +191,7 @@ function CookDirectoryResults({
   );
 }
 
-function CookDirectory({
-  cooks,
-  error,
-}: Readonly<{ cooks: PublicCook[]; error: string | null }>) {
+function CookDirectory({ cooks }: Readonly<{ cooks: PublicCook[] }>) {
   return (
     <>
       <header className="max-w-3xl">
@@ -194,8 +204,17 @@ function CookDirectory({
           Explore home cooks through the public recipes they’ve been adding.
         </p>
       </header>
-      <CookDirectoryResults cooks={cooks} error={error} />
+      <CookDirectoryResults cooks={cooks} />
     </>
+  );
+}
+
+function CooksError({ error }: Readonly<{ error: string }>) {
+  return (
+    <div className="rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
+      <p className="rt-display text-3xl">The kitchen is quiet.</p>
+      <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">{error}</p>
+    </div>
   );
 }
 
@@ -210,9 +229,10 @@ function CooksContent({
   selectedCook: PublicCook | null;
   selectedCookId: string | null;
 }>) {
+  if (error) return <CooksError error={error} />;
   if (selectedCook) return <CookProfile cook={selectedCook} />;
   if (selectedCookId) return <CookNotFound />;
-  return <CookDirectory cooks={cooks} error={error} />;
+  return <CookDirectory cooks={cooks} />;
 }
 
 export function PublicCooksView() {
@@ -226,9 +246,9 @@ export function PublicCooksView() {
     const controller = new AbortController();
     setLoading(true);
     setError(null);
-    void getDiscoverFeedPage("public", null, controller.signal, 30)
-      .then((page) => {
-        if (!controller.signal.aborted) setItems(page.items);
+    void loadPublicActivity(controller.signal)
+      .then((activity) => {
+        if (!controller.signal.aborted) setItems(activity);
       })
       .catch((cause: unknown) => {
         if (cause instanceof DOMException && cause.name === "AbortError")

--- a/ui/components/recipes/public-cooks-view.tsx
+++ b/ui/components/recipes/public-cooks-view.tsx
@@ -3,68 +3,19 @@
 import { ArrowLeft, ArrowRight, LoaderCircle, Users } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
 import { RecipeThumb } from "@/components/recipes/recipe-card";
 import { Button } from "@/components/ui/button";
 import {
-  type DiscoverFeedItem,
-  getDiscoverFeedPage,
-} from "@/lib/api/discover-feed";
+  getPublicCook,
+  getPublicCooks,
+  type PublicCookProfile,
+  type PublicCookSummary,
+} from "@/lib/api/public-cooks";
 import { savedRecipeCard } from "@/lib/domain/recipe/recipeDraft";
 
-type PublicCook = {
-  id: string;
-  name: string;
-  image: string | null;
-  activity: DiscoverFeedItem[];
-};
-
-const COOKS_FEED_PAGE_SIZE = 30;
-
-async function loadPublicActivity(signal: AbortSignal) {
-  const items: DiscoverFeedItem[] = [];
-  const seenCursors = new Set<string>();
-  let cursor: string | null = null;
-
-  do {
-    const page = await getDiscoverFeedPage(
-      "public",
-      cursor,
-      signal,
-      COOKS_FEED_PAGE_SIZE,
-    );
-    items.push(...page.items);
-    if (!page.nextCursor) return items;
-    if (seenCursors.has(page.nextCursor)) {
-      throw new Error("The cooks directory returned a repeated page.");
-    }
-    seenCursors.add(page.nextCursor);
-    cursor = page.nextCursor;
-  } while (!signal.aborted);
-
-  throw new DOMException("The request was aborted.", "AbortError");
-}
-
-function groupCooks(items: DiscoverFeedItem[]): PublicCook[] {
-  const cooks = new Map<string, PublicCook>();
-  for (const item of items) {
-    if (!item.author?.id) continue;
-    const current = cooks.get(item.author.id);
-    if (current) {
-      current.activity.push(item);
-      continue;
-    }
-    cooks.set(item.author.id, {
-      ...item.author,
-      activity: [item],
-    });
-  }
-  return Array.from(cooks.values());
-}
-
-function CookCard({ cook }: Readonly<{ cook: PublicCook }>) {
-  const latest = cook.activity[0];
+function CookCard({ cook }: Readonly<{ cook: PublicCookSummary }>) {
   return (
     <Link
       href={`/recipes/cooks?cook=${encodeURIComponent(cook.id)}`}
@@ -80,25 +31,23 @@ function CookCard({ cook }: Readonly<{ cook: PublicCook }>) {
         <div className="min-w-0 flex-1">
           <h2 className="rt-display truncate text-3xl">{cook.name}</h2>
           <p className="rt-mono mt-1 text-[var(--ink-3)]">
-            {cook.activity.length} recent{" "}
-            {cook.activity.length === 1 ? "addition" : "additions"}
+            {cook.activityCount} public{" "}
+            {cook.activityCount === 1 ? "addition" : "additions"}
           </p>
         </div>
         <ArrowRight className="size-4 text-[var(--ink-3)] transition-transform group-hover:translate-x-1 group-hover:text-[var(--terracotta)]" />
       </div>
-      {latest ? (
-        <p className="rt-body mt-5 border-t border-dashed border-[var(--line)] pt-4 text-sm text-[var(--ink-2)]">
-          Recently added{" "}
-          <span className="font-bold text-[var(--ink)]">
-            {latest.recipe.title}
-          </span>
-        </p>
-      ) : null}
+      <p className="rt-body mt-5 border-t border-dashed border-[var(--line)] pt-4 text-sm text-[var(--ink-2)]">
+        Recently added{" "}
+        <span className="font-bold text-[var(--ink)]">
+          {cook.latestRecipeTitle}
+        </span>
+      </p>
     </Link>
   );
 }
 
-function CookProfile({ cook }: Readonly<{ cook: PublicCook }>) {
+function CookProfile({ cook }: Readonly<{ cook: PublicCookProfile }>) {
   const firstName = cook.name.trim().split(/\s+/)[0] || "This cook";
   return (
     <div>
@@ -169,7 +118,9 @@ function CookNotFound() {
   );
 }
 
-function CookDirectoryResults({ cooks }: Readonly<{ cooks: PublicCook[] }>) {
+function CookDirectoryResults({
+  cooks,
+}: Readonly<{ cooks: PublicCookSummary[] }>) {
   if (cooks.length === 0) {
     return (
       <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
@@ -191,7 +142,7 @@ function CookDirectoryResults({ cooks }: Readonly<{ cooks: PublicCook[] }>) {
   );
 }
 
-function CookDirectory({ cooks }: Readonly<{ cooks: PublicCook[] }>) {
+function CookDirectory({ cooks }: Readonly<{ cooks: PublicCookSummary[] }>) {
   return (
     <>
       <header className="max-w-3xl">
@@ -224,9 +175,9 @@ function CooksContent({
   selectedCook,
   selectedCookId,
 }: Readonly<{
-  cooks: PublicCook[];
+  cooks: PublicCookSummary[];
   error: string | null;
-  selectedCook: PublicCook | null;
+  selectedCook: PublicCookProfile | null;
   selectedCookId: string | null;
 }>) {
   if (error) return <CooksError error={error} />;
@@ -238,7 +189,10 @@ function CooksContent({
 export function PublicCooksView() {
   const searchParams = useSearchParams();
   const selectedCookId = searchParams.get("cook");
-  const [items, setItems] = useState<DiscoverFeedItem[]>([]);
+  const [cooks, setCooks] = useState<PublicCookSummary[]>([]);
+  const [selectedCook, setSelectedCook] = useState<PublicCookProfile | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -246,13 +200,17 @@ export function PublicCooksView() {
     const controller = new AbortController();
     setLoading(true);
     setError(null);
-    void loadPublicActivity(controller.signal)
-      .then((activity) => {
-        if (!controller.signal.aborted) setItems(activity);
-      })
+    setSelectedCook(null);
+    const request = selectedCookId
+      ? getPublicCook(selectedCookId, controller.signal).then((cook) => {
+          if (!controller.signal.aborted) setSelectedCook(cook);
+        })
+      : getPublicCooks(controller.signal).then((nextCooks) => {
+          if (!controller.signal.aborted) setCooks(nextCooks);
+        });
+    void request
       .catch((cause: unknown) => {
-        if (cause instanceof DOMException && cause.name === "AbortError")
-          return;
+        if (controller.signal.aborted) return;
         setError(
           cause instanceof Error
             ? cause.message
@@ -263,12 +221,7 @@ export function PublicCooksView() {
         if (!controller.signal.aborted) setLoading(false);
       });
     return () => controller.abort();
-  }, []);
-
-  const cooks = useMemo(() => groupCooks(items), [items]);
-  const selectedCook = selectedCookId
-    ? cooks.find((cook) => cook.id === selectedCookId)
-    : null;
+  }, [selectedCookId]);
 
   if (loading) {
     return (

--- a/ui/components/recipes/public-cooks-view.tsx
+++ b/ui/components/recipes/public-cooks-view.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { ArrowLeft, ArrowRight, LoaderCircle, Users } from "lucide-react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
+import { RecipeThumb } from "@/components/recipes/recipe-card";
+import { Button } from "@/components/ui/button";
+import {
+  type DiscoverFeedItem,
+  getDiscoverFeedPage,
+} from "@/lib/api/discover-feed";
+import { savedRecipeCard } from "@/lib/domain/recipe/recipeDraft";
+
+type PublicCook = {
+  id: string;
+  name: string;
+  image: string | null;
+  activity: DiscoverFeedItem[];
+};
+
+function groupCooks(items: DiscoverFeedItem[]): PublicCook[] {
+  const cooks = new Map<string, PublicCook>();
+  for (const item of items) {
+    const current = cooks.get(item.author.id);
+    if (current) {
+      current.activity.push(item);
+      continue;
+    }
+    cooks.set(item.author.id, {
+      ...item.author,
+      activity: [item],
+    });
+  }
+  return Array.from(cooks.values());
+}
+
+function CookCard({ cook }: Readonly<{ cook: PublicCook }>) {
+  const latest = cook.activity[0];
+  return (
+    <Link
+      href={`/recipes/cooks?cook=${encodeURIComponent(cook.id)}`}
+      className="group rounded-2xl border border-[var(--line-strong)] bg-[var(--card)] p-5 shadow-[var(--paper-shadow)] transition-transform hover:-translate-y-0.5"
+    >
+      <div className="flex items-center gap-4">
+        <RecipeAvatar
+          name={cook.name}
+          image={cook.image}
+          size={56}
+          className="shrink-0"
+        />
+        <div className="min-w-0 flex-1">
+          <h2 className="rt-display truncate text-3xl">{cook.name}</h2>
+          <p className="rt-mono mt-1 text-[var(--ink-3)]">
+            {cook.activity.length} recent{" "}
+            {cook.activity.length === 1 ? "addition" : "additions"}
+          </p>
+        </div>
+        <ArrowRight className="size-4 text-[var(--ink-3)] transition-transform group-hover:translate-x-1 group-hover:text-[var(--terracotta)]" />
+      </div>
+      {latest ? (
+        <p className="rt-body mt-5 border-t border-dashed border-[var(--line)] pt-4 text-sm text-[var(--ink-2)]">
+          Recently added{" "}
+          <span className="font-bold text-[var(--ink)]">
+            {latest.recipe.title}
+          </span>
+        </p>
+      ) : null}
+    </Link>
+  );
+}
+
+function CookProfile({ cook }: Readonly<{ cook: PublicCook }>) {
+  const firstName = cook.name.trim().split(/\s+/)[0] || "This cook";
+  return (
+    <div>
+      <Button asChild variant="ghost" className="-ml-3 mb-6">
+        <Link href="/recipes/cooks">
+          <ArrowLeft /> All cooks
+        </Link>
+      </Button>
+      <header className="flex flex-col gap-5 border-b border-dashed border-[var(--line-strong)] pb-8 sm:flex-row sm:items-center">
+        <RecipeAvatar
+          name={cook.name}
+          image={cook.image}
+          size={88}
+          className="shadow-[var(--paper-shadow)]"
+        />
+        <div>
+          <p className="rt-mono text-[var(--terracotta)]">Cook profile</p>
+          <h1 className="rt-display mt-2 text-5xl sm:text-6xl">
+            {firstName}’s{" "}
+            <span className="text-[var(--terracotta)]">recipe activity.</span>
+          </h1>
+          <p className="rt-body mt-2 text-[var(--ink-2)]">
+            Public recipes this cook has recently added.
+          </p>
+        </div>
+      </header>
+      <div className="mt-8 grid gap-4 sm:grid-cols-2">
+        {cook.activity.map((item) => {
+          const recipe = savedRecipeCard(item.recipe);
+          return (
+            <Link
+              key={`${item.recipe.slug}-${item.createdAt}`}
+              href={`/recipes/saved?slug=${encodeURIComponent(item.recipe.slug)}`}
+              className="group flex items-center gap-4 rounded-xl border border-[var(--line-strong)] bg-[var(--card)] p-4 shadow-[var(--paper-shadow)]"
+            >
+              {recipe ? (
+                <RecipeThumb recipe={recipe} size={72} />
+              ) : (
+                <span className="flex size-[72px] shrink-0 items-center justify-center rounded-lg bg-[var(--paper-warm)] text-[var(--terracotta)]">
+                  <Users className="size-5" />
+                </span>
+              )}
+              <div className="min-w-0">
+                <p className="rt-mono text-[var(--terracotta)]">Added</p>
+                <h2 className="rt-display mt-1 text-2xl leading-none transition-colors group-hover:text-[var(--terracotta)]">
+                  {item.recipe.title}
+                </h2>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function PublicCooksView() {
+  const searchParams = useSearchParams();
+  const selectedCookId = searchParams.get("cook");
+  const [items, setItems] = useState<DiscoverFeedItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    void getDiscoverFeedPage("public", null, controller.signal, 30)
+      .then((page) => setItems(page.items))
+      .catch((cause: unknown) => {
+        if (cause instanceof DOMException && cause.name === "AbortError")
+          return;
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "The cooks directory could not be loaded.",
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, []);
+
+  const cooks = useMemo(() => groupCooks(items), [items]);
+  const selectedCook = selectedCookId
+    ? cooks.find((cook) => cook.id === selectedCookId)
+    : null;
+
+  if (loading) {
+    return (
+      <output
+        aria-label="Loading cooks"
+        className="flex min-h-[50vh] items-center justify-center"
+      >
+        <LoaderCircle className="size-6 animate-spin text-[var(--terracotta)]" />
+      </output>
+    );
+  }
+
+  return (
+    <div className="container mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:py-14">
+      {selectedCook ? (
+        <CookProfile cook={selectedCook} />
+      ) : selectedCookId ? (
+        <div className="rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
+          <p className="rt-display text-3xl">Cook not found.</p>
+          <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
+            This cook has no recent public recipe activity.
+          </p>
+          <Button asChild variant="outline" className="mt-5">
+            <Link href="/recipes/cooks">Browse all cooks</Link>
+          </Button>
+        </div>
+      ) : (
+        <>
+          <header className="max-w-3xl">
+            <p className="rt-mono text-[var(--terracotta)]">Cooks</p>
+            <h1 className="rt-display mt-3 text-6xl sm:text-7xl">
+              Meet the people{" "}
+              <span className="text-[var(--terracotta)]">
+                behind the recipes.
+              </span>
+            </h1>
+            <p className="rt-body mt-4 text-lg text-[var(--ink-2)]">
+              Explore home cooks through the public recipes they’ve been adding.
+            </p>
+          </header>
+
+          {error ? (
+            <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
+              <p className="rt-display text-3xl">The kitchen is quiet.</p>
+              <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
+                {error}
+              </p>
+            </div>
+          ) : cooks.length === 0 ? (
+            <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
+              <Users className="mx-auto size-7 text-[var(--terracotta)]" />
+              <p className="rt-display mt-3 text-3xl">No public cooks yet.</p>
+              <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
+                Profiles appear here when someone adds a public recipe.
+              </p>
+            </div>
+          ) : (
+            <div className="mt-10 grid gap-4 md:grid-cols-2">
+              {cooks.map((cook) => (
+                <CookCard key={cook.id} cook={cook} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/components/recipes/public-cooks-view.tsx
+++ b/ui/components/recipes/public-cooks-view.tsx
@@ -132,9 +132,10 @@ function CookProfile({ cook }: Readonly<{ cook: PublicCook }>) {
 function CookNotFound() {
   return (
     <div className="rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
-      <p className="rt-display text-3xl">Cook not found.</p>
+      <p className="rt-display text-3xl">No recent activity found.</p>
       <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
-        This cook has no recent public recipe activity.
+        Profiles are built from the 30 most recent public recipe additions, so
+        this cook may be outside the current activity window.
       </p>
       <Button asChild variant="outline" className="mt-5">
         <Link href="/recipes/cooks">Browse all cooks</Link>

--- a/ui/components/recipes/public-cooks-view.tsx
+++ b/ui/components/recipes/public-cooks-view.tsx
@@ -23,6 +23,7 @@ type PublicCook = {
 function groupCooks(items: DiscoverFeedItem[]): PublicCook[] {
   const cooks = new Map<string, PublicCook>();
   for (const item of items) {
+    if (!item.author?.id) continue;
     const current = cooks.get(item.author.id);
     if (current) {
       current.activity.push(item);
@@ -128,6 +129,91 @@ function CookProfile({ cook }: Readonly<{ cook: PublicCook }>) {
   );
 }
 
+function CookNotFound() {
+  return (
+    <div className="rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
+      <p className="rt-display text-3xl">Cook not found.</p>
+      <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
+        This cook has no recent public recipe activity.
+      </p>
+      <Button asChild variant="outline" className="mt-5">
+        <Link href="/recipes/cooks">Browse all cooks</Link>
+      </Button>
+    </div>
+  );
+}
+
+function CookDirectoryResults({
+  cooks,
+  error,
+}: Readonly<{ cooks: PublicCook[]; error: string | null }>) {
+  if (error) {
+    return (
+      <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
+        <p className="rt-display text-3xl">The kitchen is quiet.</p>
+        <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">{error}</p>
+      </div>
+    );
+  }
+
+  if (cooks.length === 0) {
+    return (
+      <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
+        <Users className="mx-auto size-7 text-[var(--terracotta)]" />
+        <p className="rt-display mt-3 text-3xl">No public cooks yet.</p>
+        <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
+          Profiles appear here when someone adds a public recipe.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-10 grid gap-4 md:grid-cols-2">
+      {cooks.map((cook) => (
+        <CookCard key={cook.id} cook={cook} />
+      ))}
+    </div>
+  );
+}
+
+function CookDirectory({
+  cooks,
+  error,
+}: Readonly<{ cooks: PublicCook[]; error: string | null }>) {
+  return (
+    <>
+      <header className="max-w-3xl">
+        <p className="rt-mono text-[var(--terracotta)]">Cooks</p>
+        <h1 className="rt-display mt-3 text-6xl sm:text-7xl">
+          Meet the people{" "}
+          <span className="text-[var(--terracotta)]">behind the recipes.</span>
+        </h1>
+        <p className="rt-body mt-4 text-lg text-[var(--ink-2)]">
+          Explore home cooks through the public recipes they’ve been adding.
+        </p>
+      </header>
+      <CookDirectoryResults cooks={cooks} error={error} />
+    </>
+  );
+}
+
+function CooksContent({
+  cooks,
+  error,
+  selectedCook,
+  selectedCookId,
+}: Readonly<{
+  cooks: PublicCook[];
+  error: string | null;
+  selectedCook: PublicCook | null;
+  selectedCookId: string | null;
+}>) {
+  if (selectedCook) return <CookProfile cook={selectedCook} />;
+  if (selectedCookId) return <CookNotFound />;
+  return <CookDirectory cooks={cooks} error={error} />;
+}
+
 export function PublicCooksView() {
   const searchParams = useSearchParams();
   const selectedCookId = searchParams.get("cook");
@@ -140,7 +226,9 @@ export function PublicCooksView() {
     setLoading(true);
     setError(null);
     void getDiscoverFeedPage("public", null, controller.signal, 30)
-      .then((page) => setItems(page.items))
+      .then((page) => {
+        if (!controller.signal.aborted) setItems(page.items);
+      })
       .catch((cause: unknown) => {
         if (cause instanceof DOMException && cause.name === "AbortError")
           return;
@@ -174,57 +262,12 @@ export function PublicCooksView() {
 
   return (
     <div className="container mx-auto w-full max-w-6xl flex-1 px-4 py-10 sm:py-14">
-      {selectedCook ? (
-        <CookProfile cook={selectedCook} />
-      ) : selectedCookId ? (
-        <div className="rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
-          <p className="rt-display text-3xl">Cook not found.</p>
-          <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
-            This cook has no recent public recipe activity.
-          </p>
-          <Button asChild variant="outline" className="mt-5">
-            <Link href="/recipes/cooks">Browse all cooks</Link>
-          </Button>
-        </div>
-      ) : (
-        <>
-          <header className="max-w-3xl">
-            <p className="rt-mono text-[var(--terracotta)]">Cooks</p>
-            <h1 className="rt-display mt-3 text-6xl sm:text-7xl">
-              Meet the people{" "}
-              <span className="text-[var(--terracotta)]">
-                behind the recipes.
-              </span>
-            </h1>
-            <p className="rt-body mt-4 text-lg text-[var(--ink-2)]">
-              Explore home cooks through the public recipes they’ve been adding.
-            </p>
-          </header>
-
-          {error ? (
-            <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
-              <p className="rt-display text-3xl">The kitchen is quiet.</p>
-              <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
-                {error}
-              </p>
-            </div>
-          ) : cooks.length === 0 ? (
-            <div className="mt-10 rounded-xl border border-dashed border-[var(--line-strong)] p-8 text-center">
-              <Users className="mx-auto size-7 text-[var(--terracotta)]" />
-              <p className="rt-display mt-3 text-3xl">No public cooks yet.</p>
-              <p className="rt-body mt-2 text-sm text-[var(--ink-3)]">
-                Profiles appear here when someone adds a public recipe.
-              </p>
-            </div>
-          ) : (
-            <div className="mt-10 grid gap-4 md:grid-cols-2">
-              {cooks.map((cook) => (
-                <CookCard key={cook.id} cook={cook} />
-              ))}
-            </div>
-          )}
-        </>
-      )}
+      <CooksContent
+        cooks={cooks}
+        error={error}
+        selectedCook={selectedCook ?? null}
+        selectedCookId={selectedCookId}
+      />
     </div>
   );
 }

--- a/ui/components/recipes/recipe-home.tsx
+++ b/ui/components/recipes/recipe-home.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { LoaderCircle } from "lucide-react";
 import { LoggedOutLanding } from "@/components/recipes/logged-out-landing";
 import { RecipeBoxView } from "@/components/recipes/recipe-box-view";
 import type { RecipeCardView } from "@/lib/api/recipes";
@@ -13,18 +12,7 @@ export function RecipeHome({
   recipes: RecipeCardView[];
   catalogStats: string[];
 }>) {
-  const { data: session, isPending } = authClient.useSession();
-
-  if (isPending) {
-    return (
-      <output
-        aria-label="Loading recipes"
-        className="flex min-h-[60vh] items-center justify-center"
-      >
-        <LoaderCircle className="size-6 animate-spin text-[var(--terracotta)]" />
-      </output>
-    );
-  }
+  const { data: session } = authClient.useSession();
 
   if (session) {
     return <RecipeBoxView recipes={recipes} catalogStats={catalogStats} />;

--- a/ui/components/recipes/recipe-home.tsx
+++ b/ui/components/recipes/recipe-home.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { LoaderCircle } from "lucide-react";
+import { LoggedOutLanding } from "@/components/recipes/logged-out-landing";
+import { RecipeBoxView } from "@/components/recipes/recipe-box-view";
+import type { RecipeCardView } from "@/lib/api/recipes";
+import { authClient } from "@/lib/auth-client";
+
+export function RecipeHome({
+  recipes,
+  catalogStats,
+}: Readonly<{
+  recipes: RecipeCardView[];
+  catalogStats: string[];
+}>) {
+  const { data: session, isPending } = authClient.useSession();
+
+  if (isPending) {
+    return (
+      <output
+        aria-label="Loading recipes"
+        className="flex min-h-[60vh] items-center justify-center"
+      >
+        <LoaderCircle className="size-6 animate-spin text-[var(--terracotta)]" />
+      </output>
+    );
+  }
+
+  if (session) {
+    return <RecipeBoxView recipes={recipes} catalogStats={catalogStats} />;
+  }
+
+  return <LoggedOutLanding recipes={recipes} />;
+}

--- a/ui/components/recipes/recipe-home.tsx
+++ b/ui/components/recipes/recipe-home.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { LoggedOutLanding } from "@/components/recipes/logged-out-landing";
 import { RecipeBoxView } from "@/components/recipes/recipe-box-view";
 import type { RecipeCardView } from "@/lib/api/recipes";
@@ -13,6 +14,12 @@ export function RecipeHome({
   catalogStats: string[];
 }>) {
   const { data: session } = authClient.useSession();
+
+  useEffect(() => {
+    document.title = session
+      ? "Your recipe box | Robbie's Recipes"
+      : "Recipes for real life | Robbie's Recipes";
+  }, [session]);
 
   if (session) {
     return <RecipeBoxView recipes={recipes} catalogStats={catalogStats} />;

--- a/ui/components/recipes/recipe-site-nav.tsx
+++ b/ui/components/recipes/recipe-site-nav.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { RecipeNavTabs } from "@/components/recipes/recipe-nav-tabs";
+import { authClient } from "@/lib/auth-client";
+
+const publicTabs = [
+  { href: "/recipes/discover", label: "Discover", match: "/recipes/discover" },
+  { href: "/recipes/cooks", label: "Cooks", match: "/recipes/cooks" },
+  { href: "/recipes#how-it-works", label: "How it works", match: null },
+] as const;
+
+export function RecipeSiteNav() {
+  const pathname = usePathname();
+  const { data: session, isPending } = authClient.useSession();
+
+  if (isPending) {
+    return <div className="h-6 w-56" aria-hidden="true" />;
+  }
+
+  if (session) return <RecipeNavTabs />;
+
+  return (
+    <div className="flex items-baseline gap-3 sm:gap-4">
+      {publicTabs.map((tab) => (
+        <Link
+          key={tab.label}
+          href={tab.href}
+          className="rt-tab whitespace-nowrap text-base lg:text-lg"
+          data-active={
+            tab.match && pathname?.startsWith(tab.match) ? true : undefined
+          }
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/ui/components/recipes/recipe-site-nav.tsx
+++ b/ui/components/recipes/recipe-site-nav.tsx
@@ -13,11 +13,7 @@ const publicTabs = [
 
 export function RecipeSiteNav() {
   const pathname = usePathname();
-  const { data: session, isPending } = authClient.useSession();
-
-  if (isPending) {
-    return <div className="h-6 w-56" aria-hidden="true" />;
-  }
+  const { data: session } = authClient.useSession();
 
   if (session) return <RecipeNavTabs />;
 

--- a/ui/lib/api/discover-feed.ts
+++ b/ui/lib/api/discover-feed.ts
@@ -22,7 +22,7 @@ export async function getDiscoverFeedPage(
 ): Promise<DiscoverFeedPage> {
   const params = new URLSearchParams({ scope });
   if (cursor) params.set("cursor", cursor);
-  if (limit) params.set("limit", String(limit));
+  if (limit !== undefined) params.set("limit", String(limit));
   const response = await fetch(`/api/recipes/discover/feed?${params}`, {
     credentials: "same-origin",
     signal,

--- a/ui/lib/api/discover-feed.ts
+++ b/ui/lib/api/discover-feed.ts
@@ -18,9 +18,11 @@ export async function getDiscoverFeedPage(
   scope: DiscoverFeedScope,
   cursor: string | null,
   signal?: AbortSignal,
+  limit?: number,
 ): Promise<DiscoverFeedPage> {
   const params = new URLSearchParams({ scope });
   if (cursor) params.set("cursor", cursor);
+  if (limit) params.set("limit", String(limit));
   const response = await fetch(`/api/recipes/discover/feed?${params}`, {
     credentials: "same-origin",
     signal,

--- a/ui/lib/api/public-cooks.ts
+++ b/ui/lib/api/public-cooks.ts
@@ -1,0 +1,50 @@
+import type { SavedRecipeApiRecord } from "@/lib/domain/recipe/recipeDraft";
+
+export type PublicCookSummary = {
+  id: string;
+  name: string;
+  image: string | null;
+  activityCount: number;
+  latestRecipeTitle: string;
+};
+
+export type PublicCookProfile = {
+  id: string;
+  name: string;
+  image: string | null;
+  activity: Array<{
+    type: "recipe_added";
+    recipe: SavedRecipeApiRecord;
+    createdAt: string;
+  }>;
+};
+
+async function apiJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+  const response = await fetch(url, {
+    credentials: "same-origin",
+    signal,
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new Error(body?.error ?? "The cooks directory could not be loaded.");
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function getPublicCooks(signal?: AbortSignal) {
+  const page = await apiJson<{ cooks: PublicCookSummary[] }>(
+    "/api/recipes/cooks",
+    signal,
+  );
+  return page.cooks;
+}
+
+export async function getPublicCook(id: string, signal?: AbortSignal) {
+  const page = await apiJson<{ cook: PublicCookProfile | null }>(
+    `/api/recipes/cooks?cook=${encodeURIComponent(id)}`,
+    signal,
+  );
+  return page.cook;
+}

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -102,6 +102,18 @@ describe("AuthButton", () => {
     });
   });
 
+  it("keeps sign-up available while the session is loading", async () => {
+    const user = userEvent.setup();
+    mocks.useSession.mockReturnValue({ data: null, isPending: true });
+
+    render(<AuthButton intent="signup" />);
+
+    await user.click(screen.getByRole("button", { name: /sign up/i }));
+    expect(
+      screen.getByRole("button", { name: "Continue with Google" }),
+    ).toBeInTheDocument();
+  });
+
   it("offers Access-protected test scenarios on PR previews", async () => {
     const user = userEvent.setup();
     mocks.isPreviewDeployment.mockReturnValue(true);

--- a/ui/tests/components/recipes/public-cooks-view.test.tsx
+++ b/ui/tests/components/recipes/public-cooks-view.test.tsx
@@ -1,12 +1,13 @@
 import { act, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
-  DiscoverFeedItem,
-  DiscoverFeedPage,
-} from "@/lib/api/discover-feed";
+  PublicCookProfile,
+  PublicCookSummary,
+} from "@/lib/api/public-cooks";
 
 const mocks = vi.hoisted(() => ({
-  getDiscoverFeedPage: vi.fn(),
+  getPublicCook: vi.fn(),
+  getPublicCooks: vi.fn(),
   useSearchParams: vi.fn(),
 }));
 
@@ -14,111 +15,101 @@ vi.mock("next/navigation", () => ({
   useSearchParams: mocks.useSearchParams,
 }));
 
-vi.mock("@/lib/api/discover-feed", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/lib/api/discover-feed")>()),
-  getDiscoverFeedPage: mocks.getDiscoverFeedPage,
+vi.mock("@/lib/api/public-cooks", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/public-cooks")>()),
+  getPublicCook: mocks.getPublicCook,
+  getPublicCooks: mocks.getPublicCooks,
 }));
 
 import { PublicCooksView } from "@/components/recipes/public-cooks-view";
 
-const validItem = {
-  type: "recipe_added",
-  author: { id: "cook-1", name: "Ada Cook", image: null },
-  recipe: {
-    slug: "ada-stew",
-    title: "Ada's Stew",
-    description: null,
-    body: null,
-    visibility: "public",
-    createdAt: "2026-07-16T12:00:00.000Z",
-    updatedAt: "2026-07-16T12:00:00.000Z",
-  },
-  createdAt: "2026-07-16T12:00:00.000Z",
-} satisfies DiscoverFeedItem;
+const summary = {
+  id: "cook-1",
+  name: "Ada Cook",
+  image: null,
+  activityCount: 2,
+  latestRecipeTitle: "Ada's Stew",
+} satisfies PublicCookSummary;
 
-const olderItem = {
-  ...validItem,
-  author: { id: "cook-2", name: "Grace Baker", image: null },
-  recipe: {
-    ...validItem.recipe,
-    slug: "grace-pie",
-    title: "Grace's Pie",
-  },
-  createdAt: "2026-07-15T12:00:00.000Z",
-} satisfies DiscoverFeedItem;
+const profile = {
+  id: "cook-1",
+  name: "Ada Cook",
+  image: null,
+  activity: [
+    {
+      type: "recipe_added",
+      recipe: {
+        slug: "ada-stew",
+        title: "Ada's Stew",
+        description: null,
+        body: null,
+        visibility: "public",
+        createdAt: "2026-07-16T12:00:00.000Z",
+        updatedAt: "2026-07-16T12:00:00.000Z",
+      },
+      createdAt: "2026-07-16T12:00:00.000Z",
+    },
+  ],
+} satisfies PublicCookProfile;
 
 describe("PublicCooksView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.useSearchParams.mockReturnValue(new URLSearchParams());
+    mocks.getPublicCooks.mockResolvedValue([summary]);
+    mocks.getPublicCook.mockResolvedValue(profile);
   });
 
-  it("ignores malformed activity without an author", async () => {
-    const malformedItem = {
-      ...validItem,
-      author: null,
-      recipe: { ...validItem.recipe, slug: "broken", title: "Broken Dish" },
-    } as unknown as DiscoverFeedItem;
-    mocks.getDiscoverFeedPage.mockResolvedValue({
-      items: [malformedItem, validItem],
-      nextCursor: null,
-    } satisfies DiscoverFeedPage);
-
+  it("renders lightweight cook summaries", async () => {
     render(<PublicCooksView />);
 
     expect(await screen.findByText("Ada Cook")).toBeInTheDocument();
-    expect(screen.queryByText("Broken Dish")).not.toBeInTheDocument();
+    expect(screen.getByText("Ada's Stew")).toBeInTheDocument();
+    expect(mocks.getPublicCooks).toHaveBeenCalledWith(expect.any(AbortSignal));
+    expect(mocks.getPublicCook).not.toHaveBeenCalled();
   });
 
-  it("aborts the feed request when unmounted", async () => {
-    let resolvePage: ((page: DiscoverFeedPage) => void) | undefined;
-    mocks.getDiscoverFeedPage.mockReturnValue(
-      new Promise<DiscoverFeedPage>((resolve) => {
-        resolvePage = resolve;
+  it("aborts the cooks request when unmounted", async () => {
+    let resolveCooks: ((cooks: PublicCookSummary[]) => void) | undefined;
+    mocks.getPublicCooks.mockReturnValue(
+      new Promise<PublicCookSummary[]>((resolve) => {
+        resolveCooks = resolve;
       }),
     );
 
     const { unmount } = render(<PublicCooksView />);
-    const signal = mocks.getDiscoverFeedPage.mock.calls[0]?.[2] as AbortSignal;
+    const signal = mocks.getPublicCooks.mock.calls[0]?.[0] as AbortSignal;
 
     unmount();
     expect(signal.aborted).toBe(true);
 
     await act(async () => {
-      resolvePage?.({ items: [validItem], nextCursor: null });
+      resolveCooks?.([summary]);
     });
   });
 
-  it("loads every feed page so older cooks remain discoverable", async () => {
-    mocks.getDiscoverFeedPage
-      .mockResolvedValueOnce({
-        items: [validItem],
-        nextCursor: "older-page",
-      } satisfies DiscoverFeedPage)
-      .mockResolvedValueOnce({
-        items: [olderItem],
-        nextCursor: null,
-      } satisfies DiscoverFeedPage);
+  it("loads a selected cook directly", async () => {
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams("cook=cook-1"));
 
     render(<PublicCooksView />);
 
-    expect(await screen.findByText("Grace Baker")).toBeInTheDocument();
-    expect(mocks.getDiscoverFeedPage).toHaveBeenNthCalledWith(
-      2,
-      "public",
-      "older-page",
+    expect(
+      await screen.findByRole("heading", {
+        name: /Ada.*recipe activity/,
+      }),
+    ).toBeInTheDocument();
+    expect(mocks.getPublicCook).toHaveBeenCalledWith(
+      "cook-1",
       expect.any(AbortSignal),
-      30,
     );
+    expect(mocks.getPublicCooks).not.toHaveBeenCalled();
   });
 
   it("shows request errors instead of a missing-cook message", async () => {
     mocks.useSearchParams.mockReturnValue(
       new URLSearchParams("cook=older-cook"),
     );
-    mocks.getDiscoverFeedPage.mockRejectedValue(
-      new Error("Service unavailable"),
-    );
+    mocks.getPublicCook.mockRejectedValue(new Error("Service unavailable"));
 
     render(<PublicCooksView />);
 

--- a/ui/tests/components/recipes/public-cooks-view.test.tsx
+++ b/ui/tests/components/recipes/public-cooks-view.test.tsx
@@ -1,0 +1,78 @@
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  DiscoverFeedItem,
+  DiscoverFeedPage,
+} from "@/lib/api/discover-feed";
+
+const mocks = vi.hoisted(() => ({
+  getDiscoverFeedPage: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/api/discover-feed", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/discover-feed")>()),
+  getDiscoverFeedPage: mocks.getDiscoverFeedPage,
+}));
+
+import { PublicCooksView } from "@/components/recipes/public-cooks-view";
+
+const validItem = {
+  type: "recipe_added",
+  author: { id: "cook-1", name: "Ada Cook", image: null },
+  recipe: {
+    slug: "ada-stew",
+    title: "Ada's Stew",
+    description: null,
+    body: null,
+    visibility: "public",
+    createdAt: "2026-07-16T12:00:00.000Z",
+    updatedAt: "2026-07-16T12:00:00.000Z",
+  },
+  createdAt: "2026-07-16T12:00:00.000Z",
+} satisfies DiscoverFeedItem;
+
+describe("PublicCooksView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("ignores malformed activity without an author", async () => {
+    const malformedItem = {
+      ...validItem,
+      author: null,
+      recipe: { ...validItem.recipe, slug: "broken", title: "Broken Dish" },
+    } as unknown as DiscoverFeedItem;
+    mocks.getDiscoverFeedPage.mockResolvedValue({
+      items: [malformedItem, validItem],
+      nextCursor: null,
+    } satisfies DiscoverFeedPage);
+
+    render(<PublicCooksView />);
+
+    expect(await screen.findByText("Ada Cook")).toBeInTheDocument();
+    expect(screen.queryByText("Broken Dish")).not.toBeInTheDocument();
+  });
+
+  it("aborts the feed request when unmounted", async () => {
+    let resolvePage: ((page: DiscoverFeedPage) => void) | undefined;
+    mocks.getDiscoverFeedPage.mockReturnValue(
+      new Promise<DiscoverFeedPage>((resolve) => {
+        resolvePage = resolve;
+      }),
+    );
+
+    const { unmount } = render(<PublicCooksView />);
+    const signal = mocks.getDiscoverFeedPage.mock.calls[0]?.[2] as AbortSignal;
+
+    unmount();
+    expect(signal.aborted).toBe(true);
+
+    await act(async () => {
+      resolvePage?.({ items: [validItem], nextCursor: null });
+    });
+  });
+});

--- a/ui/tests/components/recipes/public-cooks-view.test.tsx
+++ b/ui/tests/components/recipes/public-cooks-view.test.tsx
@@ -36,6 +36,17 @@ const validItem = {
   createdAt: "2026-07-16T12:00:00.000Z",
 } satisfies DiscoverFeedItem;
 
+const olderItem = {
+  ...validItem,
+  author: { id: "cook-2", name: "Grace Baker", image: null },
+  recipe: {
+    ...validItem.recipe,
+    slug: "grace-pie",
+    title: "Grace's Pie",
+  },
+  createdAt: "2026-07-15T12:00:00.000Z",
+} satisfies DiscoverFeedItem;
+
 describe("PublicCooksView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,22 +89,43 @@ describe("PublicCooksView", () => {
     });
   });
 
-  it("explains that a missing cook may be outside the activity window", async () => {
+  it("loads every feed page so older cooks remain discoverable", async () => {
+    mocks.getDiscoverFeedPage
+      .mockResolvedValueOnce({
+        items: [validItem],
+        nextCursor: "older-page",
+      } satisfies DiscoverFeedPage)
+      .mockResolvedValueOnce({
+        items: [olderItem],
+        nextCursor: null,
+      } satisfies DiscoverFeedPage);
+
+    render(<PublicCooksView />);
+
+    expect(await screen.findByText("Grace Baker")).toBeInTheDocument();
+    expect(mocks.getDiscoverFeedPage).toHaveBeenNthCalledWith(
+      2,
+      "public",
+      "older-page",
+      expect.any(AbortSignal),
+      30,
+    );
+  });
+
+  it("shows request errors instead of a missing-cook message", async () => {
     mocks.useSearchParams.mockReturnValue(
       new URLSearchParams("cook=older-cook"),
     );
-    mocks.getDiscoverFeedPage.mockResolvedValue({
-      items: [validItem],
-      nextCursor: null,
-    } satisfies DiscoverFeedPage);
+    mocks.getDiscoverFeedPage.mockRejectedValue(
+      new Error("Service unavailable"),
+    );
 
     render(<PublicCooksView />);
 
     expect(
-      await screen.findByText("No recent activity found."),
+      await screen.findByText("The kitchen is quiet."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/30 most recent public recipe additions/),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Service unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Cook not found.")).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/public-cooks-view.test.tsx
+++ b/ui/tests/components/recipes/public-cooks-view.test.tsx
@@ -7,10 +7,11 @@ import type {
 
 const mocks = vi.hoisted(() => ({
   getDiscoverFeedPage: vi.fn(),
+  useSearchParams: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: mocks.useSearchParams,
 }));
 
 vi.mock("@/lib/api/discover-feed", async (importOriginal) => ({
@@ -38,6 +39,7 @@ const validItem = {
 describe("PublicCooksView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.useSearchParams.mockReturnValue(new URLSearchParams());
   });
 
   it("ignores malformed activity without an author", async () => {
@@ -74,5 +76,24 @@ describe("PublicCooksView", () => {
     await act(async () => {
       resolvePage?.({ items: [validItem], nextCursor: null });
     });
+  });
+
+  it("explains that a missing cook may be outside the activity window", async () => {
+    mocks.useSearchParams.mockReturnValue(
+      new URLSearchParams("cook=older-cook"),
+    );
+    mocks.getDiscoverFeedPage.mockResolvedValue({
+      items: [validItem],
+      nextCursor: null,
+    } satisfies DiscoverFeedPage);
+
+    render(<PublicCooksView />);
+
+    expect(
+      await screen.findByText("No recent activity found."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/30 most recent public recipe additions/),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/recipe-home.test.tsx
+++ b/ui/tests/components/recipes/recipe-home.test.tsx
@@ -22,6 +22,7 @@ import { RecipeHome } from "@/components/recipes/recipe-home";
 describe("RecipeHome", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    document.title = "";
   });
 
   it("shows the public landing page to logged-out visitors", () => {
@@ -33,7 +34,7 @@ describe("RecipeHome", () => {
     expect(screen.queryByText("Your recipe box")).not.toBeInTheDocument();
   });
 
-  it("keeps the personal recipe box for signed-in users", () => {
+  it("keeps the personal recipe box and title for signed-in users", () => {
     mocks.useSession.mockReturnValue({
       data: { user: { id: "user-1" } },
       isPending: false,
@@ -43,6 +44,7 @@ describe("RecipeHome", () => {
 
     expect(screen.getByText("Your recipe box")).toBeInTheDocument();
     expect(screen.queryByText("Public landing")).not.toBeInTheDocument();
+    expect(document.title).toBe("Your recipe box | Robbie's Recipes");
   });
 
   it("renders the public landing while the session is loading", () => {
@@ -52,5 +54,6 @@ describe("RecipeHome", () => {
 
     expect(screen.getByText("Public landing")).toBeInTheDocument();
     expect(screen.queryByText("Your recipe box")).not.toBeInTheDocument();
+    expect(document.title).toBe("Recipes for real life | Robbie's Recipes");
   });
 });

--- a/ui/tests/components/recipes/recipe-home.test.tsx
+++ b/ui/tests/components/recipes/recipe-home.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: mocks.useSession },
+}));
+
+vi.mock("@/components/recipes/logged-out-landing", () => ({
+  LoggedOutLanding: () => <div>Public landing</div>,
+}));
+
+vi.mock("@/components/recipes/recipe-box-view", () => ({
+  RecipeBoxView: () => <div>Your recipe box</div>,
+}));
+
+import { RecipeHome } from "@/components/recipes/recipe-home";
+
+describe("RecipeHome", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the public landing page to logged-out visitors", () => {
+    mocks.useSession.mockReturnValue({ data: null, isPending: false });
+
+    render(<RecipeHome recipes={[]} catalogStats={[]} />);
+
+    expect(screen.getByText("Public landing")).toBeInTheDocument();
+    expect(screen.queryByText("Your recipe box")).not.toBeInTheDocument();
+  });
+
+  it("keeps the personal recipe box for signed-in users", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "user-1" } },
+      isPending: false,
+    });
+
+    render(<RecipeHome recipes={[]} catalogStats={[]} />);
+
+    expect(screen.getByText("Your recipe box")).toBeInTheDocument();
+    expect(screen.queryByText("Public landing")).not.toBeInTheDocument();
+  });
+
+  it("does not flash either view while the session is loading", () => {
+    mocks.useSession.mockReturnValue({ data: null, isPending: true });
+
+    render(<RecipeHome recipes={[]} catalogStats={[]} />);
+
+    expect(screen.getByLabelText("Loading recipes")).toBeInTheDocument();
+    expect(screen.queryByText("Public landing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Your recipe box")).not.toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/recipe-home.test.tsx
+++ b/ui/tests/components/recipes/recipe-home.test.tsx
@@ -45,13 +45,12 @@ describe("RecipeHome", () => {
     expect(screen.queryByText("Public landing")).not.toBeInTheDocument();
   });
 
-  it("does not flash either view while the session is loading", () => {
+  it("renders the public landing while the session is loading", () => {
     mocks.useSession.mockReturnValue({ data: null, isPending: true });
 
     render(<RecipeHome recipes={[]} catalogStats={[]} />);
 
-    expect(screen.getByLabelText("Loading recipes")).toBeInTheDocument();
-    expect(screen.queryByText("Public landing")).not.toBeInTheDocument();
+    expect(screen.getByText("Public landing")).toBeInTheDocument();
     expect(screen.queryByText("Your recipe box")).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/recipe-site-nav.test.tsx
+++ b/ui/tests/components/recipes/recipe-site-nav.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/recipes",
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: mocks.useSession },
+}));
+
+vi.mock("@/components/recipes/recipe-nav-tabs", () => ({
+  RecipeNavTabs: () => <div>Personal recipe tabs</div>,
+}));
+
+import { RecipeSiteNav } from "@/components/recipes/recipe-site-nav";
+
+describe("RecipeSiteNav", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders public navigation while the session is loading", () => {
+    mocks.useSession.mockReturnValue({ data: null, isPending: true });
+
+    render(<RecipeSiteNav />);
+
+    expect(screen.getByRole("link", { name: "Discover" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Cooks" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "How it works" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Personal recipe tabs")).not.toBeInTheDocument();
+  });
+
+  it("renders personal navigation for signed-in users", () => {
+    mocks.useSession.mockReturnValue({
+      data: { user: { id: "user-1" } },
+      isPending: false,
+    });
+
+    render(<RecipeSiteNav />);
+
+    expect(screen.getByText("Personal recipe tabs")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Discover" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/tests/integration/agent-markdown.test.ts
+++ b/ui/tests/integration/agent-markdown.test.ts
@@ -9,6 +9,21 @@ import { describe, expect, it } from "vitest";
 
 const OUT_DIR = path.join(process.cwd(), "out");
 
+// Runtime-backed recipe app pages are static export shells, not recipe content.
+// They intentionally have no Markdown, JSON, or Cooklang twins.
+const RECIPE_APP_PAGES = new Set([
+  "add",
+  "cooks",
+  "discover",
+  "kitchen",
+  "notifications",
+  "onboarding",
+  "profile",
+  "saved",
+  "settings",
+  "shopping",
+]);
+
 function read(relativePath: string): string {
   return fs.readFileSync(path.join(OUT_DIR, relativePath), "utf-8");
 }
@@ -49,25 +64,14 @@ describe("agent markdown generation", () => {
   });
 
   it("generates a markdown twin for every recipe and technology page", () => {
-    // Interactive, noindex app pages that intentionally have no Markdown twin.
-    const nonContentPages = new Set([
-      "recipes/add.html",
-      "recipes/discover.html",
-      "recipes/kitchen.html",
-      "recipes/notifications.html",
-      "recipes/onboarding.html",
-      "recipes/profile.html",
-      "recipes/saved.html",
-      "recipes/settings.html",
-      "recipes/shopping.html",
-    ]);
     for (const section of ["recipes", "technologies"]) {
       const htmlPages = fs
         .readdirSync(path.join(OUT_DIR, section))
         .filter(
           (file) =>
             file.endsWith(".html") &&
-            !nonContentPages.has(`${section}/${file}`),
+            (section !== "recipes" ||
+              !RECIPE_APP_PAGES.has(file.replace(/\.html$/, ""))),
         );
       expect(htmlPages.length).toBeGreaterThan(0);
       for (const htmlPage of htmlPages) {
@@ -80,8 +84,14 @@ describe("agent markdown generation", () => {
     }
   });
 
-  it("keeps authenticated app pages out of agent markdown outputs", () => {
-    for (const page of ["notifications", "onboarding", "profile", "settings"]) {
+  it("keeps runtime-backed app pages out of agent markdown outputs", () => {
+    for (const page of [
+      "cooks",
+      "notifications",
+      "onboarding",
+      "profile",
+      "settings",
+    ]) {
       expect(fs.existsSync(path.join(OUT_DIR, "recipes", `${page}.md`))).toBe(
         false,
       );
@@ -101,20 +111,13 @@ describe("agent markdown generation", () => {
   });
 
   it("generates JSON and Cooklang exports for every recipe", () => {
-    const nonRecipePages = new Set([
-      "add.html",
-      "discover.html",
-      "kitchen.html",
-      "notifications.html",
-      "onboarding.html",
-      "profile.html",
-      "saved.html",
-      "settings.html",
-      "shopping.html",
-    ]);
     const recipePages = fs
       .readdirSync(path.join(OUT_DIR, "recipes"))
-      .filter((file) => file.endsWith(".html") && !nonRecipePages.has(file));
+      .filter(
+        (file) =>
+          file.endsWith(".html") &&
+          !RECIPE_APP_PAGES.has(file.replace(/\.html$/, "")),
+      );
 
     for (const recipePage of recipePages) {
       const slug = recipePage.replace(/\.html$/, "");

--- a/ui/tests/integration/sitemap.test.ts
+++ b/ui/tests/integration/sitemap.test.ts
@@ -17,6 +17,7 @@ const STATIC_ASSET_SEGMENTS = new Set(["recipe-site-design"]);
 // feeds) — served but kept out of the sitemap on purpose.
 const NOINDEX_APP_PAGES = new Set([
   "recipes/add",
+  "recipes/cooks",
   "recipes/discover",
   "recipes/kitchen",
   "recipes/notifications",

--- a/ui/tests/lib/api/discover-feed.test.ts
+++ b/ui/tests/lib/api/discover-feed.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getDiscoverFeedPage } from "@/lib/api/discover-feed";
+
+describe("getDiscoverFeedPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("includes an explicitly provided zero limit", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ items: [], nextCursor: null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await getDiscoverFeedPage("public", null, undefined, 0);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/recipes/discover/feed?scope=public&limit=0",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+});

--- a/ui/tests/lib/api/public-cooks.test.ts
+++ b/ui/tests/lib/api/public-cooks.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getPublicCook, getPublicCooks } from "@/lib/api/public-cooks";
+
+describe("public cooks API", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads lightweight cook summaries", async () => {
+    const cooks = [
+      {
+        id: "cook-1",
+        name: "Ada Cook",
+        image: null,
+        activityCount: 2,
+        latestRecipeTitle: "Ada's Stew",
+      },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ cooks }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(getPublicCooks()).resolves.toEqual(cooks);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/recipes/cooks",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+
+  it("encodes the selected cook id", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ cook: null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(getPublicCook("cook/one")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/recipes/cooks?cook=cook%2Fone",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+});

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -10,6 +10,7 @@ import {
   isNull,
   lt,
   or,
+  sql,
 } from "drizzle-orm";
 import { z } from "zod";
 import { createDb, schema } from "recipe-db";
@@ -123,6 +124,7 @@ const recipeVisibilitySchema = z.enum(["public", "private", "household"]);
 const dietRecipeMatchModeSchema = z.enum(["hide", "warn"]);
 const feedScopeSchema = z.enum(["public", "household"]);
 const feedLimitSchema = z.coerce.number().int().min(1).max(30).default(12);
+const publicCookIdSchema = z.string().trim().min(1).max(128);
 
 const dietKeySchema = z
   .string()
@@ -2729,6 +2731,91 @@ app.get("/recipes/discover/feed", async (c) => {
     });
   } catch (e) {
     console.error("GET /recipes/discover/feed query failed", e);
+    return c.json({ error: "Database query failed" }, 502);
+  } finally {
+    await closeDbClient(client);
+  }
+});
+
+app.get("/recipes/cooks", async (c) => {
+  const cookValue = c.req.query("cook");
+  const cookId =
+    cookValue === undefined ? null : publicCookIdSchema.safeParse(cookValue);
+  if (cookId && !cookId.success) {
+    return c.json({ error: "Invalid cook query" }, 400);
+  }
+
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json(
+      {
+        error:
+          "No database connection configured (HYPERDRIVE or DATABASE_URL required)",
+      },
+      503,
+    );
+  }
+
+  let client: DbClient | undefined;
+  try {
+    const connection = createDb(connectionString);
+    client = connection.client;
+    const { db } = connection;
+
+    if (cookId?.success) {
+      const rows = await db
+        .select({
+          recipe: schema.recipe,
+          author: {
+            id: schema.user.id,
+            name: schema.user.name,
+            image: schema.user.image,
+          },
+        })
+        .from(schema.recipe)
+        .innerJoin(schema.user, eq(schema.recipe.userId, schema.user.id))
+        .where(
+          and(
+            eq(schema.recipe.visibility, "public"),
+            eq(schema.user.id, cookId.data),
+          ),
+        )
+        .orderBy(desc(schema.recipe.createdAt), desc(schema.recipe.id))
+        .limit(30);
+      const first = rows[0];
+      return c.json({
+        cook: first
+          ? {
+              ...first.author,
+              activity: rows.map(({ recipe }) => ({
+                type: "recipe_added" as const,
+                recipe: recipeResponse(recipe),
+                createdAt: recipe.createdAt,
+              })),
+            }
+          : null,
+      });
+    }
+
+    const latestActivityAt = sql<string>`max(${schema.recipe.createdAt})`;
+    const latestRecipeTitle =
+      sql<string>`(array_agg(${schema.recipe.title} order by ${schema.recipe.createdAt} desc, ${schema.recipe.id} desc))[1]`;
+    const cooks = await db
+      .select({
+        id: schema.user.id,
+        name: schema.user.name,
+        image: schema.user.image,
+        activityCount: count(),
+        latestRecipeTitle,
+      })
+      .from(schema.recipe)
+      .innerJoin(schema.user, eq(schema.recipe.userId, schema.user.id))
+      .where(eq(schema.recipe.visibility, "public"))
+      .groupBy(schema.user.id, schema.user.name, schema.user.image)
+      .orderBy(desc(latestActivityAt));
+    return c.json({ cooks });
+  } catch (e) {
+    console.error("GET /recipes/cooks query failed", e);
     return c.json({ error: "Database query failed" }, 502);
   } finally {
     await closeDbClient(client);

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -930,6 +930,58 @@ const dbMock = vi.hoisted(() => {
 
     if (
       query.includes('from "recipe"') &&
+      query.includes('inner join "user"') &&
+      query.includes('group by')
+    ) {
+      const publicRecipes = state.recipes.filter(
+        (recipe) => recipe.visibility === "public",
+      );
+      const grouped = new Map<string, RecipeRow[]>();
+      for (const recipe of publicRecipes) {
+        const recipes = grouped.get(recipe.userId) ?? [];
+        recipes.push(recipe);
+        grouped.set(recipe.userId, recipes);
+      }
+      return Array.from(grouped, ([userId, recipes]) => {
+        const user = state.users.find((candidate) => candidate.id === userId)!;
+        const latest = [...recipes].sort(
+          (first, second) =>
+            second.createdAt.getTime() - first.createdAt.getTime() ||
+            second.id.localeCompare(first.id),
+        )[0]!;
+        return [user.id, user.name, user.image, recipes.length, latest.title];
+      });
+    }
+
+    if (
+      query.includes('from "recipe"') &&
+      query.includes('inner join "user"') &&
+      query.includes('"user"."id" =')
+    ) {
+      const cookId = params[1] as string;
+      const user = state.users.find((candidate) => candidate.id === cookId);
+      if (!user) return [];
+      return state.recipes
+        .filter(
+          (recipe) =>
+            recipe.userId === cookId && recipe.visibility === "public",
+        )
+        .sort(
+          (first, second) =>
+            second.createdAt.getTime() - first.createdAt.getTime() ||
+            second.id.localeCompare(first.id),
+        )
+        .slice(0, 30)
+        .map((recipe) => [
+          ...recipeRow(recipe),
+          user.id,
+          user.name,
+          user.image,
+        ]);
+    }
+
+    if (
+      query.includes('from "recipe"') &&
       query.includes('"recipe"."slug" =') &&
       query.includes('"recipe"."user_id" =')
     ) {
@@ -1441,6 +1493,98 @@ describe("GET /recipes", () => {
     expect(res.status).toBe(502);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Database query failed");
+  });
+});
+
+describe("GET /recipes/cooks", () => {
+  function seedCook() {
+    dbMock.state.users.push({
+      id: "cook-1",
+      name: "Ada Cook",
+      email: "ada@example.test",
+      emailVerified: true,
+      image: null,
+      role: null,
+      banned: null,
+      banReason: null,
+      banExpires: null,
+      createdAt: dbMock.date,
+      updatedAt: dbMock.date,
+    });
+    dbMock.state.recipes.push(
+      {
+        id: "recipe-1",
+        slug: "ada-stew",
+        title: "Ada's Stew",
+        description: null,
+        body: null,
+        userId: "cook-1",
+        visibility: "public",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+      {
+        id: "recipe-private",
+        slug: "private-soup",
+        title: "Private Soup",
+        description: null,
+        body: null,
+        userId: "cook-1",
+        visibility: "private",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+    );
+  }
+
+  it("returns lightweight summaries of cooks with public recipes", async () => {
+    seedCook();
+
+    const res = await app.request("/recipes/cooks", {}, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      cooks: [
+        {
+          id: "cook-1",
+          name: "Ada Cook",
+          image: null,
+          activityCount: 1,
+          latestRecipeTitle: "Ada's Stew",
+        },
+      ],
+    });
+  });
+
+  it("returns recent public activity for one cook", async () => {
+    seedCook();
+
+    const res = await app.request("/recipes/cooks?cook=cook-1", {}, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      cook: {
+        id: "cook-1",
+        name: "Ada Cook",
+        image: null,
+        activity: [
+          expect.objectContaining({
+            type: "recipe_added",
+            recipe: expect.objectContaining({
+              slug: "ada-stew",
+              title: "Ada's Stew",
+            }),
+          }),
+        ],
+      },
+    });
+  });
+
+  it("returns null for a cook without public activity", async () => {
+    const res = await app.request("/recipes/cooks?cook=missing", {}, env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ cook: null });
   });
 });
 


### PR DESCRIPTION
## What changed

- replace the logged-out recipe box with a dedicated landing page and prominent sign-up/discovery CTAs
- keep the existing personal recipe box for signed-in users
- give logged-out visitors a focused Discover, Cooks, and How it works navigation
- add a Cooks directory with lightweight profiles derived from public recipe activity
- add session-state tests for the split homepage experience

## Why

The logged-out homepage previously reused the signed-in recipe-box view, which made the product feel like a personal collection rather than an invitation for new users. This creates a distinct acquisition experience inspired by the Before you sign up and Discover feed mid-fi designs while preserving the signed-in workflow.

## Impact

Potential users now get a clearer explanation of the product, multiple contextual sign-up CTAs, and account-free paths into public activity and cook profiles. Existing users continue to land on their own recipe content and utility navigation after signing in.

## Validation

- `mise //ui:test` — 539 tests passed
- `mise //ui:check:static` — lint/format and TypeScript checks passed
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build` — production build passed
- development smoke tests returned 200 for `/recipes` and `/recipes/cooks`