### PR TITLE
Add read-only bootstrap Terraform plan identity

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -186,6 +186,10 @@ The GitHub environments are runtime/job boundaries, not provider names:
 | `production-database-backup` | `prd_database_backup` | Scheduled encrypted Neon backup |
 | `production-ci` | `prd_ci_repo` | AI review and ML pipeline CI |
 
+`production-infra-bootstrap-plan` must require environment approval before its
+Terraform Cloud token is released. The Google identity is read-only, but the
+token still permits the local Terraform process to read the bootstrap state.
+
 Run `scripts/sync-doppler-github-envs.sh` after any Doppler change that should
 reach GitHub Actions. The script reads Doppler visibility metadata: unmasked
 values become GitHub environment variables, while masked/restricted values

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -41,6 +41,7 @@ Configs are split by environment and runtime/control boundary:
 | `prd_recipe_ingest` | Production recipe ingest Worker LLM config | `production-recipe-ingest` |
 | `prd_infra` | Production Terraform/provider credentials | `production-infra` |
 | `prd_bootstrap_infra` | Production bootstrap Terraform credentials | `production-infra-bootstrap` |
+| `prd_bootstrap_plan` | Read-only bootstrap Terraform plan credentials | `production-infra-bootstrap-plan` |
 | `prd_database_backup` | Encrypted Neon-to-R2 backup credentials and public encryption recipient | `production-database-backup` |
 | `prd_ci_repo` | Repo-wide sensitive CI like AI review and DVC | `production-ci` |
 
@@ -181,6 +182,7 @@ The GitHub environments are runtime/job boundaries, not provider names:
 | `production-site-ui` | `prd_site_ui`, `prd_pages_env` | Production UI CI/CD and Cloudflare Images health check |
 | `production-infra` | `prd_infra` | Terraform CI/CD |
 | `production-infra-bootstrap` | `prd_bootstrap_infra` | Manual bootstrap Terraform |
+| `production-infra-bootstrap-plan` | `prd_bootstrap_plan` | Read-only bootstrap Terraform PR plans |
 | `production-database-backup` | `prd_database_backup` | Scheduled encrypted Neon backup |
 | `production-ci` | `prd_ci_repo` | AI review and ML pipeline CI |
 
@@ -281,6 +283,13 @@ runtime-specific Doppler config.
 - `GCP_TERRAFORM_SERVICE_ACCOUNT` (unmasked)
 - `TF_API_TOKEN`
 
+`prd_bootstrap_plan` should own:
+
+- `GCP_PROJECT_ID` (unmasked)
+- `GCP_WORKLOAD_IDENTITY_PROVIDER` (unmasked; PR-only provider)
+- `GCP_TERRAFORM_SERVICE_ACCOUNT` (unmasked; read-only plan identity)
+- `TF_API_TOKEN`
+
 `prd_database_backup` should own:
 
 - `AGE_RECIPIENT` (unmasked; public age recipient, never the private identity)
@@ -317,7 +326,9 @@ doppler secrets --project personal-site --config dev_pages_env --only-names
 doppler secrets --project personal-site --config dev_recipe_api --only-names
 doppler secrets --project personal-site --config dev_infra --only-names
 doppler secrets --project personal-site --config dev_bootstrap_infra --only-names
+doppler secrets --project personal-site --config prd_bootstrap_plan --only-names
 doppler secrets --project personal-site --config prd_database_backup --only-names
+scripts/sync-doppler-github-envs.sh production-infra-bootstrap-plan
 scripts/sync-doppler-github-envs.sh production-database-backup
 
 mise run //:dev

--- a/infra-bootstrap/README.md
+++ b/infra-bootstrap/README.md
@@ -20,6 +20,10 @@ environment and a read-only Google service account. Its Workload Identity
 Provider accepts only `pull_request` tokens for this repository and environment;
 it cannot authenticate the main-only apply workflow.
 
+The GitHub environment requires reviewer approval before releasing its
+Terraform Cloud token. Review the PR's Terraform and workflow changes before
+approving the deployment.
+
 The environment needs:
 
 - `TF_API_TOKEN`

--- a/infra-bootstrap/README.md
+++ b/infra-bootstrap/README.md
@@ -15,6 +15,11 @@ The `.github/workflows/infra-bootstrap.yml` workflow uses the
 it for reviewing or applying changes to foundational IAM, identity trust, and
 provider bootstrap resources.
 
+Pull-request plans use the separate `production-infra-bootstrap-plan`
+environment and a read-only Google service account. Its Workload Identity
+Provider accepts only `pull_request` tokens for this repository and environment;
+it cannot authenticate the main-only apply workflow.
+
 The environment needs:
 
 - `TF_API_TOKEN`
