### PR TITLE
Harden recipe API boundaries and centralise DB types

### DIFF
--- a/packages/recipe-db/src/index.ts
+++ b/packages/recipe-db/src/index.ts
@@ -1,10 +1,13 @@
 import postgres from "postgres";
-import { drizzle } from "drizzle-orm/postgres-js";
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import * as schema from "./schema";
 
 export { schema };
 
-export function createDb(connectionString: string) {
+export type DbClient = postgres.Sql;
+export type Db = PostgresJsDatabase<typeof schema> & { $client: DbClient };
+
+export function createDb(connectionString: string): { db: Db; client: DbClient } {
   // prepare: false required for Hyperdrive — it may route requests to different
   // backend servers, so named prepared statements won't be available across connections.
   const client = postgres(connectionString, { prepare: false });

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -30,16 +30,14 @@ import {
   saveRecipeBoxProfile,
 } from "@/lib/api/recipe-box";
 import type { RecipeCardView } from "@/lib/api/recipes";
+import { fetchAllSavedRecipes } from "@/lib/api/saved-recipes";
 import { authClient } from "@/lib/auth-client";
 import { buildEffectiveDiet, filterRecipesForDiet } from "@/lib/domain/diet";
 import {
   buildRecipeAuthoringHref,
   resolveOnboardingRecipeSelection,
 } from "@/lib/domain/recipe/onboarding";
-import {
-  type SavedRecipeApiRecord,
-  savedRecipeCard,
-} from "@/lib/domain/recipe/recipeDraft";
+import { savedRecipeCard } from "@/lib/domain/recipe/recipeDraft";
 import { cn } from "@/lib/generic/styles";
 
 const STEPS = ["sign up", "your diet", "fill your box", "ready"];
@@ -147,15 +145,18 @@ function Intro() {
 }
 
 async function fetchAuthoredRecipes(signal: AbortSignal) {
-  const response = await fetch("/api/recipes?scope=owned", {
-    cache: "no-store",
-    credentials: "include",
-    signal,
-  });
-  if (!response.ok) {
+  try {
+    return await fetchAllSavedRecipes({
+      scope: "owned",
+      credentials: "include",
+      signal,
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw error;
+    }
     throw new Error("Your authored recipes could not be loaded.");
   }
-  return (await response.json()) as SavedRecipeApiRecord[];
 }
 
 function toggleValue(values: string[], value: string): string[] {

--- a/ui/components/recipes/onboarding/recipe-onboarding.tsx
+++ b/ui/components/recipes/onboarding/recipe-onboarding.tsx
@@ -152,7 +152,7 @@ async function fetchAuthoredRecipes(signal: AbortSignal) {
       signal,
     });
   } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
+    if (error instanceof Error && error.name === "AbortError") {
       throw error;
     }
     throw new Error("Your authored recipes could not be loaded.");

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -8,6 +8,7 @@ import {
   type RecipeBoxProfile,
 } from "@/lib/api/recipe-box";
 import type { RecipeCardView } from "@/lib/api/recipes";
+import { fetchAllSavedRecipes } from "@/lib/api/saved-recipes";
 import { authClient } from "@/lib/auth-client";
 import {
   type SavedRecipeApiRecord,
@@ -37,12 +38,7 @@ export function RecipeCollection({
     const controller = new AbortController();
     setLoadError(null);
     void Promise.allSettled([
-      fetch("/api/recipes", { signal: controller.signal }).then(
-        async (response) => {
-          if (!response.ok) throw new Error("Saved recipes unavailable");
-          return (await response.json()) as SavedRecipeApiRecord[];
-        },
-      ),
+      fetchAllSavedRecipes({ signal: controller.signal }),
       getRecipeBoxProfile(controller.signal),
     ]).then(([savedResult, boxResult]) => {
       if (savedResult.status === "fulfilled") {

--- a/ui/lib/api/saved-recipes.ts
+++ b/ui/lib/api/saved-recipes.ts
@@ -1,0 +1,36 @@
+import type { SavedRecipeApiRecord } from "@/lib/domain/recipe/recipeDraft";
+
+const PAGE_LIMIT = 100;
+
+type SavedRecipesPage = {
+  items: SavedRecipeApiRecord[];
+  nextCursor: string | null;
+};
+
+/**
+ * Fetch every saved recipe the caller can read, following the recipe API's
+ * limit/cursor pagination until the last page.
+ */
+export async function fetchAllSavedRecipes(options?: {
+  scope?: "owned";
+  signal?: AbortSignal;
+  credentials?: RequestCredentials;
+}): Promise<SavedRecipeApiRecord[]> {
+  const records: SavedRecipeApiRecord[] = [];
+  let cursor: string | null = null;
+  do {
+    const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+    if (options?.scope) params.set("scope", options.scope);
+    if (cursor) params.set("cursor", cursor);
+    const response = await fetch(`/api/recipes?${params}`, {
+      cache: "no-store",
+      credentials: options?.credentials ?? "same-origin",
+      signal: options?.signal,
+    });
+    if (!response.ok) throw new Error("Saved recipes unavailable");
+    const page = (await response.json()) as SavedRecipesPage;
+    records.push(...page.items);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return records;
+}

--- a/ui/lib/api/saved-recipes.ts
+++ b/ui/lib/api/saved-recipes.ts
@@ -1,6 +1,7 @@
 import type { SavedRecipeApiRecord } from "@/lib/domain/recipe/recipeDraft";
 
 const PAGE_LIMIT = 100;
+const MAX_PAGES = 100;
 
 type SavedRecipesPage = {
   items: SavedRecipeApiRecord[];
@@ -18,7 +19,11 @@ export async function fetchAllSavedRecipes(options?: {
 }): Promise<SavedRecipeApiRecord[]> {
   const records: SavedRecipeApiRecord[] = [];
   let cursor: string | null = null;
+  let pages = 0;
   do {
+    // Bound the walk so a buggy nextCursor can never loop the browser forever.
+    pages += 1;
+    if (pages > MAX_PAGES) throw new Error("Saved recipes unavailable");
     const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
     if (options?.scope) params.set("scope", options.scope);
     if (cursor) params.set("cursor", cursor);

--- a/ui/tests/components/recipes/onboarding/recipe-onboarding.test.tsx
+++ b/ui/tests/components/recipes/onboarding/recipe-onboarding.test.tsx
@@ -73,7 +73,7 @@ describe("RecipeOnboarding", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve([]),
+        json: () => Promise.resolve({ items: [], nextCursor: null }),
       }),
     );
   });

--- a/ui/tests/lib/api/saved-recipes.test.ts
+++ b/ui/tests/lib/api/saved-recipes.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchAllSavedRecipes } from "@/lib/api/saved-recipes";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchAllSavedRecipes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("follows nextCursor until the last page", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ slug: "first" }], nextCursor: "cursor-1" }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ items: [{ slug: "second" }], nextCursor: null }),
+      );
+
+    const records = await fetchAllSavedRecipes();
+
+    expect(records.map((record) => record.slug)).toEqual(["first", "second"]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/recipes?limit=100",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/recipes?limit=100&cursor=cursor-1",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+
+  it("passes the owned scope through", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ items: [], nextCursor: null }));
+
+    await fetchAllSavedRecipes({ scope: "owned", credentials: "include" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/recipes?limit=100&scope=owned",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("throws when a page request fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 502 }),
+    );
+
+    await expect(fetchAllSavedRecipes()).rejects.toThrow(
+      "Saved recipes unavailable",
+    );
+  });
+});

--- a/workers/recipe-api/src/auth.ts
+++ b/workers/recipe-api/src/auth.ts
@@ -2,7 +2,7 @@ import { betterAuth } from "better-auth";
 import { admin, lastLoginMethod } from "better-auth/plugins";
 import { withCloudflare } from "better-auth-cloudflare";
 import { and, eq, inArray } from "drizzle-orm";
-import type { createDb } from "recipe-db";
+import type { Db } from "recipe-db";
 import * as schema from "recipe-db/schema";
 import { enforceRateLimit } from "./http/rate-limit";
 import { createHouseholdNotification } from "./notifications";
@@ -12,7 +12,6 @@ import {
   syncLinkedAccountEmails,
 } from "./user-emails";
 
