### PR TITLE
Address post-merge recipe review findings

### DIFF
--- a/functions/lib/recipe-asset.ts
+++ b/functions/lib/recipe-asset.ts
@@ -6,6 +6,16 @@ export interface RecipeAssetContext {
   env: PublicRecipeEnv & { ASSETS: { fetch: typeof fetch } };
 }
 
+export function rewrittenRecipeAssetHeaders(asset: Response): Headers {
+  const headers = new Headers(asset.headers);
+  headers.delete("content-length");
+  headers.delete("content-encoding");
+  headers.delete("etag");
+  headers.delete("last-modified");
+  headers.set("cache-control", "public, max-age=60, s-maxage=300");
+  return headers;
+}
+
 export async function augmentRecipeAsset(
   context: RecipeAssetContext,
   render: (assetBody: string, recipes: StoredRecipe[], url: URL) => string,
@@ -17,11 +27,6 @@ export async function augmentRecipeAsset(
   if (!recipes) return asset;
 
   const body = render(await asset.text(), recipes, new URL(context.request.url));
-  const headers = new Headers(asset.headers);
-  headers.delete("content-length");
-  headers.delete("content-encoding");
-  headers.delete("etag");
-  headers.delete("last-modified");
-  headers.set("cache-control", "public, max-age=60, s-maxage=300");
+  const headers = rewrittenRecipeAssetHeaders(asset);
   return new Response(body, { status: asset.status, headers });
 }

--- a/functions/recipes/[[path]].ts
+++ b/functions/recipes/[[path]].ts
@@ -11,6 +11,7 @@ import {
   type RecipePayload,
   recipeMarkdown,
 } from "../lib/public-recipes";
+import { rewrittenRecipeAssetHeaders } from "../lib/recipe-asset";
 
 interface Env extends PublicRecipeEnv {
   ASSETS: { fetch: typeof fetch };
@@ -83,10 +84,13 @@ export const onRequest = async (context: Context): Promise<Response> => {
       return textResponse(recipeMarkdown(loaded.payload), "text/markdown");
     }
     const assetUrl = new URL("/recipes/saved.html", url);
+    const assetHeaders = new Headers(context.request.headers);
+    assetHeaders.delete("if-none-match");
+    assetHeaders.delete("if-modified-since");
     const asset = await context.env.ASSETS.fetch(
       new Request(assetUrl, {
         method: context.request.method,
-        headers: context.request.headers,
+        headers: assetHeaders,
       }),
     );
     if (!asset.ok || context.request.method === "HEAD") return asset;
@@ -115,9 +119,7 @@ export const onRequest = async (context: Context): Promise<Response> => {
       )
       .replace(/<meta name="robots"[^>]*>/i, "")
       .replace("</head>", `${headMarkup}</head>`);
-    const headers = new Headers(asset.headers);
-    headers.delete("content-length");
-    headers.delete("content-encoding");
+    const headers = rewrittenRecipeAssetHeaders(asset);
     return new Response(html, { status: asset.status, headers });
   }
 

--- a/ui/lib/api/recipes.ts
+++ b/ui/lib/api/recipes.ts
@@ -5,6 +5,7 @@ import type {
   KitchenIngredientView,
   KitchenRecipeView,
 } from "@/lib/domain/recipe/kitchen";
+import type { RecipeGridItem } from "@/lib/domain/recipe/recipeDraft";
 import {
   parseSavedRecipe,
   type SavedRecipeApiRecord,
@@ -20,11 +21,13 @@ export type { RecipeCardView, RecipeDetailView };
 
 export function recipeRecordsToCards(
   records: SavedRecipeApiRecord[],
-): RecipeCardView[] {
+): RecipeGridItem[] {
   return records
     .flatMap((record) => {
       const card = savedRecipeCard(record);
-      return card ? [card] : [];
+      if (!card) return [];
+      const { saved: _saved, ...catalogCard } = card;
+      return [catalogCard];
     })
     .sort(
       (left, right) =>

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -108,6 +108,9 @@ function recipeContentToDetail(
     prepTime: content.prepTime,
     cookTime: content.cookTime,
     totalTime,
+    image: content.image,
+    imageAlt: content.imageAlt,
+    canonical: content.canonical,
     cookBody: content.cookBody,
     cookware: content.cookware,
     ingredientGroups: content.ingredientGroups.map((group) => ({

--- a/ui/tests/functions/recipe-pages.test.ts
+++ b/ui/tests/functions/recipe-pages.test.ts
@@ -201,8 +201,8 @@ describe("dynamic recipe pages", () => {
         body: JSON.stringify(escapedPayload),
       }),
     ) as typeof fetch;
-    const assetFetch = vi.fn(
-      async () =>
+    const assetFetchMock = vi.fn(
+      async (_request: Request) =>
         new Response(
           '<html><head><title>Saved Recipe</title><meta name="description" content="Saved"><meta name="robots" content="noindex"></head><body></body></html>',
           {
@@ -210,16 +210,23 @@ describe("dynamic recipe pages", () => {
             headers: {
               "content-length": "999",
               "content-encoding": "gzip",
+              etag: '"shell-v1"',
+              "last-modified": "Wed, 22 Jul 2026 12:00:00 GMT",
               "x-asset": "saved-recipe",
             },
           },
         ),
-    ) as typeof fetch;
+    );
+    const assetFetch = assetFetchMock as unknown as typeof fetch;
 
     const response = await onRequest(
       context(
         "https://robbiepalmer.me/recipes/lentil-soup",
-        { accept: "text/html" },
+        {
+          accept: "text/html",
+          "if-none-match": '"recipe-v1"',
+          "if-modified-since": "Wed, 22 Jul 2026 12:00:00 GMT",
+        },
         assetFetch,
       ),
     );
@@ -229,6 +236,11 @@ describe("dynamic recipe pages", () => {
     expect(response.headers.get("x-asset")).toBe("saved-recipe");
     expect(response.headers.has("content-length")).toBe(false);
     expect(response.headers.has("content-encoding")).toBe(false);
+    expect(response.headers.has("etag")).toBe(false);
+    expect(response.headers.has("last-modified")).toBe(false);
+    const shellRequest = assetFetchMock.mock.calls[0]?.[0] as Request;
+    expect(shellRequest.headers.has("if-none-match")).toBe(false);
+    expect(shellRequest.headers.has("if-modified-since")).toBe(false);
     expect(html).toContain('<title>&lt;Soup &amp; "Stuff"&gt;</title>');
     expect(html).toContain(
       'content="Stored &quot;description&quot; &amp; &lt;detail&gt;"',

--- a/ui/tests/lib/api/recipes.test.ts
+++ b/ui/tests/lib/api/recipes.test.ts
@@ -53,9 +53,9 @@ describe("saved recipe API adapters", () => {
     const newer = recipeRecord("newer", "Newer", "2026-07-22");
     const invalid = { ...newer, slug: "invalid", body: null };
 
-    expect(
-      recipeRecordsToCards([older, invalid, newer]).map(({ slug }) => slug),
-    ).toEqual(["newer", "older"]);
+    const cards = recipeRecordsToCards([older, invalid, newer]);
+    expect(cards.map(({ slug }) => slug)).toEqual(["newer", "older"]);
+    expect(cards.every((card) => card.saved === undefined)).toBe(true);
     expect(
       recipeRecordsToDetails([invalid, newer]).map(({ slug }) => slug),
     ).toEqual(["newer"]);

--- a/ui/tests/lib/domain/recipe/recipeDraft.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeDraft.test.ts
@@ -46,6 +46,9 @@ describe("savedRecipeCard", () => {
       cuisine: [],
       servings: 2,
       tags: [],
+      image: "recipes/weeknight-rice-2026-07-22",
+      imageAlt: "A bowl of rice",
+      canonical: "https://example.test/weeknight-rice",
       ingredientGroups: [
         {
           items: [{ ingredient: "rice", amount: 200, unit: "g" }],
@@ -70,9 +73,12 @@ describe("savedRecipeCard", () => {
   }
 
   it("uses the indexable route for public recipes", () => {
-    expect(savedRecipeCard(record("public"))?.href).toBe(
-      "/recipes/weeknight-rice",
-    );
+    expect(savedRecipeCard(record("public"))).toMatchObject({
+      href: "/recipes/weeknight-rice",
+      image: "recipes/weeknight-rice-2026-07-22",
+      imageAlt: "A bowl of rice",
+      canonical: "https://example.test/weeknight-rice",
+    });
   });
 
   it.each(["private", "household"] as const)(


### PR DESCRIPTION
## Summary

- keep public catalog cards neutral instead of marking every recipe as saved
- preserve stored recipe image, alt text, and canonical metadata in parsed detail views
- prevent conditional shell responses and stale validators on dynamically rewritten recipe HTML

## Why

These findings were posted on #781 as it merged. This clean follow-up is based on the squash-merged `main` and contains only the post-merge corrections.

## Validation

- `mise //ui:test` — 632 tests passed
- `mise //ui:typecheck`
- `mise //ui:lint`
- `mise //:lint:knip`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`