### PR TITLE
Enable Google Cloud project audit logging

### DIFF
--- a/infra-bootstrap/google.tf
+++ b/infra-bootstrap/google.tf
@@ -21,6 +21,23 @@ import {
   id = var.gcp_project_id
 }
 
+resource "google_project_iam_audit_config" "all_services" {
+  project = google_project.recipes.project_id
+  service = "allServices"
+
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}
+
 locals {
   github_repository = "${var.github_repo_owner}/${var.github_repo_name}"
 


### PR DESCRIPTION
## Summary

- configure project-wide Google Cloud audit logging for `ADMIN_READ`, `DATA_READ`, and `DATA_WRITE`
- cover all current and future services through the `allServices` audit configuration
- close code-scanning alert [#78](https://github.com/Robbie-Palmer/personal-site/security/code-scanning/78) (Trivy GCP-0079)

## Operational note

Google Cloud Data Access audit logs can increase Cloud Logging ingestion and storage. This project has a narrow OAuth/control-plane scope, but the authenticated Terraform plan should still be reviewed before apply.

## Validation

- `MISE_EXPERIMENTAL=1 mise //infra-bootstrap:format:check`
- `MISE_EXPERIMENTAL=1 mise //infra-bootstrap:precommit-lint`
- `git diff --check`

An authenticated `mise //infra-bootstrap:plan` cannot run in this worktree because Google Application Default Credentials are unavailable.