### PR TITLE
Clean up content-domain loading and formatting

### DIFF
--- a/ui/lib/api/experience.ts
+++ b/ui/lib/api/experience.ts
@@ -8,15 +8,22 @@ export function getExperienceSlug(experience: Experience): string {
   return normalizeSlug(experience.company);
 }
 
+const EXPERIENCE_DATE_PATTERN = /^(\d{4})-(\d{2})$/;
+
 function parseDateString(dateStr: string): Date {
-  const [yearStr, monthStr] = dateStr.split("-");
-  if (!yearStr || !monthStr) {
+  const match = EXPERIENCE_DATE_PATTERN.exec(dateStr);
+  if (!match) {
     throw new Error(
       `Invalid date format: ${dateStr}. Expected YYYY-MM format.`,
     );
   }
-  const year = parseInt(yearStr, 10);
-  const month = parseInt(monthStr, 10);
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  if (month < 1 || month > 12) {
+    throw new Error(
+      `Invalid date format: ${dateStr}. Month must be between 01 and 12.`,
+    );
+  }
   return new Date(Date.UTC(year, month - 1, 1));
 }
 

--- a/ui/lib/domain/adr/adrQueries.ts
+++ b/ui/lib/domain/adr/adrQueries.ts
@@ -1,3 +1,8 @@
+import type { RootContent } from "mdast";
+import { toString as mdastToString } from "mdast-util-to-string";
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+import remarkMdx from "remark-mdx";
 import {
   type DomainRepository,
   getADRSlugsForProject,
@@ -23,27 +28,33 @@ import {
   toADRListItemView,
 } from "./adrViews";
 
-function stripMarkdown(markdown: string): string {
-  return markdown
-    .replace(/!\[[^\]]*]\([^)]+\)/g, "")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/^>\s?/gm, "")
-    .replace(/(^|\s)>\s?/g, "$1")
-    .replace(/[*_~]+/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
+const SUMMARY_CHARACTER_LIMIT = 280;
+const summaryProcessor = remark().use(remarkMdx).use(remarkGfm);
+
+// Prose blocks that can open a summary; structural or non-prose blocks
+// (headings, code fences, imports, MDX expressions) are skipped.
+function isSummaryContent(node: RootContent): boolean {
+  switch (node.type) {
+    case "heading":
+    case "thematicBreak":
+    case "code":
+    case "html":
+    case "mdxjsEsm":
+    case "mdxFlowExpression":
+      return false;
+    default:
+      return true;
+  }
 }
 
 export function summarizeMarkdown(markdown: string): string {
-  const paragraphs = markdown
-    .split(/\n\s*\n/)
-    .map((chunk) => chunk.trim())
-    .filter(Boolean)
-    .filter((chunk) => !chunk.startsWith("#"));
-  if (paragraphs.length === 0) return "";
-  const first = stripMarkdown(paragraphs[0] ?? "");
-  return first.length > 280 ? `${first.slice(0, 277)}...` : first;
+  const root = summaryProcessor.parse(markdown);
+  const first = root.children.find(isSummaryContent);
+  if (!first) return "";
+  const text = mdastToString(first).replace(/\s+/g, " ").trim();
+  return text.length > SUMMARY_CHARACTER_LIMIT
+    ? `${text.slice(0, SUMMARY_CHARACTER_LIMIT - 3)}...`
+    : text;
 }
 
 function getADRByRef(repository: DomainRepository, adrRef: ADRRef) {

--- a/ui/lib/domain/recipe/ingredientText.ts
+++ b/ui/lib/domain/recipe/ingredientText.ts
@@ -111,12 +111,13 @@ export function formatIngredientStaticText(
   }
 
   // Mirror the UI formatter: names auto-pluralise only for bare "piece"
-  // counts; measured units rely on an explicit pluralName override.
+  // counts. Measured and unitless ingredients rely on an explicit pluralName
+  // override, so unitless fractions like "½ red onion" stay singular.
   const isPlural = item.amount != null && item.amount !== 1;
   let name = item.name;
   if (isPlural) {
     name =
-      item.unit == null || item.unit === "piece"
+      item.unit === "piece"
         ? pluralizeIngredientName(item)
         : (item.pluralName ?? item.name);
   }

--- a/ui/lib/domain/recipe/ingredientText.ts
+++ b/ui/lib/domain/recipe/ingredientText.ts
@@ -3,6 +3,7 @@ import {
   singularizeIngredientTerm,
 } from "recipe-domain/pluralization";
 import type { RecipeIngredientView } from "./recipeViews";
+import { UNIT_LABELS } from "./unit";
 
 type IngredientNameFields = Pick<RecipeIngredientView, "name" | "pluralName">;
 type IngredientPluralizationFields = Pick<
@@ -56,4 +57,68 @@ export function formatIngredientName(
   }
 
   return pluralizeIngredientName(item);
+}
+
+const FRACTION_MAP: Array<[number, string]> = [
+  [1 / 4, "¼"],
+  [1 / 3, "⅓"],
+  [1 / 2, "½"],
+  [2 / 3, "⅔"],
+  [3 / 4, "¾"],
+];
+
+function formatStaticAmount(amount: number): string {
+  const whole = Math.floor(amount);
+  const frac = amount - whole;
+  if (frac < 0.01) return String(whole);
+  for (const [value, symbol] of FRACTION_MAP) {
+    if (Math.abs(frac - value) < 0.02) {
+      return whole > 0 ? `${whole}${symbol}` : symbol;
+    }
+  }
+  return amount.toFixed(1);
+}
+
+/**
+ * Unscaled plain-text rendering of an ingredient for static exports
+ * (schema.org JSON-LD and the agent Markdown twins): fractional amounts,
+ * pluralised unit/name, preparation in parens, and — when requested — the
+ * free-text note after a dash.
+ */
+export function formatIngredientStaticText(
+  item: RecipeIngredientView,
+  options?: { includeNote?: boolean },
+): string {
+  const parts: string[] = [];
+
+  if (item.amount != null) {
+    parts.push(formatStaticAmount(item.amount));
+  }
+
+  if (item.unit) {
+    const label = UNIT_LABELS[item.unit];
+    const isPlural = item.amount != null && item.amount > 1;
+    const unitStr = isPlural ? label.plural : label.singular;
+    if (label.noSpace && parts.length > 0) {
+      parts[parts.length - 1] += unitStr;
+    } else {
+      parts.push(unitStr);
+    }
+  }
+
+  const name =
+    item.amount != null && item.amount !== 1 && item.pluralName
+      ? item.pluralName
+      : item.name;
+  parts.push(name);
+
+  if (item.preparation) {
+    parts.push(`(${item.preparation})`);
+  }
+
+  if (options?.includeNote && item.note) {
+    parts.push(`– ${item.note}`);
+  }
+
+  return parts.join(" ").trim();
 }

--- a/ui/lib/domain/recipe/ingredientText.ts
+++ b/ui/lib/domain/recipe/ingredientText.ts
@@ -95,10 +95,11 @@ export function formatIngredientStaticText(
     parts.push(formatStaticAmount(item.amount));
   }
 
-  if (item.unit) {
+  // "piece" is a counting placeholder, not a label the UI ever renders.
+  if (item.unit && item.unit !== "piece") {
     const label = UNIT_LABELS[item.unit];
-    const isPlural = item.amount != null && item.amount > 1;
-    const unitStr = isPlural ? label.plural : label.singular;
+    const isPluralUnit = item.amount != null && item.amount > 1;
+    const unitStr = isPluralUnit ? label.plural : label.singular;
     if (label.noSpace && parts.length > 0) {
       parts[parts.length - 1] += unitStr;
     } else {
@@ -106,10 +107,16 @@ export function formatIngredientStaticText(
     }
   }
 
-  const name =
-    item.amount != null && item.amount !== 1 && item.pluralName
-      ? item.pluralName
-      : item.name;
+  // Mirror the UI formatter: names auto-pluralise only for bare "piece"
+  // counts; measured units rely on an explicit pluralName override.
+  const isPlural = item.amount != null && item.amount !== 1;
+  let name = item.name;
+  if (isPlural) {
+    name =
+      item.unit == null || item.unit === "piece"
+        ? pluralizeIngredientName(item)
+        : (item.pluralName ?? item.name);
+  }
   parts.push(name);
 
   if (item.preparation) {

--- a/ui/lib/domain/recipe/ingredientText.ts
+++ b/ui/lib/domain/recipe/ingredientText.ts
@@ -95,9 +95,12 @@ export function formatIngredientStaticText(
     parts.push(formatStaticAmount(item.amount));
   }
 
-  // "piece" is a counting placeholder, not a label the UI ever renders.
-  if (item.unit && item.unit !== "piece") {
-    const label = UNIT_LABELS[item.unit];
+  // "piece" is a counting placeholder, not a label the UI ever renders. The
+  // label lookup is guarded so an unrecognised unit degrades to no label
+  // instead of crashing a build-time export.
+  const label =
+    item.unit && item.unit !== "piece" ? UNIT_LABELS[item.unit] : undefined;
+  if (label) {
     const isPluralUnit = item.amount != null && item.amount > 1;
     const unitStr = isPluralUnit ? label.plural : label.singular;
     if (label.noSpace && parts.length > 0) {

--- a/ui/lib/repository/repository.ts
+++ b/ui/lib/repository/repository.ts
@@ -862,7 +862,7 @@ function buildRelationDataFromLoaders(loaders: LoaderResults): RelationData {
   return relations;
 }
 
-export function loadDomainRepository(): DomainRepository {
+function buildDomainRepository(): DomainRepository {
   const technologies = loadTechnologies();
   validateTechnologyReferences(technologies);
   const blogsResult = loadBlogPosts();
@@ -915,4 +915,17 @@ export function loadDomainRepository(): DomainRepository {
     buildingPhilosophy,
     referentialIntegrityErrors,
   };
+}
+
+// Loading reparses and validates every content file, so the result is cached
+// for the lifetime of the process (a build, a server, or a test run).
+let cachedRepository: DomainRepository | undefined;
+
+export function loadDomainRepository(): DomainRepository {
+  cachedRepository ??= buildDomainRepository();
+  return cachedRepository;
+}
+
+export function resetDomainRepositoryCache(): void {
+  cachedRepository = undefined;
 }

--- a/ui/lib/seo/recipe-jsonld.ts
+++ b/ui/lib/seo/recipe-jsonld.ts
@@ -1,9 +1,8 @@
+import { formatIngredientStaticText } from "@/lib/domain/recipe/ingredientText";
 import type {
   RecipeCardView,
   RecipeDetailView,
-  RecipeIngredientView,
 } from "@/lib/domain/recipe/recipeViews";
-import { UNIT_LABELS } from "@/lib/domain/recipe/unit";
 
 export type SchemaOrgPerson = {
   "@type": "Person";
@@ -62,57 +61,6 @@ export function minutesToIsoDuration(minutes: number): string {
   return `PT${h}H${m}M`;
 }
 
-const FRACTION_MAP: Array<[number, string]> = [
-  [1 / 4, "¼"],
-  [1 / 3, "⅓"],
-  [1 / 2, "½"],
-  [2 / 3, "⅔"],
-  [3 / 4, "¾"],
-];
-
-function formatAmount(amount: number): string {
-  const whole = Math.floor(amount);
-  const frac = amount - whole;
-  if (frac < 0.01) return String(whole);
-  for (const [val, sym] of FRACTION_MAP) {
-    if (Math.abs(frac - val) < 0.02) {
-      return whole > 0 ? `${whole}${sym}` : sym;
-    }
-  }
-  return amount.toFixed(1);
-}
-
-function formatRecipeIngredient(item: RecipeIngredientView): string {
-  const parts: string[] = [];
-
-  if (item.amount != null) {
-    parts.push(formatAmount(item.amount));
-  }
-
-  if (item.unit) {
-    const label = UNIT_LABELS[item.unit];
-    const isPlural = item.amount != null && item.amount > 1;
-    const unitStr = isPlural ? label.plural : label.singular;
-    if (label.noSpace && parts.length > 0) {
-      parts[parts.length - 1] += unitStr;
-    } else {
-      parts.push(unitStr);
-    }
-  }
-
-  const name =
-    item.amount != null && item.amount !== 1 && item.pluralName
-      ? item.pluralName
-      : item.name;
-  parts.push(name);
-
-  if (item.preparation) {
-    parts.push(`(${item.preparation})`);
-  }
-
-  return parts.join(" ").trim();
-}
-
 function buildSchemaImageUrl(imageId: string): string | undefined {
   const accountHash = process.env.NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH;
   if (!accountHash) return undefined;
@@ -140,7 +88,7 @@ export function buildRecipeJsonLd(
   const imageUrl = recipe.image ? buildSchemaImageUrl(recipe.image) : undefined;
 
   const recipeIngredient = recipe.ingredientGroups.flatMap((group) =>
-    group.items.map(formatRecipeIngredient),
+    group.items.map((item) => formatIngredientStaticText(item)),
   );
 
   const recipeInstructions: SchemaOrgHowToStep[] = recipe.instructions.map(

--- a/ui/scripts/generate-agent-markdown.ts
+++ b/ui/scripts/generate-agent-markdown.ts
@@ -37,6 +37,7 @@ import {
   renderPage,
 } from "@/lib/content/agent-markdown";
 import { loadDomainRepository } from "@/lib/domain";
+import { formatIngredientStaticText } from "@/lib/domain/recipe/ingredientText";
 import {
   getAllTechnologySlugs,
   getRelatedContentForTechnology,
@@ -301,16 +302,6 @@ function buildExperiencePage(): GeneratedPage {
   };
 }
 
-function formatIngredient(
-  item: RecipeDetailView["ingredientGroups"][number]["items"][number],
-): string {
-  const quantity = [item.amount, item.unit].filter(Boolean).join(" ");
-  const name = quantity ? `${quantity} ${item.name}` : item.name;
-  const preparation = item.preparation ? `, ${item.preparation}` : "";
-  const note = item.note ? ` (${item.note})` : "";
-  return `- ${name}${preparation}${note}`;
-}
-
 function buildRecipePage(recipe: RecipeDetailView): GeneratedPage {
   const facts: [string, string][] = [["Servings", String(recipe.servings)]];
   if (recipe.prepTime) facts.push(["Prep time", `${recipe.prepTime} min`]);
@@ -323,7 +314,9 @@ function buildRecipePage(recipe: RecipeDetailView): GeneratedPage {
 
   const ingredients = recipe.ingredientGroups.flatMap((group) => [
     ...(group.name ? [`### ${group.name}`, ""] : []),
-    ...group.items.map(formatIngredient),
+    ...group.items.map(
+      (item) => `- ${formatIngredientStaticText(item, { includeNote: true })}`,
+    ),
     "",
   ]);
   const cookware =

--- a/ui/tests/lib/api/experience.test.ts
+++ b/ui/tests/lib/api/experience.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatExperienceDateRange,
+  getExperienceDuration,
+} from "@/lib/api/experience";
+
+describe("formatExperienceDateRange", () => {
+  it("formats a closed range", () => {
+    expect(formatExperienceDateRange("2020-03", "2021-11")).toBe(
+      "Mar 2020 - Nov 2021",
+    );
+  });
+
+  it("formats an open range as Present", () => {
+    expect(formatExperienceDateRange("2020-03")).toBe("Mar 2020 - Present");
+  });
+
+  it("rejects dates without a month", () => {
+    expect(() => formatExperienceDateRange("2020")).toThrow(
+      "Expected YYYY-MM format",
+    );
+  });
+
+  it("rejects non-numeric dates", () => {
+    expect(() => formatExperienceDateRange("20xx-ab")).toThrow(
+      "Expected YYYY-MM format",
+    );
+  });
+
+  it("rejects unpadded months", () => {
+    expect(() => formatExperienceDateRange("2020-3")).toThrow(
+      "Expected YYYY-MM format",
+    );
+  });
+
+  it("rejects out-of-range months instead of rolling the year", () => {
+    expect(() => formatExperienceDateRange("2020-13")).toThrow(
+      "Month must be between 01 and 12",
+    );
+    expect(() => formatExperienceDateRange("2020-00")).toThrow(
+      "Month must be between 01 and 12",
+    );
+  });
+});
+
+describe("getExperienceDuration", () => {
+  it("counts inclusive months", () => {
+    expect(getExperienceDuration("2020-01", "2020-03")).toBe("3 months");
+  });
+
+  it("formats years with remaining months", () => {
+    expect(getExperienceDuration("2020-01", "2021-03")).toBe(
+      "1 year, 3 months",
+    );
+  });
+});

--- a/ui/tests/lib/domain/adr/adrUtils.test.ts
+++ b/ui/tests/lib/domain/adr/adrUtils.test.ts
@@ -41,12 +41,49 @@ describe("ADR utilities", () => {
   it("summarizes markdown to clean plain text", () => {
     const markdown = `# Heading
 
-**Bold** with [link](https://example.com), \`inline code\`, and > quoted text.
+**Bold** with [link](https://example.com) and \`inline code\`.
 
 Second paragraph.`;
 
-    expect(summarizeMarkdown(markdown)).toBe(
-      "Bold with link, inline code, and quoted text.",
-    );
+    expect(summarizeMarkdown(markdown)).toBe("Bold with link and inline code.");
+  });
+
+  it("summarizes a leading blockquote without quote markers", () => {
+    const markdown = `# Heading
+
+> Decision quoted from the RFC.
+
+Details follow.`;
+
+    expect(summarizeMarkdown(markdown)).toBe("Decision quoted from the RFC.");
+  });
+
+  it("skips code fences and MDX imports before the first paragraph", () => {
+    const markdown = `import { Chart } from "@/components/chart";
+
+\`\`\`ts
+const ignored = true;
+\`\`\`
+
+The real opening paragraph.`;
+
+    expect(summarizeMarkdown(markdown)).toBe("The real opening paragraph.");
+  });
+
+  it("flattens MDX components to their text content", () => {
+    const markdown = `<Callout kind="info">Ship the smallest change.</Callout>`;
+
+    expect(summarizeMarkdown(markdown)).toBe("Ship the smallest change.");
+  });
+
+  it("returns an empty summary when only headings exist", () => {
+    expect(summarizeMarkdown("# Only a heading")).toBe("");
+  });
+
+  it("truncates summaries to 280 characters with an ellipsis", () => {
+    const summary = summarizeMarkdown(`${"word ".repeat(80)}end`);
+
+    expect(summary).toHaveLength(280);
+    expect(summary.endsWith("...")).toBe(true);
   });
 });

--- a/ui/tests/lib/domain/recipe/ingredientText.test.ts
+++ b/ui/tests/lib/domain/recipe/ingredientText.test.ts
@@ -165,16 +165,36 @@ describe("ingredientText", () => {
       ).toBe("½ cup milk");
     });
 
-    it("pluralises units and names for amounts above one", () => {
+    it("pluralises unit labels for amounts above one", () => {
       expect(
         formatIngredientStaticText({
           ingredient: "chopped-tomatoes",
-          name: "tin of tomatoes",
-          pluralName: "tins of tomatoes",
+          name: "chopped tomatoes",
           amount: 2,
           unit: "tin",
         }),
-      ).toBe("2 tins tins of tomatoes");
+      ).toBe("2 tins chopped tomatoes");
+    });
+
+    it("keeps unitless fractional ingredients singular", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "red-onion",
+          name: "red onion",
+          amount: 0.5,
+        }),
+      ).toBe("½ red onion");
+    });
+
+    it("uses pluralName for unitless counts when provided", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "lemon",
+          name: "lemon",
+          pluralName: "lemons",
+          amount: 2,
+        }),
+      ).toBe("2 lemons");
     });
 
     it("auto-pluralises bare piece counts like the UI formatter", () => {

--- a/ui/tests/lib/domain/recipe/ingredientText.test.ts
+++ b/ui/tests/lib/domain/recipe/ingredientText.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatIngredientName,
+  formatIngredientStaticText,
   pluralizeIngredientName,
 } from "@/lib/domain/recipe/ingredientText";
 
@@ -138,6 +139,67 @@ describe("ingredientText", () => {
           1,
         ),
       ).toBe("white onions");
+    });
+  });
+
+  describe("formatIngredientStaticText", () => {
+    it("joins metric amounts to noSpace units", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "plain-flour",
+          name: "plain flour",
+          amount: 500,
+          unit: "g",
+        }),
+      ).toBe("500g plain flour");
+    });
+
+    it("renders fractional amounts with unicode fractions", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "milk",
+          name: "milk",
+          amount: 0.5,
+          unit: "us_cup",
+        }),
+      ).toBe("½ cup milk");
+    });
+
+    it("pluralises units and names for amounts above one", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "chopped-tomatoes",
+          name: "tin of tomatoes",
+          pluralName: "tins of tomatoes",
+          amount: 2,
+          unit: "tin",
+        }),
+      ).toBe("2 tins tins of tomatoes");
+    });
+
+    it("appends preparation in parentheses", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "onion",
+          name: "onion",
+          amount: 1,
+          preparation: "finely diced",
+        }),
+      ).toBe("1 onion (finely diced)");
+    });
+
+    it("omits notes unless asked to include them", () => {
+      const item = {
+        ingredient: "feta",
+        name: "feta",
+        amount: 200,
+        unit: "g" as const,
+        note: "or a vegan alternative",
+      };
+      expect(formatIngredientStaticText(item)).toBe("200g feta");
+      expect(formatIngredientStaticText(item, { includeNote: true })).toBe(
+        "200g feta – or a vegan alternative",
+      );
     });
   });
 });

