### PR TITLE
chore(ci): update workflow setup actions

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 

--- a/.github/workflows/cloudflare-images-health.yml
+++ b/.github/workflows/cloudflare-images-health.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/infra-bootstrap.yml
+++ b/.github/workflows/infra-bootstrap.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/ml-pipelines-ci.yml
+++ b/.github/workflows/ml-pipelines-ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Validate DVC remote
         run: dvc pull
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/preview-environment-cleanup.yml
+++ b/.github/workflows/preview-environment-cleanup.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -158,7 +158,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 
@@ -246,7 +246,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/recipe-api-cd.yml
+++ b/.github/workflows/recipe-api-cd.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/recipe-api-ci.yml
+++ b/.github/workflows/recipe-api-ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/recipe-ingest-cd.yml
+++ b/.github/workflows/recipe-ingest-cd.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/recipe-ingest-ci.yml
+++ b/.github/workflows/recipe-ingest-ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/ui-cd.yml
+++ b/.github/workflows/ui-cd.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
         with:
           experimental: true
 


### PR DESCRIPTION
Relates to #32.

## Why this is phase 1

This takes the dependency updates with the smallest merge-conflict and regression surface:

- updates every existing jdx/mise-action use from v4.2.0 to v4.2.1
- updates the isolated actions/setup-node use from v6 to v7.0.0
- keeps both actions pinned to full commit SHAs
- touches only existing workflow files; it does not overlap with open PRs #709, #713, #739, or #743
- avoids the shared pnpm lockfile while #739 is changing it

mise-action v4.2.1 is especially worthwhile because it verifies mise downloads against signed checksums and fixes PATH leakage into later workflow steps.

## Follow-up phases

1. After #739 lands: group low-risk lockfile-only patches for Hono, Fuse.js, OpenAI, PostHog, Simple Icons, and Wrangler. Evaluate the Tailwind patch in the same phase but keep it separate if visual/build verification warrants it.
2. After #709 lands: update zizmor and the Neon provider; also pick up the mise-action pin in the new database backup workflow introduced by that PR.
3. Isolated ecosystem majors: feed v6, Cloudflare JS SDK v7 plus Workers types v5, Vite React plugin v6, lint-staged v17, and pnpm v11. Keep pnpm last in this group because it rewrites shared lockfile metadata.
4. Dedicated migration PRs: Next.js 16 after #713, TypeScript 7 across the mixed TS 5/6 workspaces, Terraform Cloudflare v5, Terraform Google v7, and Lucide v1. Lucide remains deferred until its blocked Renovate PR is understood.

## Validation

- MISE_EXPERIMENTAL=1 mise //:lint:actions
- MISE_EXPERIMENTAL=1 mise //:lint:yaml
- MISE_EXPERIMENTAL=1 mise //:security:actions
- MISE_EXPERIMENTAL=1 mise //:pre-commit