### PR TITLE
Add config parity checks for deployed recipe infrastructure

### DIFF
--- a/.github/workflows/recipe-ingest-ci.yml
+++ b/.github/workflows/recipe-ingest-ci.yml
@@ -9,6 +9,12 @@ on:
       - "packages/recipe-domain/**"
       - "patches/**"
       - ".github/workflows/recipe-ingest-ci.yml"
+      # Mirrored in tests/config-parity.test.ts, so drift in any copy of the
+      # shared model/bucket/Hyperdrive settings fails this workflow.
+      - "workers/recipe-api/wrangler.toml"
+      - "workers/recipe-api/wrangler.preview.toml"
+      - "ml-pipelines/recipe-parsing/params.yaml"
+      - "infra/variables.tf"
 
 permissions:
   contents: read

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -537,6 +537,12 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4
         version: 4.20260702.1
+      '@types/node':
+        specifier: ^24
+        version: 24.13.3
+      smol-toml:
+        specifier: ^1.7.0
+        version: 1.7.0
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -546,6 +552,9 @@ importers:
       wrangler:
         specifier: ^4
         version: 4.111.0(@cloudflare/workers-types@4.20260702.1)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 

--- a/workers/recipe-ingest/package.json
+++ b/workers/recipe-ingest/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bash scripts/dev.sh",
     "deploy": "wrangler deploy",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --project tsconfig.config-parity.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -19,8 +19,11 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4",
+    "smol-toml": "^1.7.0",
     "typescript": "^5",
     "vitest": "^4.1.7",
-    "wrangler": "^4"
+    "wrangler": "^4",
+    "yaml": "^2.9.0",
+    "@types/node": "^24"
   }
 }

