### PR TITLE
Disable automatic GCP default network creation

### DIFF
--- a/infra-bootstrap/google.tf
+++ b/infra-bootstrap/google.tf
@@ -5,8 +5,9 @@
 # they must not be available to routine Cloudflare/Neon/PostHog deployments.
 
 resource "google_project" "recipes" {
-  name       = var.gcp_project_name
-  project_id = var.gcp_project_id
+  name                = var.gcp_project_name
+  project_id          = var.gcp_project_id
+  auto_create_network = false
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
## Summary

- set `auto_create_network = false` on the managed Google Cloud project
- close code-scanning alert [#77](https://github.com/Robbie-Palmer/personal-site/security/code-scanning/77) (Trivy GCP-0010)
- record the no-default-network policy for project creation and satisfy the IaC guardrail

## Imported-project behavior

The project is imported. In HashiCorp Google provider v6.50.0, default-network deletion runs only during project creation; the update path does not delete or inventory an existing default VPC. This PR therefore does not perform a destructive network migration.

## Validation

- `MISE_EXPERIMENTAL=1 mise //infra-bootstrap:format:check`
- `MISE_EXPERIMENTAL=1 mise //infra-bootstrap:precommit-lint`
- `git diff --check`
- Trivy IaC Security Scan passes

An authenticated `mise //infra-bootstrap:plan` was attempted but cannot run in this worktree because Google Application Default Credentials are unavailable.