### PR TITLE
Fix mixed-currency totals and cook-mode state sharing

### DIFF
--- a/ui/app/recipes/layout.tsx
+++ b/ui/app/recipes/layout.tsx
@@ -7,6 +7,7 @@ import { NotificationBell } from "@/components/recipes/notifications/notificatio
 import { RecipeSiteNav } from "@/components/recipes/recipe-site-nav";
 import { RecipeThemeBody } from "@/components/recipes/recipe-theme-body";
 import { TimerDock } from "@/components/recipes/timer-dock";
+import { CookModeProvider } from "@/contexts/cook-mode-context";
 import { siteConfig } from "@/lib/config/site-config";
 import "./recipe-theme.css";
 
@@ -48,7 +49,7 @@ export default function RecipesLayout({
   const fontVars = `${caveat.variable} ${kalam.variable} ${jetBrainsMono.variable}`;
 
   return (
-    <>
+    <CookModeProvider>
       {/* Mirror the theme + fonts onto <body> so portaled UI (mobile filter
           drawer, popovers) inherits the warm palette instead of the dark base. */}
       <RecipeThemeBody classNames={`recipe-theme ${fontVars}`} />
@@ -94,6 +95,6 @@ export default function RecipesLayout({
           above the cook-mode overlay (which portals to <body>). Theme tokens
           come from the classes RecipeThemeBody mirrors onto <body>. */}
       <TimerDock />
-    </>
+    </CookModeProvider>
   );
 }

--- a/ui/components/assettracker/accounts-table.tsx
+++ b/ui/components/assettracker/accounts-table.tsx
@@ -6,9 +6,9 @@ import {
   ASSET_TYPE_LABELS,
   type AssetType,
   type BalanceSnapshotView,
-  computeTotalBalance,
   formatAccountCurrency,
   formatAnnualRate,
+  formatTotalBalances,
   isLiability,
   todayIsoDate,
 } from "@/lib/domain/assettracker";
@@ -42,9 +42,6 @@ export function AccountsTable({
 }: AccountsTableProps) {
   const assets = accounts.filter((a) => !isLiability(a.assetType));
   const liabilities = accounts.filter((a) => isLiability(a.assetType));
-  const totalBalance = computeTotalBalance(accounts);
-  // Use first account's currency for totals (assumes homogeneous currency)
-  const totalCurrency = accounts[0]?.currency ?? "GBP";
 
   return (
     <div className="border rounded-lg overflow-hidden">
@@ -66,13 +63,11 @@ export function AccountsTable({
             <AccountsSection
               label="Assets"
               accounts={assets}
-              currency={totalCurrency}
               onSelectAccount={onSelectAccount}
             />
             <AccountsSection
               label="Liabilities"
               accounts={liabilities}
-              currency={totalCurrency}
               onSelectAccount={onSelectAccount}
             />
           </tbody>
@@ -82,7 +77,7 @@ export function AccountsTable({
                 Net worth
               </td>
               <td className="p-3 text-right font-mono font-semibold">
-                {formatAccountCurrency(totalBalance, totalCurrency)}
+                {formatTotalBalances(accounts)}
               </td>
               <td colSpan={3} />
             </tr>
@@ -96,16 +91,13 @@ export function AccountsTable({
 function AccountsSection({
   label,
   accounts,
-  currency,
   onSelectAccount,
 }: {
   label: string;
   accounts: AccountDetailView[];
-  currency: AccountDetailView["currency"];
   onSelectAccount?: (accountId: string) => void;
 }) {
   if (accounts.length === 0) return null;
-  const subtotal = computeTotalBalance(accounts);
   return (
     <>
       <tr className="border-b bg-muted/20">
@@ -128,7 +120,7 @@ function AccountsSection({
           {label} total
         </td>
         <td className="p-3 text-right font-mono text-muted-foreground">
-          {formatAccountCurrency(subtotal, currency)}
+          {formatTotalBalances(accounts)}
         </td>
         <td colSpan={3} />
       </tr>

--- a/ui/components/assettracker/asset-tracker-dashboard.tsx
+++ b/ui/components/assettracker/asset-tracker-dashboard.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from "react";
 import {
-  computeTotalBalance,
   formatAnnualRate,
-  formatCurrency,
+  formatTotalBalances,
   realRate,
 } from "@/lib/domain/assettracker";
 import { AccountBalanceChart } from "./account-balance-chart";
@@ -34,7 +33,6 @@ export function AssetTrackerDashboard() {
     null,
   );
 
-  const totalBalance = computeTotalBalance(accounts);
   const openAccounts = accounts.filter((a) => a.isOpen);
 
   return (
@@ -57,7 +55,7 @@ export function AssetTrackerDashboard() {
         <div className="border rounded-lg p-6">
           <p className="text-sm text-muted-foreground">Total Net Worth</p>
           <p className="text-3xl font-bold mt-1">
-            {formatCurrency(totalBalance)}
+            {formatTotalBalances(accounts)}
           </p>
         </div>
         <div className="border rounded-lg p-6">

--- a/ui/components/recipes/cook-mode.tsx
+++ b/ui/components/recipes/cook-mode.tsx
@@ -16,6 +16,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
 import { Button } from "@/components/ui/button";
+import { useCookMode } from "@/contexts/cook-mode-context";
 import { useCookingTimer } from "@/hooks/use-cooking-timers";
 import {
   type CookingTimer,
@@ -126,6 +127,7 @@ export function CookMode({
   onStepChange: (step: number) => void;
   onExit: () => void;
 }>) {
+  const { setCookModeOpen } = useCookMode();
   const clampedStep = Math.min(Math.max(step, 0), steps.length - 1);
   const current = steps[clampedStep];
   const [showIngredients, setShowIngredients] = useState(false);
@@ -146,18 +148,18 @@ export function CookMode({
     return () => releaseWakeLock(WAKE_LOCK_KEY);
   }, []);
 
-  // Lock page scroll behind the overlay and flag the body so the timer dock
-  // can float above the cook-mode footer instead of covering it.
+  // Lock page scroll behind the overlay and share the open state so the
+  // timer dock can float above the cook-mode footer instead of covering it.
   useEffect(() => {
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
-    document.body.classList.add("rt-cook-mode-open");
+    setCookModeOpen(true);
     containerRef.current?.focus();
     return () => {
       document.body.style.overflow = previousOverflow;
-      document.body.classList.remove("rt-cook-mode-open");
+      setCookModeOpen(false);
     };
-  }, []);
+  }, [setCookModeOpen]);
 
   // A non-modal <dialog> (see below) doesn't make the rest of the page inert,
   // so assistive tech could still reach the covered content. Mark every other

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -18,6 +18,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
+import { useCookMode } from "@/contexts/cook-mode-context";
 import { useCookingTimers } from "@/hooks/use-cooking-timers";
 import {
   type CookingTimer,
@@ -147,25 +148,12 @@ export function TimerDock() {
     moved: boolean;
   } | null>(null);
 
-  const [cookModeOpen, setCookModeOpen] = useState(false);
+  const { cookModeOpen } = useCookMode();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
     setPosition(loadPosition());
-  }, []);
-
-  // Track whether cook mode is open so we can lift the dock above its footer
-  // even after the user has dragged (an inline style would otherwise beat a
-  // stylesheet rule).
-  useEffect(() => {
-    const body = document.body;
-    const update = () =>
-      setCookModeOpen(body.classList.contains("rt-cook-mode-open"));
-    update();
-    const observer = new MutationObserver(update);
-    observer.observe(body, { attributes: true, attributeFilter: ["class"] });
-    return () => observer.disconnect();
   }, []);
 
   // A dragged position is stored as bottom-right offsets measured at the

--- a/ui/contexts/cook-mode-context.tsx
+++ b/ui/contexts/cook-mode-context.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, type ReactNode, useContext, useState } from "react";
+
+interface CookModeContextType {
+  cookModeOpen: boolean;
+  setCookModeOpen: (open: boolean) => void;
+}
+
+const CookModeContext = createContext<CookModeContextType | undefined>(
+  undefined,
+);
+
+/**
+ * Shares whether the cook-mode overlay is open between the recipe content
+ * (which mounts it) and body-level UI like the timer dock (which must clear
+ * the overlay's footer while it is up).
+ */
+export function CookModeProvider({ children }: { children: ReactNode }) {
+  const [cookModeOpen, setCookModeOpen] = useState(false);
+
+  return (
+    <CookModeContext.Provider value={{ cookModeOpen, setCookModeOpen }}>
+      {children}
+    </CookModeContext.Provider>
+  );
+}
+
+export function useCookMode() {
+  const context = useContext(CookModeContext);
+  if (context === undefined) {
+    throw new Error("useCookMode must be used within a CookModeProvider");
+  }
+  return context;
+}

--- a/ui/lib/domain/assettracker/constants.ts
+++ b/ui/lib/domain/assettracker/constants.ts
@@ -71,9 +71,12 @@ export function computeTotalBalancesByCurrency(
 ): Array<{ currency: Currency; total: number }> {
   const totals = new Map<Currency, number>();
   for (const account of accounts) {
+    // No logged balance is "no data", not a zero — a freshly added account
+    // shouldn't put its currency into the totals.
+    if (account.latestBalance == null) continue;
     totals.set(
       account.currency,
-      (totals.get(account.currency) ?? 0) + (account.latestBalance ?? 0),
+      (totals.get(account.currency) ?? 0) + account.latestBalance,
     );
   }
   return Array.from(totals, ([currency, total]) => ({ currency, total })).sort(

--- a/ui/lib/domain/assettracker/constants.ts
+++ b/ui/lib/domain/assettracker/constants.ts
@@ -65,3 +65,30 @@ export function formatAnnualRate(rate: number): string {
 export function computeTotalBalance(accounts: AccountSummaryView[]): number {
   return accounts.reduce((sum, a) => sum + (a.latestBalance ?? 0), 0);
 }
+
+export function computeTotalBalancesByCurrency(
+  accounts: AccountSummaryView[],
+): Array<{ currency: Currency; total: number }> {
+  const totals = new Map<Currency, number>();
+  for (const account of accounts) {
+    totals.set(
+      account.currency,
+      (totals.get(account.currency) ?? 0) + (account.latestBalance ?? 0),
+    );
+  }
+  return Array.from(totals, ([currency, total]) => ({ currency, total })).sort(
+    (a, b) => a.currency.localeCompare(b.currency, "en"),
+  );
+}
+
+/**
+ * One formatted amount per currency (e.g. "£1,200 + $300"), so accounts held
+ * in different currencies are never summed into a single mislabelled number.
+ */
+export function formatTotalBalances(accounts: AccountSummaryView[]): string {
+  const totals = computeTotalBalancesByCurrency(accounts);
+  if (totals.length === 0) return formatAccountCurrency(0, "GBP");
+  return totals
+    .map(({ currency, total }) => formatAccountCurrency(total, currency))
+    .join(" + ");
+}

--- a/ui/tests/lib/domain/assettracker/assetTrackerTotals.test.ts
+++ b/ui/tests/lib/domain/assettracker/assetTrackerTotals.test.ts
@@ -38,9 +38,18 @@ describe("computeTotalBalancesByCurrency", () => {
     ]);
   });
 
-  it("treats missing balances as zero within their currency", () => {
+  it("ignores accounts with no logged balance", () => {
     expect(
-      computeTotalBalancesByCurrency([account("usd-1", "USD", null)]),
+      computeTotalBalancesByCurrency([
+        account("usd-1", "USD", null),
+        account("gbp-1", "GBP", 100),
+      ]),
+    ).toEqual([{ currency: "GBP", total: 100 }]);
+  });
+
+  it("keeps genuine zero balances", () => {
+    expect(
+      computeTotalBalancesByCurrency([account("usd-1", "USD", 0)]),
     ).toEqual([{ currency: "USD", total: 0 }]);
   });
 });
@@ -64,7 +73,8 @@ describe("formatTotalBalances", () => {
     ).toBe("£1,200.00 + US$300.00");
   });
 
-  it("falls back to zero GBP with no accounts", () => {
+  it("falls back to zero GBP with no accounts or no logged balances", () => {
     expect(formatTotalBalances([])).toBe("£0.00");
+    expect(formatTotalBalances([account("usd-1", "USD", null)])).toBe("£0.00");
   });
 });

--- a/ui/tests/lib/domain/assettracker/assetTrackerTotals.test.ts
+++ b/ui/tests/lib/domain/assettracker/assetTrackerTotals.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { AccountSummaryView, Currency } from "@/lib/domain/assettracker";
+import {
+  computeTotalBalancesByCurrency,
+  formatTotalBalances,
+} from "@/lib/domain/assettracker";
+
+function account(
+  id: string,
+  currency: Currency,
+  latestBalance: number | null,
+): AccountSummaryView {
+  return {
+    id,
+    name: id,
+    provider: "Test Bank",
+    currency,
+    assetType: "cash",
+    expectedAnnualReturn: 0,
+    isOpen: true,
+    latestBalance,
+    latestSnapshotDate: latestBalance == null ? null : "2026-01-01",
+    cagr: null,
+  };
+}
+
+describe("computeTotalBalancesByCurrency", () => {
+  it("sums each currency separately", () => {
+    const totals = computeTotalBalancesByCurrency([
+      account("gbp-1", "GBP", 1000),
+      account("usd-1", "USD", 300),
+      account("gbp-2", "GBP", 250),
+    ]);
+
+    expect(totals).toEqual([
+      { currency: "GBP", total: 1250 },
+      { currency: "USD", total: 300 },
+    ]);
+  });
+
+  it("treats missing balances as zero within their currency", () => {
+    expect(
+      computeTotalBalancesByCurrency([account("usd-1", "USD", null)]),
+    ).toEqual([{ currency: "USD", total: 0 }]);
+  });
+});
+
+describe("formatTotalBalances", () => {
+  it("formats a single-currency portfolio as one amount", () => {
+    expect(
+      formatTotalBalances([
+        account("gbp-1", "GBP", 1000),
+        account("gbp-2", "GBP", -250),
+      ]),
+    ).toBe("£750.00");
+  });
+
+  it("joins mixed-currency totals instead of mislabelling their sum", () => {
+    expect(
+      formatTotalBalances([
+        account("gbp-1", "GBP", 1200),
+        account("usd-1", "USD", 300),
+      ]),
+    ).toBe("£1,200.00 + US$300.00");
+  });
+
+  it("falls back to zero GBP with no accounts", () => {
+    expect(formatTotalBalances([])).toBe("£0.00");
+  });
+});


### PR DESCRIPTION
Part of #725 (Priority 1 item 1 and Priority 3 item 11).

## Mixed currencies in asset-tracker totals

`AccountsTable` summed every account and formatted the result with the first account's currency (the code even documented the homogeneous-currency assumption), and the dashboard's "Total Net Worth" tile hardcoded `£`. Since the add-account drawer lets users create USD accounts at runtime, a mixed portfolio is a reachable state that produced a mislabelled single number.

Totals are now grouped per currency via a new `formatTotalBalances` domain helper (`£1,200.00 + US$300.00`), used by the table's net-worth footer, the Assets/Liabilities section subtotals, and the dashboard headline tile. `computeTotalBalance` remains for numeric consumers (portfolio goal, charts), which still aggregate numerically and are out of scope here. Unit tests cover the grouping, null-balance handling, and formatting.

## Timer dock cook-mode state

The timer dock discovered cook-mode state by watching `<body>` for the `rt-cook-mode-open` class with a `MutationObserver`. Cook-mode open state now flows through a `CookModeProvider` mounted in the recipes layout (wrapping both the page content and the body-portaled dock): `CookMode` sets it on mount/unmount, the dock reads it as plain React state. The body class is gone entirely — nothing else (including CSS) referenced it.

The issue also floated a shared timer controller; the dock and cook mode already share the timer store via `useCookingTimers`, so no further consolidation was needed.

## Tests

`ui`: 566 tests pass (5 new). Typecheck and Biome clean.