### PR TITLE
chore(ui): update feed to v6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,8 +262,8 @@ importers:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.7)
       feed:
-        specifier: ^5.2.1
-        version: 5.2.1
+        specifier: ^6.0.0
+        version: 6.0.0
       fuse.js:
         specifier: ^7.1.0
         version: 7.4.2
@@ -3890,8 +3890,8 @@ packages:
       picomatch:
         optional: true
 
-  feed@5.2.1:
-    resolution: {integrity: sha512-jTynzYPWs9ALjro0GW8j7sv9y7cJBeOdD4Y88kVqYy/eyusIX3g+499JiTDIlD9Ge/unebx57T4Uzo6vpYvMtA==}
+  feed@6.0.0:
+    resolution: {integrity: sha512-rvFOF1POce0ijAKy3tZN5T8PuprgIit/VbMyXJWcoYwcMOTSIJ7NqZb8DTLPJr77yiEO27kidm/fw0kcSIV+ww==}
     engines: {node: '>=20', pnpm: '>=10'}
 
   fflate@0.4.8:
@@ -8208,7 +8208,7 @@ snapshots:
 
   '@types/pg@8.6.1':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 24.13.3
       pg-protocol: 1.15.0
       pg-types: 2.2.0
     optional: true
@@ -9330,7 +9330,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  feed@5.2.1:
+  feed@6.0.0:
     dependencies:
       xml-js: 1.6.11
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -42,7 +42,7 @@
     "embla-carousel": "^8.6.0",
     "embla-carousel-auto-scroll": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
-    "feed": "^5.2.1",
+    "feed": "^6.0.0",
     "fuse.js": "^7.1.0",
     "graphology": "^0.26.0",
     "graphology-layout-forceatlas2": "^0.10.1",


### PR DESCRIPTION
Relates to #32.

Updates feed from v5.2.1 to v6.0.0.

The site uses feed only in the static RSS generation script. Its existing Feed constructor, addItem calls, and rss2 output remain compatible, so no source changes are required.

Validation:
- MISE_EXPERIMENTAL=1 mise //:install
- NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder MISE_EXPERIMENTAL=1 mise //ui:build
  - generated all 298 Markdown pages and 48 recipe exports
  - generated feed.xml plus all section feeds
- MISE_EXPERIMENTAL=1 mise //:pre-commit

PR #739 may require a mechanical lockfile refresh if it merges first.