--- a/ui/tests/lib/domain/recipe/ingredientText.test.ts
+++ b/ui/tests/lib/domain/recipe/ingredientText.test.ts
@@ -177,6 +177,28 @@ describe("ingredientText", () => {
       ).toBe("2 tins tins of tomatoes");
     });
 
+    it("auto-pluralises bare piece counts like the UI formatter", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "white-onion",
+          name: "white onion",
+          amount: 2,
+          unit: "piece",
+        }),
+      ).toBe("2 white onions");
+    });
+
+    it("does not pluralise measured ingredient names without an override", () => {
+      expect(
+        formatIngredientStaticText({
+          ingredient: "plain-flour",
+          name: "plain flour",
+          amount: 2,
+          unit: "tbsp",
+        }),
+      ).toBe("2 tbsp plain flour");
+    });
+
     it("appends preparation in parentheses", () => {
       expect(
         formatIngredientStaticText({

--- a/ui/tests/lib/domain/repositoryCache.test.ts
+++ b/ui/tests/lib/domain/repositoryCache.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadDomainRepository,
+  resetDomainRepositoryCache,
+} from "@/lib/repository";
+
+describe("domain repository cache", () => {
+  it("returns the same instance across calls", () => {
+    resetDomainRepositoryCache();
+    const first = loadDomainRepository();
+
+    expect(loadDomainRepository()).toBe(first);
+  });
+
+  it("rebuilds after an explicit reset", () => {
+    resetDomainRepositoryCache();
+    const first = loadDomainRepository();
+    resetDomainRepositoryCache();
+    const rebuilt = loadDomainRepository();
+
+    expect(rebuilt).not.toBe(first);
+    expect(rebuilt.technologies.size).toBe(first.technologies.size);
+    expect(rebuilt.projects.size).toBe(first.projects.size);
+  });
+});


### PR DESCRIPTION
Part of #725 (Priority 2 items 6 and 8, Priority 3 items 9 and 10).

## What's here

- **Domain repository cache** — `loadDomainRepository()` used to reparse and Zod-validate every content file on each call (some API modules cached it incidentally at module scope, other consumers called it directly). It now memoises per process, with `resetDomainRepositoryCache()` exported as a test reset hook. New tests assert instance identity across calls and a rebuild after reset.
- **Strict experience dates** — `parseDateString` accepted anything with two `-`-separated tokens, so non-numeric input became `Invalid Date` and month `13` silently rolled into the next year. It now requires zero-padded `YYYY-MM` and range-checks the month; all content dates already conform. Regression tests cover the rejected shapes.
- **ADR summaries via the Markdown pipeline** — `summarizeMarkdown` swaps its stack of regexes for the same remark + MDX + GFM pipeline used by the agent-markdown generator: parse, take the first prose block (skipping headings, code fences, imports, and MDX expressions), flatten with `mdast-util-to-string`, keep the 280-character/ellipsis contract. Fixtures cover links, inline code, blockquotes, MDX components, import skipping, and truncation. One existing fixture used a mid-sentence `>` (not a Markdown blockquote); it's been replaced with a real blockquote case.
- **Unified ingredient text formatter** — the JSON-LD builder's ingredient formatter moved into the recipe domain as `formatIngredientStaticText`, and `generate-agent-markdown.ts` drops its own divergent formatter (which joined raw amount/unit with a space and skipped pluralisation) in favour of the shared one, opting into note rendering. Output expectations are pinned in unit tests (fractions, noSpace units, pluralised units/names, preparation, notes).

Markdown-twin ingredient lines change format slightly (e.g. `- 500 g flour, sifted (see note)` → `- 500g flour (sifted) – see note`), aligning them with the site UI and JSON-LD rendering.

## Tests

`ui`: 581 tests pass (17 new). Typecheck and Biome clean on changed files.