### PR TITLE
Make completed recipe timers harder to miss

### DIFF
--- a/ui/app/recipes/recipe-theme.css
+++ b/ui/app/recipes/recipe-theme.css
@@ -99,6 +99,36 @@
   text-transform: uppercase;
 }
 
+/* Draw attention once, then leave a persistent high-contrast completion state
+   until the timer is dismissed. The finite motion avoids an ongoing visual
+   distraction while the static colour and copy continue to carry the state. */
+@keyframes rt-timer-attention {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow:
+      0 0 0 0 rgba(153, 57, 74, 0.55),
+      var(--paper-shadow);
+  }
+  45% {
+    transform: scale(1.08);
+    box-shadow:
+      0 0 0 0.5rem rgba(153, 57, 74, 0.18),
+      var(--paper-shadow);
+  }
+}
+
+.rt-timer-attention {
+  animation: rt-timer-attention 700ms ease-in-out 4;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rt-timer-attention {
+    animation: none;
+  }
+}
+
 /* the logo's italic accent */
 .recipe-theme .rt-logo-accent {
   font-style: italic;

--- a/ui/components/recipes/cook-mode.tsx
+++ b/ui/components/recipes/cook-mode.tsx
@@ -673,7 +673,7 @@ function CookModeTimer({
       <div
         className={[
           "flex size-32 shrink-0 items-center justify-center rounded-full border-[3px] border-[var(--ink)]",
-          state === "completed" ? "animate-pulse" : "",
+          state === "completed" ? "rt-timer-attention" : "",
         ].join(" ")}
         style={{ background: circleBackground }}
       >

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -66,6 +66,16 @@ function TimerStateIcon({ state }: Readonly<{ state: InlineTimerState }>) {
   return <Timer className="size-3" />;
 }
 
+function timerDisplayText(
+  state: InlineTimerState,
+  label: string,
+  remaining: number,
+): string {
+  if (state === "idle") return label;
+  if (state === "completed") return "Time's up!";
+  return formatCountdown(remaining);
+}
+
 /**
  * Tap-to-start countdown pill rendered inline in a method step. State lives
  * in the global timer store, so the same countdown is mirrored in cook mode
@@ -172,11 +182,7 @@ export function InlineTimer({
         aria-label={getTimerAriaLabel(state, label, remaining)}
       >
         <TimerStateIcon state={state} />
-        {state === "idle"
-          ? label
-          : state === "completed"
-            ? "Time's up!"
-            : formatCountdown(remaining)}
+        {timerDisplayText(state, label, remaining)}
       </button>
       {showReset && (
         <button

--- a/ui/components/recipes/inline-timer.tsx
+++ b/ui/components/recipes/inline-timer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Pause, RotateCcw, Timer, X } from "lucide-react";
+import { BellRing, Pause, Timer, X } from "lucide-react";
 import { useCallback } from "react";
 import { AddTimerPopover } from "@/components/recipes/add-timer-popover";
 import { badgeVariants } from "@/components/ui/badge";
@@ -56,13 +56,13 @@ function getTimerAriaLabel(
     case "paused":
       return `Resume timer, ${formatCountdown(remaining)} remaining`;
     case "completed":
-      return "Timer complete, click to dismiss";
+      return `Time's up for ${label}. Dismiss timer`;
   }
 }
 
 function TimerStateIcon({ state }: Readonly<{ state: InlineTimerState }>) {
   if (state === "paused") return <Pause className="size-3" />;
-  if (state === "completed") return <RotateCcw className="size-3" />;
+  if (state === "completed") return <BellRing className="size-3" />;
   return <Timer className="size-3" />;
 }
 
@@ -162,7 +162,7 @@ export function InlineTimer({
         // The idle timer should read as an inviting, tappable control rather
         // than recede into the method text — warm fill + emphasised label.
         state === "idle" && "bg-[var(--butter-soft)] text-[var(--ink)]",
-        state === "completed" && "animate-pulse",
+        state === "completed" && "rt-timer-attention",
       )}
     >
       <button
@@ -172,7 +172,11 @@ export function InlineTimer({
         aria-label={getTimerAriaLabel(state, label, remaining)}
       >
         <TimerStateIcon state={state} />
-        {state === "idle" ? label : formatCountdown(remaining)}
+        {state === "idle"
+          ? label
+          : state === "completed"
+            ? "Time's up!"
+            : formatCountdown(remaining)}
       </button>
       {showReset && (
         <button

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  BellRing,
   ChevronDown,
   ChevronUp,
   GripVertical,
@@ -84,7 +85,7 @@ function byUrgency(a: CookingTimer, b: CookingTimer): number {
 }
 
 function dotColor(timer: CookingTimer): string {
-  if (timer.state === "completed") return "var(--terracotta)";
+  if (timer.state === "completed") return "var(--butter)";
   if (timer.state === "paused") return "var(--ink-4)";
   return "var(--butter)";
 }
@@ -296,6 +297,8 @@ export function TimerDock() {
     );
   }
 
+  const completedTimers = sorted.filter((timer) => timer.state === "completed");
+
   const grip = (
     <button
       type="button"
@@ -322,8 +325,20 @@ export function TimerDock() {
       className="rt-timer-dock fixed right-3 bottom-3 z-[80] sm:right-4 sm:bottom-4"
       style={style}
     >
+      {completedTimers.length > 0 && (
+        <span role="alert" aria-atomic="true" className="sr-only">
+          {completedTimers.length === 1
+            ? `Time's up for ${completedTimers[0]?.label}.`
+            : `${completedTimers.length} cooking timers are complete.`}
+        </span>
+      )}
       {expanded ? (
-        <div className="flex min-w-60 max-w-[calc(100vw-1rem)] flex-col rounded-2xl bg-[var(--ink)] p-2 text-[var(--paper)] shadow-lg">
+        <div
+          className={[
+            "flex min-w-60 max-w-[calc(100vw-1rem)] flex-col rounded-2xl bg-[var(--ink)] p-2 text-[var(--paper)] shadow-lg",
+            completedTimers.length > 0 ? "rt-timer-attention" : "",
+          ].join(" ")}
+        >
           <div className="flex items-center gap-1">
             {grip}
             <span className="rt-mono flex-1 text-[9px] text-[var(--ink-4)]">
@@ -351,26 +366,43 @@ export function TimerDock() {
           </div>
         </div>
       ) : (
-        <div className="flex items-center rounded-full bg-[var(--ink)] py-1 pr-2.5 pl-1.5 text-[var(--paper)] shadow-lg">
+        <div
+          className={[
+            "flex items-center rounded-full py-1 pr-2.5 pl-1.5 text-[var(--paper)] shadow-lg",
+            primary.state === "completed"
+              ? "rt-timer-attention bg-[var(--berry)]"
+              : "bg-[var(--ink)]",
+          ].join(" ")}
+        >
           {grip}
           <button
             type="button"
             onClick={() => setExpanded(true)}
             aria-expanded="false"
-            aria-label={`Expand cooking timers (${sorted.length})`}
+            aria-label={
+              primary.state === "completed"
+                ? `Time's up for ${primary.label}. Expand cooking timers (${sorted.length})`
+                : `Expand cooking timers (${sorted.length})`
+            }
             className="flex items-center gap-2 py-0.5 pl-1"
           >
+            {primary.state === "completed" && (
+              <BellRing className="size-5 shrink-0 text-[var(--butter)]" />
+            )}
             <span className="flex min-w-0 flex-col text-left leading-tight">
               <span
-                className={[
-                  "rt-mono max-w-40 truncate text-[9px]",
-                  primary.state === "completed" ? "animate-pulse" : "",
-                ].join(" ")}
+                className="rt-mono max-w-40 truncate text-[9px]"
                 style={{ color: dotColor(primary) }}
               >
                 ● {primary.label}
                 {stepTag(primary) && (
-                  <span className="text-[var(--ink-4)]">
+                  <span
+                    className={
+                      primary.state === "completed"
+                        ? "text-[var(--paper)]/75"
+                        : "text-[var(--ink-4)]"
+                    }
+                  >
                     {" "}
                     · {stepTag(primary)}
                   </span>
@@ -380,11 +412,10 @@ export function TimerDock() {
                 className={[
                   "rt-display text-xl leading-none tabular-nums",
                   primary.state === "paused" ? "opacity-60" : "",
-                  primary.state === "completed" ? "animate-pulse" : "",
                 ].join(" ")}
               >
                 {primary.state === "completed"
-                  ? "done!"
+                  ? "time's up!"
                   : formatCountdown(primary.remainingSeconds)}
               </span>
             </span>
@@ -428,10 +459,7 @@ function DockRow({ timer }: Readonly<{ timer: CookingTimer }>) {
     .filter(Boolean)
     .join(" — ");
 
-  const detailClassName = [
-    "flex min-w-0 flex-1 flex-col leading-tight",
-    completed ? "animate-pulse" : "",
-  ].join(" ");
+  const detailClassName = "flex min-w-0 flex-1 flex-col leading-tight";
   const detail = (
     <>
       <span
@@ -439,9 +467,23 @@ function DockRow({ timer }: Readonly<{ timer: CookingTimer }>) {
         style={{ color: dotColor(timer) }}
       >
         ● {timer.label}
-        {tag && <span className="text-[var(--ink-4)]"> · {tag}</span>}
+        {tag && (
+          <span
+            className={
+              completed ? "text-[var(--paper)]/75" : "text-[var(--ink-4)]"
+            }
+          >
+            {" "}
+            · {tag}
+          </span>
+        )}
       </span>
-      <span className="max-w-40 truncate font-[family-name:var(--font-kalam)] text-[10px] text-[var(--ink-4)]">
+      <span
+        className={[
+          "max-w-40 truncate font-[family-name:var(--font-kalam)] text-[10px]",
+          completed ? "text-[var(--paper)]/75" : "text-[var(--ink-4)]",
+        ].join(" ")}
+      >
         {subtitle}
       </span>
       <span
@@ -450,13 +492,18 @@ function DockRow({ timer }: Readonly<{ timer: CookingTimer }>) {
           paused ? "opacity-60" : "",
         ].join(" ")}
       >
-        {completed ? "done!" : formatCountdown(timer.remainingSeconds)}
+        {completed ? "time's up!" : formatCountdown(timer.remainingSeconds)}
       </span>
     </>
   );
 
   return (
-    <div className="flex items-center gap-1.5 rounded-lg px-1 py-0.5">
+    <div
+      className={[
+        "flex items-center gap-1.5 rounded-lg px-1 py-0.5",
+        completed ? "bg-[var(--berry)]" : "",
+      ].join(" ")}
+    >
       {/* A plain <a> (full navigation), not next/link: deep-linking into cook
           mode relies on RecipeContent reading ?cook=1&step=N on mount, which a
           client-side transition to the same recipe route wouldn't retrigger.

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -85,9 +85,23 @@ function byUrgency(a: CookingTimer, b: CookingTimer): number {
 }
 
 function dotColor(timer: CookingTimer): string {
-  if (timer.state === "completed") return "var(--butter)";
   if (timer.state === "paused") return "var(--ink-4)";
   return "var(--butter)";
+}
+
+function completionAnnouncement(timers: readonly CookingTimer[]): string {
+  if (timers.length === 0) return "";
+  if (timers.length === 1) return `Time's up for ${timers[0]?.label}.`;
+  return `${timers.length} cooking timers are complete.`;
+}
+
+function completedTimerIdsKey(timers: readonly CookingTimer[]): string {
+  return JSON.stringify(
+    timers
+      .filter((timer) => timer.state === "completed")
+      .map((timer) => timer.id)
+      .sort(),
+  );
 }
 
 /**
@@ -129,6 +143,95 @@ function stepTag(timer: CookingTimer): string | null {
   return timer.stepIndex === undefined ? null : `step ${timer.stepIndex + 1}`;
 }
 
+function CollapsedTimerDock({
+  grip,
+  primary,
+  timerCount,
+  onExpand,
+}: Readonly<{
+  grip: React.ReactNode;
+  primary: CookingTimer;
+  timerCount: number;
+  onExpand: () => void;
+}>) {
+  const completed = primary.state === "completed";
+  const tag = stepTag(primary);
+
+  return (
+    <div
+      className={[
+        "flex items-center rounded-full py-1 pr-2.5 pl-1.5 text-[var(--paper)] shadow-lg",
+        completed ? "bg-[var(--berry)]" : "bg-[var(--ink)]",
+      ].join(" ")}
+    >
+      {grip}
+      <button
+        type="button"
+        onClick={onExpand}
+        aria-expanded="false"
+        aria-label={
+          completed
+            ? `Time's up for ${primary.label}. Expand cooking timers (${timerCount})`
+            : `Expand cooking timers (${timerCount})`
+        }
+        className="flex items-center gap-2 py-0.5 pl-1"
+      >
+        {completed && (
+          <BellRing className="size-5 shrink-0 text-[var(--butter)]" />
+        )}
+        <span className="flex min-w-0 flex-col text-left leading-tight">
+          <span
+            className="rt-mono max-w-40 truncate text-[9px]"
+            style={{ color: dotColor(primary) }}
+          >
+            ● {primary.label}
+            {tag && (
+              <span
+                className={
+                  completed
+                    ? "text-[var(--paper)] opacity-75"
+                    : "text-[var(--ink-4)]"
+                }
+              >
+                {" "}
+                · {tag}
+              </span>
+            )}
+          </span>
+          <span
+            className={[
+              "rt-display text-xl leading-none tabular-nums",
+              primary.state === "paused" ? "opacity-60" : "",
+            ].join(" ")}
+          >
+            {completed
+              ? "time's up!"
+              : formatCountdown(primary.remainingSeconds)}
+          </span>
+        </span>
+        {timerCount > 1 && (
+          <span className="rt-mono rounded-full bg-[var(--paper)]/15 px-1.5 py-0.5 text-[9px]">
+            +{timerCount - 1}
+          </span>
+        )}
+        <ChevronUp className="size-3.5 opacity-60" />
+      </button>
+      <AddTimerPopover
+        align="end"
+        trigger={
+          <button
+            type="button"
+            aria-label="Add a custom timer"
+            className="ml-1 rounded-full p-1.5 text-[var(--paper)]/80 transition-colors hover:bg-[var(--paper)]/15 hover:text-[var(--paper)]"
+          >
+            <Plus className="size-4" />
+          </button>
+        }
+      />
+    </div>
+  );
+}
+
 /**
  * Floating dock for every active cooking timer. Collapsed (the default) it is
  * a single compact pill showing the most urgent timer plus a count of the
@@ -139,7 +242,10 @@ export function TimerDock() {
   const timers = useCookingTimers();
   const [expanded, setExpanded] = useState(false);
   const [position, setPosition] = useState<DockPosition | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const [attentionRevision, setAttentionRevision] = useState(0);
   const dockRef = useRef<HTMLElement>(null);
+  const previousCompletedIdsRef = useRef<ReadonlySet<string>>(new Set());
   const dragRef = useRef<{
     pointerId: number;
     startX: number;
@@ -156,6 +262,31 @@ export function TimerDock() {
     setMounted(true);
     setPosition(loadPosition());
   }, []);
+
+  const completedTimers = timers.filter((timer) => timer.state === "completed");
+  const completedIdsKey = completedTimerIdsKey(timers);
+  const nextAnnouncement = completionAnnouncement(completedTimers);
+
+  // Keep the live region empty before inserting its message so restored
+  // completions are announced too. Track newly completed ids separately from
+  // dock expansion, so the visual cue replays for a later timer but not when
+  // someone opens or closes the dock to act on an existing alert.
+  useEffect(() => {
+    const completedIds = new Set<string>(JSON.parse(completedIdsKey));
+    const hasNewCompletion = [...completedIds].some(
+      (id) => !previousCompletedIdsRef.current.has(id),
+    );
+    previousCompletedIdsRef.current = completedIds;
+    setAnnouncement("");
+    if (!hasNewCompletion) return;
+
+    setAttentionRevision((revision) => revision + 1);
+    const announceHandle = globalThis.setTimeout(
+      () => setAnnouncement(nextAnnouncement),
+      100,
+    );
+    return () => globalThis.clearTimeout(announceHandle);
+  }, [completedIdsKey, nextAnnouncement]);
 
   // A dragged position is stored as bottom-right offsets measured at the
   // dock's size at drag time. Expanding, gaining timers, or rotating the
@@ -297,8 +428,6 @@ export function TimerDock() {
     );
   }
 
-  const completedTimers = sorted.filter((timer) => timer.state === "completed");
-
   const grip = (
     <button
       type="button"
@@ -325,121 +454,55 @@ export function TimerDock() {
       className="rt-timer-dock fixed right-3 bottom-3 z-[80] sm:right-4 sm:bottom-4"
       style={style}
     >
-      {completedTimers.length > 0 && (
-        <span role="alert" aria-atomic="true" className="sr-only">
-          {completedTimers.length === 1
-            ? `Time's up for ${completedTimers[0]?.label}.`
-            : `${completedTimers.length} cooking timers are complete.`}
-        </span>
-      )}
-      {expanded ? (
-        <div
-          className={[
-            "flex min-w-60 max-w-[calc(100vw-1rem)] flex-col rounded-2xl bg-[var(--ink)] p-2 text-[var(--paper)] shadow-lg",
-            completedTimers.length > 0 ? "rt-timer-attention" : "",
-          ].join(" ")}
-        >
-          <div className="flex items-center gap-1">
-            {grip}
-            <span className="rt-mono flex-1 text-[9px] text-[var(--ink-4)]">
-              cooking timers
-            </span>
-            <button
-              type="button"
-              onClick={() => setExpanded(false)}
-              aria-expanded="true"
-              aria-label="Collapse timers"
-              className="rounded-full p-2 opacity-70 transition-opacity hover:opacity-100"
-            >
-              <ChevronDown className="size-4" />
-            </button>
-          </div>
-          {/* Many timers must scroll inside the panel rather than grow it
-              past the top of the screen. */}
-          <div className="max-h-[45vh] overflow-y-auto overscroll-contain">
-            {sorted.map((timer) => (
-              <DockRow key={timer.id} timer={timer} />
-            ))}
-          </div>
-          <div className="mt-1 border-t border-[var(--paper)]/10 pt-1">
-            {addTimerControl}
-          </div>
-        </div>
-      ) : (
-        <div
-          className={[
-            "flex items-center rounded-full py-1 pr-2.5 pl-1.5 text-[var(--paper)] shadow-lg",
-            primary.state === "completed"
-              ? "rt-timer-attention bg-[var(--berry)]"
-              : "bg-[var(--ink)]",
-          ].join(" ")}
-        >
-          {grip}
-          <button
-            type="button"
-            onClick={() => setExpanded(true)}
-            aria-expanded="false"
-            aria-label={
-              primary.state === "completed"
-                ? `Time's up for ${primary.label}. Expand cooking timers (${sorted.length})`
-                : `Expand cooking timers (${sorted.length})`
-            }
-            className="flex items-center gap-2 py-0.5 pl-1"
-          >
-            {primary.state === "completed" && (
-              <BellRing className="size-5 shrink-0 text-[var(--butter)]" />
-            )}
-            <span className="flex min-w-0 flex-col text-left leading-tight">
-              <span
-                className="rt-mono max-w-40 truncate text-[9px]"
-                style={{ color: dotColor(primary) }}
-              >
-                ● {primary.label}
-                {stepTag(primary) && (
-                  <span
-                    className={
-                      primary.state === "completed"
-                        ? "text-[var(--paper)]/75"
-                        : "text-[var(--ink-4)]"
-                    }
-                  >
-                    {" "}
-                    · {stepTag(primary)}
-                  </span>
-                )}
+      <span role="alert" aria-atomic="true" className="sr-only">
+        {announcement}
+      </span>
+      <div
+        key={attentionRevision}
+        className={[
+          expanded ? "rounded-2xl" : "rounded-full",
+          attentionRevision > 0 && completedTimers.length > 0
+            ? "rt-timer-attention"
+            : "",
+        ].join(" ")}
+      >
+        {expanded ? (
+          <div className="flex min-w-60 max-w-[calc(100vw-1rem)] flex-col rounded-2xl bg-[var(--ink)] p-2 text-[var(--paper)] shadow-lg">
+            <div className="flex items-center gap-1">
+              {grip}
+              <span className="rt-mono flex-1 text-[9px] text-[var(--ink-4)]">
+                cooking timers
               </span>
-              <span
-                className={[
-                  "rt-display text-xl leading-none tabular-nums",
-                  primary.state === "paused" ? "opacity-60" : "",
-                ].join(" ")}
-              >
-                {primary.state === "completed"
-                  ? "time's up!"
-                  : formatCountdown(primary.remainingSeconds)}
-              </span>
-            </span>
-            {sorted.length > 1 && (
-              <span className="rt-mono rounded-full bg-[var(--paper)]/15 px-1.5 py-0.5 text-[9px]">
-                +{sorted.length - 1}
-              </span>
-            )}
-            <ChevronUp className="size-3.5 opacity-60" />
-          </button>
-          <AddTimerPopover
-            align="end"
-            trigger={
               <button
                 type="button"
-                aria-label="Add a custom timer"
-                className="ml-1 rounded-full p-1.5 text-[var(--paper)]/80 transition-colors hover:bg-[var(--paper)]/15 hover:text-[var(--paper)]"
+                onClick={() => setExpanded(false)}
+                aria-expanded="true"
+                aria-label="Collapse timers"
+                className="rounded-full p-2 opacity-70 transition-opacity hover:opacity-100"
               >
-                <Plus className="size-4" />
+                <ChevronDown className="size-4" />
               </button>
-            }
+            </div>
+            {/* Many timers must scroll inside the panel rather than grow it
+              past the top of the screen. */}
+            <div className="max-h-[45vh] overflow-y-auto overscroll-contain">
+              {sorted.map((timer) => (
+                <DockRow key={timer.id} timer={timer} />
+              ))}
+            </div>
+            <div className="mt-1 border-t border-[var(--paper)]/10 pt-1">
+              {addTimerControl}
+            </div>
+          </div>
+        ) : (
+          <CollapsedTimerDock
+            grip={grip}
+            primary={primary}
+            timerCount={sorted.length}
+            onExpand={() => setExpanded(true)}
           />
-        </div>
-      )}
+        )}
+      </div>
     </section>,
     document.body,
   );
