### PR TITLE
Add gitleaks for pre-commit and full-history secret scanning (ADR 054)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,49 @@
+name: Gitleaks Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    # Weekly full-history scan every Wednesday at 00:00 UTC
+    # (Trivy owns Monday, Scorecard owns Tuesday)
+    - cron: "0 0 * * 3"
+  workflow_dispatch: # Allow manual trigger
+
+permissions: {}
+
+jobs:
+  gitleaks:
+    name: Scan git history for secrets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history: gitleaks scans every commit, not just the checkout
+          fetch-depth: 0
+
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          experimental: true
+
+      - name: Run gitleaks
+        # Advisory on findings, but not on failure. --exit-code 0 makes
+        # gitleaks exit 0 when it *finds* leaks (they surface in the Security
+        # tab rather than gating the PR, matching the zizmor/Trivy posture,
+        # ADRs 047/049) — historical findings cannot be fixed by the PR that
+        # trips over them. A genuine tool failure still exits non-zero, so the
+        # scan cannot silently skip its job. --redact keeps candidate secrets
+        # out of logs and the SARIF report.
+        run: mise exec -- gitleaks git --redact --exit-code 0 --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload gitleaks results to GitHub Security
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks

--- a/.mise.toml
+++ b/.mise.toml
@@ -26,6 +26,7 @@ terraform = "1.15.8"
 tflint = "0.64.0"
 actionlint = "1.7.12"
 zizmor = "1.26.1"
+gitleaks = "8.30.1"
 
 [env]
 MISE_EXPERIMENTAL = "1"
@@ -103,9 +104,17 @@ run = "actionlint"
 description = "Audit GitHub Actions workflows for security issues with zizmor"
 run = "zizmor ."
 
+[tasks."security:secrets"]
+description = "Scan staged changes for secrets with gitleaks"
+run = "gitleaks git --pre-commit --staged --redact --verbose"
+
+[tasks."security:secrets:history"]
+description = "Scan the full git history for secrets with gitleaks"
+run = "gitleaks git --redact"
+
 [tasks.pre-commit]
 description = "Run pre-commit checks (called by Husky)"
-run = "pnpm lint-staged"
+run = ["pnpm lint-staged", "mise run //:security:secrets"]
 depends = ["//:install"]
 
 [tasks.dev]

