### PR TITLE
Add TFLint for Terraform correctness linting (ADR 051)

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -4,15 +4,36 @@ on:
   pull_request:
     paths:
       - "infra/**"
+      - "infra-bootstrap/**"
       - ".github/workflows/infra-ci.yml"
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
+  tflint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          experimental: true
+
+      - name: Lint infra with TFLint
+        run: mise run //infra:lint:tflint
+
+      - name: Lint infra-bootstrap with TFLint
+        run: mise run //infra-bootstrap:lint:tflint
+
   terraform:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     environment:
       name: production-infra
     defaults:

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -4,31 +4,11 @@ on:
   pull_request:
     paths:
       - "infra/**"
-      - "infra-bootstrap/**"
       - ".github/workflows/infra-ci.yml"
 
 permissions: {}
 
 jobs:
-  tflint:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
-        with:
-          experimental: true
-
-      - name: Lint infra with TFLint
-        run: mise run //infra:lint:tflint
-
-      - name: Lint infra-bootstrap with TFLint
-        run: mise run //infra-bootstrap:lint:tflint
-
   terraform:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/tflint-ci.yml
+++ b/.github/workflows/tflint-ci.yml
@@ -1,0 +1,31 @@
+name: TFLint CI
+
+on:
+  pull_request:
+    paths:
+      - "**/*.tf"
+      - "**/.tflint.hcl"
+      - ".mise.toml"
+      - ".github/workflows/tflint-ci.yml"
+
+permissions: {}
+
+jobs:
+  tflint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          experimental: true
+
+      - name: Lint infra with TFLint
+        run: mise run //infra:lint:tflint
+
+      - name: Lint infra-bootstrap with TFLint
+        run: mise run //infra-bootstrap:lint:tflint

--- a/.mise.toml
+++ b/.mise.toml
@@ -23,6 +23,7 @@ verbose = false
 node = "lts"
 "github:pnpm/pnpm" = "11.15.0"
 terraform = "1.15.8"
+tflint = "0.64.0"
 actionlint = "1.7.12"
 zizmor = "1.26.1"
 
@@ -32,7 +33,7 @@ MISE_EXPERIMENTAL = "1"
 # Root-level tasks for repo-wide tooling
 [tasks.lint]
 description = "Lint all files across the entire repo"
-depends = ["//:lint:markdown", "//:lint:mdx", "//:lint:yaml", "//:lint:actions", "//ui:lint", "//infra:lint", "//infra-bootstrap:lint"]
+depends = ["//:lint:markdown", "//:lint:mdx", "//:lint:yaml", "//:lint:actions", "//ui:lint", "//infra:lint", "//infra:lint:tflint", "//infra-bootstrap:lint", "//infra-bootstrap:lint:tflint"]
 
 [tasks."lint:markdown"]
 description = "Lint and fix Markdown files (optionally pass files as args)"

--- a/infra-bootstrap/.tflint.hcl
+++ b/infra-bootstrap/.tflint.hcl
@@ -1,0 +1,4 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/infra-bootstrap/mise.toml
+++ b/infra-bootstrap/mise.toml
@@ -31,6 +31,10 @@ description = "Validate bootstrap Terraform configuration"
 depends = ["//infra-bootstrap:init"]
 run = "terraform validate"
 
