### PR TITLE
Add typos spell-checker with blocking Lint CI step (ADR 055)

### DIFF
--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - "**/*.md"
+      - "**/*.mdx"
       - "**/*.yml"
       - "**/*.yaml"
       - ".github/workflows/lint-ci.yml"
       - ".mise.toml"
       - ".markdownlint.json"
       - ".yamllint"
+      - "_typos.toml"
       - "package.json"
 
 permissions:
@@ -49,3 +51,6 @@ jobs:
 
       - name: Lint GitHub Actions workflows
         run: mise run //:lint:actions
+
+      - name: Check spelling
+        run: mise run //:lint:typos

--- a/.github/workflows/lint-ci.yml
+++ b/.github/workflows/lint-ci.yml
@@ -7,6 +7,14 @@ on:
       - "**/*.mdx"
       - "**/*.yml"
       - "**/*.yaml"
+      # Code files: only the spelling step checks these, but without them a
+      # code-only PR would skip the typos gate entirely
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.js"
+      - "**/*.jsx"
+      - "**/*.mjs"
+      - "**/*.cjs"
       - ".github/workflows/lint-ci.yml"
       - ".mise.toml"
       - ".markdownlint.json"

--- a/.mise.toml
+++ b/.mise.toml
@@ -27,6 +27,7 @@ tflint = "0.64.0"
 actionlint = "1.7.12"
 zizmor = "1.26.1"
 gitleaks = "8.30.1"
+typos = "1.48.0"
 
 [env]
 MISE_EXPERIMENTAL = "1"
@@ -34,7 +35,7 @@ MISE_EXPERIMENTAL = "1"
 # Root-level tasks for repo-wide tooling
 [tasks.lint]
 description = "Lint all files across the entire repo"
-depends = ["//:lint:markdown", "//:lint:mdx", "//:lint:yaml", "//:lint:actions", "//:lint:knip", "//ui:lint", "//infra:lint", "//infra:lint:tflint", "//infra-bootstrap:lint", "//infra-bootstrap:lint:tflint"]
+depends = ["//:lint:markdown", "//:lint:mdx", "//:lint:yaml", "//:lint:typos", "//:lint:knip", "//:lint:actions", "//ui:lint", "//infra:lint", "//infra:lint:tflint", "//infra-bootstrap:lint", "//infra-bootstrap:lint:tflint"]
 
 [tasks."lint:markdown"]
 description = "Lint and fix Markdown files (optionally pass files as args)"
@@ -95,6 +96,14 @@ fi
 description = "Detect unused files, dependencies, and exports across the monorepo with Knip"
 run = "pnpm exec knip"
 depends = ["//:install"]
+
+[tasks."lint:typos"]
+description = "Check spelling across the repo with typos"
+run = "typos"
+
+[tasks."lint:typos:fix"]
+description = "Fix typos across the repo with typos"
+run = "typos --write-changes"
 
 [tasks."lint:actions"]
 description = "Lint GitHub Actions workflows with actionlint"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,20 @@
+# Config for the typos spell-checker (mise run //:lint:typos)
+
+[default.extend-words]
+# Legitimate words and proper nouns the dictionary would "correct"
+unparseable = "unparseable" # valid English; also a user-facing diagnostic string in recipe-parsing
+Hashi = "Hashi" # HashiCorp
+Juni = "Juni" # coding agent referenced in ADR 012
+Symetry = "Symetry" # SymetryML, streaming ML product
+Vertica = "Vertica" # Vertica analytics database
+SIE = "SIE" # split from the SIEM(s) acronym
+
+[files]
+extend-exclude = [
+    # Deliberate typo examples demonstrating fuzzy search ("machne" -> "machine")
+    "ui/content/projects/personal-site/adrs/022-fuse-js.mdx",
+    # The typos ADR quotes the misspellings it fixed
+    "ui/content/projects/personal-site/adrs/055-typos.mdx",
+    # Standalone design artifact full of encoded SVG/data strings
+    "ui/public/recipe-site-design/",
+]

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,13 +1,14 @@
 # Config for the typos spell-checker (mise run //:lint:typos)
 
 [default.extend-words]
-# Legitimate words and proper nouns the dictionary would "correct"
+# Legitimate words and proper nouns the dictionary would "correct".
+# Keys are lowercase per typos convention; matching is case-insensitive.
 unparseable = "unparseable" # valid English; also a user-facing diagnostic string in recipe-parsing