@@ -26,6 +31,11 @@ The GCP values are identifiers for the current bootstrap resources, not
 secrets. Store them as unmasked Doppler values so
 `scripts/sync-doppler-github-envs.sh` publishes them as GitHub environment
 variables.
+
+The plan environment uses the same names, populated from the dedicated
+`prd_bootstrap_plan` Doppler config. `GCP_WORKLOAD_IDENTITY_PROVIDER` and
+`GCP_TERRAFORM_SERVICE_ACCOUNT` identify the plan-only provider and service
+account.
 
 ## Local Commands
 

--- a/infra-bootstrap/google.tf
+++ b/infra-bootstrap/google.tf
@@ -50,7 +50,8 @@ locals {
     "sts.googleapis.com",
   ])
 
-  github_actions_principal = "principal://iam.googleapis.com/projects/${google_project.recipes.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/subject/repo:${local.github_repository}:environment:production-infra-bootstrap"
+  github_actions_principal      = "principal://iam.googleapis.com/projects/${google_project.recipes.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/subject/repo:${local.github_repository}:environment:production-infra-bootstrap"
+  github_actions_plan_principal = "principal://iam.googleapis.com/projects/${google_project.recipes.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/subject/repo:${local.github_repository}:environment:production-infra-bootstrap-plan"
 }
 
 resource "google_project_service" "required" {
@@ -78,6 +79,23 @@ resource "google_project_iam_member" "github_terraform" {
   project = google_project.recipes.project_id
   role    = each.value
   member  = "serviceAccount:${google_service_account.github_terraform.email}"
+}
+
+resource "google_service_account" "github_terraform_plan" {
+  project      = google_project.recipes.project_id
+  account_id   = var.gcp_terraform_plan_service_account_id
+  display_name = "GitHub Actions read-only GCP Terraform plan"
+  description  = "Impersonated by pull-request bootstrap plans via Workload Identity Federation."
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_project_iam_member" "github_terraform_plan" {
+  for_each = var.gcp_terraform_plan_service_account_roles
+
+  project = google_project.recipes.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.github_terraform_plan.email}"
 }
 
 resource "google_iam_workload_identity_pool" "github_actions" {
@@ -112,6 +130,28 @@ resource "google_iam_workload_identity_pool_provider" "bootstrap" {
   }
 }
 
