### PR TITLE
chore(tooling): update pnpm to v11

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -18,7 +18,7 @@ verbose = false
 
 [tools]
 node = "lts"
-pnpm = "10.34.5"
+"github:pnpm/pnpm" = "11.15.0"
 terraform = "1.15.8"
 actionlint = "1.7.12"
 zizmor = "1.26.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "personal-site",
   "version": "0.1.0",
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@11.15.0",
   "private": true,
   "type": "module",
   "description": "Personal website mono-repo - root package for repo-wide tooling",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,16 @@ packages:
   - 'ml-pipelines/recipe-parsing'
   - 'ml-pipelines/recipe-parsing/tools/viz'
 
+# pnpm 10 already skipped these dependency lifecycle scripts. pnpm 11 requires
+# the policy to be explicit; keep installs reproducible without expanding the
+# set of third-party code allowed to execute during dependency installation.
+allowBuilds:
+  core-js: false
+  esbuild: false
+  puppeteer: false
+  sharp: false
+  workerd: false
+
 # Dedupe postcss onto the patched 8.5.x line. Next pulls in 8.4.31, which is
 # affected by GHSA-qx2v-qp2m-jg93 (XSS via unescaped </style> in stringify);
 # 8.5.x is already in the tree via @tailwindcss/postcss and is API-compatible.
@@ -38,6 +48,7 @@ overrides:
   'lighthouse>@sentry/node': '^10.66.0'
   js-yaml: '^5.0.0'
   postcss: '^8.5.10'
+
 patchedDependencies:
   '@cooklang/cooklang@0.18.7': patches/@cooklang__cooklang@0.18.7.patch
   gray-matter@4.0.3: patches/gray-matter@4.0.3.patch


### PR DESCRIPTION
Relates to #32.

Updates pnpm from v10.34.5 to v11.15.0 in packageManager and mise.

The pnpm 11 GitHub release archives no longer match the current mise registry backend asset name, so the mise pin uses the documented platform-aware GitHub backend. This also verifies release checksums and GitHub attestations.

pnpm 11 requires Node 22 or newer; the repo uses Node 24. Its stricter lifecycle-script policy surfaced scripts pnpm 10 already ignored, so allowBuilds now explicitly denies those same scripts. Full builds pass without expanding install-time code execution.

The existing lockfile format is pnpm 11-compatible, so this PR does not rewrite pnpm-lock.yaml.

Validation with pnpm 11.15.0:
- MISE_EXPERIMENTAL=1 mise //:install
- MISE_EXPERIMENTAL=1 mise //:pre-commit
- NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder MISE_EXPERIMENTAL=1 mise //ui:build
- MISE_EXPERIMENTAL=1 mise exec -- pnpm --filter recipe-parsing-viz build
- MISE_EXPERIMENTAL=1 mise //workers/recipe-api:check
- MISE_EXPERIMENTAL=1 mise //workers/recipe-ingest:check

The static UI/RSS build, visualization build, both Worker typechecks, 172 Worker tests, and migration consistency checks all pass.