### PR TITLE
Add OpenSSF Scorecard for repo security posture monitoring (ADR 053)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,39 @@
+name: OpenSSF Scorecard
+
+on:
+  # Re-evaluate when branch protection settings change
+  branch_protection_rule:
+  push:
+    branches: [main]
+  schedule:
+    # Weekly scan every Tuesday at 00:00 UTC (Trivy owns Monday)
+    - cron: "0 0 * * 2"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Upload SARIF to code scanning
+      id-token: write # Publish results (OIDC signing, needed by scorecard.dev)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Upload results to GitHub Security
         uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        if: always()
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=Robbie-Palmer_personal-site&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=Robbie-Palmer_personal-site)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=Robbie-Palmer_personal-site&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=Robbie-Palmer_personal-site)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=Robbie-Palmer_personal-site&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=Robbie-Palmer_personal-site)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Robbie-Palmer/personal-site/badge)](https://scorecard.dev/viewer/?uri=github.com/Robbie-Palmer/personal-site)
 
 Personal website with blog and interactive resume.
 

--- a/ui/content/projects/personal-site/adrs/053-openssf-scorecard.mdx
+++ b/ui/content/projects/personal-site/adrs/053-openssf-scorecard.mdx
@@ -1,0 +1,119 @@
+---
+title: "ADR 053: OpenSSF Scorecard (Repo Security Posture)"
+date: "2026-07-20"
+status: "Accepted"
+tech_stack: ["OpenSSF Scorecard"]
+---
+
+# Context
+
+The security stack now covers source code (CodeQL,
+[ADR 032](/projects/personal-site/adrs/032-codeql)), dependencies and IaC
+(Trivy, [ADR 047](/projects/personal-site/adrs/047-trivy)), and workflows
+(zizmor, [ADR 049](/projects/personal-site/adrs/049-zizmor)). Each tool watches
+*artifacts in the repository*. None of them watches **the repository itself**:
+branch protection, token permission defaults, whether dependencies and actions
+stay pinned, whether a security policy exists, whether releases are signed.
+
+Those settings are exactly the ones that decay silently. A branch-protection
+rule relaxed during an incident, a default `GITHUB_TOKEN` permission widened by
+a new workflow, an unpinned action reintroduced by a copy-paste — no existing
+check would say anything, because each individual scanner assumes the
+repo-level ground it stands on.
+
+There is also an outward-facing angle: this repo is public and doubles as a
+portfolio. Its security posture is part of what it demonstrates, and much of
+the hardening Scorecard measures (SHA-pinned actions, scoped permissions,
+active dependency update tooling) has already been done deliberately across
+ADRs 013, 018, 024, 032, 047, and 049 — currently with nothing measuring or
+displaying it.
+
+# Decision
+
+Adopt **OpenSSF Scorecard** via its official GitHub Action:
+
+* A scheduled weekly workflow (Tuesdays — Trivy owns Mondays), also triggered
+  on pushes to `main` and branch-protection changes, uploading SARIF to the
+  **GitHub Security tab** like Trivy and zizmor — findings live where every
+  other scanner's findings live, no new console.
+* `publish_results: true`, so the score is verifiable at scorecard.dev and the
+  README carries a live badge alongside the SonarQube ones.
+* Actions SHA-pinned like everything else
+  ([ADR 049](/projects/personal-site/adrs/049-zizmor)); Renovate keeps the
+  digests fresh.
+
+Scorecard is a *meta-check*: it is deliberately **not blocking** on PRs. Its
+findings are posture regressions to triage weekly, not diff-level defects —
+the same Security-tab role Trivy's scheduled scan plays, and several of its
+checks (branch protection, token permissions) are about settings PRs cannot
+change anyway.
+
+# Why It Adds Something New
+
+Every existing scanner answers "is this artifact safe?"; Scorecard answers
+"is this repository configured so that unsafe artifacts get caught?" — it
+audits the layer the other tools depend on. The overlaps are intentional
+agreement rather than redundancy: its pinned-dependencies check confirms what
+zizmor enforces per-PR, its SAST/dependency-update checks confirm CodeQL and
+Renovate are actually wired in and running. Where zizmor audits workflow
+*content*, Scorecard audits repo *settings* — adjacent layers, no substitute
+relationship in either direction.
+
+# Alternatives Considered
+
+| Tool | Role | Pros | Cons | Verdict |
+| --- | --- | --- | --- | --- |
+| **OpenSSF Scorecard** *(accepted)* | Posture meta-check | Industry-standard rubric (OpenSSF/Linux Foundation); SARIF + badge; zero config to maintain. | Some checks are heuristic; a few (fuzzing, CII badge) will never apply to a personal site. | **Accepted.** |
+| **GitHub security overview** | Native settings page | Zero setup. | A dashboard to remember to read, not a check with history, alerts, or a public score. | Rejected: watch-it-or-lose-it. |
+| **allstar** (OpenSSF) | Posture *enforcement* | Can auto-enforce policies. | An installed GitHub App with write access — heavier trust footprint than a read-only weekly scan warrants here. | Rejected: [Less Is More](/projects?tab=philosophy#less-is-more). |
+| **Manual periodic review** | n/a | No tooling. | Exactly the silent-decay failure mode this closes. | Rejected. |
+
+# Where It Sits On The Adoption Curve
+
+**Early-to-late majority.** Scorecard has run at scale since 2020, scores a
+million-plus repos, and its rubric is referenced by supply-chain frameworks
+(SLSA, S2C2F); the scoring heuristics still evolve between releases. Mature
+enough to trust, standard enough that the badge means something to a reader —
+comfortably inside the [Goldilocks zone](/projects?tab=philosophy#the-goldilocks-zone).
+
+# Relation To Building Philosophy
+
+* [Less Is More](/projects?tab=philosophy#less-is-more). One workflow file, one
+  badge; findings in the same Security tab as Trivy and zizmor. The rejected
+  alternative (allstar) would have added an app with write access.
+* [Short Feedback Loops](/projects?tab=philosophy#short-feedback-loops). A
+  posture regression surfaces within a week, with the specific check and
+  remediation named, instead of at the next manual audit (i.e. never).
+* [Build Flywheels](/projects?tab=philosophy#build-flywheels). The hardening
+  work of ADRs 013–049 becomes a measured, maintained score rather than a
+  one-time effort; each future repo inherits the rubric for free.
+* [Respect Goodhart's Law](/projects?tab=philosophy#respect-goodharts-and-conways-laws).
+  The score is a diagnostic, not a target: checks that don't apply (fuzzing a
+  content site) stay red rather than being gamed green, and the number is
+  published so the incentive is honesty.
+
+# Gaps & Risks
+
+* **Heuristic checks.** Scorecard infers some practices (e.g. code review) from
+  public signals and can under- or over-credit them; scores move between
+  Scorecard releases. Accepted: the value is the trend and the named
+  regressions, not the absolute number.
+* **Weekly cadence.** A posture regression can live for up to a week before the
+  scheduled run flags it; the `main`-push and branch-protection triggers narrow
+  the common cases.
+* **Public score.** A visibly imperfect score is by design — see Goodhart above.
+
+# Consequences
+
+## Positive
+
+* The repo-settings layer every other scanner assumes is now itself monitored,
+  with regressions surfacing in the Security tab.
+* Existing hardening becomes externally verifiable (badge + scorecard.dev).
+* Free, no new platform, no config to maintain.
+
+## Negative
+
+* One more scheduled workflow and Security-tab category to triage.
+* Some rubric checks will permanently not apply to a personal static site,
+  capping the headline score below 10.

--- a/ui/content/projects/personal-site/adrs/053-openssf-scorecard.mdx
+++ b/ui/content/projects/personal-site/adrs/053-openssf-scorecard.mdx
@@ -9,23 +9,23 @@ tech_stack: ["OpenSSF Scorecard"]
 
 The security stack now covers source code (CodeQL,
 [ADR 032](/projects/personal-site/adrs/032-codeql)), dependencies and IaC
-(Trivy, [ADR 047](/projects/personal-site/adrs/047-trivy)), and workflows
-(zizmor, [ADR 049](/projects/personal-site/adrs/049-zizmor)). Each tool watches
-*artifacts in the repository*. None of them watches **the repository itself**:
-branch protection, token permission defaults, whether dependencies and actions
-stay pinned, whether a security policy exists, whether releases are signed.
+(Trivy, [ADR 047](/projects/personal-site/adrs/047-trivy)), and workflow
+*content* (zizmor, [ADR 049](/projects/personal-site/adrs/049-zizmor)). Each
+watches *files in the repository*. None watches **the repository's own
+configuration**: branch protection, the default `GITHUB_TOKEN` permission,
+whether a security policy exists, whether releases are signed.
 
-Those settings are exactly the ones that decay silently. A branch-protection
-rule relaxed during an incident, a default `GITHUB_TOKEN` permission widened by
-a new workflow, an unpinned action reintroduced by a copy-paste — no existing
-check would say anything, because each individual scanner assumes the
-repo-level ground it stands on.
+That configuration is exactly what decays silently. zizmor already flags an
+unpinned action or an over-broad `permissions:` block *within a changed
+workflow file*, on the PR that introduces it — but a branch-protection rule
+relaxed during an incident, or the default token permission widened in repo
+settings, lives in GitHub settings, not in any file a scanner reads. Every
+existing tool assumes that repo-level ground rather than checking it.
 
-There is also an outward-facing angle: this repo is public and doubles as a
-portfolio. Its security posture is part of what it demonstrates, and much of
-the hardening Scorecard measures (SHA-pinned actions, scoped permissions,
-active dependency update tooling) has already been done deliberately across
-ADRs 013, 018, 024, 032, 047, and 049 — currently with nothing measuring or
+This repo is also public and doubles as a portfolio, so its posture is part of
+what it demonstrates. Much of the hardening Scorecard measures — SHA-pinned
+actions, scoped permissions, active dependency-update tooling — is already done
+deliberately (ADRs 013, 018, 024, 032, 047, 049), with nothing yet measuring or
 displaying it.
 
 # Decision
@@ -63,7 +63,7 @@ relationship in either direction.
 
 | Tool | Role | Pros | Cons | Verdict |
 | --- | --- | --- | --- | --- |
-| **OpenSSF Scorecard** *(accepted)* | Posture meta-check | Industry-standard rubric (OpenSSF/Linux Foundation); SARIF + badge; zero config to maintain. | Some checks are heuristic; a few (fuzzing, CII badge) will never apply to a personal site. | **Accepted.** |
+| **OpenSSF Scorecard** *(accepted)* | Posture meta-check | Industry-standard rubric (OpenSSF/Linux Foundation); SARIF + badge; zero config to maintain. | Some checks are heuristic; a few (fuzzing, best-practices badge) aren't worth pursuing for this stack and stay red by choice. | **Accepted.** |
 | **GitHub security overview** | Native settings page | Zero setup. | A dashboard to remember to read, not a check with history, alerts, or a public score. | Rejected: watch-it-or-lose-it. |
 | **allstar** (OpenSSF) | Posture *enforcement* | Can auto-enforce policies. | An installed GitHub App with write access — heavier trust footprint than a read-only weekly scan warrants here. | Rejected: [Less Is More](/projects?tab=philosophy#less-is-more). |
 | **Manual periodic review** | n/a | No tooling. | Exactly the silent-decay failure mode this closes. | Rejected. |
@@ -88,9 +88,10 @@ comfortably inside the [Goldilocks zone](/projects?tab=philosophy#the-goldilocks
   work of ADRs 013–049 becomes a measured, maintained score rather than a
   one-time effort; each future repo inherits the rubric for free.
 * [Respect Goodhart's Law](/projects?tab=philosophy#respect-goodharts-and-conways-laws).
-  The score is a diagnostic, not a target: checks that don't apply (fuzzing a
-  content site) stay red rather than being gamed green, and the number is
-  published so the incentive is honesty.
+  The score is a diagnostic, not a target: checks we deliberately skip — e.g.
+  fuzzing, whose payoff doesn't map onto a memory-safe TS/Python site — stay
+  red rather than being gamed green, and the number is published so the
+  incentive is honesty.
 
 # Gaps & Risks
 
@@ -115,5 +116,6 @@ comfortably inside the [Goldilocks zone](/projects?tab=philosophy#the-goldilocks
 ## Negative
 
 * One more scheduled workflow and Security-tab category to triage.
-* Some rubric checks will permanently not apply to a personal static site,
-  capping the headline score below 10.
+* A few rubric checks (e.g. fuzzing, best-practices badge) aren't worth
+  pursuing for this stack and stay red by choice, capping the headline score
+  below 10.

--- a/ui/content/projects/recipe-site/adrs/057-openssf-scorecard.mdx
+++ b/ui/content/projects/recipe-site/adrs/057-openssf-scorecard.mdx
@@ -1,0 +1,28 @@
+---
+inherits_from: "personal-site:053-openssf-scorecard"
+---
+
+# Additional Context for Recipe Site
+
+Scorecard audits the repository layer, so the recipe site inherits the same
+weekly posture check (see
+[personal-site ADR 053](/projects/personal-site/adrs/053-openssf-scorecard)).
+The stakes are higher on this side of the monorepo: the branch-protection,
+token-permission, and dangerous-workflow checks guard the path by which code
+reaches the deployed Workers and the Neon database, and the preview-environment
+workflows handle real credentials on pull requests
+([ADR 046 zizmor](/projects/recipe-site/adrs/046-zizmor) covers their content;
+Scorecard covers the settings around them).
+
+# Consequences
+
+## Positive
+
+* Regressions in the repo settings that gate deploy credentials (branch
+  protection, default token permissions) now surface within a week instead of
+  silently persisting.
+
+## Negative
+
+* Scorecard evaluates the repository as a whole; it cannot score the
+  recipe-site backend's posture separately from the static site's.

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -884,7 +884,7 @@ export const technologies: TechnologyContent[] = [
     name: "OpenSSF Scorecard",
     added: "2026-07-20",
     description:
-      "Weekly automated audit of repository security posture: branch protection, token permissions, pinned dependencies, and update hygiene",
+      "Automated audit of a repository's security posture: branch protection, token permissions, pinned dependencies, and update-tooling hygiene",
     website: "https://scorecard.dev",
     type: "tool",
   },

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -880,4 +880,12 @@ export const technologies: TechnologyContent[] = [
     website: "https://knip.dev",
     type: "tool",
   },
+  {
+    name: "OpenSSF Scorecard",
+    added: "2026-07-20",
+    description:
+      "Weekly automated audit of repository security posture: branch protection, token permissions, pinned dependencies, and update hygiene",
+    website: "https://scorecard.dev",
+    type: "tool",
+  },
 ];


### PR DESCRIPTION
Adds **OpenSSF Scorecard** as a weekly meta-check on the repository layer every other scanner depends on. CodeQL/Trivy/zizmor/SonarQube all watch *artifacts in the repo*; nothing watched *the repo itself* — branch protection, default token permissions, whether actions and dependencies stay pinned, update-tooling hygiene. Those settings decay silently; Scorecard makes regressions surface in the Security tab within a week. Full reasoning in the included ADR 053.

## Changes

- `scorecard.yml` workflow: weekly Tuesday schedule (Trivy owns Mondays), plus `main`-push and `branch_protection_rule` triggers; SHA-pinned actions; `permissions: {}` at workflow level with job-scoped `contents: read` / `security-events: write` / `id-token: write`
- SARIF uploads to GitHub code scanning under the `scorecard` category — same Security-tab home as Trivy and zizmor, no new console
- `publish_results: true` + live badge in the README next to the SonarQube badges (score verifiable at scorecard.dev)
- Deliberately **not blocking** on PRs: posture findings are weekly triage items, and several checks concern repo settings PRs can't change
- ADR 053 (personal-site) + inherited stub ADR 057 (recipe-site), `technologies.ts` entry

## Notes

- The hardening this measures is already largely done (SHA-pinned actions, scoped permissions, Renovate/Dependabot, CodeQL) — this makes it measured and externally verifiable rather than one-time
- First publish to scorecard.dev happens on the first `main` run after merge; the badge may 404 until then
- Touches `technologies.ts` like the sibling static-analysis PRs — trivial append conflict, merge in any order and I'll rebase

## Verification

- zizmor (offline audits), yamllint, markdownlint, remark (MDX), Biome, `tsc --noEmit`: clean
- Content-graph integration tests: passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQpZQern2o1v8BuNz8U9jE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQpZQern2o1v8BuNz8U9jE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated OpenSSF Scorecard checks for repository security posture.
  * Results are published to GitHub Security and scorecard.dev on scheduled and manual runs.
  * Added OpenSSF Scorecard to the project’s technology listings.

* **Documentation**
  * Added OpenSSF Scorecard badges to the README.
  * Documented the security-posture decision for both site projects, including scope and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->