+resource "google_iam_workload_identity_pool_provider" "bootstrap_plan" {
+  project                            = google_project.recipes.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
+  workload_identity_pool_provider_id = var.gcp_github_workload_identity_plan_provider_id
+  display_name                       = "personal-site-bootstrap-plan"
+  description                        = "GitHub Actions OIDC provider for read-only bootstrap plans in ${local.github_repository}."
+
+  attribute_mapping = {
+    "google.subject"        = "assertion.sub"
+    "attribute.actor"       = "assertion.actor"
+    "attribute.environment" = "assertion.environment"
+    "attribute.repository"  = "assertion.repository"
+    "attribute.ref"         = "assertion.ref"
+  }
+
+  attribute_condition = "assertion.repository == '${local.github_repository}' && assertion.environment == 'production-infra-bootstrap-plan' && assertion.event_name == 'pull_request' && assertion.base_ref == 'refs/heads/main' && assertion.ref.startsWith('refs/pull/')"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
 moved {
   from = google_iam_workload_identity_pool_provider.gcp_infra
   to   = google_iam_workload_identity_pool_provider.bootstrap
@@ -121,4 +161,10 @@ resource "google_service_account_iam_member" "github_actions_workload_identity_u
   service_account_id = google_service_account.github_terraform.name
   role               = "roles/iam.workloadIdentityUser"
   member             = local.github_actions_principal
+}
+
+resource "google_service_account_iam_member" "github_actions_plan_workload_identity_user" {
+  service_account_id = google_service_account.github_terraform_plan.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = local.github_actions_plan_principal
 }

--- a/infra-bootstrap/google.tf
+++ b/infra-bootstrap/google.tf
@@ -145,7 +145,7 @@ resource "google_iam_workload_identity_pool_provider" "bootstrap_plan" {
     "attribute.ref"         = "assertion.ref"
   }
 
-  attribute_condition = "assertion.repository == '${local.github_repository}' && assertion.environment == 'production-infra-bootstrap-plan' && assertion.event_name == 'pull_request' && assertion.base_ref == 'refs/heads/main' && assertion.ref.startsWith('refs/pull/')"
+  attribute_condition = "assertion.repository == '${local.github_repository}' && assertion.environment == 'production-infra-bootstrap-plan' && assertion.event_name == 'pull_request' && assertion.base_ref == 'main' && assertion.ref.startsWith('refs/pull/')"
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"

--- a/infra-bootstrap/outputs.tf
+++ b/infra-bootstrap/outputs.tf
@@ -7,3 +7,13 @@ output "gcp_workload_identity_provider" {
   description = "Workload Identity Provider resource name for google-github-actions/auth"
   value       = "projects/${google_project.recipes.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.bootstrap.workload_identity_pool_provider_id}"
 }
+
+output "gcp_terraform_plan_service_account_email" {
+  description = "Read-only service account GitHub Actions impersonates for pull-request plans"
+  value       = google_service_account.github_terraform_plan.email
+}
+
+output "gcp_plan_workload_identity_provider" {
+  description = "Pull-request plan Workload Identity Provider resource name for google-github-actions/auth"
+  value       = "projects/${google_project.recipes.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.github_actions.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.bootstrap_plan.workload_identity_pool_provider_id}"
+}

--- a/infra-bootstrap/variables.tf
+++ b/infra-bootstrap/variables.tf
@@ -53,6 +53,12 @@ variable "gcp_terraform_service_account_id" {
   default     = "github-terraform"
 }
 
+variable "gcp_terraform_plan_service_account_id" {
+  description = "Account ID for the read-only service account GitHub Actions impersonates for pull-request plans"
+  type        = string
+  default     = "github-terraform-plan"
+}
+
 variable "gcp_github_workload_identity_pool_id" {
   description = "Workload Identity Pool ID for GitHub Actions"
   type        = string
@@ -65,6 +71,12 @@ variable "gcp_github_workload_identity_provider_id" {
   default     = "personal-site"
 }
 
+variable "gcp_github_workload_identity_plan_provider_id" {
+  description = "Workload Identity Provider ID for pull-request bootstrap Terraform plans"
+  type        = string
+  default     = "personal-site-plan"
+}
+
 variable "gcp_terraform_service_account_roles" {
   description = "Project-level roles granted to the privileged GCP Terraform service account"
   type        = set(string)
@@ -74,5 +86,17 @@ variable "gcp_terraform_service_account_roles" {
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/resourcemanager.projectIamAdmin",
     "roles/serviceusage.serviceUsageAdmin",
+  ]
+}
+
+variable "gcp_terraform_plan_service_account_roles" {
+  description = "Project-level read-only roles granted to the pull-request Terraform plan service account"
+  type        = set(string)
+  default = [
+    "roles/browser",
+    "roles/iam.securityReviewer",
+    "roles/iam.serviceAccountViewer",
+    "roles/iam.workloadIdentityPoolViewer",
+    "roles/serviceusage.serviceUsageViewer",
   ]
 }

--- a/scripts/sync-doppler-github-envs.sh
+++ b/scripts/sync-doppler-github-envs.sh
@@ -156,6 +156,7 @@ known_environments=(
   production-site-ui
   production-infra
   production-infra-bootstrap
+  production-infra-bootstrap-plan
   production-database-backup
   production-ci
 )
@@ -175,6 +176,7 @@ sync_requested_env production-recipe-ingest prd_recipe_ingest prd_site_ui
 sync_requested_env production-site-ui prd_site_ui prd_pages_env
 sync_requested_env production-infra prd_infra
 sync_requested_env production-infra-bootstrap prd_bootstrap_infra
+sync_requested_env production-infra-bootstrap-plan prd_bootstrap_plan
 sync_requested_env production-database-backup prd_database_backup
 sync_requested_env production-ci prd_ci_repo
 


### PR DESCRIPTION
## What changed

- add a dedicated Google service account for bootstrap Terraform plans
- grant it only read-oriented project, IAM, Workload Identity, and Service Usage roles
- add a PR-only Workload Identity provider restricted to this repository, the `production-infra-bootstrap-plan` environment, pull requests targeting `main`, and `refs/pull/*`
- add Terraform outputs for the plan provider and service account
- add `prd_bootstrap_plan` → `production-infra-bootstrap-plan` to the Doppler/GitHub environment sync
- document the trust boundary and required configuration

## Why

Bootstrap plans cannot use the existing identity because its WIF condition intentionally accepts only `main`, and that identity can change project IAM. This creates a subordinate read-only identity so untrusted PR code cannot inherit bootstrap apply permissions.

## Validation

- `mise //infra-bootstrap:check`
- `mise //:lint:markdown:check infra-bootstrap/README.md docs/secrets.md`
- `mise //:lint:yaml`
- `bash -n scripts/sync-doppler-github-envs.sh`
- pre-commit hooks, TFLint, and gitleaks

The local plan reports `9 to add, 1 to change, 0 to destroy`. Eight additions belong to this change. The remaining audit-config addition and `auto_create_network` reconciliation are pre-existing unapplied changes already present on `main` and should be reviewed before applying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated, read-only Terraform plan environment for pull requests targeting the main branch.
  * Introduced separate plan-only cloud identity, service account, and permissions to support safer bootstrap plan review.
  * Added support to synchronise the new environment’s configuration values.

* **Documentation**
  * Documented the plan environment’s setup, approval requirement, security restrictions, credentials ownership, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->