### PR TITLE
Fix recipe login callback URL

### DIFF
--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -322,9 +322,7 @@ export function AuthButton({
     setError(null);
 
     const currentURL =
-      intent === "signup"
-        ? "/recipes/onboarding"
-        : `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      intent === "signup" ? "/recipes/onboarding" : window.location.href;
     try {
       const result = await authClient.signIn.social({
         provider,

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -81,8 +81,8 @@ describe("AuthButton", () => {
 
     expect(mocks.signInSocial).toHaveBeenCalledWith({
       provider: "github",
-      callbackURL: "/recipes/pasta?servings=4#method",
-      errorCallbackURL: "/recipes/pasta?servings=4#method",
+      callbackURL: "http://localhost:3000/recipes/pasta?servings=4#method",
+      errorCallbackURL: "http://localhost:3000/recipes/pasta?servings=4#method",
     });
   });
 


### PR DESCRIPTION
## Summary

- send the current recipe page as an absolute, same-origin OAuth callback URL
- preserve the current path, query string, and fragment after authentication
- update the auth button regression test for the absolute callback

## Root cause

The logged-out recipe landing page links to `#how-it-works`. The auth button passed `/recipes#how-it-works` as a relative callback URL, which Better Auth rejected with `Invalid callbackURL`. Better Auth accepts the same fragment when the callback is expressed as an absolute URL on the trusted application origin.

## User impact

Users can start Google or GitHub login from anchored recipe pages without seeing the invalid callback URL error, and they return to the same location after authentication.

## Validation

- `mise run //ui:test -- tests/components/recipes/auth-button.test.tsx` — 12 tests passed
- `mise run //ui:typecheck` — passed
- `mise run //ui:lint` — passed with existing warnings
- `git diff --check` — passed
- production auth endpoint accepted the corrected absolute callback URL