-type Db = ReturnType<typeof createDb>["db"];
 
 type AuthEnv = {
   BETTER_AUTH_URL: string;
@@ -72,7 +71,7 @@ function rateLimitStorage(db: Db) {
 }
 
 export function createAuth(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   env: AuthEnv,
   options: CreateAuthOptions = {},
 ) {

--- a/workers/recipe-api/src/http/authorization.ts
+++ b/workers/recipe-api/src/http/authorization.ts
@@ -1,9 +1,8 @@
 import type { Context, MiddlewareHandler } from "hono";
 import { createAuth, type Auth } from "../auth";
-import type { createDb } from "recipe-db";
+import type { Db } from "recipe-db";
 
 type AuthorizationEnv = Parameters<typeof createAuth>[1];
-type Db = ReturnType<typeof createDb>["db"];
 
 export type AuthenticatedSession = NonNullable<
   Awaited<ReturnType<Auth["api"]["getSession"]>>

--- a/workers/recipe-api/src/http/rate-limit.ts
+++ b/workers/recipe-api/src/http/rate-limit.ts
@@ -1,9 +1,7 @@
 import { sql } from "drizzle-orm";
 import type { Context } from "hono";
-import type { createDb } from "recipe-db";
+import type { Db } from "recipe-db";
 import { appRateLimit } from "recipe-db/schema";
-
-type Db = ReturnType<typeof createDb>["db"];
 
 export type RateLimitRule = {
   max: number;

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -507,11 +507,17 @@ async function requireRecipeSession(
   }
 }
 
-async function withRecipeSession(
+type WithDbOptions = {
+  // Map domain errors to responses before the generic 502 fallback applies.
+  onError?: (error: unknown) => Response | undefined;
+};
+
+async function withDatabase(
   c: Context<AppEnv>,
-  failureKind: "query" | "mutation",
+  failureKind: "query" | "mutation" | "lookup",
   logMessage: string,
-  action: (context: RecipeSessionContext) => Promise<Response> | Response,
+  action: (db: Db) => Promise<Response> | Response,
+  options?: WithDbOptions,
 ): Promise<Response> {
   const connectionString = requireDatabaseConnection(c);
   if (connectionString instanceof Response) return connectionString;
@@ -520,15 +526,35 @@ async function withRecipeSession(
   try {
     const connection = createDb(connectionString);
     client = connection.client;
-    const session = await requireRecipeSession(c, connection.db);
-    if (!session.success) return session.response;
-    return await action({ db: connection.db, session: session.session });
+    return await action(connection.db);
   } catch (e) {
+    const mapped = options?.onError?.(e);
+    if (mapped) return mapped;
     console.error(logMessage, e);
     return c.json({ error: `Database ${failureKind} failed` }, 502);
   } finally {
     await closeDbClient(client);
   }
+}
+
+async function withRecipeSession(
+  c: Context<AppEnv>,
+  failureKind: "query" | "mutation" | "lookup",
+  logMessage: string,
+  action: (context: RecipeSessionContext) => Promise<Response> | Response,
+  options?: WithDbOptions,
+): Promise<Response> {
+  return withDatabase(
+    c,
+    failureKind,
+    logMessage,
+    async (db) => {
+      const session = await requireRecipeSession(c, db);
+      if (!session.success) return session.response;
+      return action({ db, session: session.session });
+    },
+    options,
+  );
 }
 
 function isUniqueViolation(error: unknown): boolean {
@@ -1621,47 +1647,37 @@ app.put("/api/profile/recipe-box", async (c) => {
 });
 
 app.get("/households", async (c) => {
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "query",
+    "GET /households query failed",
+    async ({ db, session }) => {
+      const households = await db
+        .select({
+          id: schema.organization.id,
+          name: schema.organization.name,
+          slug: schema.organization.slug,
+          logo: schema.organization.logo,
+          createdAt: schema.organization.createdAt,
+          updatedAt: schema.organization.updatedAt,
+          memberId: schema.member.id,
+          role: schema.member.role,
+        })
+        .from(schema.member)
+        .innerJoin(
+          schema.organization,
+          eq(schema.member.organizationId, schema.organization.id),
+        )
+        .where(eq(schema.member.userId, session.user.id));
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const households = await db
-      .select({
-        id: schema.organization.id,
-        name: schema.organization.name,
-        slug: schema.organization.slug,
-        logo: schema.organization.logo,
-        createdAt: schema.organization.createdAt,
-        updatedAt: schema.organization.updatedAt,
-        memberId: schema.member.id,
-        role: schema.member.role,
-      })
-      .from(schema.member)
-      .innerJoin(
-        schema.organization,
-        eq(schema.member.organizationId, schema.organization.id),
-      )
-      .where(eq(schema.member.userId, session.session.user.id));
-
-    return c.json(
-      households.map(({ memberId, role, ...household }) => ({
-        ...household,
-        membership: { id: memberId, role },
-      })),
-    );
-  } catch (e) {
-    console.error("GET /households query failed", e);
-    return c.json({ error: "Database query failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json(
+        households.map(({ memberId, role, ...household }) => ({
+          ...household,
+          membership: { id: memberId, role },
+        })),
+      );
+    },
+  );
 });
 
 app.get("/households/invitations", async (c) => {
@@ -1708,60 +1724,53 @@ app.post("/households", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /households mutation failed",
+    async ({ db, session }) => {
+      const existingMembership = await findUserHouseholdMembership(
+        db,
+        session.user.id,
+      );
+      if (existingMembership) {
+        return c.json({ error: "User already belongs to a household" }, 409);
+      }
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
+      const body = await parseJsonBody(c, createHouseholdBodySchema);
+      if (!body.success) return body.response;
 
-    const existingMembership = await findUserHouseholdMembership(
-      db,
-      session.session.user.id,
-    );
-    if (existingMembership) {
-      return c.json({ error: "User already belongs to a household" }, 409);
-    }
+      const householdId = createId();
+      const household = await db.transaction(async (tx) => {
+        const [createdHousehold] = await tx
+          .insert(schema.organization)
+          .values({
+            id: householdId,
+            name: body.data.name ?? `${session.user.name}'s household`,
+            slug: householdSlug(),
+          })
+          .returning();
+        if (!createdHousehold) throw new Error("Household insert failed");
 
-    const body = await parseJsonBody(c, createHouseholdBodySchema);
-    if (!body.success) return body.response;
+        await tx.insert(schema.member).values({
+          id: createId(),
+          organizationId: householdId,
+          userId: session.user.id,
+          role: "owner",
+        });
 
-    const householdId = createId();
-    const household = await db.transaction(async (tx) => {
-      const [createdHousehold] = await tx
-        .insert(schema.organization)
-        .values({
-          id: householdId,
-          name: body.data.name ?? `${session.session.user.name}'s household`,
-          slug: householdSlug(),
-        })
-        .returning();
-      if (!createdHousehold) throw new Error("Household insert failed");
-
-      await tx.insert(schema.member).values({
-        id: createId(),
-        organizationId: householdId,
-        userId: session.session.user.id,
-        role: "owner",
+        return createdHousehold;
       });
 
-      return createdHousehold;
-    });
-
-    return c.json(householdResponse(household), 201);
-  } catch (e) {
-    if (isUniqueViolation(e)) {
-      return c.json({ error: "User already belongs to a household" }, 409);
-    }
-    console.error("POST /households mutation failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json(householdResponse(household), 201);
+    },
+    {
+      onError: (error) =>
+        isUniqueViolation(error)
+          ? c.json({ error: "User already belongs to a household" }, 409)
+          : undefined,
+    },
+  );
 });
 
 app.patch("/households/:householdId", async (c) => {
@@ -1801,50 +1810,40 @@ app.patch("/households/:householdId", async (c) => {
 app.get("/households/:householdId/members", async (c) => {
   const householdId = uuidParam(c, "householdId", "household ID");
   if (householdId instanceof Response) return householdId;
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "query",
+    "GET /households/:householdId/members query failed",
+    async ({ db, session }) => {
+      const memberFailure = await requireHouseholdMemberResponse(
+        c,
+        db,
+        householdId,
+        session,
+      );
+      if (memberFailure) return memberFailure;
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
+      const members = await db
+        .select({
+          id: schema.member.id,
+          organizationId: schema.member.organizationId,
+          userId: schema.member.userId,
+          role: schema.member.role,
+          createdAt: schema.member.createdAt,
+          user: {
+            id: schema.user.id,
+            email: schema.user.email,
+            name: schema.user.name,
+            image: schema.user.image,
+          },
+        })
+        .from(schema.member)
+        .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
+        .where(eq(schema.member.organizationId, householdId));
 
-    const memberFailure = await requireHouseholdMemberResponse(
-      c,
-      db,
-      householdId,
-      session.session,
-    );
-    if (memberFailure) return memberFailure;
-
-    const members = await db
-      .select({
-        id: schema.member.id,
-        organizationId: schema.member.organizationId,
-        userId: schema.member.userId,
-        role: schema.member.role,
-        createdAt: schema.member.createdAt,
-        user: {
-          id: schema.user.id,
-          email: schema.user.email,
-          name: schema.user.name,
-          image: schema.user.image,
-        },
-      })
-      .from(schema.member)
-      .innerJoin(schema.user, eq(schema.member.userId, schema.user.id))
-      .where(eq(schema.member.organizationId, householdId));
-
-    return c.json(members.map(memberResponse));
-  } catch (e) {
-    console.error("GET /households/:householdId/members query failed", e);
-    return c.json({ error: "Database query failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json(members.map(memberResponse));
+    },
+  );
 });
 
 app.get("/households/:householdId/invitations", async (c) => {
@@ -1885,97 +1884,87 @@ app.post("/households/:householdId/invitations", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const ownerFailure = await authorizeHouseholdOwnerResponse(
-      c,
-      db,
-      householdId,
-      session.session,
-    );
-    if (ownerFailure) return ownerFailure;
-
-    const inviteLimit = await enforceRateLimit(
-      db,
-      `household-invite:${session.session.user.id}`,
-      HOUSEHOLD_INVITE_RATE_LIMIT,
-    );
-    if (!inviteLimit.allowed) {
-      return rateLimitedResponse(c, inviteLimit.retryAfter);
-    }
-
-    const body = await parseJsonBody(c, inviteHouseholdMemberBodySchema);
-    if (!body.success) return body.response;
-
-    const email = normalizeEmail(body.data.email);
-
-    const [existingInvitation] = await db
-      .select()
-      .from(schema.invitation)
-      .where(
-        and(
-          eq(schema.invitation.organizationId, householdId),
-          eq(schema.invitation.email, email),
-          eq(schema.invitation.status, "pending"),
-          gt(schema.invitation.expiresAt, new Date()),
-        ),
-      )
-      .limit(1);
-    if (existingInvitation) {
-      return c.json(
-        { error: "A pending invitation already exists for this email" },
-        409,
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /households/:householdId/invitations failed",
+    async ({ db, session }) => {
+      const ownerFailure = await authorizeHouseholdOwnerResponse(
+        c,
+        db,
+        householdId,
+        session,
       );
-    }
+      if (ownerFailure) return ownerFailure;
 
-    const [inviteeUserId, household] = await Promise.all([
-      verifiedEmailOwnerId(db, email),
-      findHouseholdById(db, householdId),
-    ]);
-    const invitation = await db.transaction(async (tx) => {
-      const [created] = await tx
-        .insert(schema.invitation)
-        .values({
-          id: createId(),
-          organizationId: householdId,
-          email,
-          role: "member",
-          status: "pending",
-          expiresAt: new Date(Date.now() + INVITATION_EXPIRY_MS),
-          inviterId: session.session.user.id,
-        })
-        .returning();
-      if (!created) throw new Error("Invitation insert failed");
-      if (inviteeUserId && household) {
-        await createHouseholdNotification(tx, {
-          recipientUserIds: [inviteeUserId],
-          kind: "household_invited",
-          household,
-          actor: {
-            id: session.session.user.id,
-            name: session.session.user.name,
-          },
-          invitationId: created.id,
-        });
+      const inviteLimit = await enforceRateLimit(
+        db,
+        `household-invite:${session.user.id}`,
+        HOUSEHOLD_INVITE_RATE_LIMIT,
+      );
+      if (!inviteLimit.allowed) {
+        return rateLimitedResponse(c, inviteLimit.retryAfter);
       }
-      return created;
-    });
-    return c.json(invitationResponse(invitation), 201);
-  } catch (e) {
-    console.error("POST /households/:householdId/invitations failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+
+      const body = await parseJsonBody(c, inviteHouseholdMemberBodySchema);
+      if (!body.success) return body.response;
+
+      const email = normalizeEmail(body.data.email);
+
+      const [existingInvitation] = await db
+        .select()
+        .from(schema.invitation)
+        .where(
+          and(
+            eq(schema.invitation.organizationId, householdId),
+            eq(schema.invitation.email, email),
+            eq(schema.invitation.status, "pending"),
+            gt(schema.invitation.expiresAt, new Date()),
+          ),
+        )
+        .limit(1);
+      if (existingInvitation) {
+        return c.json(
+          { error: "A pending invitation already exists for this email" },
+          409,
+        );
+      }
+
+      const [inviteeUserId, household] = await Promise.all([
+        verifiedEmailOwnerId(db, email),
+        findHouseholdById(db, householdId),
+      ]);
+      const invitation = await db.transaction(async (tx) => {
+        const [created] = await tx
+          .insert(schema.invitation)
+          .values({
+            id: createId(),
+            organizationId: householdId,
+            email,
+            role: "member",
+            status: "pending",
+            expiresAt: new Date(Date.now() + INVITATION_EXPIRY_MS),
+            inviterId: session.user.id,
+          })
+          .returning();
+        if (!created) throw new Error("Invitation insert failed");
+        if (inviteeUserId && household) {
+          await createHouseholdNotification(tx, {
+            recipientUserIds: [inviteeUserId],
+            kind: "household_invited",
+            household,
+            actor: {
+              id: session.user.id,
+              name: session.user.name,
+            },
+            invitationId: created.id,
+          });
+        }
+        return created;
+      });
+      return c.json(invitationResponse(invitation), 201);
+    },
+  );
 });
 
 app.post("/households/invitations/:invitationId/accept", async (c) => {
@@ -1984,35 +1973,24 @@ app.post("/households/invitations/:invitationId/accept", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const result = await performInvitationAction(
-      db,
-      session.session.user,
-      invitationId,
-      "accept",
-    );
-    return c.json({
-      invitation: invitationResponse(result.invitation),
-      membershipCreated: result.membershipCreated,
-    });
-  } catch (e) {
-    const failure = invitationActionFailure(c, e);
-    if (failure) return failure;
-    console.error("POST /households/invitations/:invitationId/accept failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /households/invitations/:invitationId/accept failed",
+    async ({ db, session }) => {
+      const result = await performInvitationAction(
+        db,
+        session.user,
+        invitationId,
+        "accept",
+      );
+      return c.json({
+        invitation: invitationResponse(result.invitation),
+        membershipCreated: result.membershipCreated,
+      });
+    },
+    { onError: (error) => invitationActionFailure(c, error) },
+  );
 });
 
 app.post("/households/invitations/:invitationId/decline", async (c) => {
@@ -2021,32 +1999,21 @@ app.post("/households/invitations/:invitationId/decline", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const result = await performInvitationAction(
-      db,
-      session.session.user,
-      invitationId,
-      "decline",
-    );
-    return c.json(invitationResponse(result.invitation));
-  } catch (e) {
-    const failure = invitationActionFailure(c, e);
-    if (failure) return failure;
-    console.error("POST /households/invitations/:invitationId/decline failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /households/invitations/:invitationId/decline failed",
+    async ({ db, session }) => {
+      const result = await performInvitationAction(
+        db,
+        session.user,
+        invitationId,
+        "decline",
+      );
+      return c.json(invitationResponse(result.invitation));
+    },
+    { onError: (error) => invitationActionFailure(c, error) },
+  );
 });
 
 app.delete(
@@ -2059,64 +2026,51 @@ app.delete(
     const csrfFailure = validateCsrf(c);
     if (csrfFailure) return csrfFailure;
 
-    const connectionString = requireDatabaseConnection(c);
-    if (connectionString instanceof Response) return connectionString;
+    return withRecipeSession(
+      c,
+      "mutation",
+      "DELETE /households/:householdId/invitations/:invitationId failed",
+      async ({ db, session }) => {
+        const ownerFailure = await authorizeHouseholdOwnerResponse(
+          c,
+          db,
+          householdId,
+          session,
+        );
+        if (ownerFailure) return ownerFailure;
 
-    let client: DbClient | undefined;
-    try {
-      const connection = createDb(connectionString);
-      client = connection.client;
-      const { db } = connection;
-      const session = await requireRecipeSession(c, db);
-      if (!session.success) return session.response;
+        const [invitation] = await db
+          .select()
+          .from(schema.invitation)
+          .where(
+            and(
+              eq(schema.invitation.id, invitationId),
+              eq(schema.invitation.organizationId, householdId),
+            ),
+          )
+          .limit(1);
+        if (!invitation) return c.notFound();
+        if (invitation.status !== "pending") {
+          return c.json({ error: "Invitation is not pending" }, 409);
+        }
 
-      const ownerFailure = await authorizeHouseholdOwnerResponse(
-        c,
-        db,
-        householdId,
-        session.session,
-      );
-      if (ownerFailure) return ownerFailure;
-
-      const [invitation] = await db
-        .select()
-        .from(schema.invitation)
-        .where(
-          and(
-            eq(schema.invitation.id, invitationId),
-            eq(schema.invitation.organizationId, householdId),
-          ),
-        )
-        .limit(1);
-      if (!invitation) return c.notFound();
-      if (invitation.status !== "pending") {
-        return c.json({ error: "Invitation is not pending" }, 409);
-      }
-
-      const [revoked] = await db
-        .update(schema.invitation)
-        .set({ status: "canceled" })
-        .where(
-          and(
-            eq(schema.invitation.id, invitationId),
-            eq(schema.invitation.organizationId, householdId),
-            eq(schema.invitation.status, "pending"),
-          ),
-        )
-        .returning();
-      if (!revoked) {
-        return c.json({ error: "Invitation is not pending" }, 409);
-      }
-      return c.json(invitationResponse(revoked));
-    } catch (e) {
-      console.error(
-        "DELETE /households/:householdId/invitations/:invitationId failed",
-        e,
-      );
-      return c.json({ error: "Database mutation failed" }, 502);
-    } finally {
-      await closeDbClient(client);
-    }
+        const [revoked] = await db
+          .update(schema.invitation)
+          .set({ status: "canceled" })
+          .where(
+            and(
+              eq(schema.invitation.id, invitationId),
+              eq(schema.invitation.organizationId, householdId),
+              eq(schema.invitation.status, "pending"),
+            ),
+          )
+          .returning();
+        if (!revoked) {
+          return c.json({ error: "Invitation is not pending" }, 409);
+        }
+        return c.json(invitationResponse(revoked));
+      },
+    );
   },
 );
 
@@ -2128,71 +2082,61 @@ app.delete("/households/:householdId/members/:memberId", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "DELETE /households/:householdId/members/:memberId failed",
+    async ({ db, session }) => {
+      const ownerFailure = await authorizeHouseholdOwnerResponse(
+        c,
+        db,
+        householdId,
+        session,
+      );
+      if (ownerFailure) return ownerFailure;
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const ownerFailure = await authorizeHouseholdOwnerResponse(
-      c,
-      db,
-      householdId,
-      session.session,
-    );
-    if (ownerFailure) return ownerFailure;
-
-    const [member] = await db
-      .select()
-      .from(schema.member)
-      .where(
-        and(
-          eq(schema.member.id, memberId),
-          eq(schema.member.organizationId, householdId),
-        ),
-      )
-      .limit(1);
-    if (!member) return c.notFound();
-    if (member.role === "owner") {
-      return c.json({ error: "Household owner cannot be revoked" }, 400);
-    }
-
-    const household = await findHouseholdById(db, householdId);
-    if (!household) return c.notFound();
-
-    await db.transaction(async (tx) => {
-      await tx
-        .update(schema.recipe)
-        .set({ visibility: "private" })
+      const [member] = await db
+        .select()
+        .from(schema.member)
         .where(
           and(
-            eq(schema.recipe.visibility, "household"),
-            eq(schema.recipe.userId, member.userId),
+            eq(schema.member.id, memberId),
+            eq(schema.member.organizationId, householdId),
           ),
-        );
-      await createHouseholdNotification(tx, {
-        recipientUserIds: [member.userId],
-        kind: "household_removed",
-        household,
-        actor: {
-          id: session.session.user.id,
-          name: session.session.user.name,
-        },
+        )
+        .limit(1);
+      if (!member) return c.notFound();
+      if (member.role === "owner") {
+        return c.json({ error: "Household owner cannot be revoked" }, 400);
+      }
+
+      const household = await findHouseholdById(db, householdId);
+      if (!household) return c.notFound();
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(schema.recipe)
+          .set({ visibility: "private" })
+          .where(
+            and(
+              eq(schema.recipe.visibility, "household"),
+              eq(schema.recipe.userId, member.userId),
+            ),
+          );
+        await createHouseholdNotification(tx, {
+          recipientUserIds: [member.userId],
+          kind: "household_removed",
+          household,
+          actor: {
+            id: session.user.id,
+            name: session.user.name,
+          },
+        });
+        await tx.delete(schema.member).where(eq(schema.member.id, memberId));
       });
-      await tx.delete(schema.member).where(eq(schema.member.id, memberId));
-    });
-    return c.body(null, 204);
-  } catch (e) {
-    console.error("DELETE /households/:householdId/members/:memberId failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.body(null, 204);
+    },
+  );
 });
 
 app.post("/households/:householdId/leave", async (c) => {
@@ -2201,62 +2145,52 @@ app.post("/households/:householdId/leave", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /households/:householdId/leave failed",
+    async ({ db, session }) => {
+      const household = await findHouseholdById(db, householdId);
+      if (!household) return c.notFound();
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const household = await findHouseholdById(db, householdId);
-    if (!household) return c.notFound();
-
-    const member = await findHouseholdMembership(
-      db,
-      householdId,
-      session.session.user.id,
-    );
-    if (!member) return authorizationResponse(c, forbidden());
-    if (member.role === "owner") {
-      return c.json({ error: "Household owner cannot leave" }, 400);
-    }
-
-    const owner = await findHouseholdOwner(db, householdId);
-
-    await db.transaction(async (tx) => {
-      await tx
-        .update(schema.recipe)
-        .set({ visibility: "private" })
-        .where(
-          and(
-            eq(schema.recipe.visibility, "household"),
-            eq(schema.recipe.userId, session.session.user.id),
-          ),
-        );
-      if (owner) {
-        await createHouseholdNotification(tx, {
-          recipientUserIds: [owner.userId],
-          kind: "household_member_left",
-          household,
-          actor: {
-            id: session.session.user.id,
-            name: session.session.user.name,
-          },
-        });
+      const member = await findHouseholdMembership(
+        db,
+        householdId,
+        session.user.id,
+      );
+      if (!member) return authorizationResponse(c, forbidden());
+      if (member.role === "owner") {
+        return c.json({ error: "Household owner cannot leave" }, 400);
       }
-      await tx.delete(schema.member).where(eq(schema.member.id, member.id));
-    });
-    return c.body(null, 204);
-  } catch (e) {
-    console.error("POST /households/:householdId/leave failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+
+      const owner = await findHouseholdOwner(db, householdId);
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(schema.recipe)
+          .set({ visibility: "private" })
+          .where(
+            and(
+              eq(schema.recipe.visibility, "household"),
+              eq(schema.recipe.userId, session.user.id),
+            ),
+          );
+        if (owner) {
+          await createHouseholdNotification(tx, {
+            recipientUserIds: [owner.userId],
+            kind: "household_member_left",
+            household,
+            actor: {
+              id: session.user.id,
+              name: session.user.name,
+            },
+          });
+        }
+        await tx.delete(schema.member).where(eq(schema.member.id, member.id));
+      });
+      return c.body(null, 204);
+    },
+  );
 });
 
 app.delete("/households/:householdId", async (c) => {
@@ -2264,65 +2198,56 @@ app.delete("/households/:householdId", async (c) => {
   if (householdId instanceof Response) return householdId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "DELETE /households/:householdId failed",
+    async ({ db, session }) => {
+      const ownerFailure = await authorizeHouseholdOwnerResponse(
+        c,
+        db,
+        householdId,
+        session,
+      );
+      if (ownerFailure) return ownerFailure;
+      const household = await findHouseholdById(db, householdId);
+      if (!household) return c.notFound();
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-    const ownerFailure = await authorizeHouseholdOwnerResponse(
-      c,
-      db,
-      householdId,
-      session.session,
-    );
-    if (ownerFailure) return ownerFailure;
-    const household = await findHouseholdById(db, householdId);
-    if (!household) return c.notFound();
+      await db.transaction(async (tx) => {
+        const [lockedHousehold] = await tx
+          .select({ id: schema.organization.id })
+          .from(schema.organization)
+          .where(eq(schema.organization.id, householdId))
+          .for("update")
+          .limit(1);
+        if (!lockedHousehold) throw new Error("Household no longer exists");
+        const memberIds = await findHouseholdMemberUserIds(tx, householdId);
 
-    await db.transaction(async (tx) => {
-      const [lockedHousehold] = await tx
-        .select({ id: schema.organization.id })
-        .from(schema.organization)
-        .where(eq(schema.organization.id, householdId))
-        .for("update")
-        .limit(1);
-      if (!lockedHousehold) throw new Error("Household no longer exists");
-      const memberIds = await findHouseholdMemberUserIds(tx, householdId);
-
-      await createHouseholdNotification(tx, {
-        recipientUserIds: memberIds.filter(
-          (userId) => userId !== session.session.user.id,
-        ),
-        kind: "household_deleted",
-        household,
-        actor: {
-          id: session.session.user.id,
-          name: session.session.user.name,
-        },
-      });
-      await tx
-        .update(schema.recipe)
-        .set({ visibility: "private" })
-        .where(
-          and(
-            eq(schema.recipe.visibility, "household"),
-            inArray(schema.recipe.userId, memberIds),
+        await createHouseholdNotification(tx, {
+          recipientUserIds: memberIds.filter(
+            (userId) => userId !== session.user.id,
           ),
-        );
-      await tx.delete(schema.organization).where(eq(schema.organization.id, householdId));
-    });
-    return c.body(null, 204);
-  } catch (e) {
-    console.error("DELETE /households/:householdId failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+          kind: "household_deleted",
+          household,
+          actor: {
+            id: session.user.id,
+            name: session.user.name,
+          },
+        });
+        await tx
+          .update(schema.recipe)
+          .set({ visibility: "private" })
+          .where(
+            and(
+              eq(schema.recipe.visibility, "household"),
+              inArray(schema.recipe.userId, memberIds),
+            ),
+          );
+        await tx.delete(schema.organization).where(eq(schema.organization.id, householdId));
+      });
+      return c.body(null, 204);
+    },
+  );
 });
 
 app.get("/notifications", async (c) => {
@@ -2330,70 +2255,62 @@ app.get("/notifications", async (c) => {
   if (!Number.isSafeInteger(offset) || offset < 0) {
     return c.json({ error: "Invalid notification offset" }, 400);
   }
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-    const [deliveries, [unread]] = await Promise.all([
-      db
-        .select(notificationBaseSelection)
-        .from(schema.notificationDelivery)
-        .innerJoin(
-          schema.notificationEvent,
-          eq(schema.notificationDelivery.eventId, schema.notificationEvent.id),
-        )
-        .where(
-          and(
-            eq(
-              schema.notificationDelivery.recipientUserId,
-              session.session.user.id,
+  return withRecipeSession(
+    c,
+    "query",
+    "GET /notifications failed",
+    async ({ db, session }) => {
+      const [deliveries, [unread]] = await Promise.all([
+        db
+          .select(notificationBaseSelection)
+          .from(schema.notificationDelivery)
+          .innerJoin(
+            schema.notificationEvent,
+            eq(schema.notificationDelivery.eventId, schema.notificationEvent.id),
+          )
+          .where(
+            and(
+              eq(
+                schema.notificationDelivery.recipientUserId,
+                session.user.id,
+              ),
+              isNull(schema.notificationDelivery.dismissedAt),
             ),
-            isNull(schema.notificationDelivery.dismissedAt),
-          ),
-        )
-        .orderBy(
-          desc(schema.notificationEvent.occurredAt),
-          desc(schema.notificationDelivery.id),
-        )
-        .limit(NOTIFICATION_PAGE_SIZE + 1)
-        .offset(offset),
-      db
-        .select({ value: count() })
-        .from(schema.notificationDelivery)
-        .where(
-          and(
-            eq(
-              schema.notificationDelivery.recipientUserId,
-              session.session.user.id,
+          )
+          .orderBy(
+            desc(schema.notificationEvent.occurredAt),
+            desc(schema.notificationDelivery.id),
+          )
+          .limit(NOTIFICATION_PAGE_SIZE + 1)
+          .offset(offset),
+        db
+          .select({ value: count() })
+          .from(schema.notificationDelivery)
+          .where(
+            and(
+              eq(
+                schema.notificationDelivery.recipientUserId,
+                session.user.id,
+              ),
+              isNull(schema.notificationDelivery.readAt),
+              isNull(schema.notificationDelivery.dismissedAt),
             ),
-            isNull(schema.notificationDelivery.readAt),
-            isNull(schema.notificationDelivery.dismissedAt),
           ),
-        ),
-    ]);
-    const hasMore = deliveries.length > NOTIFICATION_PAGE_SIZE;
-    const items = await hydrateNotifications(
-      db,
-      deliveries.slice(0, NOTIFICATION_PAGE_SIZE),
-    );
-    return c.json(
-      {
-        items,
-        nextOffset: hasMore ? offset + NOTIFICATION_PAGE_SIZE : null,
-        unreadCount: unread?.value ?? 0,
-      },
-    );
-  } catch (e) {
-    console.error("GET /notifications failed", e);
-    return c.json({ error: "Database query failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      ]);
+      const hasMore = deliveries.length > NOTIFICATION_PAGE_SIZE;
+      const items = await hydrateNotifications(
+        db,
+        deliveries.slice(0, NOTIFICATION_PAGE_SIZE),
+      );
+      return c.json(
+        {
+          items,
+          nextOffset: hasMore ? offset + NOTIFICATION_PAGE_SIZE : null,
+          unreadCount: unread?.value ?? 0,
+        },
+      );
+    },
+  );
 });
 
 async function mutateAllNotifications(
@@ -2402,43 +2319,35 @@ async function mutateAllNotifications(
 ): Promise<Response> {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-    const mutationTime = new Date();
-    await db
-      .update(schema.notificationDelivery)
-      .set(
-        action === "clear"
-          ? { readAt: mutationTime, dismissedAt: mutationTime }
-          : { readAt: mutationTime },
-      )
-      .where(
-        and(
-          eq(
-            schema.notificationDelivery.recipientUserId,
-            session.session.user.id,
+  return withRecipeSession(
+    c,
+    "mutation",
+    `POST /notifications/${action}-all failed`,
+    async ({ db, session }) => {
+      const mutationTime = new Date();
+      await db
+        .update(schema.notificationDelivery)
+        .set(
+          action === "clear"
+            ? { readAt: mutationTime, dismissedAt: mutationTime }
+            : { readAt: mutationTime },
+        )
+        .where(
+          and(
+            eq(
+              schema.notificationDelivery.recipientUserId,
+              session.user.id,
+            ),
+            isNull(
+              action === "clear"
+                ? schema.notificationDelivery.dismissedAt
+                : schema.notificationDelivery.readAt,
+            ),
           ),
-          isNull(
-            action === "clear"
-              ? schema.notificationDelivery.dismissedAt
-              : schema.notificationDelivery.readAt,
-          ),
-        ),
-      );
-    return c.body(null, 204);
-  } catch (e) {
-    console.error(`POST /notifications/${action}-all failed`, e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+        );
+      return c.body(null, 204);
+    },
+  );
 }
 
 app.post("/notifications/read-all", (c) => mutateAllNotifications(c, "read"));
@@ -2450,73 +2359,62 @@ app.post("/notifications/:notificationId/actions/:actionKey", async (c) => {
   const action = c.req.param("actionKey");
   const notificationId = uuidParam(c, "notificationId", "notification ID");
   if (notificationId instanceof Response) return notificationId;
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const [target] = await db
-      .select({
-        eventId: schema.notificationEvent.id,
-        kind: schema.notificationEvent.kind,
-      })
-      .from(schema.notificationDelivery)
-      .innerJoin(
-        schema.notificationEvent,
-        eq(schema.notificationDelivery.eventId, schema.notificationEvent.id),
-      )
-      .where(
-        and(
-          eq(schema.notificationDelivery.id, notificationId),
-          eq(
-            schema.notificationDelivery.recipientUserId,
-            session.session.user.id,
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /notifications/:notificationId/actions/:actionKey failed",
+    async ({ db, session }) => {
+      const [target] = await db
+        .select({
+          eventId: schema.notificationEvent.id,
+          kind: schema.notificationEvent.kind,
+        })
+        .from(schema.notificationDelivery)
+        .innerJoin(
+          schema.notificationEvent,
+          eq(schema.notificationDelivery.eventId, schema.notificationEvent.id),
+        )
+        .where(
+          and(
+            eq(schema.notificationDelivery.id, notificationId),
+            eq(
+              schema.notificationDelivery.recipientUserId,
+              session.user.id,
+            ),
+            isNull(schema.notificationDelivery.dismissedAt),
           ),
-          isNull(schema.notificationDelivery.dismissedAt),
-        ),
-      )
-      .limit(1);
-    if (!target) return c.notFound();
-    await dispatchNotificationAction(
-      db,
-      session.session.user,
-      { id: target.eventId, kind: target.kind },
-      action,
-    );
-    const [updated] = await db
-      .select(notificationBaseSelection)
-      .from(schema.notificationDelivery)
-      .innerJoin(
-        schema.notificationEvent,
-        eq(schema.notificationDelivery.eventId, schema.notificationEvent.id),
-      )
-      .where(
-        and(
-          eq(schema.notificationDelivery.id, notificationId),
-          eq(
-            schema.notificationDelivery.recipientUserId,
-            session.session.user.id,
+        )
+        .limit(1);
+      if (!target) return c.notFound();
+      await dispatchNotificationAction(
+        db,
+        session.user,
+        { id: target.eventId, kind: target.kind },
+        action,
+      );
+      const [updated] = await db
+        .select(notificationBaseSelection)
+        .from(schema.notificationDelivery)
+        .innerJoin(
+          schema.notificationEvent,
+          eq(schema.notificationDelivery.eventId, schema.notificationEvent.id),
+        )
+        .where(
+          and(
+            eq(schema.notificationDelivery.id, notificationId),
+            eq(
+              schema.notificationDelivery.recipientUserId,
+              session.user.id,
+            ),
           ),
-        ),
-      )
-      .limit(1);
-    if (!updated) return c.notFound();
-    const [item] = await hydrateNotifications(db, [updated]);
-    return c.json({ item });
-  } catch (e) {
-    const failure = invitationActionFailure(c, e);
-    if (failure) return failure;
-    console.error("POST /notifications/:notificationId/actions/:actionKey failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+        )
+        .limit(1);
+      if (!updated) return c.notFound();
+      const [item] = await hydrateNotifications(db, [updated]);
+      return c.json({ item });
+    },
+    { onError: (error) => invitationActionFailure(c, error) },
+  );
 });
 
 app.patch("/notifications/:notificationId", async (c) => {
@@ -2524,48 +2422,40 @@ app.patch("/notifications/:notificationId", async (c) => {
   if (csrfFailure) return csrfFailure;
   const notificationId = uuidParam(c, "notificationId", "notification ID");
   if (notificationId instanceof Response) return notificationId;
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-    const body = await parseJsonBody(
-      c,
-      z.object({ read: z.boolean().optional(), dismissed: z.boolean().optional() }).strict(),
-    );
-    if (!body.success) return body.response;
-    const mutationTime = new Date();
-    await db
-      .update(schema.notificationDelivery)
-      .set({
-        ...(body.data.read !== undefined
-          ? { readAt: body.data.read ? mutationTime : null }
-          : {}),
-        ...(body.data.dismissed ? { readAt: mutationTime } : {}),
-        ...(body.data.dismissed !== undefined
-          ? { dismissedAt: body.data.dismissed ? mutationTime : null }
-          : {}),
-      })
-      .where(
-        and(
-          eq(schema.notificationDelivery.id, notificationId),
-          eq(
-            schema.notificationDelivery.recipientUserId,
-            session.session.user.id,
-          ),
-        ),
+  return withRecipeSession(
+    c,
+    "mutation",
+    "PATCH /notifications/:notificationId failed",
+    async ({ db, session }) => {
+      const body = await parseJsonBody(
+        c,
+        z.object({ read: z.boolean().optional(), dismissed: z.boolean().optional() }).strict(),
       );
-    return c.body(null, 204);
-  } catch (e) {
-    console.error("PATCH /notifications/:notificationId failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      if (!body.success) return body.response;
+      const mutationTime = new Date();
+      await db
+        .update(schema.notificationDelivery)
+        .set({
+          ...(body.data.read !== undefined
+            ? { readAt: body.data.read ? mutationTime : null }
+            : {}),
+          ...(body.data.dismissed ? { readAt: mutationTime } : {}),
+          ...(body.data.dismissed !== undefined
+            ? { dismissedAt: body.data.dismissed ? mutationTime : null }
+            : {}),
+        })
+        .where(
+          and(
+            eq(schema.notificationDelivery.id, notificationId),
+            eq(
+              schema.notificationDelivery.recipientUserId,
+              session.user.id,
+            ),
+          ),
+        );
+      return c.body(null, 204);
+    },
+  );
 });
 
 app.get("/recipes", async (c) => {
@@ -2584,31 +2474,25 @@ app.get("/recipes", async (c) => {
   // bare requests keep the legacy array shape, bounded to the default limit.
   const paginated = limitValue !== undefined || cursorValue !== undefined;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    let visibilityFilter: SQL | undefined;
-    if (scope === "owned") {
-      const session = await requireRecipeSession(c, db);
-      if (!session.success) return session.response;
-      visibilityFilter = eq(schema.recipe.userId, session.session.user.id);
-    } else {
-      const session = await loadOptionalRecipeSession(c, db);
-      visibilityFilter = await readableRecipeFilter(db, session?.user.id);
-    }
-    const page = await listRecipesPage(db, visibilityFilter, cursor, limit.data);
-    const items = page.recipes.map(recipeResponse);
-    return c.json(paginated ? { items, nextCursor: page.nextCursor } : items);
-  } catch (e) {
-    console.error("GET /recipes query failed", e);
-    return c.json({ error: "Database query failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+  return withDatabase(
+    c,
+    "query",
+    "GET /recipes query failed",
+    async (db) => {
+      let visibilityFilter: SQL | undefined;
+      if (scope === "owned") {
+        const session = await requireRecipeSession(c, db);
+        if (!session.success) return session.response;
+        visibilityFilter = eq(schema.recipe.userId, session.session.user.id);
+      } else {
+        const session = await loadOptionalRecipeSession(c, db);
+        visibilityFilter = await readableRecipeFilter(db, session?.user.id);
+      }
+      const page = await listRecipesPage(db, visibilityFilter, cursor, limit.data);
+      const items = page.recipes.map(recipeResponse);
+      return c.json(paginated ? { items, nextCursor: page.nextCursor } : items);
+    },
+  );
 });
 
 app.get("/recipes/discover/feed", async (c) => {
@@ -2620,63 +2504,56 @@ app.get("/recipes/discover/feed", async (c) => {
     return c.json({ error: "Invalid feed query" }, 400);
   }
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withDatabase(
+    c,
+    "query",
+    "GET /recipes/discover/feed query failed",
+    async (db) => {
+      let visibilityFilter = eq(schema.recipe.visibility, "public");
+      if (scope.data === "household") {
+        const session = await loadOptionalRecipeSession(c, db);
+        if (!session) return authorizationResponse(c, unauthenticated());
+        const membership = await findUserHouseholdMembership(db, session.user.id);
+        if (!membership) return c.json({ items: [], nextCursor: null });
+        const memberIds = await findHouseholdMemberUserIds(
+          db,
+          membership.organizationId,
+        );
+        visibilityFilter = and(
+          inArray(schema.recipe.userId, memberIds),
+          inArray(schema.recipe.visibility, ["public", "household"]),
+        )!;
+      }
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    let visibilityFilter = eq(schema.recipe.visibility, "public");
-    if (scope.data === "household") {
-      const session = await loadOptionalRecipeSession(c, db);
-      if (!session) return authorizationResponse(c, unauthenticated());
-      const membership = await findUserHouseholdMembership(db, session.user.id);
-      if (!membership) return c.json({ items: [], nextCursor: null });
-      const memberIds = await findHouseholdMemberUserIds(
-        db,
-        membership.organizationId,
-      );
-      visibilityFilter = and(
-        inArray(schema.recipe.userId, memberIds),
-        inArray(schema.recipe.visibility, ["public", "household"]),
-      )!;
-    }
+      const cursorFilter = recipeFeedCursorFilter(cursor);
+      const rows = await db
+        .select({
+          recipe: schema.recipe,
+          cursorCreatedAt: recipeFeedCursorTimestamp(),
+          author: {
+            id: schema.user.id,
+            name: schema.user.name,
+            image: schema.user.image,
+          },
+        })
+        .from(schema.recipe)
+        .innerJoin(schema.user, eq(schema.recipe.userId, schema.user.id))
+        .where(cursorFilter ? and(visibilityFilter, cursorFilter) : visibilityFilter)
+        .orderBy(desc(schema.recipe.createdAt), desc(schema.recipe.id))
+        .limit(limit.data + 1);
 
-    const cursorFilter = recipeFeedCursorFilter(cursor);
-    const rows = await db
-      .select({
-        recipe: schema.recipe,
-        cursorCreatedAt: recipeFeedCursorTimestamp(),
-        author: {
-          id: schema.user.id,
-          name: schema.user.name,
-          image: schema.user.image,
-        },
-      })
-      .from(schema.recipe)
-      .innerJoin(schema.user, eq(schema.recipe.userId, schema.user.id))
-      .where(cursorFilter ? and(visibilityFilter, cursorFilter) : visibilityFilter)
-      .orderBy(desc(schema.recipe.createdAt), desc(schema.recipe.id))
-      .limit(limit.data + 1);
-
-    const page = paginateRecipeFeed(rows, limit.data);
-    return c.json({
-      items: page.items.map(({ recipe, author }) => ({
-        type: "recipe_added" as const,
-        recipe: recipeResponse(recipe),
-        author,
-        createdAt: recipe.createdAt,
-      })),
-      nextCursor: page.nextCursor,
-    });
-  } catch (e) {
-    console.error("GET /recipes/discover/feed query failed", e);
-    return c.json({ error: "Database query failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      const page = paginateRecipeFeed(rows, limit.data);
+      return c.json({
+        items: page.items.map(({ recipe, author }) => ({
+          type: "recipe_added" as const,
+          recipe: recipeResponse(recipe),
+          author,
+          createdAt: recipe.createdAt,
+        })),
+        nextCursor: page.nextCursor,
+      });
+    },
+  );
 });
 
 app.get("/recipes/cooks", async (c) => {
@@ -2687,223 +2564,195 @@ app.get("/recipes/cooks", async (c) => {
     return c.json({ error: "Invalid cook query" }, 400);
   }
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withDatabase(
+    c,
+    "query",
+    "GET /recipes/cooks query failed",
+    async (db) => {
+      if (cookId?.success) {
+        const rows = await db
+          .select({
+            recipe: schema.recipe,
+            author: {
+              id: schema.user.id,
+              name: schema.user.name,
+              image: schema.user.image,
+            },
+          })
+          .from(schema.recipe)
+          .innerJoin(schema.user, eq(schema.recipe.userId, schema.user.id))
+          .where(
+            and(
+              eq(schema.recipe.visibility, "public"),
+              eq(schema.user.id, cookId.data),
+            ),
+          )
+          .orderBy(desc(schema.recipe.createdAt), desc(schema.recipe.id))
+          .limit(30);
+        const first = rows[0];
+        return c.json({
+          cook: first
+            ? {
+                ...first.author,
+                activity: rows.map(({ recipe }) => ({
+                  type: "recipe_added" as const,
+                  recipe: recipeResponse(recipe),
+                  createdAt: recipe.createdAt,
+                })),
+              }
+            : null,
+        });
+      }
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-
-    if (cookId?.success) {
-      const rows = await db
+      const latestActivityAt = sql<string>`max(${schema.recipe.createdAt})`;
+      const latestRecipeTitle =
+        sql<string>`(array_agg(${schema.recipe.title} order by ${schema.recipe.createdAt} desc, ${schema.recipe.id} desc))[1]`;
+      const cooks = await db
         .select({
-          recipe: schema.recipe,
-          author: {
-            id: schema.user.id,
-            name: schema.user.name,
-            image: schema.user.image,
-          },
+          id: schema.user.id,
+          name: schema.user.name,
+          image: schema.user.image,
+          activityCount: count(),
+          latestRecipeTitle,
         })
         .from(schema.recipe)
         .innerJoin(schema.user, eq(schema.recipe.userId, schema.user.id))
-        .where(
-          and(
-            eq(schema.recipe.visibility, "public"),
-            eq(schema.user.id, cookId.data),
-          ),
-        )
-        .orderBy(desc(schema.recipe.createdAt), desc(schema.recipe.id))
-        .limit(30);
-      const first = rows[0];
-      return c.json({
-        cook: first
-          ? {
-              ...first.author,
-              activity: rows.map(({ recipe }) => ({
-                type: "recipe_added" as const,
-                recipe: recipeResponse(recipe),
-                createdAt: recipe.createdAt,
-              })),
-            }
-          : null,
-      });
-    }
-
-    const latestActivityAt = sql<string>`max(${schema.recipe.createdAt})`;
-    const latestRecipeTitle =
-      sql<string>`(array_agg(${schema.recipe.title} order by ${schema.recipe.createdAt} desc, ${schema.recipe.id} desc))[1]`;
-    const cooks = await db
-      .select({
-        id: schema.user.id,
-        name: schema.user.name,
-        image: schema.user.image,
-        activityCount: count(),
-        latestRecipeTitle,
-      })
-      .from(schema.recipe)
-      .innerJoin(schema.user, eq(schema.recipe.userId, schema.user.id))
-      .where(eq(schema.recipe.visibility, "public"))
-      .groupBy(schema.user.id, schema.user.name, schema.user.image)
-      .orderBy(desc(latestActivityAt));
-    return c.json({ cooks });
-  } catch (e) {
-    console.error("GET /recipes/cooks query failed", e);
-    return c.json({ error: "Database query failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+        .where(eq(schema.recipe.visibility, "public"))
+        .groupBy(schema.user.id, schema.user.name, schema.user.image)
+        .orderBy(desc(latestActivityAt));
+      return c.json({ cooks });
+    },
+  );
 });
 
 app.post("/recipes/import-url", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /recipes/import-url failed",
+    async ({ db, session }) => {
+      const body = await parseJsonBody(c, importRecipeUrlBodySchema);
+      if (!body.success) return body.response;
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const session = await requireRecipeSession(c, connection.db);
-    if (!session.success) return session.response;
-
-    const body = await parseJsonBody(c, importRecipeUrlBodySchema);
-    if (!body.success) return body.response;
-
-    const importLimit = await enforceRateLimit(
-      connection.db,
-      `recipe-url-import:${session.session.user.id}`,
-      RECIPE_URL_IMPORT_RATE_LIMIT,
-    );
-    if (!importLimit.allowed) {
-      return rateLimitedResponse(c, importLimit.retryAfter);
-    }
-
-    const page = await fetchRecipePage(body.data.url);
-    const recipe = await parseSchemaOrgRecipeHtml(page.html, page.url);
-    if (!recipe) {
-      return c.json(
-        {
-          error:
-            "No complete schema.org Recipe was found on that page. It must include a name, ingredients, and instructions.",
-        },
-        422,
+      const importLimit = await enforceRateLimit(
+        db,
+        `recipe-url-import:${session.user.id}`,
+        RECIPE_URL_IMPORT_RATE_LIMIT,
       );
-    }
-    if (recipe.source.length > 10_000) {
-      return c.json(
-        {
-          error:
-            "That recipe is too long to import. The Cooklang draft exceeds 10,000 characters.",
-        },
-        422,
-      );
-    }
-    return c.json({ ...recipe, url: page.url });
-  } catch (error) {
-    if (error instanceof RecipeUrlImportError) {
-      return c.json({ error: error.message }, error.status);
-    }
-    console.error("POST /recipes/import-url failed", error);
-    return c.json({ error: "The recipe could not be imported" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      if (!importLimit.allowed) {
+        return rateLimitedResponse(c, importLimit.retryAfter);
+      }
+
+      const page = await fetchRecipePage(body.data.url);
+      const recipe = await parseSchemaOrgRecipeHtml(page.html, page.url);
+      if (!recipe) {
+        return c.json(
+          {
+            error:
+              "No complete schema.org Recipe was found on that page. It must include a name, ingredients, and instructions.",
+          },
+          422,
+        );
+      }
+      if (recipe.source.length > 10_000) {
+        return c.json(
+          {
+            error:
+              "That recipe is too long to import. The Cooklang draft exceeds 10,000 characters.",
+          },
+          422,
+        );
+      }
+      return c.json({ ...recipe, url: page.url });
+    },
+    {
+      onError: (error) =>
+        error instanceof RecipeUrlImportError
+          ? c.json({ error: error.message }, error.status)
+          : undefined,
+    },
+  );
 });
 
 app.get("/recipes/:slug", async (c) => {
   const slug = parseRecipeSlug(c);
   if (!slug.success) return slug.response;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withDatabase(
+    c,
+    "query",
+    "GET /recipes/:slug query failed",
+    async (db) => {
+      const session = await loadOptionalRecipeSession(c, db);
+      const recipe = await findRecipeBySlug(db, slug.slug);
+      if (!recipe) return c.notFound();
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await loadOptionalRecipeSession(c, db);
-    const recipe = await findRecipeBySlug(db, slug.slug);
-    if (!recipe) return c.notFound();
+      if (recipe.visibility !== "public") {
+        if (!session) return c.notFound();
+        const household = {
+          userSharesHouseholdWithOwner: await usersShareHousehold(
+            db,
+            recipe.userId,
+            session.user.id,
+          ),
+        };
+        const decision = authorizeRecipeRead(session.user, recipe, household);
+        if (!decision.allowed) return c.notFound();
+      }
 
-    if (recipe.visibility !== "public") {
-      if (!session) return c.notFound();
-      const household = {
-        userSharesHouseholdWithOwner: await usersShareHousehold(
-          db,
-          recipe.userId,
-          session.user.id,
-        ),
-      };
-      const decision = authorizeRecipeRead(session.user, recipe, household);
-      if (!decision.allowed) return c.notFound();
-    }
-
-    return c.json(recipeResponse(recipe));
-  } catch (e) {
-    console.error("GET /recipes/:slug query failed", e);
-    return c.json({ error: "Database query failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json(recipeResponse(recipe));
+    },
+  );
 });
 
 app.post("/recipes", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /recipes mutation failed",
+    async ({ db, session }) => {
+      const body = await parseJsonBody(c, createRecipeBodySchema);
+      if (!body.success) return body.response;
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
+      if (body.data.visibility === "household") {
+        const membership = await findUserHouseholdMembership(
+          db,
+          session.user.id,
+        );
+        if (!membership) return authorizationResponse(c, forbidden());
+      }
 
-    const body = await parseJsonBody(c, createRecipeBodySchema);
-    if (!body.success) return body.response;
+      const [recipe] = await db
+        .insert(schema.recipe)
+        .values({
+          ...body.data,
+          userId: session.user.id,
+        })
+        .returning();
 
-    if (body.data.visibility === "household") {
-      const membership = await findUserHouseholdMembership(
-        db,
-        session.session.user.id,
-      );
-      if (!membership) return authorizationResponse(c, forbidden());
-    }
+      if (!recipe) return c.json({ error: "Database mutation failed" }, 502);
 
-    const [recipe] = await db
-      .insert(schema.recipe)
-      .values({
-        ...body.data,
-        userId: session.session.user.id,
-      })
-      .returning();
-
-    if (!recipe) return c.json({ error: "Database mutation failed" }, 502);
-
-    return c.json(recipeResponse(recipe), 201);
-  } catch (e) {
-    if (isUniqueViolation(e)) {
-      return c.json(
-        {
-          error:
-            "A recipe with this name already exists. Choose a different name.",
-        },
-        409,
-      );
-    }
-    console.error("POST /recipes mutation failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json(recipeResponse(recipe), 201);
+    },
+    {
+      onError: (error) =>
+        isUniqueViolation(error)
+          ? c.json(
+              {
+                error:
+                  "A recipe with this name already exists. Choose a different name.",
+              },
+              409,
+            )
+          : undefined,
+    },
+  );
 });
 
 app.patch("/recipes/:slug", async (c) => {
@@ -2913,62 +2762,52 @@ app.patch("/recipes/:slug", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
-
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const recipe = await findOwnedRecipeBySlug(
-      db,
-      slug.slug,
-      session.session.user.id,
-    );
-    if (!recipe) return c.notFound();
-
-    const body = await parseJsonBody(c, updateRecipeBodySchema);
-    if (!body.success) return body.response;
-
-    const ownerDecision = authorizeOwnerOnly(session.session.user, recipe);
-    if (!ownerDecision.allowed) return authorizationResponse(c, ownerDecision);
-
-    if (body.data.visibility === "household") {
-      const membership = await findUserHouseholdMembership(
+  return withRecipeSession(
+    c,
+    "mutation",
+    "PATCH /recipes/:slug mutation failed",
+    async ({ db, session }) => {
+      const recipe = await findOwnedRecipeBySlug(
         db,
-        session.session.user.id,
+        slug.slug,
+        session.user.id,
       );
-      if (!membership) return authorizationResponse(c, forbidden());
-    }
+      if (!recipe) return c.notFound();
 
-    const updates = {
-      ...body.data,
-    };
+      const body = await parseJsonBody(c, updateRecipeBodySchema);
+      if (!body.success) return body.response;
 
-    const [updatedRecipe] = await db
-      .update(schema.recipe)
-      .set(updates)
-      .where(
-        and(
-          eq(schema.recipe.id, recipe.id),
-          eq(schema.recipe.userId, session.session.user.id),
-        ),
-      )
-      .returning();
+      const ownerDecision = authorizeOwnerOnly(session.user, recipe);
+      if (!ownerDecision.allowed) return authorizationResponse(c, ownerDecision);
 
-    if (!updatedRecipe) return c.notFound();
+      if (body.data.visibility === "household") {
+        const membership = await findUserHouseholdMembership(
+          db,
+          session.user.id,
+        );
+        if (!membership) return authorizationResponse(c, forbidden());
+      }
 
-    return c.json(recipeResponse(updatedRecipe));
-  } catch (e) {
-    console.error("PATCH /recipes/:slug mutation failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      const updates = {
+        ...body.data,
+      };
+
+      const [updatedRecipe] = await db
+        .update(schema.recipe)
+        .set(updates)
+        .where(
+          and(
+            eq(schema.recipe.id, recipe.id),
+            eq(schema.recipe.userId, session.user.id),
+          ),
+        )
+        .returning();
+
+      if (!updatedRecipe) return c.notFound();
+
+      return c.json(recipeResponse(updatedRecipe));
+    },
+  );
 });
 
 app.post("/recipes/:slug/household-share", async (c) => {
@@ -2978,51 +2817,41 @@ app.post("/recipes/:slug/household-share", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /recipes/:slug/household-share failed",
+    async ({ db, session }) => {
+      const recipe = await findOwnedRecipeBySlug(
+        db,
+        slug.slug,
+        session.user.id,
+      );
+      if (!recipe) return c.notFound();
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
+      const membership = await findUserHouseholdMembership(
+        db,
+        session.user.id,
+      );
+      if (!membership) return authorizationResponse(c, forbidden());
 
-    const recipe = await findOwnedRecipeBySlug(
-      db,
-      slug.slug,
-      session.session.user.id,
-    );
-    if (!recipe) return c.notFound();
+      const [updatedRecipe] = await db
+        .update(schema.recipe)
+        .set({
+          visibility: "household",
+        })
+        .where(
+          and(
+            eq(schema.recipe.id, recipe.id),
+            eq(schema.recipe.userId, session.user.id),
+          ),
+        )
+        .returning();
 
-    const membership = await findUserHouseholdMembership(
-      db,
-      session.session.user.id,
-    );
-    if (!membership) return authorizationResponse(c, forbidden());
-
-    const [updatedRecipe] = await db
-      .update(schema.recipe)
-      .set({
-        visibility: "household",
-      })
-      .where(
-        and(
-          eq(schema.recipe.id, recipe.id),
-          eq(schema.recipe.userId, session.session.user.id),
-        ),
-      )
-      .returning();
-
-    if (!updatedRecipe) return c.notFound();
-    return c.json(recipeResponse(updatedRecipe));
-  } catch (e) {
-    console.error("POST /recipes/:slug/household-share failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      if (!updatedRecipe) return c.notFound();
+      return c.json(recipeResponse(updatedRecipe));
+    },
+  );
 });
 
 app.delete("/recipes/:slug/household-share", async (c) => {
@@ -3032,50 +2861,40 @@ app.delete("/recipes/:slug/household-share", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "DELETE /recipes/:slug/household-share failed",
+    async ({ db, session }) => {
+      const recipe = await findOwnedRecipeBySlug(
+        db,
+        slug.slug,
+        session.user.id,
+      );
+      if (!recipe) return c.notFound();
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
+      const ownerDecision = authorizeOwnerOnly(session.user, recipe);
+      if (!ownerDecision.allowed) {
+        return authorizationResponse(c, ownerDecision);
+      }
 
-    const recipe = await findOwnedRecipeBySlug(
-      db,
-      slug.slug,
-      session.session.user.id,
-    );
-    if (!recipe) return c.notFound();
+      const [updatedRecipe] = await db
+        .update(schema.recipe)
+        .set({
+          visibility: "private",
+        })
+        .where(
+          and(
+            eq(schema.recipe.id, recipe.id),
+            eq(schema.recipe.userId, session.user.id),
+          ),
+        )
+        .returning();
 
-    const ownerDecision = authorizeOwnerOnly(session.session.user, recipe);
-    if (!ownerDecision.allowed) {
-      return authorizationResponse(c, ownerDecision);
-    }
-
-    const [updatedRecipe] = await db
-      .update(schema.recipe)
-      .set({
-        visibility: "private",
-      })
-      .where(
-        and(
-          eq(schema.recipe.id, recipe.id),
-          eq(schema.recipe.userId, session.session.user.id),
-        ),
-      )
-      .returning();
-
-    if (!updatedRecipe) return c.notFound();
-    return c.json(recipeResponse(updatedRecipe));
-  } catch (e) {
-    console.error("DELETE /recipes/:slug/household-share failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      if (!updatedRecipe) return c.notFound();
+      return c.json(recipeResponse(updatedRecipe));
+    },
+  );
 });
 
 app.delete("/recipes/:slug", async (c) => {
@@ -3085,42 +2904,32 @@ app.delete("/recipes/:slug", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "DELETE /recipes/:slug mutation failed",
+    async ({ db, session }) => {
+      const recipe = await findOwnedRecipeBySlug(
+        db,
+        slug.slug,
+        session.user.id,
+      );
+      if (!recipe) return c.notFound();
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
+      const [deletedRecipe] = await db
+        .delete(schema.recipe)
+        .where(
+          and(
+            eq(schema.recipe.id, recipe.id),
+            eq(schema.recipe.userId, session.user.id),
+          ),
+        )
+        .returning({ id: schema.recipe.id });
+      if (!deletedRecipe) return c.notFound();
 
-    const recipe = await findOwnedRecipeBySlug(
-      db,
-      slug.slug,
-      session.session.user.id,
-    );
-    if (!recipe) return c.notFound();
-
-    const [deletedRecipe] = await db
-      .delete(schema.recipe)
-      .where(
-        and(
-          eq(schema.recipe.id, recipe.id),
-          eq(schema.recipe.userId, session.session.user.id),
-        ),
-      )
-      .returning({ id: schema.recipe.id });
-    if (!deletedRecipe) return c.notFound();
-
-    return c.body(null, 204);
-  } catch (e) {
-    console.error("DELETE /recipes/:slug mutation failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.body(null, 204);
+    },
+  );
 });
 
 // This API owns recipe photo import auth, quotas, job creation,
@@ -3226,231 +3035,202 @@ app.post("/recipe-imports", async (c) => {
     return c.json({ error: "Recipe import is not configured" }, 503);
   }
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /recipe-imports mutation failed",
+    async ({ db, session }) => {
+      const userId = session.user.id;
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-    const userId = session.session.user.id;
-
-    const form = await c.req.formData().catch(() => undefined);
-    if (!form) {
-      return c.json(
-        { error: "Request body must be multipart/form-data" },
-        415,
-      );
-    }
-    const parsed = parseImportImages(c, form);
-    if (!parsed.success) return parsed.response;
-    const { images } = parsed;
-
-    const dayStart = new Date();
-    dayStart.setUTCHours(0, 0, 0, 0);
-
-    type QuotaOutcome =
-      | { ok: true; job: RecipeImportJob }
-      | { ok: false; reason: "active" | "daily" };
-
-    const outcome = await db.transaction(async (tx): Promise<QuotaOutcome> => {
-      // Serialize per-user job creation so concurrent uploads cannot slip past the limits.
-      await tx
-        .select({ id: schema.user.id })
-        .from(schema.user)
-        .where(eq(schema.user.id, userId))
-        .for("update");
-
-      const [active] = await tx
-        .select({ value: count() })
-        .from(schema.recipeImportJob)
-        .where(
-          and(
-            eq(schema.recipeImportJob.userId, userId),
-            inArray(schema.recipeImportJob.status, ["queued", "running"]),
-          ),
+      const form = await c.req.formData().catch(() => undefined);
+      if (!form) {
+        return c.json(
+          { error: "Request body must be multipart/form-data" },
+          415,
         );
-      if ((active?.value ?? 0) >= RECIPE_IMPORT_MAX_ACTIVE_JOBS) {
-        return { ok: false, reason: "active" };
       }
+      const parsed = parseImportImages(c, form);
+      if (!parsed.success) return parsed.response;
+      const { images } = parsed;
 
-      const [today] = await tx
-        .select({ value: count() })
-        .from(schema.recipeImportJob)
-        .where(
-          and(
-            eq(schema.recipeImportJob.userId, userId),
-            gte(schema.recipeImportJob.createdAt, dayStart),
-          ),
+      const dayStart = new Date();
+      dayStart.setUTCHours(0, 0, 0, 0);
+
+      type QuotaOutcome =
+        | { ok: true; job: RecipeImportJob }
+        | { ok: false; reason: "active" | "daily" };
+
+      const outcome = await db.transaction(async (tx): Promise<QuotaOutcome> => {
+        // Serialize per-user job creation so concurrent uploads cannot slip past the limits.
+        await tx
+          .select({ id: schema.user.id })
+          .from(schema.user)
+          .where(eq(schema.user.id, userId))
+          .for("update");
+
+        const [active] = await tx
+          .select({ value: count() })
+          .from(schema.recipeImportJob)
+          .where(
+            and(
+              eq(schema.recipeImportJob.userId, userId),
+              inArray(schema.recipeImportJob.status, ["queued", "running"]),
+            ),
+          );
+        if ((active?.value ?? 0) >= RECIPE_IMPORT_MAX_ACTIVE_JOBS) {
+          return { ok: false, reason: "active" };
+        }
+
+        const [today] = await tx
+          .select({ value: count() })
+          .from(schema.recipeImportJob)
+          .where(
+            and(
+              eq(schema.recipeImportJob.userId, userId),
+              gte(schema.recipeImportJob.createdAt, dayStart),
+            ),
+          );
+        if ((today?.value ?? 0) >= RECIPE_IMPORT_DAILY_JOB_LIMIT) {
+          return { ok: false, reason: "daily" };
+        }
+
+        const [job] = await tx
+          .insert(schema.recipeImportJob)
+          .values({ userId, imageCount: images.length })
+          .returning();
+        if (!job) throw new Error("Recipe import job insert returned no row");
+        return { ok: true, job };
+      });
+
+      if (!outcome.ok) {
+        return c.json(
+          {
+            error:
+              outcome.reason === "active"
+                ? "Too many imports in progress"
+                : "Daily import limit reached",
+          },
+          429,
         );
-      if ((today?.value ?? 0) >= RECIPE_IMPORT_DAILY_JOB_LIMIT) {
-        return { ok: false, reason: "daily" };
       }
+      const job = outcome.job;
 
-      const [job] = await tx
-        .insert(schema.recipeImportJob)
-        .values({ userId, imageCount: images.length })
-        .returning();
-      if (!job) throw new Error("Recipe import job insert returned no row");
-      return { ok: true, job };
-    });
-
-    if (!outcome.ok) {
-      return c.json(
-        {
-          error:
-            outcome.reason === "active"
-              ? "Too many imports in progress"
-              : "Daily import limit reached",
-        },
-        429,
-      );
-    }
-    const job = outcome.job;
-
-    try {
-      await Promise.all(
-        images.map(({ file, extension }, index) =>
-          artifacts.put(
-            `imports/${job.id}/source/${index}.${extension}`,
-            file,
-            { httpMetadata: { contentType: file.type } },
-          ),
-        ),
-      );
-      await workflow.create({ id: job.id, params: { jobId: job.id } });
-    } catch (error) {
-      console.error("POST /recipe-imports failed to start workflow", error);
-      // Best-effort cleanup so partially uploaded images don't accumulate.
       try {
-        const uploaded = await artifacts.list({
-          prefix: `imports/${job.id}/`,
-        });
         await Promise.all(
-          uploaded.objects.map((object) => artifacts.delete(object.key)),
+          images.map(({ file, extension }, index) =>
+            artifacts.put(
+              `imports/${job.id}/source/${index}.${extension}`,
+              file,
+              { httpMetadata: { contentType: file.type } },
+            ),
+          ),
         );
-      } catch (cleanupError) {
-        console.error(
-          `Failed to clean up R2 objects for import ${job.id}`,
-          cleanupError,
-        );
+        await workflow.create({ id: job.id, params: { jobId: job.id } });
+      } catch (error) {
+        console.error("POST /recipe-imports failed to start workflow", error);
+        // Best-effort cleanup so partially uploaded images don't accumulate.
+        try {
+          const uploaded = await artifacts.list({
+            prefix: `imports/${job.id}/`,
+          });
+          await Promise.all(
+            uploaded.objects.map((object) => artifacts.delete(object.key)),
+          );
+        } catch (cleanupError) {
+          console.error(
+            `Failed to clean up R2 objects for import ${job.id}`,
+            cleanupError,
+          );
+        }
+        await db
+          .update(schema.recipeImportJob)
+          .set({
+            status: "failed",
+            progressLabel: "Import failed",
+            errorType: "StartError",
+            errorMessage: "Failed to start the import",
+            finishedAt: new Date(),
+          })
+          .where(eq(schema.recipeImportJob.id, job.id));
+        return c.json({ error: "Failed to start the import" }, 502);
       }
-      await db
-        .update(schema.recipeImportJob)
-        .set({
-          status: "failed",
-          progressLabel: "Import failed",
-          errorType: "StartError",
-          errorMessage: "Failed to start the import",
-          finishedAt: new Date(),
-        })
-        .where(eq(schema.recipeImportJob.id, job.id));
-      return c.json({ error: "Failed to start the import" }, 502);
-    }
 
-    return c.json(importJobResponse(job), 202);
-  } catch (e) {
-    console.error("POST /recipe-imports mutation failed", e);
-    return c.json({ error: "Database mutation failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json(importJobResponse(job), 202);
+    },
+  );
 });
 
 app.get("/recipe-imports", async (c) => {
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "lookup",
+    "GET /recipe-imports lookup failed",
+    async ({ db, session }) => {
+      const jobs = await db
+        .select()
+        .from(schema.recipeImportJob)
+        .where(eq(schema.recipeImportJob.userId, session.user.id))
+        .orderBy(desc(schema.recipeImportJob.createdAt))
+        .limit(20);
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
-
-    const jobs = await db
-      .select()
-      .from(schema.recipeImportJob)
-      .where(eq(schema.recipeImportJob.userId, session.session.user.id))
-      .orderBy(desc(schema.recipeImportJob.createdAt))
-      .limit(20);
-
-    return c.json({ imports: jobs.map(importJobResponse) });
-  } catch (e) {
-    console.error("GET /recipe-imports lookup failed", e);
-    return c.json({ error: "Database lookup failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json({ imports: jobs.map(importJobResponse) });
+    },
+  );
 });
 
 app.get("/recipe-imports/:jobId", async (c) => {
   const jobId = recipeImportIdSchema.safeParse(c.req.param("jobId"));
   if (!jobId.success) return c.json({ error: "Import not found" }, 404);
 
-  const connectionString = requireDatabaseConnection(c);
-  if (connectionString instanceof Response) return connectionString;
+  return withRecipeSession(
+    c,
+    "lookup",
+    "GET /recipe-imports/:jobId lookup failed",
+    async ({ db, session }) => {
+      const [job] = await db
+        .select()
+        .from(schema.recipeImportJob)
+        .where(eq(schema.recipeImportJob.id, jobId.data))
+        .limit(1);
+      if (!job || job.userId !== session.user.id) {
+        return c.json({ error: "Import not found" }, 404);
+      }
 
-  let client: DbClient | undefined;
-  try {
-    const connection = createDb(connectionString);
-    client = connection.client;
-    const { db } = connection;
-    const session = await requireRecipeSession(c, db);
-    if (!session.success) return session.response;
+      const artifacts = await db
+        .select({
+          stage: schema.recipeImportArtifact.stage,
+          kind: schema.recipeImportArtifact.kind,
+          r2Key: schema.recipeImportArtifact.r2Key,
+          checksum: schema.recipeImportArtifact.checksum,
+          schemaVersion: schema.recipeImportArtifact.schemaVersion,
+          model: schema.recipeImportArtifact.model,
+          provider: schema.recipeImportArtifact.provider,
+          createdAt: schema.recipeImportArtifact.createdAt,
+        })
+        .from(schema.recipeImportArtifact)
+        .where(eq(schema.recipeImportArtifact.jobId, job.id))
+        .orderBy(schema.recipeImportArtifact.createdAt);
 
-    const [job] = await db
-      .select()
-      .from(schema.recipeImportJob)
-      .where(eq(schema.recipeImportJob.id, jobId.data))
-      .limit(1);
-    if (!job || job.userId !== session.session.user.id) {
-      return c.json({ error: "Import not found" }, 404);
-    }
+      const draft =
+        job.status === "succeeded"
+          ? (
+              await db
+                .select({ preview: schema.recipeImportArtifact.preview })
+                .from(schema.recipeImportArtifact)
+                .where(
+                  and(
+                    eq(schema.recipeImportArtifact.jobId, job.id),
+                    eq(schema.recipeImportArtifact.stage, "finalize"),
+                    eq(schema.recipeImportArtifact.kind, "draft"),
+                  ),
+                )
+                .limit(1)
+            )[0]?.preview
+          : undefined;
 
-    const artifacts = await db
-      .select({
-        stage: schema.recipeImportArtifact.stage,
-        kind: schema.recipeImportArtifact.kind,
-        r2Key: schema.recipeImportArtifact.r2Key,
-        checksum: schema.recipeImportArtifact.checksum,
-        schemaVersion: schema.recipeImportArtifact.schemaVersion,
-        model: schema.recipeImportArtifact.model,
-        provider: schema.recipeImportArtifact.provider,
-        createdAt: schema.recipeImportArtifact.createdAt,
-      })
-      .from(schema.recipeImportArtifact)
-      .where(eq(schema.recipeImportArtifact.jobId, job.id))
-      .orderBy(schema.recipeImportArtifact.createdAt);
-
-    const draft =
-      job.status === "succeeded"
-        ? (
-            await db
-              .select({ preview: schema.recipeImportArtifact.preview })
-              .from(schema.recipeImportArtifact)
-              .where(
-                and(
-                  eq(schema.recipeImportArtifact.jobId, job.id),
-                  eq(schema.recipeImportArtifact.stage, "finalize"),
-                  eq(schema.recipeImportArtifact.kind, "draft"),
-                ),
-              )
-              .limit(1)
-          )[0]?.preview
-        : undefined;
-
-    return c.json({ ...importJobResponse(job), artifacts, draft });
-  } catch (e) {
-    console.error("GET /recipe-imports/:jobId lookup failed", e);
-    return c.json({ error: "Database lookup failed" }, 502);
-  } finally {
-    await closeDbClient(client);
-  }
+      return c.json({ ...importJobResponse(job), artifacts, draft });
+    },
+  );
 });
 
 export { app };

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -11,9 +11,10 @@ import {
   lt,
   or,
   sql,
+  type SQL,
 } from "drizzle-orm";
 import { z } from "zod";
-import { createDb, schema } from "recipe-db";
+import { createDb, type Db, type DbClient, schema } from "recipe-db";
 import { RecipeContentSchema } from "recipe-domain";
 import { parseSchemaOrgRecipeHtml } from "recipe-parsing/schema-org";
 import { createAuth } from "./auth";
@@ -21,6 +22,7 @@ import { verifyCloudflareAccess } from "./cloudflare-access";
 import { hasPostgresErrorCode } from "./db/errors";
 import {
   decodeFeedCursor,
+  type FeedCursor,
   paginateRecipeFeed,
   recipeFeedCursorFilter,
   recipeFeedCursorTimestamp,
@@ -84,8 +86,6 @@ type InvitationNotificationStatus =
   | "declined"
   | "expired"
   | "unavailable";
-type DbClient = ReturnType<typeof createDb>["client"];
-type Db = ReturnType<typeof createDb>["db"];
 type AuthSessionResult =
   | { success: true; session: AuthenticatedSession }
   | { success: false; response: Response };
@@ -124,6 +124,7 @@ const recipeVisibilitySchema = z.enum(["public", "private", "household"]);
 const dietRecipeMatchModeSchema = z.enum(["hide", "warn"]);
 const feedScopeSchema = z.enum(["public", "household"]);
 const feedLimitSchema = z.coerce.number().int().min(1).max(30).default(12);
+const recipeListLimitSchema = z.coerce.number().int().min(1).max(100).default(100);
 const publicCookIdSchema = z.string().trim().min(1).max(128);
 
 const dietKeySchema = z
@@ -270,6 +271,17 @@ function databaseConnection(env: Bindings): string | undefined {
   return env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL;
 }
 
+const NO_DATABASE_CONNECTION_ERROR =
+  "No database connection configured (HYPERDRIVE or DATABASE_URL required)";
+
+function requireDatabaseConnection(c: Context<AppEnv>): string | Response {
+  const connectionString = databaseConnection(c.env);
+  if (!connectionString) {
+    return c.json({ error: NO_DATABASE_CONNECTION_ERROR }, 503);
+  }
+  return connectionString;
+}
+
 async function closeDbClient(client: DbClient | undefined) {
   if (!client) return;
   try {
@@ -413,6 +425,19 @@ function parseRecipeSlug(c: Context<AppEnv>) {
   return { success: true, slug: result.data } as const;
 }
 
+const uuidIdSchema = z.string().uuid();
+
+function uuidParam(
+  c: Context<AppEnv>,
+  name: "householdId" | "invitationId" | "memberId" | "notificationId",
+  label: string,
+): string | Response {
+  const result = uuidIdSchema.safeParse(c.req.param(name));
+  return result.success
+    ? result.data
+    : c.json({ error: `Invalid ${label}` }, 400);
+}
+
 function hasAuthConfiguration(env: Bindings): boolean {
   if (!env.BETTER_AUTH_URL || !env.BETTER_AUTH_SECRET) return false;
   if (env.DEPLOYMENT_ENV === "preview") {
@@ -436,7 +461,7 @@ function hasLoadableAuthConfiguration(env: Bindings): boolean {
 
 async function loadOptionalRecipeSession(
   c: Context<AppEnv>,
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
 ): Promise<AuthenticatedSession | null> {
   if (!hasLoadableAuthConfiguration(c.env)) return null;
   try {
@@ -488,13 +513,8 @@ async function withRecipeSession(
   logMessage: string,
   action: (context: RecipeSessionContext) => Promise<Response> | Response,
 ): Promise<Response> {
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -520,7 +540,7 @@ function isForeignKeyViolation(error: unknown): boolean {
 }
 
 async function findRecipeBySlug(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   slug: string,
 ): Promise<Recipe | undefined> {
   const [recipe] = await db
@@ -531,16 +551,11 @@ async function findRecipeBySlug(
   return recipe;
 }
 
-async function findReadableRecipes(
-  db: ReturnType<typeof createDb>["db"],
+async function readableRecipeFilter(
+  db: Db,
   userId: string | undefined,
-): Promise<Recipe[]> {
-  if (!userId) {
-    return db
-      .select()
-      .from(schema.recipe)
-      .where(eq(schema.recipe.visibility, "public"));
-  }
+): Promise<SQL | undefined> {
+  if (!userId) return eq(schema.recipe.visibility, "public");
 
   const householdMembership = await findUserHouseholdMembership(db, userId);
   const householdMemberIds = householdMembership
@@ -558,32 +573,44 @@ async function findReadableRecipes(
         )
       : undefined;
 
-  return db
-    .select()
-    .from(schema.recipe)
-    .where(
-      householdFilter
-        ? or(
-            eq(schema.recipe.visibility, "public"),
-            eq(schema.recipe.userId, userId),
-            householdFilter,
-          )
-        : or(eq(schema.recipe.visibility, "public"), eq(schema.recipe.userId, userId)),
-    );
+  return householdFilter
+    ? or(
+        eq(schema.recipe.visibility, "public"),
+        eq(schema.recipe.userId, userId),
+        householdFilter,
+      )
+    : or(eq(schema.recipe.visibility, "public"), eq(schema.recipe.userId, userId));
 }
 
-async function findOwnedRecipes(
-  db: ReturnType<typeof createDb>["db"],
-  userId: string,
-): Promise<Recipe[]> {
-  return db
-    .select()
+async function listRecipesPage(
+  db: Db,
+  visibilityFilter: SQL | undefined,
+  cursor: FeedCursor | undefined,
+  limit: number,
+): Promise<{ recipes: Recipe[]; nextCursor: string | null }> {
+  const cursorFilter = recipeFeedCursorFilter(cursor);
+  const rows = await db
+    .select({
+      recipe: schema.recipe,
+      cursorCreatedAt: recipeFeedCursorTimestamp(),
+    })
     .from(schema.recipe)
-    .where(eq(schema.recipe.userId, userId));
+    .where(
+      visibilityFilter && cursorFilter
+        ? and(visibilityFilter, cursorFilter)
+        : (cursorFilter ?? visibilityFilter),
+    )
+    .orderBy(desc(schema.recipe.createdAt), desc(schema.recipe.id))
+    .limit(limit + 1);
+  const page = paginateRecipeFeed(rows, limit);
+  return {
+    recipes: page.items.map(({ recipe }) => recipe),
+    nextCursor: page.nextCursor,
+  };
 }
 
 async function findOwnedRecipeBySlug(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   slug: string,
   userId: string,
 ): Promise<Recipe | undefined> {
@@ -596,7 +623,7 @@ async function findOwnedRecipeBySlug(
 }
 
 async function usersShareHousehold(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   firstUserId: string,
   secondUserId: string,
 ): Promise<boolean> {
@@ -614,7 +641,7 @@ async function usersShareHousehold(
 }
 
 async function findUserHouseholdMembership(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   userId: string,
 ): Promise<HouseholdMember | undefined> {
   const [member] = await db
@@ -991,7 +1018,7 @@ async function findHouseholdMemberUserIds(
 }
 
 async function findHouseholdById(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   householdId: string,
 ): Promise<Household | undefined> {
   const [household] = await db
@@ -1003,7 +1030,7 @@ async function findHouseholdById(
 }
 
 async function findHouseholdOwner(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   householdId: string,
 ): Promise<HouseholdMember | undefined> {
   const [owner] = await db
@@ -1020,7 +1047,7 @@ async function findHouseholdOwner(
 }
 
 async function findHouseholdMembership(
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   householdId: string,
   userId: string,
 ): Promise<HouseholdMember | undefined> {
@@ -1231,7 +1258,7 @@ async function findMissingDietReferences(
 
 async function authorizeHouseholdOwnerResponse(
   c: Context<AppEnv>,
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   householdId: string,
   session: AuthenticatedSession,
 ): Promise<Response | undefined> {
@@ -1250,7 +1277,7 @@ async function authorizeHouseholdOwnerResponse(
 
 async function requireHouseholdMemberResponse(
   c: Context<AppEnv>,
-  db: ReturnType<typeof createDb>["db"],
+  db: Db,
   householdId: string,
   session: AuthenticatedSession,
 ): Promise<Response | undefined> {
@@ -1303,10 +1330,8 @@ app.post("/api/auth/preview/sign-up", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json({ error: "No database connection configured" }, 503);
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   const { db, client } = createDb(connectionString);
   const suffix = crypto.randomUUID();
@@ -1355,10 +1380,8 @@ app.post("/api/auth/preview/sign-in", async (c) => {
   const scenario = findPreviewScenario(body.data.scenario);
   if (!scenario) return c.json({ error: "Unknown preview scenario" }, 400);
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json({ error: "No database connection configured" }, 503);
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   const { db, client } = createDb(connectionString);
   try {
@@ -1398,10 +1421,8 @@ app.on(["POST", "GET"], "/api/auth/*", async (c) => {
     return c.notFound();
   }
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json({ error: "No database connection configured" }, 503);
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
   if (!hasAuthConfiguration(c.env)) {
     return c.json({ error: "Auth configuration is incomplete" }, 503);
   }
@@ -1600,13 +1621,8 @@ app.put("/api/profile/recipe-box", async (c) => {
 });
 
 app.get("/households", async (c) => {
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -1692,13 +1708,8 @@ app.post("/households", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -1754,7 +1765,8 @@ app.post("/households", async (c) => {
 });
 
 app.patch("/households/:householdId", async (c) => {
-  const householdId = c.req.param("householdId");
+  const householdId = uuidParam(c, "householdId", "household ID");
+  if (householdId instanceof Response) return householdId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
@@ -1787,14 +1799,10 @@ app.patch("/households/:householdId", async (c) => {
 });
 
 app.get("/households/:householdId/members", async (c) => {
-  const householdId = c.req.param("householdId");
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const householdId = uuidParam(c, "householdId", "household ID");
+  if (householdId instanceof Response) return householdId;
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -1840,7 +1848,8 @@ app.get("/households/:householdId/members", async (c) => {
 });
 
 app.get("/households/:householdId/invitations", async (c) => {
-  const householdId = c.req.param("householdId");
+  const householdId = uuidParam(c, "householdId", "household ID");
+  if (householdId instanceof Response) return householdId;
   return withRecipeSession(
     c,
     "query",
@@ -1871,17 +1880,13 @@ app.get("/households/:householdId/invitations", async (c) => {
 });
 
 app.post("/households/:householdId/invitations", async (c) => {
-  const householdId = c.req.param("householdId");
+  const householdId = uuidParam(c, "householdId", "household ID");
+  if (householdId instanceof Response) return householdId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -1974,17 +1979,13 @@ app.post("/households/:householdId/invitations", async (c) => {
 });
 
 app.post("/households/invitations/:invitationId/accept", async (c) => {
-  const invitationId = c.req.param("invitationId");
+  const invitationId = uuidParam(c, "invitationId", "invitation ID");
+  if (invitationId instanceof Response) return invitationId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2015,17 +2016,13 @@ app.post("/households/invitations/:invitationId/accept", async (c) => {
 });
 
 app.post("/households/invitations/:invitationId/decline", async (c) => {
-  const invitationId = c.req.param("invitationId");
+  const invitationId = uuidParam(c, "invitationId", "invitation ID");
+  if (invitationId instanceof Response) return invitationId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2055,18 +2052,15 @@ app.post("/households/invitations/:invitationId/decline", async (c) => {
 app.delete(
   "/households/:householdId/invitations/:invitationId",
   async (c) => {
-    const householdId = c.req.param("householdId");
-    const invitationId = c.req.param("invitationId");
+    const householdId = uuidParam(c, "householdId", "household ID");
+    if (householdId instanceof Response) return householdId;
+    const invitationId = uuidParam(c, "invitationId", "invitation ID");
+    if (invitationId instanceof Response) return invitationId;
     const csrfFailure = validateCsrf(c);
     if (csrfFailure) return csrfFailure;
 
-    const connectionString = databaseConnection(c.env);
-    if (!connectionString) {
-      return c.json(
-        { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-        503,
-      );
-    }
+    const connectionString = requireDatabaseConnection(c);
+    if (connectionString instanceof Response) return connectionString;
 
     let client: DbClient | undefined;
     try {
@@ -2127,18 +2121,15 @@ app.delete(
 );
 
 app.delete("/households/:householdId/members/:memberId", async (c) => {
-  const householdId = c.req.param("householdId");
-  const memberId = c.req.param("memberId");
+  const householdId = uuidParam(c, "householdId", "household ID");
+  if (householdId instanceof Response) return householdId;
+  const memberId = uuidParam(c, "memberId", "member ID");
+  if (memberId instanceof Response) return memberId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2205,17 +2196,13 @@ app.delete("/households/:householdId/members/:memberId", async (c) => {
 });
 
 app.post("/households/:householdId/leave", async (c) => {
-  const householdId = c.req.param("householdId");
+  const householdId = uuidParam(c, "householdId", "household ID");
+  if (householdId instanceof Response) return householdId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2273,11 +2260,12 @@ app.post("/households/:householdId/leave", async (c) => {
 });
 
 app.delete("/households/:householdId", async (c) => {
-  const householdId = c.req.param("householdId");
+  const householdId = uuidParam(c, "householdId", "household ID");
+  if (householdId instanceof Response) return householdId;
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) return c.json({ error: "No database connection configured" }, 503);
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2342,8 +2330,8 @@ app.get("/notifications", async (c) => {
   if (!Number.isSafeInteger(offset) || offset < 0) {
     return c.json({ error: "Invalid notification offset" }, 400);
   }
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) return c.json({ error: "No database connection configured" }, 503);
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
   let client: DbClient | undefined;
   try {
     const connection = createDb(connectionString);
@@ -2414,8 +2402,8 @@ async function mutateAllNotifications(
 ): Promise<Response> {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) return c.json({ error: "No database connection configured" }, 503);
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
   let client: DbClient | undefined;
   try {
     const connection = createDb(connectionString);
@@ -2460,10 +2448,10 @@ app.post("/notifications/:notificationId/actions/:actionKey", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
   const action = c.req.param("actionKey");
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json({ error: "No database connection configured" }, 503);
-  }
+  const notificationId = uuidParam(c, "notificationId", "notification ID");
+  if (notificationId instanceof Response) return notificationId;
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2473,7 +2461,6 @@ app.post("/notifications/:notificationId/actions/:actionKey", async (c) => {
     const session = await requireRecipeSession(c, db);
     if (!session.success) return session.response;
 
-    const notificationId = c.req.param("notificationId");
     const [target] = await db
       .select({
         eventId: schema.notificationEvent.id,
@@ -2535,8 +2522,10 @@ app.post("/notifications/:notificationId/actions/:actionKey", async (c) => {
 app.patch("/notifications/:notificationId", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) return c.json({ error: "No database connection configured" }, 503);
+  const notificationId = uuidParam(c, "notificationId", "notification ID");
+  if (notificationId instanceof Response) return notificationId;
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
   let client: DbClient | undefined;
   try {
     const connection = createDb(connectionString);
@@ -2563,10 +2552,7 @@ app.patch("/notifications/:notificationId", async (c) => {
       })
       .where(
         and(
-          eq(
-            schema.notificationDelivery.id,
-            c.req.param("notificationId"),
-          ),
+          eq(schema.notificationDelivery.id, notificationId),
           eq(
             schema.notificationDelivery.recipientUserId,
             session.session.user.id,
@@ -2587,29 +2573,36 @@ app.get("/recipes", async (c) => {
   if (scope && scope !== "owned") {
     return c.json({ error: "Invalid recipe scope" }, 400);
   }
-
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
+  const limitValue = c.req.query("limit");
+  const cursorValue = c.req.query("cursor");
+  const limit = recipeListLimitSchema.safeParse(limitValue);
+  const cursor = decodeFeedCursor(cursorValue);
+  if (!limit.success || (cursorValue && !cursor)) {
+    return c.json({ error: "Invalid recipe query" }, 400);
   }
+  // Requests that opt into pagination get an { items, nextCursor } envelope;
+  // bare requests keep the legacy array shape, bounded to the default limit.
+  const paginated = limitValue !== undefined || cursorValue !== undefined;
+
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
   let client: DbClient | undefined;
   try {
     const connection = createDb(connectionString);
     client = connection.client;
     const { db } = connection;
-    let recipes: Recipe[];
+    let visibilityFilter: SQL | undefined;
     if (scope === "owned") {
       const session = await requireRecipeSession(c, db);
       if (!session.success) return session.response;
-      recipes = await findOwnedRecipes(db, session.session.user.id);
+      visibilityFilter = eq(schema.recipe.userId, session.session.user.id);
     } else {
       const session = await loadOptionalRecipeSession(c, db);
-      recipes = await findReadableRecipes(db, session?.user.id);
+      visibilityFilter = await readableRecipeFilter(db, session?.user.id);
     }
-    return c.json(recipes.map(recipeResponse));
+    const page = await listRecipesPage(db, visibilityFilter, cursor, limit.data);
+    const items = page.recipes.map(recipeResponse);
+    return c.json(paginated ? { items, nextCursor: page.nextCursor } : items);
   } catch (e) {
     console.error("GET /recipes query failed", e);
     return c.json({ error: "Database query failed" }, 502);
@@ -2627,13 +2620,8 @@ app.get("/recipes/discover/feed", async (c) => {
     return c.json({ error: "Invalid feed query" }, 400);
   }
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2699,16 +2687,8 @@ app.get("/recipes/cooks", async (c) => {
     return c.json({ error: "Invalid cook query" }, 400);
   }
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      {
-        error:
-          "No database connection configured (HYPERDRIVE or DATABASE_URL required)",
-      },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2780,13 +2760,8 @@ app.post("/recipes/import-url", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2843,13 +2818,8 @@ app.get("/recipes/:slug", async (c) => {
   const slug = parseRecipeSlug(c);
   if (!slug.success) return slug.response;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2886,13 +2856,8 @@ app.post("/recipes", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -2948,13 +2913,8 @@ app.patch("/recipes/:slug", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -3018,13 +2978,8 @@ app.post("/recipes/:slug/household-share", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -3046,14 +3001,6 @@ app.post("/recipes/:slug/household-share", async (c) => {
       session.session.user.id,
     );
     if (!membership) return authorizationResponse(c, forbidden());
-
-    const memberFailure = await requireHouseholdMemberResponse(
-      c,
-      db,
-      membership.organizationId,
-      session.session,
-    );
-    if (memberFailure) return memberFailure;
 
     const [updatedRecipe] = await db
       .update(schema.recipe)
@@ -3085,13 +3032,8 @@ app.delete("/recipes/:slug/household-share", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -3143,13 +3085,8 @@ app.delete("/recipes/:slug", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -3289,13 +3226,8 @@ app.post("/recipe-imports", async (c) => {
     return c.json({ error: "Recipe import is not configured" }, 503);
   }
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -3429,13 +3361,8 @@ app.post("/recipe-imports", async (c) => {
 });
 
 app.get("/recipe-imports", async (c) => {
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {
@@ -3465,13 +3392,8 @@ app.get("/recipe-imports/:jobId", async (c) => {
   const jobId = recipeImportIdSchema.safeParse(c.req.param("jobId"));
   if (!jobId.success) return c.json({ error: "Import not found" }, 404);
 
-  const connectionString = databaseConnection(c.env);
-  if (!connectionString) {
-    return c.json(
-      { error: "No database connection configured (HYPERDRIVE or DATABASE_URL required)" },
-      503,
-    );
-  }
+  const connectionString = requireDatabaseConnection(c);
+  if (connectionString instanceof Response) return connectionString;
 
   let client: DbClient | undefined;
   try {

--- a/workers/recipe-api/src/notifications.ts
+++ b/workers/recipe-api/src/notifications.ts
@@ -1,8 +1,6 @@
 import { and, eq, inArray } from "drizzle-orm";
-import type { createDb } from "recipe-db";
+import type { Db } from "recipe-db";
 import * as schema from "recipe-db/schema";
-
-type Db = ReturnType<typeof createDb>["db"];
 
 export type HouseholdNotificationKind =
   | "household_invited"

--- a/workers/recipe-api/src/user-emails.ts
+++ b/workers/recipe-api/src/user-emails.ts
@@ -1,8 +1,6 @@
 import { and, eq, ne } from "drizzle-orm";
-import type { createDb } from "recipe-db";
+import type { Db } from "recipe-db";
 import * as schema from "recipe-db/schema";
-
-type Db = ReturnType<typeof createDb>["db"];
 type UserEmailIdentity = {
   id: string;
   email: string;

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -1523,25 +1523,15 @@ describe("GET /recipes", () => {
     ]);
   });
 
-  it("rejects an unknown recipe scope", async () => {
-    const res = await app.request("/recipes?scope=household", {}, env);
+  it.each([
+    ["an unknown scope", "/recipes?scope=household", "Invalid recipe scope"],
+    ["an invalid cursor", "/recipes?cursor=not-a-cursor", "Invalid recipe query"],
+    ["an out-of-range limit", "/recipes?limit=0", "Invalid recipe query"],
+  ])("rejects %s with a 400", async (_case, url, error) => {
+    const res = await app.request(url, {}, env);
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "Invalid recipe scope" });
-  });
-
-  it("rejects an invalid cursor", async () => {
-    const res = await app.request("/recipes?cursor=not-a-cursor", {}, env);
-
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "Invalid recipe query" });
-  });
-
-  it("rejects an out-of-range limit", async () => {
-    const res = await app.request("/recipes?limit=0", {}, env);
-
-    expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "Invalid recipe query" });
+    expect(await res.json()).toEqual({ error });
   });
 
   it("pages newest-first through recipes when a limit is provided", async () => {

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -187,6 +187,40 @@ const dbMock = vi.hoisted(() => {
     recipe.createdAt,
     recipe.updatedAt,
   ];
+  // Emulates the paginated recipe list query: newest-first ordering, an
+  // optional keyset cursor (three params), a limit param, and the trailing
+  // created_at::text cursor column.
+  const paginatedRecipeRows = (
+    recipes: RecipeRow[],
+    query: string,
+    params: unknown[],
+    cursorParamIndex: number,
+  ) => {
+    let page = [...recipes].sort(
+      (first, second) =>
+        second.createdAt.getTime() - first.createdAt.getTime() ||
+        second.id.localeCompare(first.id),
+    );
+    let index = cursorParamIndex;
+    if (query.includes("::timestamptz")) {
+      const cursorCreatedAt = new Date(params[index] as string).getTime();
+      const cursorId = params[index + 2] as string;
+      index += 3;
+      page = page.filter(
+        (recipe) =>
+          recipe.createdAt.getTime() < cursorCreatedAt ||
+          (recipe.createdAt.getTime() === cursorCreatedAt &&
+            recipe.id.localeCompare(cursorId) < 0),
+      );
+    }
+    const limit = params[index];
+    if (typeof limit === "number") page = page.slice(0, limit);
+    return page.map((recipe) => [
+      ...recipeRow(recipe),
+      recipe.createdAt.toISOString(),
+    ]);
+  };
+
   const dietProfileRow = (profile: DietProfileRow) => [
     profile.userId,
     profile.recipeMatchMode,
@@ -994,12 +1028,16 @@ const dbMock = vi.hoisted(() => {
 
     if (
       query.includes('from "recipe"') &&
-      query.includes('"recipe"."user_id" =')
+      query.includes('"recipe"."user_id" =') &&
+      !query.includes('"recipe"."visibility" =')
     ) {
       const userId = params[0] as string;
-      return state.recipes
-        .filter((recipe) => recipe.userId === userId)
-        .map(recipeRow);
+      return paginatedRecipeRows(
+        state.recipes.filter((recipe) => recipe.userId === userId),
+        query,
+        params,
+        1,
+      );
     }
 
     if (
@@ -1013,23 +1051,30 @@ const dbMock = vi.hoisted(() => {
     }
 
     if (query.includes('from "recipe"')) {
-      const publicVisibility = params[0] as string | undefined;
-      const ownerUserId = params[1] as string | undefined;
-      const householdVisibilityIndex = params.indexOf("household");
+      const trailingParams =
+        (query.includes("::timestamptz") ? 3 : 0) +
+        (query.includes("limit ") ? 1 : 0);
+      const filterParams = params.slice(0, params.length - trailingParams);
+      const publicVisibility = filterParams[0] as string | undefined;
+      const ownerUserId = filterParams[1] as string | undefined;
+      const householdVisibilityIndex = filterParams.indexOf("household");
       const householdUserIds =
         householdVisibilityIndex >= 0
-          ? new Set(params.slice(householdVisibilityIndex + 1))
+          ? new Set(filterParams.slice(householdVisibilityIndex + 1))
           : new Set();
 
-      return state.recipes
-        .filter(
+      return paginatedRecipeRows(
+        state.recipes.filter(
           (recipe) =>
             recipe.visibility === publicVisibility ||
             recipe.userId === ownerUserId ||
             (recipe.visibility === "household" &&
               householdUserIds.has(recipe.userId)),
-        )
-        .map(recipeRow);
+        ),
+        query,
+        params,
+        filterParams.length,
+      );
     }
 
     if (query.includes('from "diet_preset_excluded_group"')) {
@@ -1192,6 +1237,17 @@ vi.mock("jose", () => ({
 
 import handler, { app } from "../src/index";
 
+// Route ids are validated as UUIDs before any query runs, so seeded rows and
+// request paths use fixed UUID ids.
+const HOUSEHOLD_ID = "11111111-1111-4111-8111-111111111111";
+const MISSING_HOUSEHOLD_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const OWNER_MEMBER_ID = "33333333-3333-4333-8333-333333333333";
+const MEMBER_MEMBER_ID = "44444444-4444-4444-8444-444444444444";
+const INVITATION_ID = "22222222-2222-4222-8222-222222222222";
+const PENDING_INVITATION_ID = "55555555-5555-4555-8555-555555555555";
+const ALIAS_INVITATION_ID = "66666666-6666-4666-8666-666666666666";
+const EXPIRING_INVITATION_ID = "77777777-7777-4777-8777-777777777777";
+
 function sessionFor(user: { id: string; email: string; name: string }) {
   const email = user.email.toLowerCase();
   if (!dbMock.state.userEmails.some((candidate) => candidate.email === email)) {
@@ -1267,7 +1323,7 @@ function seedHousehold() {
     },
   );
   dbMock.state.organizations.push({
-    id: "household-1",
+    id: HOUSEHOLD_ID,
     name: "Owner household",
     slug: "owner-household",
     logo: null,
@@ -1287,15 +1343,15 @@ function seedHousehold() {
   );
   dbMock.state.members.push(
     {
-      id: "owner-member",
-      organizationId: "household-1",
+      id: OWNER_MEMBER_ID,
+      organizationId: HOUSEHOLD_ID,
       userId: "owner-user",
       role: "owner",
       createdAt: dbMock.date,
     },
     {
-      id: "member-member",
-      organizationId: "household-1",
+      id: MEMBER_MEMBER_ID,
+      organizationId: HOUSEHOLD_ID,
       userId: "member-user",
       role: "member",
       createdAt: dbMock.date,
@@ -1472,6 +1528,66 @@ describe("GET /recipes", () => {
 
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "Invalid recipe scope" });
+  });
+
+  it("rejects an invalid cursor", async () => {
+    const res = await app.request("/recipes?cursor=not-a-cursor", {}, env);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid recipe query" });
+  });
+
+  it("rejects an out-of-range limit", async () => {
+    const res = await app.request("/recipes?limit=0", {}, env);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid recipe query" });
+  });
+
+  it("pages newest-first through recipes when a limit is provided", async () => {
+    const recipeIds = [
+      "0b0b0b0b-0b0b-4b0b-8b0b-0b0b0b0b0b01",
+      "0b0b0b0b-0b0b-4b0b-8b0b-0b0b0b0b0b02",
+      "0b0b0b0b-0b0b-4b0b-8b0b-0b0b0b0b0b03",
+    ];
+    dbMock.state.recipes.push(
+      ...recipeIds.map((id, index) => ({
+        id,
+        slug: `soup-${index + 1}`,
+        title: `Soup ${index + 1}`,
+        description: null,
+        body: null,
+        userId: "other-user",
+        visibility: "public" as const,
+        createdAt: new Date(`2026-01-0${index + 1}T00:00:00.000Z`),
+        updatedAt: dbMock.date,
+      })),
+    );
+
+    const firstRes = await app.request("/recipes?limit=2", {}, env);
+    expect(firstRes.status).toBe(200);
+    const firstPage = (await firstRes.json()) as {
+      items: { slug: string }[];
+      nextCursor: string | null;
+    };
+    expect(firstPage.items.map((recipe) => recipe.slug)).toEqual([
+      "soup-3",
+      "soup-2",
+    ]);
+    expect(firstPage.nextCursor).toBeTruthy();
+
+    const secondRes = await app.request(
+      `/recipes?limit=2&cursor=${firstPage.nextCursor}`,
+      {},
+      env,
+    );
+    expect(secondRes.status).toBe(200);
+    const secondPage = (await secondRes.json()) as {
+      items: { slug: string }[];
+      nextCursor: string | null;
+    };
+    expect(secondPage.items.map((recipe) => recipe.slug)).toEqual(["soup-1"]);
+    expect(secondPage.nextCursor).toBeNull();
   });
 
   it("returns 502 when database query fails", async () => {
@@ -2339,7 +2455,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1",
+      `/households/${HOUSEHOLD_ID}`,
       {
         method: "PATCH",
         headers: {
@@ -2353,7 +2469,7 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      id: "household-1",
+      id: HOUSEHOLD_ID,
       name: "Park Road kitchen",
     });
   });
@@ -2362,8 +2478,8 @@ describe("household membership flows", () => {
     seedHousehold();
     dbMock.state.invitations.push(
       {
-        id: "pending-invitation",
-        organizationId: "household-1",
+        id: PENDING_INVITATION_ID,
+        organizationId: HOUSEHOLD_ID,
         email: "new@example.test",
         role: "member",
         status: "pending",
@@ -2373,7 +2489,7 @@ describe("household membership flows", () => {
       },
       {
         id: "accepted-invitation",
-        organizationId: "household-1",
+        organizationId: HOUSEHOLD_ID,
         email: "old@example.test",
         role: "member",
         status: "accepted",
@@ -2389,7 +2505,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {},
       env,
     );
@@ -2397,7 +2513,7 @@ describe("household membership flows", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([
       expect.objectContaining({
-        id: "pending-invitation",
+        id: PENDING_INVITATION_ID,
         status: "pending",
       }),
     ]);
@@ -2406,8 +2522,8 @@ describe("household membership flows", () => {
   it("returns incoming invitations for the signed-in email", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "pending-invitation",
-      organizationId: "household-1",
+      id: PENDING_INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "invitee@example.test",
       role: "member",
       status: "pending",
@@ -2426,8 +2542,8 @@ describe("household membership flows", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([
       expect.objectContaining({
-        id: "pending-invitation",
-        household: { id: "household-1", name: "Owner household" },
+        id: PENDING_INVITATION_ID,
+        household: { id: HOUSEHOLD_ID, name: "Owner household" },
       }),
     ]);
   });
@@ -2443,8 +2559,8 @@ describe("household membership flows", () => {
       updatedAt: dbMock.date,
     });
     dbMock.state.invitations.push({
-      id: "alias-invitation",
-      organizationId: "household-1",
+      id: ALIAS_INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "invitee.alias@example.test",
       role: "member",
       status: "pending",
@@ -2462,7 +2578,7 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual([
-      expect.objectContaining({ id: "alias-invitation" }),
+      expect.objectContaining({ id: ALIAS_INVITATION_ID }),
     ]);
   });
 
@@ -2475,7 +2591,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1",
+      `/households/${HOUSEHOLD_ID}`,
       {
         method: "DELETE",
         headers: { origin: "http://localhost:3000" },
@@ -2486,6 +2602,12 @@ describe("household membership flows", () => {
     expect(res.status).toBe(204);
     expect(dbMock.state.organizations).toHaveLength(0);
     expect(dbMock.state.members).toHaveLength(0);
+    expect(dbMock.state.notificationEvents).toEqual([
+      expect.objectContaining({ kind: "household_deleted" }),
+    ]);
+    expect(dbMock.state.notificationDeliveries).toEqual([
+      expect.objectContaining({ recipientUserId: "member-user" }),
+    ]);
   });
 
   it("lists household members for existing members", async () => {
@@ -2496,18 +2618,18 @@ describe("household membership flows", () => {
       name: "Member",
     });
 
-    const res = await app.request("/households/household-1/members", {}, env);
+    const res = await app.request(`/households/${HOUSEHOLD_ID}/members`, {}, env);
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: "owner-member",
+          id: OWNER_MEMBER_ID,
           role: "owner",
           user: expect.objectContaining({ email: "owner@example.test" }),
         }),
         expect.objectContaining({
-          id: "member-member",
+          id: MEMBER_MEMBER_ID,
           role: "member",
           user: expect.objectContaining({ email: "member@example.test" }),
         }),
@@ -2523,7 +2645,7 @@ describe("household membership flows", () => {
       name: "Outsider",
     });
 
-    const res = await app.request("/households/household-1/members", {}, env);
+    const res = await app.request(`/households/${HOUSEHOLD_ID}/members`, {}, env);
 
     expect(res.status).toBe(403);
     expect(await res.json()).toEqual({ error: "Authorization required" });
@@ -2538,7 +2660,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2552,7 +2674,7 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(201);
     expect(await res.json()).toMatchObject({
-      householdId: "household-1",
+      householdId: HOUSEHOLD_ID,
       email: "newmember@example.test",
       role: "member",
       status: "pending",
@@ -2576,7 +2698,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2614,7 +2736,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2638,7 +2760,7 @@ describe("household membership flows", () => {
       name: "Owner",
     });
     const inviteResponse = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2755,7 +2877,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2777,8 +2899,8 @@ describe("household membership flows", () => {
   it("returns 409 when a pending invitation already exists for the email", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
-      organizationId: "household-1",
+      id: INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "newmember@example.test",
       role: "member",
       status: "pending",
@@ -2793,7 +2915,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2816,7 +2938,7 @@ describe("household membership flows", () => {
     seedHousehold();
     dbMock.state.invitations.push({
       id: "expired-invitation",
-      organizationId: "household-1",
+      organizationId: HOUSEHOLD_ID,
       email: "newmember@example.test",
       role: "member",
       status: "pending",
@@ -2831,7 +2953,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2860,7 +2982,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations",
+      `/households/${HOUSEHOLD_ID}/invitations`,
       {
         method: "POST",
         headers: {
@@ -2879,8 +3001,8 @@ describe("household membership flows", () => {
   it("allows invited users to accept invitations", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
-      organizationId: "household-1",
+      id: INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "outsider@example.test",
       role: "member",
       status: "pending",
@@ -2895,7 +3017,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/invitation-1/accept",
+      `/households/invitations/${INVITATION_ID}/accept`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -2905,13 +3027,13 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      invitation: { id: "invitation-1", status: "accepted" },
+      invitation: { id: INVITATION_ID, status: "accepted" },
       membershipCreated: true,
     });
     expect(dbMock.state.members).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          organizationId: "household-1",
+          organizationId: HOUSEHOLD_ID,
           userId: "outsider-user",
           role: "member",
         }),
@@ -2930,8 +3052,8 @@ describe("household membership flows", () => {
       updatedAt: dbMock.date,
     });
     dbMock.state.invitations.push({
-      id: "alias-invitation",
-      organizationId: "household-1",
+      id: ALIAS_INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "outsider.alias@example.test",
       role: "member",
       status: "pending",
@@ -2946,7 +3068,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/alias-invitation/accept",
+      `/households/invitations/${ALIAS_INVITATION_ID}/accept`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -2965,8 +3087,8 @@ describe("household membership flows", () => {
   it("does not accept an invitation that expires before its atomic update", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "expiring-invitation",
-      organizationId: "household-1",
+      id: EXPIRING_INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "outsider@example.test",
       role: "member",
       status: "pending",
@@ -2982,7 +3104,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/expiring-invitation/accept",
+      `/households/invitations/${EXPIRING_INVITATION_ID}/accept`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3010,8 +3132,8 @@ describe("household membership flows", () => {
       updatedAt: dbMock.date,
     });
     dbMock.state.invitations.push({
-      id: "alias-invitation",
-      organizationId: "household-1",
+      id: ALIAS_INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "outsider.alias@example.test",
       role: "member",
       status: "pending",
@@ -3026,7 +3148,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/alias-invitation/accept",
+      `/households/invitations/${ALIAS_INVITATION_ID}/accept`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3045,8 +3167,8 @@ describe("household membership flows", () => {
   it("returns 403 when a different user accepts an invitation", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
-      organizationId: "household-1",
+      id: INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "member@example.test",
       role: "member",
       status: "pending",
@@ -3061,7 +3183,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/invitation-1/accept",
+      `/households/invitations/${INVITATION_ID}/accept`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3076,7 +3198,7 @@ describe("household membership flows", () => {
   it("prevents a user from accepting an invite while already in a household", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
+      id: INVITATION_ID,
       organizationId: "other-household",
       email: "member@example.test",
       role: "member",
@@ -3092,7 +3214,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/invitation-1/accept",
+      `/households/invitations/${INVITATION_ID}/accept`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3109,8 +3231,8 @@ describe("household membership flows", () => {
   it("allows invited users to decline invitations", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
-      organizationId: "household-1",
+      id: INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "member@example.test",
       role: "member",
       status: "pending",
@@ -3125,7 +3247,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/invitation-1/decline",
+      `/households/invitations/${INVITATION_ID}/decline`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3135,7 +3257,7 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      id: "invitation-1",
+      id: INVITATION_ID,
       status: "rejected",
     });
   });
@@ -3143,8 +3265,8 @@ describe("household membership flows", () => {
   it("prevents declining finalized invitations", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
-      organizationId: "household-1",
+      id: INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "member@example.test",
       role: "member",
       status: "accepted",
@@ -3159,7 +3281,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/invitations/invitation-1/decline",
+      `/households/invitations/${INVITATION_ID}/decline`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3176,8 +3298,8 @@ describe("household membership flows", () => {
   it("allows owners to revoke pending invitations", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
-      organizationId: "household-1",
+      id: INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "outsider@example.test",
       role: "member",
       status: "pending",
@@ -3192,7 +3314,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations/invitation-1",
+      `/households/${HOUSEHOLD_ID}/invitations/${INVITATION_ID}`,
       {
         method: "DELETE",
         headers: { origin: "http://localhost:3000" },
@@ -3202,7 +3324,7 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      id: "invitation-1",
+      id: INVITATION_ID,
       status: "canceled",
     });
   });
@@ -3210,8 +3332,8 @@ describe("household membership flows", () => {
   it("prevents owners from revoking finalized invitations", async () => {
     seedHousehold();
     dbMock.state.invitations.push({
-      id: "invitation-1",
-      organizationId: "household-1",
+      id: INVITATION_ID,
+      organizationId: HOUSEHOLD_ID,
       email: "outsider@example.test",
       role: "member",
       status: "accepted",
@@ -3226,7 +3348,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/invitations/invitation-1",
+      `/households/${HOUSEHOLD_ID}/invitations/${INVITATION_ID}`,
       {
         method: "DELETE",
         headers: { origin: "http://localhost:3000" },
@@ -3260,7 +3382,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/members/member-member",
+      `/households/${HOUSEHOLD_ID}/members/${MEMBER_MEMBER_ID}`,
       {
         method: "DELETE",
         headers: { origin: "http://localhost:3000" },
@@ -3270,7 +3392,7 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(204);
     expect(dbMock.state.members).not.toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: "member-member" })]),
+      expect.arrayContaining([expect.objectContaining({ id: MEMBER_MEMBER_ID })]),
     );
     expect(dbMock.state.recipes).toEqual(
       expect.arrayContaining([
@@ -3302,7 +3424,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/household-1/leave",
+      `/households/${HOUSEHOLD_ID}/leave`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3312,7 +3434,7 @@ describe("household membership flows", () => {
 
     expect(res.status).toBe(204);
     expect(dbMock.state.members).not.toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: "member-member" })]),
+      expect.arrayContaining([expect.objectContaining({ id: MEMBER_MEMBER_ID })]),
     );
     expect(dbMock.state.recipes).toEqual(
       expect.arrayContaining([
@@ -3333,7 +3455,7 @@ describe("household membership flows", () => {
     });
 
     const res = await app.request(
-      "/households/missing-household/leave",
+      `/households/${MISSING_HOUSEHOLD_ID}/leave`,
       {
         method: "POST",
         headers: { origin: "http://localhost:3000" },
@@ -3342,6 +3464,59 @@ describe("household membership flows", () => {
     );
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe("route id validation", () => {
+  it("rejects a malformed household id before any database access", async () => {
+    const res = await app.request(
+      "/households/not-a-uuid/members",
+      {},
+      { DATABASE_URL: "" },
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid household ID" });
+  });
+
+  it("rejects a malformed invitation id", async () => {
+    const res = await app.request(
+      "/households/invitations/not-a-uuid/accept",
+      { method: "POST", headers: { origin: "http://localhost:3000" } },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid invitation ID" });
+  });
+
+  it("rejects a malformed member id", async () => {
+    const res = await app.request(
+      `/households/${HOUSEHOLD_ID}/members/not-a-uuid`,
+      { method: "DELETE", headers: { origin: "http://localhost:3000" } },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid member ID" });
+  });
+
+  it("rejects a malformed notification id", async () => {
+    const res = await app.request(
+      "/notifications/not-a-uuid",
+      {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ read: true }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid notification ID" });
   });
 });
 

--- a/workers/recipe-ingest/src/db.ts
+++ b/workers/recipe-ingest/src/db.ts
@@ -1,7 +1,7 @@
-import { createDb } from "recipe-db";
+import { createDb, type Db } from "recipe-db";
 import type { Env } from "./env";
 
-export type Db = ReturnType<typeof createDb>["db"];
+export type { Db };
 
 export async function withDb<T>(
   env: Env,


### PR DESCRIPTION
Part of #725 (Priority 1 items 2–3 and Priority 2 items 4–5).

## What's here

- **UUID route-param validation** — household, invitation, member, and notification ids are validated as UUIDs before any database access, returning `400` with an `Invalid <thing> ID` error for malformed values. All of these ids are minted with `crypto.randomUUID()`, so no valid row can be shadowed. Route tests cover each param.
- **Bounded `GET /recipes`** — the general recipes endpoint now reuses the discover-feed keyset pagination. Bare requests keep the legacy array shape (bounded to the default limit of 100); requests that pass `limit`/`cursor` get an `{ items, nextCursor }` envelope. Invalid limits/cursors return `400`. The two UI consumers now page through `fetchAllSavedRecipes`.
- **Centralised DB types** — `recipe-db` now exports `Db`/`DbClient`; the consumer-local `ReturnType<typeof createDb>` aliases in both workers are gone.
- **Consolidated missing-connection response** — the ~30 copies of the "No database connection configured" 503 block collapse into `requireDatabaseConnection`, without hiding per-route client cleanup. The handful of routes that used a shorter variant of the message now all use the same one.
- **Household-share** — dropped the redundant household + membership recheck (`requireHouseholdMemberResponse`) that ran right after the handler had already fetched the user's membership; the 403 behavior is preserved by the existing focused tests.

## Bug found along the way

`DELETE /households/:householdId` was registered twice: the original handler from #702 and a newer one from #712 that locks the household row and creates `household_deleted` notifications. Hono dispatches to the first registration, so the newer handler was dead code and **deletion notifications were never sent**. This PR removes the stale handler and adds assertions that deleting a household notifies the remaining members.

## Tests

- `workers/recipe-api`: 161 tests pass (new coverage for id validation, pagination paging/400s, and the delete-household notification path). Seeded household/invitation/member ids in the suite moved to fixed UUID constants to satisfy the new validation.
- `ui`: 564 tests pass (new unit tests for the paginating fetch helper).
- Typechecks pass for `recipe-api`, `recipe-ingest`, and `ui`; Biome is clean on the changed files.