### PR TITLE
Fix recipe auth and personalization loading states

### DIFF
--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/recipes/auth-providers";
 import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/generic/styles";
 import { isPreviewDeployment } from "@/lib/preview-environment";
@@ -204,19 +205,12 @@ export function AuthButton({
   }
 
   if (isPending) {
-    if (intent === "signin") {
-      return (
-        <Button
-          variant="outline"
-          size="sm"
-          disabled
-          aria-label="Loading session"
-        >
-          <LoaderCircle className="animate-spin" />
-          <span className="hidden sm:inline">Log in</span>
-        </Button>
-      );
-    }
+    return (
+      <Skeleton
+        aria-hidden="true"
+        className={intent === "signup" ? "h-9 w-20" : "h-9 w-16"}
+      />
+    );
   }
 
   if (session && intent === "signup") return null;

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -206,10 +206,19 @@ export function AuthButton({
 
   if (isPending) {
     return (
-      <Skeleton
-        aria-hidden="true"
-        className={intent === "signup" ? "h-9 w-20" : "h-9 w-16"}
-      />
+      <>
+        <Skeleton
+          aria-hidden="true"
+          className={intent === "signup" ? "h-9 w-20" : "h-9 w-16"}
+        />
+        <output
+          aria-label="Loading session"
+          aria-live="polite"
+          className="sr-only"
+        >
+          Loading session…
+        </output>
+      </>
     );
   }
 

--- a/ui/components/recipes/diet-provider.tsx
+++ b/ui/components/recipes/diet-provider.tsx
@@ -43,6 +43,14 @@ type DietState = {
   status: "idle" | "loading" | "ready" | "error";
 };
 
+async function fetchEffectiveDiet(signal: AbortSignal) {
+  const [profile, options] = await Promise.all([
+    getDietProfile(signal),
+    getDietOptions(signal),
+  ]);
+  return buildEffectiveDiet(profile, options);
+}
+
 export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
   const { data: session, isPending } = authClient.useSession();
   const sessionUserId = session?.user.id;
@@ -60,36 +68,37 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
     }
 
     let controller: AbortController | null = null;
+    let retainedDiet = fallbackDiet;
     const load = () => {
       controller?.abort();
       controller = new AbortController();
       const signal = controller.signal;
-      setState((current) => ({
+      setState({
         userId: sessionUserId,
-        diet: current.userId === sessionUserId ? current.diet : fallbackDiet,
+        diet: retainedDiet,
         status: "loading",
-      }));
-      void Promise.all([getDietProfile(signal), getDietOptions(signal)])
-        .then(([profile, options]) => {
+      });
+      void fetchEffectiveDiet(signal)
+        .then((diet) => {
+          if (signal.aborted) return;
+          retainedDiet = diet;
           setState({
             userId: sessionUserId,
-            diet: buildEffectiveDiet(profile, options),
+            diet,
             status: "ready",
           });
         })
         .catch((error: unknown) => {
-          if (!signal.aborted) {
-            setState((current) => ({
-              userId: sessionUserId,
-              diet:
-                current.userId === sessionUserId ? current.diet : fallbackDiet,
-              status: "error",
-            }));
-            console.error(
-              "[DietProvider] Failed to load diet preferences.",
-              error,
-            );
-          }
+          if (signal.aborted) return;
+          setState({
+            userId: sessionUserId,
+            diet: retainedDiet,
+            status: "error",
+          });
+          console.error(
+            "[DietProvider] Failed to load diet preferences.",
+            error,
+          );
         });
     };
 

--- a/ui/components/recipes/diet-provider.tsx
+++ b/ui/components/recipes/diet-provider.tsx
@@ -37,19 +37,25 @@ export const DIET_PROFILE_UPDATED_EVENT = "recipe-diet-profile-updated";
 const fallbackDiet = buildEffectiveDiet(emptyDietProfile, emptyDietOptions);
 const DietContext = createContext<DietContextValue | null>(null);
 
+type DietState = {
+  userId: string | null;
+  diet: EffectiveDiet;
+  status: "idle" | "loading" | "ready" | "error";
+};
+
 export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
   const { data: session, isPending } = authClient.useSession();
   const sessionUserId = session?.user.id;
-  const [diet, setDiet] = useState(fallbackDiet);
-  const [error, setError] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [state, setState] = useState<DietState>({
+    userId: null,
+    diet: fallbackDiet,
+    status: "idle",
+  });
 
   useEffect(() => {
     if (isPending) return;
     if (!sessionUserId) {
-      setDiet(fallbackDiet);
-      setError(false);
-      setLoading(false);
+      setState({ userId: null, diet: fallbackDiet, status: "idle" });
       return;
     }
 
@@ -58,24 +64,32 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
       controller?.abort();
       controller = new AbortController();
       const signal = controller.signal;
-      setError(false);
-      setLoading(true);
+      setState((current) => ({
+        userId: sessionUserId,
+        diet: current.userId === sessionUserId ? current.diet : fallbackDiet,
+        status: "loading",
+      }));
       void Promise.all([getDietProfile(signal), getDietOptions(signal)])
         .then(([profile, options]) => {
-          setDiet(buildEffectiveDiet(profile, options));
-          setError(false);
+          setState({
+            userId: sessionUserId,
+            diet: buildEffectiveDiet(profile, options),
+            status: "ready",
+          });
         })
         .catch((error: unknown) => {
           if (!signal.aborted) {
-            setError(true);
+            setState((current) => ({
+              userId: sessionUserId,
+              diet:
+                current.userId === sessionUserId ? current.diet : fallbackDiet,
+              status: "error",
+            }));
             console.error(
               "[DietProvider] Failed to load diet preferences.",
               error,
             );
           }
-        })
-        .finally(() => {
-          if (!signal.aborted) setLoading(false);
         });
     };
 
@@ -87,6 +101,18 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
     };
   }, [isPending, sessionUserId]);
 
+  const diet =
+    sessionUserId && state.userId === sessionUserId ? state.diet : fallbackDiet;
+  const loading =
+    isPending ||
+    Boolean(
+      sessionUserId &&
+        (state.userId !== sessionUserId || state.status === "loading"),
+    );
+  const error = Boolean(
+    sessionUserId && state.userId === sessionUserId && state.status === "error",
+  );
+
   const matchRecipe = useCallback(
     (recipe: DietRecipe) => matchRecipeToDiet(recipe, diet),
     [diet],
@@ -96,15 +122,15 @@ export function DietProvider({ children }: Readonly<{ children: ReactNode }>) {
     () => ({
       diet,
       error,
-      loading: isPending || loading,
+      loading,
       matchRecipe,
     }),
-    [diet, error, isPending, loading, matchRecipe],
+    [diet, error, loading, matchRecipe],
   );
 
   return (
     <DietContext.Provider value={value}>
-      {error && !isPending && <DietLoadErrorNotice />}
+      {error && <DietLoadErrorNotice />}
       {children}
     </DietContext.Provider>
   );

--- a/ui/components/recipes/recipe-box-view.tsx
+++ b/ui/components/recipes/recipe-box-view.tsx
@@ -6,6 +6,12 @@ import { RecipeCollection } from "@/components/recipes/recipe-collection";
 import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { RecipeCardView } from "@/lib/api/recipes";
+import { authClient } from "@/lib/auth-client";
+
+type VisibleRecipeCountState = {
+  userId: string | null;
+  count: number;
+};
 
 function formatRecipeCount(count: number | null) {
   if (count == null) return null;
@@ -20,13 +26,19 @@ export function RecipeBoxView({
   recipes: RecipeCardView[];
   catalogStats: string[];
 }>) {
-  const [visibleRecipeCount, setVisibleRecipeCount] = useState<number | null>(
+  const { data: session, isPending } = authClient.useSession();
+  const sessionUserId = session?.user.id ?? null;
+  const [countState, setCountState] = useState<VisibleRecipeCountState | null>(
     null,
   );
   const updateVisibleRecipeCount = useCallback(
-    (count: number) => setVisibleRecipeCount(count),
-    [],
+    (count: number) => setCountState({ userId: sessionUserId, count }),
+    [sessionUserId],
   );
+  const visibleRecipeCount =
+    !isPending && countState?.userId === sessionUserId
+      ? countState.count
+      : null;
   const recipeCountLabel = formatRecipeCount(visibleRecipeCount);
   const stats = recipeCountLabel
     ? [recipeCountLabel, ...catalogStats]

--- a/ui/components/recipes/recipe-box-view.tsx
+++ b/ui/components/recipes/recipe-box-view.tsx
@@ -7,6 +7,12 @@ import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { RecipeCardView } from "@/lib/api/recipes";
 
+function formatRecipeCount(count: number | null) {
+  if (count == null) return null;
+  const label = count === 1 ? "recipe" : "recipes";
+  return `${count.toLocaleString()} ${label}`;
+}
+
 export function RecipeBoxView({
   recipes,
   catalogStats,
@@ -21,12 +27,7 @@ export function RecipeBoxView({
     (count: number) => setVisibleRecipeCount(count),
     [],
   );
-  const recipeCountLabel =
-    visibleRecipeCount == null
-      ? null
-      : `${visibleRecipeCount.toLocaleString()} ${
-          visibleRecipeCount === 1 ? "recipe" : "recipes"
-        }`;
+  const recipeCountLabel = formatRecipeCount(visibleRecipeCount);
   const stats = recipeCountLabel
     ? [recipeCountLabel, ...catalogStats]
     : catalogStats;

--- a/ui/components/recipes/recipe-box-view.tsx
+++ b/ui/components/recipes/recipe-box-view.tsx
@@ -4,6 +4,7 @@ import { Suspense, useCallback, useState } from "react";
 import { AddRecipeButton } from "@/components/recipes/add-recipe-button";
 import { RecipeCollection } from "@/components/recipes/recipe-collection";
 import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { RecipeCardView } from "@/lib/api/recipes";
 
 export function RecipeBoxView({
@@ -13,15 +14,22 @@ export function RecipeBoxView({
   recipes: RecipeCardView[];
   catalogStats: string[];
 }>) {
-  const [visibleRecipeCount, setVisibleRecipeCount] = useState(recipes.length);
+  const [visibleRecipeCount, setVisibleRecipeCount] = useState<number | null>(
+    null,
+  );
   const updateVisibleRecipeCount = useCallback(
     (count: number) => setVisibleRecipeCount(count),
     [],
   );
-  const recipeCountLabel = `${visibleRecipeCount.toLocaleString()} ${
-    visibleRecipeCount === 1 ? "recipe" : "recipes"
-  }`;
-  const stats = [recipeCountLabel, ...catalogStats];
+  const recipeCountLabel =
+    visibleRecipeCount == null
+      ? null
+      : `${visibleRecipeCount.toLocaleString()} ${
+          visibleRecipeCount === 1 ? "recipe" : "recipes"
+        }`;
+  const stats = recipeCountLabel
+    ? [recipeCountLabel, ...catalogStats]
+    : catalogStats;
 
   return (
     <div className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-10 md:pt-7 md:pb-14">
@@ -31,16 +39,23 @@ export function RecipeBoxView({
           <h1 className="rt-display mt-2 text-5xl sm:text-6xl lg:text-7xl">
             What's <span className="text-[var(--terracotta)]">cooking?</span>
           </h1>
-          <p className="rt-body mt-3 flex flex-wrap gap-x-2 gap-y-1 text-base leading-snug text-[var(--ink-2)] sm:text-lg">
-            {stats.map((stat, index) => (
-              <span key={stat} className="whitespace-nowrap">
-                {stat}
-                {index < stats.length - 1 && (
-                  <span className="text-[var(--ink-3)]"> ·</span>
-                )}
-              </span>
-            ))}
-          </p>
+          <div className="rt-body mt-3 flex flex-wrap gap-x-2 gap-y-1 text-base leading-snug text-[var(--ink-2)] sm:text-lg">
+            {recipeCountLabel == null ? (
+              <Skeleton
+                aria-label="Loading recipe count"
+                className="h-5 w-52"
+              />
+            ) : (
+              stats.map((stat, index) => (
+                <span key={stat} className="whitespace-nowrap">
+                  {stat}
+                  {index < stats.length - 1 && (
+                    <span className="text-[var(--ink-3)]"> ·</span>
+                  )}
+                </span>
+              ))
+            )}
+          </div>
         </div>
         <AddRecipeButton />
       </div>

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -2,7 +2,9 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { useDiet } from "@/components/recipes/diet-provider";
 import { RecipeList } from "@/components/recipes/recipe-list";
+import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
 import {
   getRecipeBoxProfile,
   type RecipeBoxProfile,
@@ -15,6 +17,14 @@ import {
   savedRecipeCard,
 } from "@/lib/domain/recipe/recipeDraft";
 
+type RecipeCollectionState = {
+  userId: string | null;
+  status: "idle" | "loading" | "ready";
+  saved: SavedRecipeApiRecord[];
+  box: RecipeBoxProfile | null;
+  loadError: string | null;
+};
+
 export function RecipeCollection({
   recipes,
   onDietVisibleCountChange,
@@ -23,31 +33,42 @@ export function RecipeCollection({
   onDietVisibleCountChange?: (count: number) => void;
 }>) {
   const { data: session, isPending } = authClient.useSession();
-  const [saved, setSaved] = useState<SavedRecipeApiRecord[]>([]);
-  const [box, setBox] = useState<RecipeBoxProfile | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const { loading: dietLoading } = useDiet();
+  const sessionUserId = session?.user.id;
+  const [state, setState] = useState<RecipeCollectionState>({
+    userId: null,
+    status: "idle",
+    saved: [],
+    box: null,
+    loadError: null,
+  });
 
   useEffect(() => {
     if (isPending) return;
-    if (!session) {
-      setSaved([]);
-      setBox(null);
-      setLoadError(null);
+    if (!sessionUserId) {
+      setState({
+        userId: null,
+        status: "idle",
+        saved: [],
+        box: null,
+        loadError: null,
+      });
       return;
     }
     const controller = new AbortController();
-    setLoadError(null);
+    const userId = sessionUserId;
+    setState({
+      userId,
+      status: "loading",
+      saved: [],
+      box: null,
+      loadError: null,
+    });
     void Promise.allSettled([
       fetchAllSavedRecipes({ signal: controller.signal }),
       getRecipeBoxProfile(controller.signal),
     ]).then(([savedResult, boxResult]) => {
-      if (savedResult.status === "fulfilled") {
-        setSaved(savedResult.value);
-      }
-      if (boxResult.status === "fulfilled") {
-        setBox(boxResult.value);
-      }
-
+      if (controller.signal.aborted) return;
       const errors = [savedResult, boxResult].flatMap((result) =>
         result.status === "rejected" ? [result.reason] : [],
       );
@@ -57,13 +78,29 @@ export function RecipeCollection({
       );
       if (nonAbortErrors.length > 0) {
         console.error("Failed to load some recipe box data", nonAbortErrors);
-        setLoadError(
-          "Some recipe box data could not be loaded. Available recipes are still shown.",
-        );
       }
+      setState({
+        userId,
+        status: "ready",
+        saved: savedResult.status === "fulfilled" ? savedResult.value : [],
+        box: boxResult.status === "fulfilled" ? boxResult.value : null,
+        loadError:
+          nonAbortErrors.length > 0
+            ? "Some recipe box data could not be loaded. Available recipes are still shown."
+            : null,
+      });
     });
     return () => controller.abort();
-  }, [isPending, session]);
+  }, [isPending, sessionUserId]);
+
+  const stateMatchesSession = state.userId === sessionUserId;
+  const personalizationLoading = Boolean(
+    sessionUserId &&
+      (!stateMatchesSession || state.status !== "ready" || dietLoading),
+  );
+  const saved = stateMatchesSession ? state.saved : [];
+  const box = stateMatchesSession ? state.box : null;
+  const loadError = stateMatchesSession ? state.loadError : null;
 
   const combined = useMemo(() => {
     const dynamic = saved.flatMap((record) => {
@@ -83,6 +120,15 @@ export function RecipeCollection({
       ),
     ];
   }, [box, recipes, saved]);
+
+  if (isPending || personalizationLoading) {
+    return (
+      <div role="status" aria-label="Loading personalized recipes">
+        <CardGridSkeleton variant="filters" />
+        <span className="sr-only">Loading personalized recipes…</span>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -123,9 +123,11 @@ export function RecipeCollection({
 
   if (isPending || personalizationLoading) {
     return (
-      <div role="status" aria-label="Loading personalized recipes">
+      <div>
         <CardGridSkeleton variant="filters" />
-        <span className="sr-only">Loading personalized recipes…</span>
+        <output aria-label="Loading personalized recipes" className="sr-only">
+          Loading personalized recipes…
+        </output>
       </div>
     );
   }

--- a/ui/components/recipes/recipe-home-skeleton.tsx
+++ b/ui/components/recipes/recipe-home-skeleton.tsx
@@ -3,11 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export function RecipeHomeSkeleton() {
   return (
-    <div
-      role="status"
-      aria-label="Loading recipes"
-      className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-10 md:pt-7 md:pb-14"
-    >
+    <div className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-10 md:pt-7 md:pb-14">
       <div className="mb-6 flex flex-wrap items-end justify-between gap-4 md:mb-8">
         <div className="space-y-3">
           <Skeleton className="h-3 w-28" />
@@ -17,7 +13,9 @@ export function RecipeHomeSkeleton() {
         <Skeleton className="h-10 w-32 rounded-full" />
       </div>
       <CardGridSkeleton variant="filters" />
-      <span className="sr-only">Loading recipes…</span>
+      <output aria-label="Loading recipes" className="sr-only">
+        Loading recipes…
+      </output>
     </div>
   );
 }

--- a/ui/components/recipes/recipe-home-skeleton.tsx
+++ b/ui/components/recipes/recipe-home-skeleton.tsx
@@ -1,0 +1,23 @@
+import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function RecipeHomeSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading recipes"
+      className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-10 md:pt-7 md:pb-14"
+    >
+      <div className="mb-6 flex flex-wrap items-end justify-between gap-4 md:mb-8">
+        <div className="space-y-3">
+          <Skeleton className="h-3 w-28" />
+          <Skeleton className="h-16 w-72 max-w-[75vw] sm:h-20 sm:w-96" />
+          <Skeleton className="h-5 w-52 max-w-[60vw]" />
+        </div>
+        <Skeleton className="h-10 w-32 rounded-full" />
+      </div>
+      <CardGridSkeleton variant="filters" />
+      <span className="sr-only">Loading recipes…</span>
+    </div>
+  );
+}

--- a/ui/components/recipes/recipe-home.tsx
+++ b/ui/components/recipes/recipe-home.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { LoggedOutLanding } from "@/components/recipes/logged-out-landing";
 import { RecipeBoxView } from "@/components/recipes/recipe-box-view";
+import { RecipeHomeSkeleton } from "@/components/recipes/recipe-home-skeleton";
 import type { RecipeCardView } from "@/lib/api/recipes";
 import { authClient } from "@/lib/auth-client";
 
@@ -13,13 +14,18 @@ export function RecipeHome({
   recipes: RecipeCardView[];
   catalogStats: string[];
 }>) {
-  const { data: session } = authClient.useSession();
+  const { data: session, isPending } = authClient.useSession();
 
   useEffect(() => {
+    if (isPending) return;
     document.title = session
       ? "Your recipe box | Robbie's Recipes"
       : "Recipes for real life | Robbie's Recipes";
-  }, [session]);
+  }, [isPending, session]);
+
+  if (isPending) {
+    return <RecipeHomeSkeleton />;
+  }
 
   if (session) {
     return <RecipeBoxView recipes={recipes} catalogStats={catalogStats} />;

--- a/ui/components/recipes/recipe-site-nav.tsx
+++ b/ui/components/recipes/recipe-site-nav.tsx
@@ -18,14 +18,13 @@ export function RecipeSiteNav() {
 
   if (isPending) {
     return (
-      <div
-        role="status"
-        aria-label="Loading recipe navigation"
-        className="flex items-center gap-3 sm:gap-4"
-      >
+      <div className="flex items-center gap-3 sm:gap-4">
         <Skeleton className="h-6 w-20" />
         <Skeleton className="h-6 w-16" />
         <Skeleton className="h-6 w-24" />
+        <output aria-label="Loading recipe navigation" className="sr-only">
+          Loading recipe navigation…
+        </output>
       </div>
     );
   }

--- a/ui/components/recipes/recipe-site-nav.tsx
+++ b/ui/components/recipes/recipe-site-nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { RecipeNavTabs } from "@/components/recipes/recipe-nav-tabs";
+import { Skeleton } from "@/components/ui/skeleton";
 import { authClient } from "@/lib/auth-client";
 
 const publicTabs = [
@@ -13,7 +14,21 @@ const publicTabs = [
 
 export function RecipeSiteNav() {
   const pathname = usePathname();
-  const { data: session } = authClient.useSession();
+  const { data: session, isPending } = authClient.useSession();
+
+  if (isPending) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading recipe navigation"
+        className="flex items-center gap-3 sm:gap-4"
+      >
+        <Skeleton className="h-6 w-20" />
+        <Skeleton className="h-6 w-16" />
+        <Skeleton className="h-6 w-24" />
+      </div>
+    );
+  }
 
   if (session) return <RecipeNavTabs />;
 

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -102,16 +102,15 @@ describe("AuthButton", () => {
     });
   });
 
-  it("keeps sign-up available while the session is loading", async () => {
-    const user = userEvent.setup();
+  it("does not expose anonymous auth actions while the session is loading", () => {
     mocks.useSession.mockReturnValue({ data: null, isPending: true });
 
-    render(<AuthButton intent="signup" />);
+    const { container } = render(<AuthButton intent="signup" />);
 
-    await user.click(screen.getByRole("button", { name: /sign up/i }));
     expect(
-      screen.getByRole("button", { name: "Continue with Google" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /sign up/i }),
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy();
   });
 
   it("offers Access-protected test scenarios on PR previews", async () => {

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -110,6 +110,9 @@ describe("AuthButton", () => {
     expect(
       screen.queryByRole("button", { name: /sign up/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: "Loading session" }),
+    ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="skeleton"]')).toBeTruthy();
   });
 

--- a/ui/tests/components/recipes/diet-provider.test.tsx
+++ b/ui/tests/components/recipes/diet-provider.test.tsx
@@ -7,6 +7,10 @@ const apiMocks = vi.hoisted(() => ({
   getDietProfile: vi.fn(),
 }));
 
+const authMocks = vi.hoisted(() => ({
+  useSession: vi.fn(),
+}));
+
 vi.mock("@/lib/api/diet", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api/diet")>()),
   ...apiMocks,
@@ -14,16 +18,17 @@ vi.mock("@/lib/api/diet", async (importOriginal) => ({
 
 vi.mock("@/lib/auth-client", () => ({
   authClient: {
-    useSession: () => ({
-      data: { user: { id: "qa-user" } },
-      isPending: false,
-    }),
+    useSession: authMocks.useSession,
   },
 }));
 
 describe("DietProvider", () => {
   beforeEach(() => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
+    authMocks.useSession.mockReturnValue({
+      data: { user: { id: "qa-user" } },
+      isPending: false,
+    });
   });
 
   afterEach(() => {
@@ -59,5 +64,46 @@ describe("DietProvider", () => {
     expect(() => render(<UnwrappedConsumer />)).toThrow(
       "useDiet must be used within a DietProvider.",
     );
+  });
+
+  it("reports loading immediately for a newly authenticated user", async () => {
+    let resolveProfile!: (value: {
+      presetDietKeys: string[];
+      excludedIngredientSlugs: string[];
+      excludedGroupKeys: string[];
+      recipeMatchMode: "hide";
+    }) => void;
+    apiMocks.getDietProfile.mockReturnValue(
+      new Promise((resolve) => {
+        resolveProfile = resolve;
+      }),
+    );
+    apiMocks.getDietOptions.mockResolvedValue({
+      presets: [],
+      groups: [],
+      ingredients: [],
+    });
+
+    function LoadingProbe() {
+      const { loading } = useDiet();
+      return <p>{loading ? "Diet loading" : "Diet ready"}</p>;
+    }
+
+    render(
+      <DietProvider>
+        <LoadingProbe />
+      </DietProvider>,
+    );
+
+    expect(screen.getByText("Diet loading")).toBeInTheDocument();
+
+    resolveProfile({
+      presetDietKeys: [],
+      excludedIngredientSlugs: [],
+      excludedGroupKeys: [],
+      recipeMatchMode: "hide",
+    });
+
+    expect(await screen.findByText("Diet ready")).toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/recipe-box-view.test.tsx
+++ b/ui/tests/components/recipes/recipe-box-view.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  session: {
+    data: { user: { id: "user-1" } },
+    isPending: false,
+  },
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: () => mocks.session },
+}));
+
+vi.mock("@/components/recipes/add-recipe-button", () => ({
+  AddRecipeButton: () => null,
+}));
+
+vi.mock("@/components/recipes/recipe-collection", () => ({
+  RecipeCollection: ({
+    onDietVisibleCountChange,
+  }: {
+    onDietVisibleCountChange?: (count: number) => void;
+  }) => (
+    <button type="button" onClick={() => onDietVisibleCountChange?.(7)}>
+      Report visible recipes
+    </button>
+  ),
+}));
+
+import { RecipeBoxView } from "@/components/recipes/recipe-box-view";
+
+describe("RecipeBoxView", () => {
+  beforeEach(() => {
+    mocks.session = {
+      data: { user: { id: "user-1" } },
+      isPending: false,
+    };
+  });
+
+  it("hides the previous user's count as soon as the account changes", async () => {
+    const user = userEvent.setup();
+    const view = render(<RecipeBoxView recipes={[]} catalogStats={[]} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Report visible recipes" }),
+    );
+    expect(screen.getByText("7 recipes")).toBeInTheDocument();
+
+    mocks.session = {
+      data: { user: { id: "user-2" } },
+      isPending: false,
+    };
+    view.rerender(<RecipeBoxView recipes={[]} catalogStats={[]} />);
+
+    expect(screen.queryByText("7 recipes")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Loading recipe count")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/recipe-collection.test.tsx
+++ b/ui/tests/components/recipes/recipe-collection.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  session: { data: { user: { id: "user-1" } }, isPending: false },
+  dietLoading: false,
+  fetchSaved: vi.fn(),
+  fetchBox: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: () => mocks.session },
+}));
+
+vi.mock("@/components/recipes/diet-provider", () => ({
+  useDiet: () => ({ loading: mocks.dietLoading }),
+}));
+
+vi.mock("@/lib/api/saved-recipes", () => ({
+  fetchAllSavedRecipes: mocks.fetchSaved,
+}));
+
+vi.mock("@/lib/api/recipe-box", () => ({
+  getRecipeBoxProfile: mocks.fetchBox,
+}));
+
+vi.mock("@/lib/domain/recipe/recipeDraft", () => ({
+  savedRecipeCard: (record: { slug: string; title: string }) => ({
+    ...record,
+    description: "Saved recipe",
+    date: "2026-07-19",
+    cuisine: [],
+    tags: [],
+    servings: 2,
+    ingredientNames: [],
+    ingredientSlugs: [],
+    cookware: [],
+  }),
+}));
+
+vi.mock("@/components/ui/card-grid-skeleton", () => ({
+  CardGridSkeleton: () => <div>Loading personalized recipes</div>,
+}));
+
+vi.mock("@/components/recipes/recipe-list", () => ({
+  RecipeList: ({ recipes }: { recipes: { title: string }[] }) => (
+    <div>Recipes: {recipes.map((recipe) => recipe.title).join(", ")}</div>
+  ),
+}));
+
+import { RecipeCollection } from "@/components/recipes/recipe-collection";
+import type { RecipeCardView } from "@/lib/api/recipes";
+
+const staticRecipes = [
+  { slug: "starter", title: "Selected starter" },
+  { slug: "not-selected", title: "Default catalogue recipe" },
+] as RecipeCardView[];
+
+describe("RecipeCollection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.session = {
+      data: { user: { id: "user-1" } },
+      isPending: false,
+    };
+    mocks.dietLoading = false;
+  });
+
+  it("keeps default recipes hidden until personalization is ready", async () => {
+    let resolveSaved!: (value: { slug: string; title: string }[]) => void;
+    let resolveBox!: (value: {
+      completed: boolean;
+      staticRecipeSlugs: string[];
+    }) => void;
+    mocks.fetchSaved.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSaved = resolve;
+      }),
+    );
+    mocks.fetchBox.mockReturnValue(
+      new Promise((resolve) => {
+        resolveBox = resolve;
+      }),
+    );
+
+    render(<RecipeCollection recipes={staticRecipes} />);
+
+    expect(
+      screen.getByText("Loading personalized recipes"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Default catalogue recipe/),
+    ).not.toBeInTheDocument();
+
+    resolveSaved([{ slug: "saved", title: "My saved recipe" }]);
+    resolveBox({ completed: true, staticRecipeSlugs: ["starter"] });
+
+    expect(
+      await screen.findByText("Recipes: My saved recipe, Selected starter"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Default catalogue recipe/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not expose one user's recipes while another user loads", async () => {
+    mocks.fetchSaved.mockResolvedValueOnce([
+      { slug: "first", title: "First user's recipe" },
+    ]);
+    mocks.fetchBox.mockResolvedValueOnce({
+      completed: true,
+      staticRecipeSlugs: [],
+    });
+
+    const view = render(<RecipeCollection recipes={staticRecipes} />);
+    expect(
+      await screen.findByText("Recipes: First user's recipe"),
+    ).toBeInTheDocument();
+
+    mocks.session = {
+      data: { user: { id: "user-2" } },
+      isPending: false,
+    };
+    mocks.fetchSaved.mockReturnValueOnce(new Promise(() => undefined));
+    mocks.fetchBox.mockReturnValueOnce(new Promise(() => undefined));
+    view.rerender(<RecipeCollection recipes={staticRecipes} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Loading personalized recipes"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/First user's recipe/)).not.toBeInTheDocument();
+  });
+
+  it("waits for diet preferences before rendering the recipe list", async () => {
+    mocks.dietLoading = true;
+    mocks.fetchSaved.mockResolvedValue([]);
+    mocks.fetchBox.mockResolvedValue({
+      completed: true,
+      staticRecipeSlugs: ["starter"],
+    });
+
+    const view = render(<RecipeCollection recipes={staticRecipes} />);
+    expect(
+      screen.getByText("Loading personalized recipes"),
+    ).toBeInTheDocument();
+
+    mocks.dietLoading = false;
+    view.rerender(<RecipeCollection recipes={staticRecipes} />);
+
+    expect(
+      await screen.findByText("Recipes: Selected starter"),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/recipe-collection.test.tsx
+++ b/ui/tests/components/recipes/recipe-collection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -125,11 +125,9 @@ describe("RecipeCollection", () => {
     mocks.fetchBox.mockReturnValueOnce(new Promise(() => undefined));
     view.rerender(<RecipeCollection recipes={staticRecipes} />);
 
-    await waitFor(() =>
-      expect(
-        screen.getByText("Loading personalized recipes"),
-      ).toBeInTheDocument(),
-    );
+    expect(
+      await screen.findByText("Loading personalized recipes"),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/First user's recipe/)).not.toBeInTheDocument();
   });
 

--- a/ui/tests/components/recipes/recipe-home.test.tsx
+++ b/ui/tests/components/recipes/recipe-home.test.tsx
@@ -17,6 +17,10 @@ vi.mock("@/components/recipes/recipe-box-view", () => ({
   RecipeBoxView: () => <div>Your recipe box</div>,
 }));
 
+vi.mock("@/components/recipes/recipe-home-skeleton", () => ({
+  RecipeHomeSkeleton: () => <div>Neutral recipe shell</div>,
+}));
+
 import { RecipeHome } from "@/components/recipes/recipe-home";
 
 describe("RecipeHome", () => {
@@ -47,13 +51,14 @@ describe("RecipeHome", () => {
     expect(document.title).toBe("Your recipe box | Robbie's Recipes");
   });
 
-  it("renders the public landing while the session is loading", () => {
+  it("renders a neutral shell while the session is loading", () => {
     mocks.useSession.mockReturnValue({ data: null, isPending: true });
 
     render(<RecipeHome recipes={[]} catalogStats={[]} />);
 
-    expect(screen.getByText("Public landing")).toBeInTheDocument();
+    expect(screen.getByText("Neutral recipe shell")).toBeInTheDocument();
+    expect(screen.queryByText("Public landing")).not.toBeInTheDocument();
     expect(screen.queryByText("Your recipe box")).not.toBeInTheDocument();
-    expect(document.title).toBe("Recipes for real life | Robbie's Recipes");
+    expect(document.title).toBe("");
   });
 });

--- a/ui/tests/components/recipes/recipe-site-nav.test.tsx
+++ b/ui/tests/components/recipes/recipe-site-nav.test.tsx
@@ -24,16 +24,17 @@ describe("RecipeSiteNav", () => {
     vi.clearAllMocks();
   });
 
-  it("renders public navigation while the session is loading", () => {
+  it("renders neutral navigation while the session is loading", () => {
     mocks.useSession.mockReturnValue({ data: null, isPending: true });
 
     render(<RecipeSiteNav />);
 
-    expect(screen.getByRole("link", { name: "Discover" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Cooks" })).toBeInTheDocument();
     expect(
-      screen.getByRole("link", { name: "How it works" }),
+      screen.getByRole("status", { name: "Loading recipe navigation" }),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Discover" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("Personal recipe tabs")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What changed

- render a neutral, layout-stable recipe shell while the Better Auth session is unresolved
- keep public navigation and sign-up controls hidden until anonymous state is confirmed
- keep the recipe grid and recipe count neutral until saved recipes, recipe-box selection, and diet preferences are ready
- key diet and recipe-box state by user so data cannot flash across account changes
- add transition tests for auth pending, personalization pending, diet pending, and account switching

## Why

The static recipe page treated `session === null` as logged out even while Better Auth was still loading. After authentication resolved, `box === null`, `saved === []`, and the fallback diet were treated as real defaults, producing a deterministic marketing → default catalogue → personalized box sequence.

This change gives unknown, loading, anonymous, and authenticated states distinct render paths. It removes misleading intermediate content without changing the static-export architecture.

## User impact

Hard refreshes now show a neutral branded skeleton until identity and critical personalization are known, then transition directly to either the public landing page or the correct personalized recipe box. Recipe counts no longer advertise the full static catalogue while personalization loads.

## Validation

- `CI=true mise //ui:check` — 77 files / 610 tests passed; type-check, lint, and format checks passed (existing non-blocking Biome warnings remain)
- `CI=true NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build` — production static export passed
- targeted auth, navigation, diet, recipe collection, and recipe home tests passed
- `git diff --check`

The in-app browser host was unavailable in this environment, so visual verification is covered by the production build, static output inspection, and component transition tests.