@@ -470,7 +533,9 @@ function DockRow({ timer }: Readonly<{ timer: CookingTimer }>) {
         {tag && (
           <span
             className={
-              completed ? "text-[var(--paper)]/75" : "text-[var(--ink-4)]"
+              completed
+                ? "text-[var(--paper)] opacity-75"
+                : "text-[var(--ink-4)]"
             }
           >
             {" "}
@@ -481,7 +546,7 @@ function DockRow({ timer }: Readonly<{ timer: CookingTimer }>) {
       <span
         className={[
           "max-w-40 truncate font-[family-name:var(--font-kalam)] text-[10px]",
-          completed ? "text-[var(--paper)]/75" : "text-[var(--ink-4)]",
+          completed ? "text-[var(--paper)] opacity-75" : "text-[var(--ink-4)]",
         ].join(" ")}
       >
         {subtitle}

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -100,7 +100,7 @@ function completedTimerIdsKey(timers: readonly CookingTimer[]): string {
     timers
       .filter((timer) => timer.state === "completed")
       .map((timer) => timer.id)
-      .sort(),
+      .sort((a, b) => a.localeCompare(b)),
   );
 }
 
@@ -245,6 +245,7 @@ export function TimerDock() {
   const [announcement, setAnnouncement] = useState("");
   const [attentionRevision, setAttentionRevision] = useState(0);
   const dockRef = useRef<HTMLElement>(null);
+  const attentionRef = useRef<HTMLDivElement>(null);
   const previousCompletedIdsRef = useRef<ReadonlySet<string>>(new Set());
   const dragRef = useRef<{
     pointerId: number;
@@ -287,6 +288,19 @@ export function TimerDock() {
     );
     return () => globalThis.clearTimeout(announceHandle);
   }, [completedIdsKey, nextAnnouncement]);
+
+  // Replay the finite attention animation whenever a new timer completes.
+  // Restarting it in place — rather than remounting the dock via a changing
+  // key — keeps the interactive subtree (notably AddTimerPopover's open state
+  // and typed-in values) intact while a later timer expires.
+  useLayoutEffect(() => {
+    if (attentionRevision === 0) return;
+    const node = attentionRef.current;
+    if (!node) return;
+    node.classList.remove("rt-timer-attention");
+    void node.offsetWidth; // force reflow so the re-added class restarts the animation
+    node.classList.add("rt-timer-attention");
+  }, [attentionRevision]);
 
   // A dragged position is stored as bottom-right offsets measured at the
   // dock's size at drag time. Expanding, gaining timers, or rotating the
@@ -458,7 +472,7 @@ export function TimerDock() {
         {announcement}
       </span>
       <div
-        key={attentionRevision}
+        ref={attentionRef}
         className={[
           expanded ? "rounded-2xl" : "rounded-full",
           attentionRevision > 0 && completedTimers.length > 0

--- a/ui/tests/components/recipes/inline-timer.test.tsx
+++ b/ui/tests/components/recipes/inline-timer.test.tsx
@@ -66,7 +66,7 @@ describe("InlineTimer", () => {
   it.each([
     ["running", "Pause timer, 2:00 remaining", pauseTimer],
     ["paused", "Resume timer, 2:00 remaining", resumeTimer],
-    ["completed", "Timer complete, click to dismiss", dismissTimer],
+    ["completed", "Time's up for 5 minutes. Dismiss timer", dismissTimer],
   ] as const)("routes the %s action", async (state, accessibleName, action) => {
     const user = userEvent.setup();
     mockUseCookingTimer.mockReturnValue({

--- a/ui/tests/components/recipes/timer-dock.test.tsx
+++ b/ui/tests/components/recipes/timer-dock.test.tsx
@@ -99,11 +99,45 @@ describe("TimerDock", () => {
       vi.advanceTimersByTime(100);
     });
 
-    expect(document.querySelector(".rt-timer-attention")).not.toBe(
+    // The attention cue replays in place rather than remounting the dock, so
+    // the same node keeps carrying the persistent completion state.
+    expect(document.querySelector(".rt-timer-attention")).toBe(
       firstAttentionCue,
     );
     expect(screen.getByRole("alert")).toHaveTextContent(
       "2 cooking timers are complete.",
     );
+  });
+
+  it("keeps the add-timer popover and its typed values while another timer completes", () => {
+    vi.useFakeTimers();
+    startTimer({
+      id: "roast-timer",
+      label: "roast",
+      durationSeconds: 3,
+    });
+
+    render(
+      <CookModeProvider>
+        <TimerDock />
+      </CookModeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add a custom timer" }));
+
+    const labelInput = screen.getByPlaceholderText("e.g. pasta");
+    fireEvent.change(labelInput, { target: { value: "pasta" } });
+    expect(labelInput).toHaveValue("pasta");
+
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Time's up for roast.");
+    // The completion must not tear down the open popover or discard the label.
+    expect(screen.getByPlaceholderText("e.g. pasta")).toHaveValue("pasta");
   });
 });

--- a/ui/tests/components/recipes/timer-dock.test.tsx
+++ b/ui/tests/components/recipes/timer-dock.test.tsx
@@ -1,0 +1,57 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TimerDock } from "@/components/recipes/timer-dock";
+import { CookModeProvider } from "@/contexts/cook-mode-context";
+import {
+  __resetTimerStoreForTests,
+  startTimer,
+} from "@/lib/cooking/timerStore";
+
+describe("TimerDock", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetTimerStoreForTests();
+  });
+
+  afterEach(() => {
+    __resetTimerStoreForTests();
+    vi.useRealTimers();
+  });
+
+  it("turns a completed timer into a persistent, accessible alert", () => {
+    vi.useFakeTimers();
+    startTimer({
+      id: "roast-timer",
+      recipeSlug: "roast-vegetables",
+      recipeTitle: "Roast vegetables",
+      label: "roast vegetables",
+      stepIndex: 1,
+      stepText: "Roast until golden",
+      durationSeconds: 1,
+    });
+
+    render(
+      <CookModeProvider>
+        <TimerDock />
+      </CookModeProvider>,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Time's up for roast vegetables.",
+    );
+
+    const expandButton = screen.getByRole("button", {
+      name: "Time's up for roast vegetables. Expand cooking timers (1)",
+    });
+    expect(expandButton).toHaveTextContent("time's up!");
+    expect(expandButton.parentElement).toHaveClass(
+      "rt-timer-attention",
+      "bg-[var(--berry)]",
+    );
+    expect(expandButton.parentElement).not.toHaveClass("animate-pulse");
+  });
+});

--- a/ui/tests/components/recipes/timer-dock.test.tsx
+++ b/ui/tests/components/recipes/timer-dock.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TimerDock } from "@/components/recipes/timer-dock";
 import { CookModeProvider } from "@/contexts/cook-mode-context";
@@ -16,6 +16,30 @@ describe("TimerDock", () => {
   afterEach(() => {
     __resetTimerStoreForTests();
     vi.useRealTimers();
+  });
+
+  it("announces a timer that was already complete when the dock mounts", () => {
+    vi.useFakeTimers();
+    startTimer({
+      id: "restored-timer",
+      label: "restored timer",
+      durationSeconds: 1,
+    });
+    vi.advanceTimersByTime(1_000);
+
+    render(
+      <CookModeProvider>
+        <TimerDock />
+      </CookModeProvider>,
+    );
+
+    expect(screen.getByRole("alert")).toBeEmptyDOMElement();
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Time's up for restored timer.",
+    );
   });
 
   it("turns a completed timer into a persistent, accessible alert", () => {
@@ -39,6 +63,9 @@ describe("TimerDock", () => {
     act(() => {
       vi.advanceTimersByTime(1_000);
     });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Time's up for roast vegetables.",
@@ -48,10 +75,35 @@ describe("TimerDock", () => {
       name: "Time's up for roast vegetables. Expand cooking timers (1)",
     });
     expect(expandButton).toHaveTextContent("time's up!");
-    expect(expandButton.parentElement).toHaveClass(
-      "rt-timer-attention",
-      "bg-[var(--berry)]",
+    expect(expandButton.parentElement).toHaveClass("bg-[var(--berry)]");
+    const firstAttentionCue = expandButton.closest(".rt-timer-attention");
+    expect(firstAttentionCue).not.toBeNull();
+    expect(firstAttentionCue).not.toHaveClass("animate-pulse");
+
+    fireEvent.click(expandButton);
+    expect(document.querySelector(".rt-timer-attention")).toBe(
+      firstAttentionCue,
     );
-    expect(expandButton.parentElement).not.toHaveClass("animate-pulse");
+
+    act(() => {
+      startTimer({
+        id: "sauce-timer",
+        label: "sauce",
+        durationSeconds: 1,
+      });
+    });
+    act(() => {
+      vi.advanceTimersByTime(1_250);
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(document.querySelector(".rt-timer-attention")).not.toBe(
+      firstAttentionCue,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "2 cooking timers are complete.",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- replace subtle opacity flashing with a brief scale-and-halo completion cue
- keep completed timers persistently berry-red with explicit “Time’s up!” copy and a ringing-bell icon
- announce completions to screen readers without stealing focus
- respect reduced-motion preferences while preserving the persistent alert state
- cover both recipe-bound and custom timers

## UX rationale

The completion cue is finite (2.8 seconds) to attract attention without creating continuous movement. The colour, icon, and wording remain until dismissal so the state does not depend on animation or sound alone.

## Testing

- MISE_EXPERIMENTAL=1 mise run //ui:format:check -- app/recipes/recipe-theme.css components/recipes/cook-mode.tsx components/recipes/inline-timer.tsx components/recipes/timer-dock.tsx tests/components/recipes/inline-timer.test.tsx tests/components/recipes/timer-dock.test.tsx
- MISE_EXPERIMENTAL=1 mise run //ui:test -- tests/components/recipes/inline-timer.test.tsx tests/components/recipes/timer-dock.test.tsx tests/lib/cooking/timer-store.test.ts
- MISE_EXPERIMENTAL=1 mise //ui:typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Completed recipe timers now provide clearer “Time’s up!” messaging.
  - Visual attention indicators and bell notifications highlight completed timers.
  - Screen-reader alerts announce completed timers in the timer dock.
  - Completed timers use updated colours, icons, labels and accessibility text.
  - Attention animations respect reduced-motion preferences.

- **Bug Fixes**
  - Improved visibility and accessibility of timers when they finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->