+[tasks."lint:tflint"]
+description = "Lint bootstrap Terraform with TFLint (provider-agnostic correctness rules)"
+run = "tflint --format compact"
+
 [tasks.precommit-lint]
 description = "Validate bootstrap Terraform configuration (lightweight for pre-commit)"
 run = """
@@ -52,4 +56,4 @@ run = "bash scripts/doppler-terraform-env terraform apply -auto-approve .planfil
 
 [tasks.check]
 description = "Run all bootstrap Terraform checks"
-depends = ["//infra-bootstrap:format:check", "//infra-bootstrap:lint", "//infra-bootstrap:plan"]
+depends = ["//infra-bootstrap:format:check", "//infra-bootstrap:lint", "//infra-bootstrap:lint:tflint", "//infra-bootstrap:plan"]

--- a/infra-bootstrap/mise.toml
+++ b/infra-bootstrap/mise.toml
@@ -33,7 +33,11 @@ run = "terraform validate"
 
 [tasks."lint:tflint"]
 description = "Lint bootstrap Terraform with TFLint (provider-agnostic correctness rules)"
-run = "tflint --format compact"
+run = """
+#!/usr/bin/env bash
+# Lints the whole root; ignores file args appended by lint-staged
+tflint --format compact
+"""
 
 [tasks.precommit-lint]
 description = "Validate bootstrap Terraform configuration (lightweight for pre-commit)"

--- a/infra/.tflint.hcl
+++ b/infra/.tflint.hcl
@@ -1,0 +1,4 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/infra/mise.toml
+++ b/infra/mise.toml
@@ -33,7 +33,11 @@ run = "terraform validate"
 
 [tasks."lint:tflint"]
 description = "Lint Terraform with TFLint (provider-agnostic correctness rules)"
-run = "tflint --format compact"
+run = """
+#!/usr/bin/env bash
+# Lints the whole root; ignores file args appended by lint-staged
+tflint --format compact
+"""
 
 [tasks.precommit-lint]
 description = "Validate Terraform configuration (lightweight for pre-commit)"

--- a/infra/mise.toml
+++ b/infra/mise.toml
@@ -31,6 +31,10 @@ description = "Validate Terraform configuration"
 depends = ["//infra:init"]
 run = "terraform validate"
 
+[tasks."lint:tflint"]
+description = "Lint Terraform with TFLint (provider-agnostic correctness rules)"
+run = "tflint --format compact"
+
 [tasks.precommit-lint]
 description = "Validate Terraform configuration (lightweight for pre-commit)"
 run = """
@@ -53,4 +57,4 @@ run = "bash scripts/doppler-terraform-env terraform apply -auto-approve .planfil
 
 [tasks.check]
 description = "Run all checks (format, lint, plan)"
-depends = ["//infra:format:check", "//infra:lint", "//infra:plan"]
+depends = ["//infra:format:check", "//infra:lint", "//infra:lint:tflint", "//infra:plan"]