-Hashi = "Hashi" # HashiCorp
-Juni = "Juni" # coding agent referenced in ADR 012
-Symetry = "Symetry" # SymetryML, streaming ML product
-Vertica = "Vertica" # Vertica analytics database
-SIE = "SIE" # split from the SIEM(s) acronym
+hashi = "hashi" # HashiCorp
+juni = "juni" # coding agent referenced in ADR 012
+symetry = "symetry" # SymetryML, streaming ML product
+vertica = "vertica" # Vertica analytics database
+sie = "sie" # split from the SIEM(s) acronym
 
 [files]
 extend-exclude = [

--- a/ui/content/blog/2020-07-25-why-you-should-not-buy-a-house.mdx
+++ b/ui/content/blog/2020-07-25-why-you-should-not-buy-a-house.mdx
@@ -123,7 +123,7 @@ already.
 
 > A REIT is a Real Estate Investment Trust.
 > Through this trust you have partial ownership of real estate.
-> This is usually commerical property but may include residential property.
+> This is usually commercial property but may include residential property.
 
 When you are younger, your pension will mostly be a diversified set of stocks.
 These are the best asset for growing your wealth.

--- a/ui/content/blog/2020-09-27-how-to-build-wealth.mdx
+++ b/ui/content/blog/2020-09-27-how-to-build-wealth.mdx
@@ -325,28 +325,28 @@ An investment is liquid if you can easily turn it into cash.
 
 ### Company Stock
 
-* Volatily: High
+* Volatility: High
 * Liquidity: High
 * Potential for growth: High
 * Minimum investment: Low
 
 ### Bonds
 
-* Volatily: Low
+* Volatility: Low
 * Liquidity: Medium
 * Potential for growth: Low
 * Minimum investment: Low
 
 ### Property
 
-* Volatily: Low
+* Volatility: Low
 * Liquidity: Very Low
 * Potential for growth: Medium
 * Minimum investment: Very High
 
 ### Commodities
 
-* Volatily: Low
+* Volatility: Low
 * Liquidity: Medium
 * Potential for growth: Low
 * Minimum investment: Medium

--- a/ui/content/blog/2022-02-07-post-modern-management.mdx
+++ b/ui/content/blog/2022-02-07-post-modern-management.mdx
@@ -33,7 +33,7 @@ Only those with financial backing and social status could bring their creations 
 As technology has advanced, we continue to discover ever more efficient methodologies and build ever more powerful tools.
 This has led to reorganisations occurring and non-creative work vanishing at an astonishing rate.
 
-A positive feedback loop has been kicked off. New efficiencies, lead to more efficently discovering new efficiencies.
+A positive feedback loop has been kicked off. New efficiencies, lead to more efficiently discovering new efficiencies.
 
 Discovering and implementing efficiencies enables us to discover and implement meta-efficiencies.
 

--- a/ui/content/projects/personal-site/adrs/055-typos.mdx
+++ b/ui/content/projects/personal-site/adrs/055-typos.mdx
@@ -1,0 +1,116 @@
+---
+title: "ADR 055: typos (Spell Checking)"
+date: "2026-07-20"
+status: "Accepted"
+tech_stack: ["typos"]
+---
+
+# Context
+
+This repo is unusually prose-heavy for a codebase: a blog, project write-ups,
+recipes, and 55-and-counting ADRs, all published to a public site that doubles
+as a portfolio. Nothing deterministic checks any of that text for spelling.
+markdownlint and remark check *structure*, not words; AI reviewers catch typos
+non-deterministically, and only in the diff under review — never in the
+backlog.
+
+The backlog made the case concretely: a first run over the repo found six real
+misspellings sitting in published blog posts, some for six years
+("Volatily" in a table header four times, "commerical", "efficently").
+
+The standing objection to spell-checking code repos is false-positive noise —
+dictionaries hate identifiers, and a checker that cries wolf gets deleted. So
+the tool choice hinges on precision more than recall.
+
+# Decision
+
+Adopt **typos** (the Rust CLI), mise-pinned like the other linters:
+
+* `mise run //:lint:typos` in the root `lint` aggregate, plus a
+  `lint:typos:fix` task (`--write-changes`) matching the check/fix split of
+  the Markdown tasks.
+* A **blocking** step in the existing Lint CI workflow alongside
+  markdownlint/yamllint/actionlint — the baseline is green because the six
+  real findings were fixed in the adopting change. Lint CI's trigger now also
+  covers `**/*.mdx`, where most prose lives.
+* A committed `_typos.toml` documenting the false-positive taxonomy the first
+  run produced: proper nouns split from CamelCase ("Hashi" from HashiCorp,
+  "Symetry" from SymetryML), product names ("Vertica", "Juni"), legitimate
+  words outside the dictionary ("unparseable"), and two path exclusions —
+  the Fuse.js ADR (whose *deliberate* typo examples demonstrate fuzzy search)
+  and a generated design artifact full of encoded SVG data.
+
+# Why It Adds Something New
+
+Spelling is a class of defect no existing tool owns: it lives mostly in
+content files that Biome, CodeQL, and SonarQube never parse, and the tools
+that do parse them (markdownlint, remark) check syntax. typos applies the
+stack's standard determinism argument ([ADR 048](/projects/personal-site/adrs/048-sonarqube))
+to the one artifact type this repo publishes more of than code.
+
+typos is chosen over the generic spell-checkers for its design point:
+instead of flagging every word not in a dictionary (cspell's model, which
+needs per-project word lists to stay quiet), it only flags *known
+misspellings* via edit-distance against a curated corpus. That asymmetry is
+why the first full-repo run produced 29 findings rather than thousands — and
+why 6 of the 29 were real.
+
+# Alternatives Considered
+
+| Tool | Role | Pros | Cons | Verdict |
+| --- | --- | --- | --- | --- |
+| **typos** *(accepted)* | Known-misspelling checker | Very low false-positive rate by design; single fast binary; understands CamelCase/snake_case; TOML config; `--write-changes` fix mode. | Won't catch a novel misspelling absent from its corpus. | **Accepted.** |
+| **cspell** | Dictionary spell-checker | Higher recall; huge dictionary ecosystem. | Inverted noise profile: every identifier and name needs allowlisting; word-list maintenance becomes a chore that erodes the gate. | Rejected: precision over recall here. |
+| **codespell** | Known-misspelling checker (Python) | Same philosophy as typos. | Python toolchain in a Node monorepo; smaller corpus; slower. | Rejected: typos dominates it. |
+| **Vale** | Prose *style* linter | Enforces style guides, not just spelling. | A style-rule programme is a much bigger commitment than the gap (spelling) warrants. | Rejected: [Less Is More](/projects?tab=philosophy#less-is-more); could complement later. |
+| **AI reviewers only** (status quo) | Non-deterministic | Already running. | Six-year-old typos in published posts show the miss rate; never audits the backlog. | Rejected. |
+
+# Where It Sits On The Adoption Curve
+
+**Early-to-late majority.** typos has become the default spell-check gate in
+large Rust/Python/JS open-source projects and pre-commit setups; stable CLI,
+maintained corpus. Comfortably in the
+[Goldilocks zone](/projects?tab=philosophy#the-goldilocks-zone), with
+codespell as the decade-old fallback if it ever stalls.
+
+# Relation To Building Philosophy
+
+* [Less Is More](/projects?tab=philosophy#less-is-more). One binary, one small
+  TOML file, one step in an existing workflow — no service, no dictionary
+  sprawl.
+* [Short Feedback Loops](/projects?tab=philosophy#short-feedback-loops). A typo
+  in a new blog post fails the PR that introduces it, instead of shipping to
+  the public site until a reader notices.
+* [LLM-Optimized](/projects?tab=philosophy#llm-optimized). Agents generate most
+  content drafts; a deterministic spelling floor means the same slip fails the
+  same way every time. The committed config also teaches agents which
+  "misspellings" here are intentional.
+* [Respect Goodhart's Law](/projects?tab=philosophy#respect-goodharts-and-conways-laws).
+  Every allowlist entry is a reviewed line in `_typos.toml` with a stated
+  reason, not a silent suppression.
+
+# Gaps & Risks
+
+* **Recall is bounded by the corpus**: a misspelling typos has never seen
+  passes. Accepted — the low-noise design is what makes the gate sustainable.
+* **British/American variants** are both accepted by default, so inconsistent
+  variant usage isn't flagged. That's a style concern (Vale's domain), out of
+  scope.
+* **Corpus updates can add findings**: a mise version bump may flag words it
+  previously ignored; Renovate surfaces that as an explicit PR
+  ([ADR 024](/projects/personal-site/adrs/024-renovate)).
+
+# Consequences
+
+## Positive
+
+* Six real misspellings in published content fixed; spelling regressions now
+  blocked at PR time across code, docs, and content.
+* Near-zero-noise gate: 23 of 29 first-run findings were resolved by config
+  taxonomy, not suppressed ad hoc.
+* Free, single binary, mise/CI parity.
+
+## Negative
+
+* One more blocking lint step (sub-second on this repo).
+* `_typos.toml` grows as new proper nouns enter the content.

--- a/ui/content/projects/recipe-site/adrs/059-typos.mdx
+++ b/ui/content/projects/recipe-site/adrs/059-typos.mdx
@@ -1,0 +1,30 @@
+---
+inherits_from: "personal-site:055-typos"
+---
+
+# Additional Context for Recipe Site
+
+The recipe site adds the content type where spelling errors are most
+user-visible: recipe titles, ingredient names, and instructions, rendered both
+on the site and in the schema.org Recipe JSON twins consumed by other tools
+(see [personal-site ADR 055](/projects/personal-site/adrs/055-typos)).
+Ingredient vocabulary is also exactly where dictionary-based checkers drown in
+noise — cuisine terms, brand names, non-English loanwords — which is why the
+known-misspellings design matters doubly here.
+
+The recipe-parsing package also demonstrates the config's judgement calls: its
+diagnostics use "unparseable", a legitimate word typos' dictionary would
+"correct", now allowlisted in `_typos.toml` rather than rewritten in
+user-facing strings.
+
+# Consequences
+
+## Positive
+
+* Typos in recipe content are caught before they ship to the site and its
+  machine-readable JSON twins.
+
+## Negative
+
+* Loanword-heavy recipe vocabulary may occasionally need `_typos.toml`
+  entries as content grows.

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -896,4 +896,12 @@ export const technologies: TechnologyContent[] = [
     website: "https://gitleaks.io",
     type: "tool",
   },
+  {
+    name: "typos",
+    added: "2026-07-20",
+    description:
+      "Low-noise spell checker flagging known misspellings across code, docs, and content instead of everything outside a dictionary",
+    website: "https://github.com/crate-ci/typos",
+    type: "tool",
+  },
 ];


### PR DESCRIPTION
Adds **typos** (the Rust known-misspellings checker) as a blocking step in Lint CI. This repo publishes more prose than most codebases — blog, recipes, 55+ ADRs — and nothing deterministic checked any of it for spelling: markdownlint/remark check structure, AI reviewers only see the diff. Full reasoning in the included ADR 055.

## What the first run found

29 findings, triaged one by one:

- **6 real misspellings fixed**, all in published blog posts, some live for six years: `commerical` → commercial, `efficently` → efficiently, and `Volatily` → Volatility ×4 in a table header
- **23 false positives resolved by config taxonomy** in `_typos.toml`, each with a stated reason: CamelCase-split proper nouns (`Hashi` from HashiCorp, `Symetry` from SymetryML, `SIE` from SIEMs), product names (`Vertica`, `Juni`), legitimate words (`unparseable` — also a user-facing diagnostic string in recipe-parsing, deliberately not renamed), the Fuse.js ADR whose *intentional* typo examples demonstrate fuzzy search, and a generated design artifact full of encoded SVG data

typos was chosen over cspell/codespell for its precision-first design — it flags known misspellings by edit distance rather than everything outside a dictionary, which is why a full-repo first run produced 29 findings instead of thousands.

## Wiring

- **typos 1.48.0** pinned via mise; `//:lint:typos` in the root `lint` aggregate + `//:lint:typos:fix` (`--write-changes`), matching the check/fix split of the Markdown tasks
- Blocking **Check spelling** step in the existing Lint CI workflow; its trigger now also covers `**/*.mdx` and `_typos.toml`
- ADR 055 (personal-site) + inherited stub ADR 059 (recipe-site), `technologies.ts` entry

## Verification

- `typos` exits clean on the whole repo (verified locally with the same 1.48.0 the mise pin installs)
- zizmor (offline audits), yamllint, remark (MDX), Biome, content-graph integration tests: clean
- Touches `.mise.toml`, `lint-ci.yml`, and `technologies.ts` like the sibling PRs — trivial append conflicts; merge in any order and I'll rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQpZQern2o1v8BuNz8U9jE

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQpZQern2o1v8BuNz8U9jE)_