--- a/ui/content/projects/personal-site/adrs/054-gitleaks.mdx
+++ b/ui/content/projects/personal-site/adrs/054-gitleaks.mdx
@@ -1,0 +1,123 @@
+---
+title: "ADR 054: Gitleaks (Secret Scanning)"
+date: "2026-07-20"
+status: "Accepted"
+tech_stack: ["Gitleaks"]
+---
+
+# Context
+
+Secrets management is solved at the storage layer — Doppler holds runtime
+secrets ([ADR 035](/projects/personal-site/adrs/035-doppler)), GitHub
+environments hold CI credentials
+([ADR 018](/projects/personal-site/adrs/018-github-secrets)). The unsolved
+layer is *accidental commits*: a `.env` pasted into a script, a connection
+string in a test fixture, an API key in a debugging commit.
+
+The existing net for that is **GitHub secret scanning**, and it has two
+structural limits:
+
+1. **It fires after the push.** On a public repo that is too late by
+   definition: the secret is in clone caches, mirrors, and scrapers the moment
+   it lands. History rewrites un-publish nothing; the only real remediation is
+   rotation. Detection that arrives post-push is an incident report, not a
+   guard.
+2. **It matches known provider patterns.** Tokens with vendor-recognisable
+   shapes are caught; a generic high-entropy string, a database URL with an
+   inline password, or a private key in an unusual wrapper may not be.
+
+On the determinism axis of [ADR 048](/projects/personal-site/adrs/048-sonarqube):
+AI reviewers might notice a pasted credential, non-deterministically, at PR
+time — also after the secret has already left the laptop.
+
+# Decision
+
+Adopt **gitleaks**, mise-pinned like every other scanner, at two points in the
+pipeline:
+
+* **Pre-commit** (the layer that actually prevents leaks): a
+  `//:security:secrets` task runs `gitleaks git --pre-commit --staged` after
+  lint-staged in the Husky hook, so a staged secret blocks the commit while it
+  is still only on the laptop. `--redact` keeps the candidate value out of
+  terminal scrollback.
+* **CI, Security-tab posture** ([ADR 047](/projects/personal-site/adrs/047-trivy) /
+  [ADR 049](/projects/personal-site/adrs/049-zizmor) pattern): a workflow scans
+  the *full history* on PRs, `main` pushes, and a weekly Wednesday schedule,
+  uploading SARIF with `--exit-code 0`. Findings gate via Code Scanning's
+  new-alert behaviour rather than failing the job — a historical finding
+  predating the scan cannot be fixed by whichever PR happens to trip over it,
+  and the remediation for anything historical is rotation, not a red build.
+  A genuine tool failure still fails the job, so the scan cannot silently
+  skip itself.
+
+GitHub secret scanning stays on; the two overlap on known provider patterns
+(harmless redundancy, per the ADR 048/049 precedent) and differ everywhere
+that matters: timing (pre-commit vs post-push) and breadth (generic entropy
+and custom rules vs vendor patterns).
+
+# Why It Adds Something New
+
+Every other scanner in the stack examines code *after it is shared* — the
+pre-commit hook is the only place in the entire pipeline where detection
+precedes disclosure, and on a public repo that distinction is the whole game.
+The CI scan adds the complementary posture view: the complete history audited
+by a ruleset broader than vendor patterns, with findings in the same Security
+tab as Trivy, zizmor, and Scorecard.
+
+# Alternatives Considered
+
+| Tool | Role | Pros | Cons | Verdict |
+| --- | --- | --- | --- | --- |
+| **gitleaks** *(accepted)* | Secret detection | De-facto standard; single binary in mise; pre-commit + full-history modes; SARIF; TOML allowlist config when needed. | Pattern/entropy-based → occasional false positives to allowlist. | **Accepted.** |
+| **GitHub push protection** | Push-time block | Native, free on public repos, zero config. | Known provider patterns only; fires at push, later than pre-commit; not a substitute for history auditing. | **Complementary** — worth enabling in repo settings, not a replacement. |
+| **TruffleHog** | Detection + verification | Verifies candidates against live APIs (fewer false positives). | Verification means sending candidates to providers; heavier tool; OSS/paid split has churned. | Rejected: verification isn't worth the weight here. |
+| **detect-secrets** (Yelp) | Baseline-driven detection | Mature baseline workflow. | Python toolchain in a Node monorepo; slower-moving project. | Rejected: gitleaks covers it in one binary. |
+| **gitleaks-action** | Same engine, packaged | Turnkey. | Org licensing terms; less control than running the mise-pinned binary the hook already uses. | Rejected: run the same binary both places instead. |
+| **Status quo** (GitHub secret scanning only) | n/a | Zero effort. | Post-push detection only, vendor patterns only. | Rejected: detection after publication is rotation, not prevention. |
+
+# Where It Sits On The Adoption Curve
+
+**Late majority.** Gitleaks has been the default open-source secret scanner
+for years — stable CLI, huge deployment base, deep LLM corpus
+([LLM-Optimized](/projects?tab=philosophy#llm-optimized)). No Goldilocks
+trade-off to accept this time.
+
+# Relation To Building Philosophy
+
+* [Short Feedback Loops](/projects?tab=philosophy#short-feedback-loops). The
+  loop cannot get shorter: the finding lands before the commit exists.
+* [Less Is More](/projects?tab=philosophy#less-is-more). One binary serving
+  both the hook and CI; findings in the existing Security tab; no platform, no
+  account.
+* [LLM-Optimized](/projects?tab=philosophy#llm-optimized). Agents commit
+  autonomously in this repo; a deterministic pre-commit gate on secrets is the
+  control that scales with that, rather than hoping each agent notices.
+* [Respect Goodhart's Law](/projects?tab=philosophy#respect-goodharts-and-conways-laws).
+  Historical findings surface for triage instead of failing unrelated PRs —
+  pressure lands on rotating the credential, not on silencing the scanner.
+
+# Gaps & Risks
+
+* **False positives** (test fixtures, example configs) will need
+  `.gitleaks.toml` allowlist entries over time; the config is committed and
+  reviewable, so exceptions are visible rather than silent.
+* **Pattern-based detection is not proof of absence** — a secret in a shape no
+  rule anticipates still gets through; pre-commit is a strong net, not a
+  guarantee.
+* **The hook can be bypassed** (`--no-verify`); the CI history scan is the
+  backstop that still catches what skipped the hook.
+
+# Consequences
+
+## Positive
+
+* Secret detection moves from post-push (irreversible on a public repo) to
+  pre-commit (still private, still preventable).
+* Full-history coverage with generic/entropy rules, surfaced in the Security
+  tab alongside Trivy/zizmor/Scorecard.
+* Free, one binary, mise/CI parity like every other scanner in the stack.
+
+## Negative
+
+* Pre-commit gains a scan step (sub-second on staged changes).
+* Occasional false positives require allowlist maintenance in `.gitleaks.toml`.

--- a/ui/content/projects/recipe-site/adrs/058-gitleaks.mdx
+++ b/ui/content/projects/recipe-site/adrs/058-gitleaks.mdx
@@ -1,0 +1,34 @@
+---
+inherits_from: "personal-site:054-gitleaks"
+---
+
+# Additional Context for Recipe Site
+
+The recipe site concentrates the credentials worth stealing: Neon Postgres
+connection strings, better-auth secrets, OAuth client secrets (Google/GitHub
+login), OpenRouter API keys, and Cloudflare tokens for the Workers. Most of
+these are exactly the shapes GitHub's provider-pattern scanning is weakest on —
+a Postgres URL with an inline password or a better-auth signing secret has no
+vendor-recognisable format, but does trip gitleaks' generic and entropy rules
+(see [personal-site ADR 054](/projects/personal-site/adrs/054-gitleaks)).
+
+The financial-risk framing from
+[ADR 035 (application security baseline)](/projects/recipe-site/adrs/035-application-security-baseline)
+applies directly: a leaked OpenRouter key or database URL converts to
+unauthorized usage cost or a data breach of user accounts, so blocking the
+commit beats rotating after disclosure.
+
+# Consequences
+
+## Positive
+
+* Database URLs and auth secrets — the credential shapes vendor-pattern
+  scanning misses — are checked before a commit exists, on the side of the
+  monorepo where they circulate most (local `.dev.vars`, seeded QA scenarios,
+  integration-test configs).
+
+## Negative
+
+* Seeded QA fixtures and example configs are the likeliest source of false
+  positives; expect the first `.gitleaks.toml` allowlist entries to come from
+  the recipe-site test surface.

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -888,4 +888,12 @@ export const technologies: TechnologyContent[] = [
     website: "https://scorecard.dev",
     type: "tool",
   },
+  {
+    name: "Gitleaks",
+    added: "2026-07-20",
+    description:
+      "Secret scanner blocking credentials at pre-commit and auditing full git history with generic and entropy-based rules",
+    website: "https://gitleaks.io",
+    type: "tool",
+  },
 ];


### PR DESCRIPTION
Adds **gitleaks** at the two points GitHub secret scanning structurally can't cover. GitHub's scanning fires *after* the push — on a public repo that's already disclosure, and history rewrites un-publish nothing — and it matches known provider patterns only, missing generic shapes like Postgres URLs with inline passwords or auth signing secrets. Full reasoning in the included ADR 054.

## Changes

- **Pre-commit** (the layer that actually prevents leaks): new `//:security:secrets` mise task runs `gitleaks git --pre-commit --staged --redact` after lint-staged in the Husky hook — a staged secret blocks the commit while it's still only on the laptop
- **CI**: `gitleaks.yml` workflow scans the **full git history** (fetch-depth 0) on PRs, `main` pushes, and a weekly Wednesday schedule (Trivy=Mon, Scorecard=Tue). SARIF uploads to the Security tab under the `gitleaks` category with `--exit-code 0` — the exact zizmor/Trivy posture from ADRs 047/049: Code Scanning gates *new* alerts, historical findings are rotation work rather than a red build on whichever PR trips over them, and a genuine tool failure still fails the job
- `//:security:secrets:history` task for on-demand local full-history scans
- **gitleaks 8.30.1** pinned via mise so the hook and CI run the identical binary
- GitHub secret scanning stays on — overlap on provider patterns is harmless redundancy; the deltas are timing (pre-commit vs post-push) and breadth (entropy/generic rules). The ADR also recommends enabling GitHub **push protection** in repo settings as a free complementary layer (a settings toggle only you can flip)
- ADR 054 (personal-site) + inherited stub ADR 058 (recipe-site), `technologies.ts` entry

## Verification

- zizmor (offline audits), yamllint, remark (MDX), Biome, content-graph integration tests: clean
- ⚠️ gitleaks itself couldn't run in my sandbox (GitHub release downloads blocked by the session proxy), so the first CI run establishes the history baseline — I'm watching the PR and will triage anything it surfaces. The CLI invocations match the flags gitleaks' own pre-commit hook definition uses
- Touches `.mise.toml` + `technologies.ts` like the sibling PRs — trivial append conflicts; merge in any order and I'll rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQpZQern2o1v8BuNz8U9jE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQpZQern2o1v8BuNz8U9jE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated secret scanning for staged changes and repository history.
  * Security checks now run during pre-commit, pull requests, main-branch updates, weekly scans, and on demand.
  * Scan results are available in GitHub Security for review.
* **Documentation**
  * Added guidance covering secret-scanning practices, coverage, risks, and project-specific rules.
* **Updates**
  * Added Gitleaks to the technology catalogue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->