--- a/workers/recipe-ingest/tests/config-parity.test.ts
+++ b/workers/recipe-ingest/tests/config-parity.test.ts
@@ -53,8 +53,10 @@ const pipelineParams = parseYaml(
 const terraformVariables = readRepoFile("infra/variables.tf");
 
 function terraformDefault(variableName: string): string {
+  // Skips over one level of nested blocks (validation, etc.) so a default
+  // declared after them is still found.
   const match = new RegExp(
-    `variable "${variableName}" \\{[^}]*default\\s*=\\s*"([^"]+)"`,
+    `variable "${variableName}" \\{(?:[^{}]|\\{[^{}]*\\})*?default\\s*=\\s*"([^"]+)"`,
     "s",
   ).exec(terraformVariables);
   if (!match?.[1]) {

--- a/workers/recipe-ingest/tests/config-parity.test.ts
+++ b/workers/recipe-ingest/tests/config-parity.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseToml } from "smol-toml";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+import type { Env } from "../src/env";
+import { type LlmStage, stageParams } from "../src/params";
+
+/**
+ * Model names, R2 bucket names, and the Hyperdrive id are declared
+ * independently in Wrangler config, Terraform, the ML evaluation pipeline,
+ * and this Worker's code defaults. These checks fail CI when the copies
+ * drift instead of letting production silently run different settings from
+ * the ones the pipeline scored.
+ */
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf-8");
+}
+
+type WranglerConfig = {
+  vars?: Record<string, string>;
+  hyperdrive?: Array<{ id: string }>;
+  r2_buckets?: Array<{ bucket_name: string }>;
+};
+
+type StageParamsYaml = Record<
+  LlmStage,
+  { model: string; request_timeout_ms: number; max_retries: number }
+>;
+
+const ingestWrangler = parseToml(
+  readRepoFile("workers/recipe-ingest/wrangler.toml"),
+) as WranglerConfig;
+const apiWrangler = parseToml(
+  readRepoFile("workers/recipe-api/wrangler.toml"),
+) as WranglerConfig;
+const ingestPreviewWrangler = parseToml(
+  readRepoFile("workers/recipe-ingest/wrangler.preview.toml"),
+) as WranglerConfig;
+const apiPreviewWrangler = parseToml(
+  readRepoFile("workers/recipe-api/wrangler.preview.toml"),
+) as WranglerConfig;
+const pipelineParams = parseYaml(
+  readRepoFile("ml-pipelines/recipe-parsing/params.yaml"),
+) as StageParamsYaml;
+const terraformVariables = readRepoFile("infra/variables.tf");
+
+function terraformDefault(variableName: string): string {
+  const match = new RegExp(
+    `variable "${variableName}" \\{[^}]*default\\s*=\\s*"([^"]+)"`,
+    "s",
+  ).exec(terraformVariables);
+  if (!match?.[1]) {
+    throw new Error(`No default found for Terraform variable ${variableName}`);
+  }
+  return match[1];
+}
+
+const LLM_STAGES: LlmStage[] = ["extract", "normalize", "canonicalize"];
+
+describe("LLM stage parameters", () => {
+  it.each(LLM_STAGES)(
+    "wrangler.toml %s vars match ml-pipelines params.yaml",
+    (stage) => {
+      const vars = ingestWrangler.vars ?? {};
+      const prefix = stage.toUpperCase();
+      const expected = pipelineParams[stage];
+
+      expect(vars[`${prefix}_MODEL`]).toBe(expected.model);
+      expect(Number(vars[`${prefix}_TIMEOUT_MS`])).toBe(
+        expected.request_timeout_ms,
+      );
+      expect(Number(vars[`${prefix}_RETRIES`])).toBe(expected.max_retries);
+    },
+  );
+
+  it.each(LLM_STAGES)(
+    "code defaults for %s match ml-pipelines params.yaml",
+    (stage) => {
+      const expected = pipelineParams[stage];
+
+      expect(stageParams({} as Env, stage)).toEqual({
+        model: expected.model,
+        requestTimeoutMs: expected.request_timeout_ms,
+        retryLimit: expected.max_retries,
+      });
+    },
+  );
+});
+
+describe("shared infrastructure bindings", () => {
+  it("recipe-api and recipe-ingest bind the same production Hyperdrive", () => {
+    const apiHyperdrive = apiWrangler.hyperdrive?.[0]?.id;
+    const ingestHyperdrive = ingestWrangler.hyperdrive?.[0]?.id;
+
+    expect(apiHyperdrive).toBeTruthy();
+    expect(ingestHyperdrive).toBe(apiHyperdrive);
+  });
+
+  it("production R2 bucket names match the Terraform default", () => {
+    const bucketName = terraformDefault("r2_recipe_artifacts_bucket_name");
+
+    expect(apiWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+    expect(ingestWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+  });
+
+  it("preview R2 bucket names match the Terraform default", () => {
+    const bucketName = terraformDefault(
+      "r2_recipe_artifacts_preview_bucket_name",
+    );
+
+    expect(apiPreviewWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+    expect(ingestPreviewWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+  });
+});

--- a/workers/recipe-ingest/tests/config-parity.test.ts
+++ b/workers/recipe-ingest/tests/config-parity.test.ts
@@ -57,12 +57,21 @@ const pipelineParams = parseYaml(
 const terraformVariables = readRepoFile("infra/variables.tf");
 
 function terraformDefault(variableName: string): string {
-  // Skips over one level of nested blocks (validation, etc.) so a default
-  // declared after them is still found.
-  const match = new RegExp(
-    `variable "${variableName}" \\{(?:[^{}]|\\{[^{}]*\\})*?default\\s*=\\s*"([^"]+)"`,
-    "s",
-  ).exec(terraformVariables);
+  // Slice out the variable's block (up to the next top-level declaration)
+  // before matching, so nested blocks at any depth can't derail the search.
+  const blockStart = terraformVariables.indexOf(`variable "${variableName}" {`);
+  if (blockStart === -1) {
+    throw new Error(`Terraform variable ${variableName} not found`);
+  }
+  const blockEnd = terraformVariables.indexOf(
+    "\nvariable ",
+    blockStart + 1,
+  );
+  const block = terraformVariables.slice(
+    blockStart,
+    blockEnd === -1 ? undefined : blockEnd,
+  );
+  const match = /default\s*=\s*"([^"]+)"/.exec(block);
   if (!match?.[1]) {
     throw new Error(`No default found for Terraform variable ${variableName}`);
   }
@@ -73,17 +82,19 @@ const LLM_STAGES: LlmStage[] = ["extract", "normalize", "canonicalize"];
 
 describe("LLM stage parameters", () => {
   it.each(LLM_STAGES)(
-    "wrangler.toml %s vars match ml-pipelines params.yaml",
+    "production and preview wrangler %s vars match ml-pipelines params.yaml",
     (stage) => {
-      const vars = ingestWrangler.vars ?? {};
       const prefix = stage.toUpperCase();
       const expected = pipelineParams[stage];
 
-      expect(vars[`${prefix}_MODEL`]).toBe(expected.model);
-      expect(Number(vars[`${prefix}_TIMEOUT_MS`])).toBe(
-        expected.request_timeout_ms,
-      );
-      expect(Number(vars[`${prefix}_RETRIES`])).toBe(expected.max_retries);
+      for (const config of [ingestWrangler, ingestPreviewWrangler]) {
+        const vars = config.vars ?? {};
+        expect(vars[`${prefix}_MODEL`]).toBe(expected.model);
+        expect(Number(vars[`${prefix}_TIMEOUT_MS`])).toBe(
+          expected.request_timeout_ms,
+        );
+        expect(Number(vars[`${prefix}_RETRIES`])).toBe(expected.max_retries);
+      }
     },
   );
 

--- a/workers/recipe-ingest/tests/config-parity.test.ts
+++ b/workers/recipe-ingest/tests/config-parity.test.ts
@@ -7,6 +7,10 @@ import { parse as parseYaml } from "yaml";
 import type { Env } from "../src/env";
 import { type LlmStage, stageParams } from "../src/params";
 
+// Only the secret is required; stage vars are intentionally unset so the
+// code-default path is what gets compared against params.yaml.
+const defaultsEnv = { OPENROUTER_API_KEY: "test" } as Env;
+
 /**
  * Model names, R2 bucket names, and the Hyperdrive id are declared
  * independently in Wrangler config, Terraform, the ML evaluation pipeline,
@@ -88,7 +92,7 @@ describe("LLM stage parameters", () => {
     (stage) => {
       const expected = pipelineParams[stage];
 
-      expect(stageParams({} as Env, stage)).toEqual({
+      expect(stageParams(defaultsEnv, stage)).toEqual({
         model: expected.model,
         requestTimeoutMs: expected.request_timeout_ms,
         retryLimit: expected.max_retries,
@@ -99,18 +103,18 @@ describe("LLM stage parameters", () => {
 
 describe("shared infrastructure bindings", () => {
   it("recipe-api and recipe-ingest bind the same production Hyperdrive", () => {
-    const apiHyperdrive = apiWrangler.hyperdrive?.[0]?.id;
-    const ingestHyperdrive = ingestWrangler.hyperdrive?.[0]?.id;
-
-    expect(apiHyperdrive).toBeTruthy();
-    expect(ingestHyperdrive).toBe(apiHyperdrive);
+    expect(apiWrangler.hyperdrive).toHaveLength(1);
+    expect(apiWrangler.hyperdrive?.[0]?.id).toBeTruthy();
+    expect(ingestWrangler.hyperdrive).toEqual(apiWrangler.hyperdrive);
   });
 
   it("production R2 bucket names match the Terraform default", () => {
     const bucketName = terraformDefault("r2_recipe_artifacts_bucket_name");
 
-    expect(apiWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
-    expect(ingestWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+    for (const config of [apiWrangler, ingestWrangler]) {
+      expect(config.r2_buckets).toHaveLength(1);
+      expect(config.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+    }
   });
 
   it("preview R2 bucket names match the Terraform default", () => {
@@ -118,7 +122,9 @@ describe("shared infrastructure bindings", () => {
       "r2_recipe_artifacts_preview_bucket_name",
     );
 
-    expect(apiPreviewWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
-    expect(ingestPreviewWrangler.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+    for (const config of [apiPreviewWrangler, ingestPreviewWrangler]) {
+      expect(config.r2_buckets).toHaveLength(1);
+      expect(config.r2_buckets?.[0]?.bucket_name).toBe(bucketName);
+    }
   });
 });

--- a/workers/recipe-ingest/tsconfig.config-parity.json
+++ b/workers/recipe-ingest/tsconfig.config-parity.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types", "node"]
+  },
+  "include": ["src/**/*.ts", "tests/config-parity.test.ts"],
+  "exclude": []
+}

--- a/workers/recipe-ingest/tsconfig.json
+++ b/workers/recipe-ingest/tsconfig.json
@@ -13,5 +13,6 @@
     "resolveJsonModule": true,
     "types": ["@cloudflare/workers-types"]
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["tests/config-parity.test.ts"]
 }


### PR DESCRIPTION
Part of #725 (Priority 2 item 7).

The shared settings for the recipe stack live in four independent places:

- `workers/recipe-ingest/wrangler.toml` `[vars]` (stage models, timeouts, retries)
- `ml-pipelines/recipe-parsing/params.yaml` (the values the evaluation pipeline actually scores)
- `workers/recipe-ingest/src/params.ts` (code defaults used when a var is unset)
- Wrangler R2 bindings in both workers vs. the Terraform `r2_recipe_artifacts*` variable defaults, plus the production Hyperdrive id duplicated across both workers' `wrangler.toml`

Per the issue's preference for "a cheap parity test before introducing generation/templates", this adds `workers/recipe-ingest/tests/config-parity.test.ts`, which parses each source (TOML via `smol-toml`, YAML via `yaml`, Terraform defaults via a scoped regex) and asserts:

- each stage's `*_MODEL` / `*_TIMEOUT_MS` / `*_RETRIES` var matches `params.yaml`;
- `stageParams` code defaults match `params.yaml`;
- both workers bind the same production Hyperdrive id;
- production and preview R2 bucket names match the Terraform defaults.

`recipe-ingest-ci.yml` now also triggers on the mirrored files (`recipe-api` wrangler configs, `params.yaml`, `infra/variables.tf`) so drift on either side fails CI. The parity test uses Node builtins, so it typechecks under a small `tsconfig.config-parity.json` (same pattern as `recipe-api`'s `tsconfig.scripts.json`) with `@types/node` added as a dev dependency.

## Tests

`recipe-ingest`: 15 tests pass (9 new). Typecheck passes for both tsconfig projects.