### PR TITLE
Configure SonarCloud source encoding

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,4 @@
 # Vendored design prototypes exported from Claude Design and their generated
 # standalone build are not part of the maintained application source.
 sonar.exclusions=ui/content/projects/*/designs/**,ui/public/recipe-site-design/standalone.html
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

- configure SonarCloud Automatic Analysis to decode source files as UTF-8
- retain the existing vendored-design exclusions

## Why

The latest SonarCloud analysis completed successfully but reported an advisory file-encoding warning. All 619 files indexed by that analysis validate as UTF-8, while 143 contain legitimate non-ASCII characters. The project did not explicitly set `sonar.sourceEncoding`, so the scanner fell back to its system encoding.

Setting the encoding explicitly removes that environment-dependent behavior and should clear the warning on the next automatic analysis.

## Impact

No application or infrastructure runtime behavior changes. This affects SonarCloud analysis configuration only.

## Validation

- `.sonarcloud.properties` validated as UTF-8 with `iconv`
- `git diff --check`
- `mise //:lint`