--- a/package.json
+++ b/package.json
@@ -26,11 +26,13 @@
     ],
     "infra/**/*.tf": [
       "mise run //infra:format",
-      "mise run //infra:precommit-lint"
+      "mise run //infra:precommit-lint",
+      "mise run //infra:lint:tflint"
     ],
     "infra-bootstrap/**/*.tf": [
       "mise run //infra-bootstrap:format",
-      "mise run //infra-bootstrap:precommit-lint"
+      "mise run //infra-bootstrap:precommit-lint",
+      "mise run //infra-bootstrap:lint:tflint"
     ],
     "**/*.md": [
       "mise run //:lint:markdown"

--- a/ui/content/projects/personal-site/adrs/051-tflint.mdx
+++ b/ui/content/projects/personal-site/adrs/051-tflint.mdx
@@ -1,0 +1,125 @@
+---
+title: "ADR 051: TFLint (Terraform Linting)"
+date: "2026-07-20"
+status: "Accepted"
+tech_stack: ["TFLint"]
+---
+
+# Context
+
+The Terraform layer (`infra/`, `infra-bootstrap/`) currently has two deterministic
+checks, and both leave a gap between them:
+
+* **`terraform fmt` + `terraform validate`** ([ADR 010](/projects/personal-site/adrs/010-terraform))
+  enforce formatting and catch what the language itself considers an error.
+  `validate` is deliberately permissive: it accepts deprecated syntax, unused
+  variable/local/output declarations, missing `required_version` constraints,
+  and provider argument values that only fail at `apply` time.
+* **Trivy's IaC config scan** ([ADR 047](/projects/personal-site/adrs/047-trivy))
+  looks for *security* misconfigurations — exposed resources, excessive
+  permissions — not correctness or hygiene.
+
+Mapping this onto the determinism axis from
+[ADR 048 (SonarQube)](/projects/personal-site/adrs/048-sonarqube), the way
+[ADR 049 (zizmor)](/projects/personal-site/adrs/049-zizmor) did for workflows:
+
+| | Terraform security | Terraform correctness/hygiene |
+| --- | --- | --- |
+| **Deterministic** | Trivy | `validate` only (permissive) — **gap** |
+| **Non-deterministic** | AI reviewers | AI reviewers |
+
+The practical consequence of the gap: dead declarations accumulate silently as
+infrastructure evolves (the exact class of drift that erodes iteration speed),
+and a mistyped provider argument or deprecated interpolation is only caught by
+a human, an AI reviewer that may or may not flag it, or a failed `apply`.
+
+# Decision
+
+Adopt **TFLint** with its bundled `terraform` ruleset on the `recommended`
+preset, for both Terraform roots. Like the other linters it is managed through
+[mise](/projects/personal-site/adrs/004-mise) so CI and laptop run the same
+pinned version:
+
+* A `.tflint.hcl` per Terraform root enables the bundled ruleset — no plugin
+  downloads, so the lint needs no network and no `tflint --init` in CI.
+* `mise run //infra:lint:tflint` / `//infra-bootstrap:lint:tflint` tasks, wired
+  into the root `lint` aggregate, each root's `check` aggregate, and lint-staged
+  so a finding blocks the commit locally before it blocks the PR.
+* A dedicated `tflint` job in the Infrastructure CI workflow. It runs as a
+  **blocking** check (the actionlint role from ADR 049, not the Security-tab
+  role), because lint findings here are correctness issues to fix, not risk
+  findings to triage. The job needs no Terraform Cloud token and no
+  `production-infra` environment, so it also gives infra PRs a fast secrets-free
+  signal before the plan job runs.
+
+The CI workflow now also triggers on `infra-bootstrap/**`, which previously had
+no pull-request check at all (its workflow is `workflow_dispatch`-only).
+
+# Why It Adds Something New
+
+TFLint is the specialist for the Terraform-correctness quadrant, and its ruleset
+is disjoint from what already runs: `validate` accepts what TFLint flags
+(unused declarations, deprecated syntax, missing version constraints), and
+Trivy's rules are security-shaped rather than hygiene-shaped. The overlap with
+either existing tool is effectively zero, mirroring the
+zizmor-vs-generalists reasoning in ADR 049: generalists each carry a rule or two
+about Terraform hygiene; TFLint carries the whole ruleset.
+
+# Alternatives Considered
+
+Weighted by the same test as [ADR 047](/projects/personal-site/adrs/047-trivy)
+and [ADR 049](/projects/personal-site/adrs/049-zizmor): deterministic, free,
+no new platform, mise-manageable.
+
+| Tool | Role | Pros | Cons | Verdict |
+| --- | --- | --- | --- | --- |
+| **TFLint** *(accepted)* | Terraform linter | De-facto standard linter; bundled ruleset needs no network; mise/CI/pre-commit friendly; provider rulesets available if ever needed. | Cloudflare/Neon have no provider-specific ruleset, so coverage is language-level only. | **Accepted.** |
+| **checkov / tfsec** | IaC security scanners | Broad policy libraries. | Security-shaped: overlaps Trivy's config scan, not the hygiene gap. tfsec is folded into Trivy upstream. | Rejected: duplicates ADR 047. |
+| **OPA / conftest** | Policy engine | Arbitrary custom policies over plans. | A policy *language* to author and maintain, not a curated ruleset; heavier than the gap warrants. | Rejected: [Less Is More](/projects?tab=philosophy#less-is-more). |
+| **HCP Terraform policies (Sentinel)** | Managed policy | Runs where the plan runs. | Paid tier; platform lock-in for a linting concern. | Rejected: free tooling covers the gap. |
+| **Status quo** (`validate` + Trivy) | n/a | No new tool. | Leaves the deterministic-hygiene quadrant empty. | Rejected: closing that gap is the point. |
+
+# Where It Sits On The Adoption Curve
+
+**Late majority.** TFLint has been the default Terraform linter for most of a
+decade, with a stable CLI and a deep documentation/LLM corpus — squarely in the
+maturity band the philosophy favours for infrastructure tooling
+([LLM-Optimized](/projects?tab=philosophy#llm-optimized)), and a counterweight
+to the early-majority picks (zizmor) elsewhere in the stack.
+
+# Relation To Building Philosophy
+
+* [Less Is More](/projects?tab=philosophy#less-is-more). One binary, one config
+  file per root, one CI job; no platform, no account, no dashboard.
+* [Short Feedback Loops](/projects?tab=philosophy#short-feedback-loops).
+  Findings surface at commit time via lint-staged, and the CI job is the fastest
+  check on an infra PR because it skips Terraform init entirely.
+* [LLM-Optimized](/projects?tab=philosophy#llm-optimized). Agents author most
+  Terraform changes here; a deterministic lint floor means the same hygiene
+  regression fails the same way every time, rather than depending on which AI
+  reviewer notices.
+* [Build Flywheels](/projects?tab=philosophy#build-flywheels). The same config
+  shape drops into any future Terraform root in the monorepo.
+
+# Gaps & Risks
+
+* **No Cloudflare/Neon provider ruleset exists**, so provider-specific argument
+  validation stays with `terraform plan` and review. If either provider ships a
+  ruleset, enabling it is a two-line `.tflint.hcl` change.
+* **Rule preset drift.** `recommended` evolves across TFLint versions; a mise
+  version bump can introduce new findings. Renovate makes that an explicit PR
+  rather than a silent change ([ADR 024](/projects/personal-site/adrs/024-renovate)).
+
+# Consequences
+
+## Positive
+
+* Fills the deterministic Terraform-hygiene quadrant with a blocking, secrets-free
+  CI check and a pre-commit hook.
+* Gives `infra-bootstrap/` its first pull-request check of any kind.
+* Free, offline-capable, mise-pinned for local/CI parity.
+
+## Negative
+
+* One more tool version to keep updated (delegated to Renovate).
+* Language-level rules only — provider-specific mistakes still reach `plan`.

--- a/ui/content/projects/personal-site/adrs/051-tflint.mdx
+++ b/ui/content/projects/personal-site/adrs/051-tflint.mdx
@@ -45,15 +45,17 @@ pinned version:
 * `mise run //infra:lint:tflint` / `//infra-bootstrap:lint:tflint` tasks, wired
   into the root `lint` aggregate, each root's `check` aggregate, and lint-staged
   so a finding blocks the commit locally before it blocks the PR.
-* A dedicated `tflint` job in the Infrastructure CI workflow. It runs as a
-  **blocking** check (the actionlint role from ADR 049, not the Security-tab
-  role), because lint findings here are correctness issues to fix, not risk
-  findings to triage. The job needs no Terraform Cloud token and no
-  `production-infra` environment, so it also gives infra PRs a fast secrets-free
-  signal before the plan job runs.
+* A dedicated **TFLint CI** workflow, triggered by any `*.tf` or `.tflint.hcl`
+  change across the monorepo. It runs as a **blocking** check (the actionlint
+  role from ADR 049, not the Security-tab role), because lint findings here are
+  correctness issues to fix, not risk findings to triage. A separate workflow
+  rather than a job in Infrastructure CI keeps two properties: the lint needs no
+  Terraform Cloud token and no `production-infra` environment, and
+  `infra-bootstrap/`-only changes don't trigger a no-op plan of `infra/` behind
+  that environment's gate.
 
-The CI workflow now also triggers on `infra-bootstrap/**`, which previously had
-no pull-request check at all (its workflow is `workflow_dispatch`-only).
+This gives `infra-bootstrap/**` its first pull-request check of any kind (its
+own workflow is `workflow_dispatch`-only).
 
 # Why It Adds Something New
 

--- a/ui/content/projects/recipe-site/adrs/055-tflint.mdx
+++ b/ui/content/projects/recipe-site/adrs/055-tflint.mdx
@@ -1,0 +1,28 @@
+---
+inherits_from: "personal-site:051-tflint"
+---
+
+# Additional Context for Recipe Site
+
+The recipe site's infrastructure — Neon Postgres, Hyperdrive, and the
+recipe-api/recipe-ingest Workers — is defined in the same `infra/` Terraform
+root, so it is covered by the same TFLint configuration and CI job (see
+[personal-site ADR 051](/projects/personal-site/adrs/051-tflint)).
+
+The hygiene rules matter most where the Terraform churns fastest, and that is
+the recipe-site backend: preview environments, database branches, and Worker
+bindings have driven most recent infra changes. Unused declarations and
+deprecated syntax left behind by that churn are exactly what the
+`recommended` preset flags.
+
+# Consequences
+
+## Positive
+
+* The most actively edited Terraform (recipe-site backend resources) gains a
+  blocking correctness lint on every PR, before the plan job needs secrets.
+
+## Negative
+
+* No Neon provider ruleset exists, so Neon-specific argument mistakes still
+  surface only at `terraform plan`.

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -864,4 +864,12 @@ export const technologies: TechnologyContent[] = [
     website: "https://opentelemetry.io",
     type: "tool",
   },
+  {
+    name: "TFLint",
+    added: "2026-07-20",
+    description:
+      "Terraform linter catching what validate accepts: deprecated syntax, unused declarations, and missing version constraints",
+    website: "https://github.com/terraform-linters/tflint",
+    type: "tool",
+  },
 ];


### PR DESCRIPTION
Adds **TFLint** to fill the deterministic Terraform-hygiene gap: `terraform validate` is deliberately permissive (accepts deprecated syntax, unused declarations, missing version constraints) and Trivy's config scan is security-shaped, so nothing deterministic watched Terraform *correctness*. Full reasoning in the included ADR 051.

## Changes

- **TFLint 0.64.0** pinned in root `.mise.toml` alongside terraform/actionlint/zizmor
- `.tflint.hcl` per Terraform root (`infra/`, `infra-bootstrap/`) enabling the bundled `terraform` ruleset on the `recommended` preset — no plugin downloads, no network, no `tflint --init` needed in CI
- New `lint:tflint` mise tasks in both roots (bash script blocks so lint-staged's appended file args are ignored — flagged by Gemini), wired into the root `lint` aggregate, each root's `check` aggregate, and lint-staged
- New dedicated **TFLint CI workflow** (blocking, secrets-free), triggered by `**/*.tf` / `**/.tflint.hcl` paths. Originally a job inside Infrastructure CI, but Greptile correctly flagged that adding `infra-bootstrap/**` to that workflow's trigger would run the secrets-gated `terraform` plan job on bootstrap-only changes — the split keeps Infrastructure CI's trigger untouched
- `infra-bootstrap/**` gets its first pull-request check of any kind (its own workflow is `workflow_dispatch`-only)
- Infrastructure CI permissions scoped to job level (zizmor-clean in both workflows)
- ADR 051 (personal-site) + inherited stub ADR 055 (recipe-site), `technologies.ts` entry

## Verification

- ✅ The `tflint` CI job passed green on its first run — no baseline findings in either root
- zizmor (offline audits), yamllint, remark (MDX), Biome, `tsc --noEmit`: clean
- Content-graph integration tests + tech-icon tests: passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQpZQern2o1v8BuNz8U9jE