### PR TITLE
Restore recipe box catalog stats

### DIFF
--- a/ui/components/recipes/recipe-box-view.tsx
+++ b/ui/components/recipes/recipe-box-view.tsx
@@ -17,10 +17,17 @@ type RecipeCatalogStatsState = RecipeCatalogStats & {
   userId: string | null;
 };
 
-function formatRecipeCount(count: number | null) {
-  if (count == null) return null;
-  const label = count === 1 ? "recipe" : "recipes";
+function formatCount(count: number, singular: string, plural: string) {
+  const label = count === 1 ? singular : plural;
   return `${count.toLocaleString()} ${label}`;
+}
+
+function formatRecipeCount(count: number | null) {
+  return count == null ? null : formatCount(count, "recipe", "recipes");
+}
+
+function formatCatalogCount(count: number, singular: string, plural: string) {
+  return count > 0 ? formatCount(count, singular, plural) : null;
 }
 
 export function RecipeBoxView() {
@@ -56,11 +63,9 @@ export function RecipeBoxView() {
     const { cuisineCount, ingredientCount, equipmentCount } = catalogStatsState;
     return [
       recipeCountLabel,
-      cuisineCount > 0
-        ? `${cuisineCount.toLocaleString()} ${cuisineCount === 1 ? "cuisine" : "cuisines"}`
-        : null,
-      `${ingredientCount.toLocaleString()} ${ingredientCount === 1 ? "ingredient" : "ingredients"}`,
-      `${equipmentCount.toLocaleString()} ${equipmentCount === 1 ? "tool" : "tools"}`,
+      formatCatalogCount(cuisineCount, "cuisine", "cuisines"),
+      formatCatalogCount(ingredientCount, "ingredient", "ingredients"),
+      formatCatalogCount(equipmentCount, "tool", "tools"),
     ].filter((stat): stat is string => stat != null);
   }, [catalogStatsState, isPending, recipeCountLabel, sessionUserId]);
 

--- a/ui/components/recipes/recipe-box-view.tsx
+++ b/ui/components/recipes/recipe-box-view.tsx
@@ -1,15 +1,20 @@
 "use client";
 
-import { Suspense, useCallback, useState } from "react";
+import { Suspense, useCallback, useMemo, useState } from "react";
 import { AddRecipeButton } from "@/components/recipes/add-recipe-button";
 import { RecipeCollection } from "@/components/recipes/recipe-collection";
 import { CardGridSkeleton } from "@/components/ui/card-grid-skeleton";
 import { Skeleton } from "@/components/ui/skeleton";
 import { authClient } from "@/lib/auth-client";
+import type { RecipeCatalogStats } from "@/lib/domain/recipe/recipeViews";
 
 type VisibleRecipeCountState = {
   userId: string | null;
   count: number;
+};
+
+type RecipeCatalogStatsState = RecipeCatalogStats & {
+  userId: string | null;
 };
 
 function formatRecipeCount(count: number | null) {
@@ -24,8 +29,15 @@ export function RecipeBoxView() {
   const [countState, setCountState] = useState<VisibleRecipeCountState | null>(
     null,
   );
+  const [catalogStatsState, setCatalogStatsState] =
+    useState<RecipeCatalogStatsState | null>(null);
   const updateVisibleRecipeCount = useCallback(
     (count: number) => setCountState({ userId: sessionUserId, count }),
+    [sessionUserId],
+  );
+  const updateCatalogStats = useCallback(
+    (stats: RecipeCatalogStats) =>
+      setCatalogStatsState({ userId: sessionUserId, ...stats }),
     [sessionUserId],
   );
   const visibleRecipeCount =
@@ -33,6 +45,24 @@ export function RecipeBoxView() {
       ? countState.count
       : null;
   const recipeCountLabel = formatRecipeCount(visibleRecipeCount);
+  const catalogStats = useMemo(() => {
+    if (
+      isPending ||
+      catalogStatsState?.userId !== sessionUserId ||
+      recipeCountLabel == null
+    ) {
+      return null;
+    }
+    const { cuisineCount, ingredientCount, equipmentCount } = catalogStatsState;
+    return [
+      recipeCountLabel,
+      cuisineCount > 0
+        ? `${cuisineCount.toLocaleString()} ${cuisineCount === 1 ? "cuisine" : "cuisines"}`
+        : null,
+      `${ingredientCount.toLocaleString()} ${ingredientCount === 1 ? "ingredient" : "ingredients"}`,
+      `${equipmentCount.toLocaleString()} ${equipmentCount === 1 ? "tool" : "tools"}`,
+    ].filter((stat): stat is string => stat != null);
+  }, [catalogStatsState, isPending, recipeCountLabel, sessionUserId]);
 
   return (
     <div className="container mx-auto min-h-screen max-w-7xl px-4 pt-5 pb-10 md:pt-7 md:pb-14">
@@ -43,13 +73,20 @@ export function RecipeBoxView() {
             What's <span className="text-[var(--terracotta)]">cooking?</span>
           </h1>
           <div className="rt-body mt-3 flex flex-wrap gap-x-2 gap-y-1 text-base leading-snug text-[var(--ink-2)] sm:text-lg">
-            {recipeCountLabel == null ? (
+            {catalogStats == null ? (
               <Skeleton
-                aria-label="Loading recipe count"
+                aria-label="Loading recipe stats"
                 className="h-5 w-52"
               />
             ) : (
-              <span className="whitespace-nowrap">{recipeCountLabel}</span>
+              catalogStats.map((stat, index) => (
+                <span key={stat} className="whitespace-nowrap">
+                  {stat}
+                  {index < catalogStats.length - 1 && (
+                    <span className="text-[var(--ink-3)]"> ·</span>
+                  )}
+                </span>
+              ))
             )}
           </div>
         </div>
@@ -57,7 +94,10 @@ export function RecipeBoxView() {
       </div>
 
       <Suspense fallback={<CardGridSkeleton variant="filters" />}>
-        <RecipeCollection onDietVisibleCountChange={updateVisibleRecipeCount} />
+        <RecipeCollection
+          onCatalogStatsChange={updateCatalogStats}
+          onDietVisibleCountChange={updateVisibleRecipeCount}
+        />
       </Suspense>
     </div>
   );

--- a/ui/components/recipes/recipe-collection.tsx
+++ b/ui/components/recipes/recipe-collection.tsx
@@ -12,6 +12,7 @@ import {
   type SavedRecipeApiRecord,
   savedRecipeCard,
 } from "@/lib/domain/recipe/recipeDraft";
+import type { RecipeCatalogStats } from "@/lib/domain/recipe/recipeViews";
 
 type RecipeCollectionState = {
   userId: string | null;
@@ -22,8 +23,10 @@ type RecipeCollectionState = {
 };
 
 export function RecipeCollection({
+  onCatalogStatsChange,
   onDietVisibleCountChange,
 }: Readonly<{
+  onCatalogStatsChange?: (stats: RecipeCatalogStats) => void;
   onDietVisibleCountChange?: (count: number) => void;
 }>) {
   const { data: session, isPending } = authClient.useSession();
@@ -101,6 +104,30 @@ export function RecipeCollection({
       }),
     [saved],
   );
+  const catalogStats = useMemo(
+    () => ({
+      cuisineCount: new Set(combined.flatMap((recipe) => recipe.cuisine)).size,
+      ingredientCount: new Set(
+        combined.flatMap((recipe) => recipe.ingredientNames),
+      ).size,
+      equipmentCount: new Set(combined.flatMap((recipe) => recipe.cookware))
+        .size,
+    }),
+    [combined],
+  );
+
+  useEffect(() => {
+    if (!sessionUserId || !stateMatchesSession || state.status !== "ready") {
+      return;
+    }
+    onCatalogStatsChange?.(catalogStats);
+  }, [
+    catalogStats,
+    onCatalogStatsChange,
+    sessionUserId,
+    state.status,
+    stateMatchesSession,
+  ]);
 
   if (isPending || personalizationLoading) {
     return (

--- a/ui/lib/domain/recipe/recipeViews.ts
+++ b/ui/lib/domain/recipe/recipeViews.ts
@@ -2,6 +2,12 @@ import type { IngredientSlug } from "./ingredient";
 import type { RecipeInstructionSdk } from "./recipe";
 import type { Unit } from "./unit";
 
+export type RecipeCatalogStats = {
+  cuisineCount: number;
+  ingredientCount: number;
+  equipmentCount: number;
+};
+
 export type RecipeIngredientView = {
   ingredient: IngredientSlug;
   name: string;

--- a/ui/tests/components/recipes/recipe-box-view.test.tsx
+++ b/ui/tests/components/recipes/recipe-box-view.test.tsx
@@ -19,11 +19,27 @@ vi.mock("@/components/recipes/add-recipe-button", () => ({
 
 vi.mock("@/components/recipes/recipe-collection", () => ({
   RecipeCollection: ({
+    onCatalogStatsChange,
     onDietVisibleCountChange,
   }: {
+    onCatalogStatsChange?: (stats: {
+      cuisineCount: number;
+      ingredientCount: number;
+      equipmentCount: number;
+    }) => void;
     onDietVisibleCountChange?: (count: number) => void;
   }) => (
-    <button type="button" onClick={() => onDietVisibleCountChange?.(7)}>
+    <button
+      type="button"
+      onClick={() => {
+        onDietVisibleCountChange?.(7);
+        onCatalogStatsChange?.({
+          cuisineCount: 2,
+          ingredientCount: 18,
+          equipmentCount: 6,
+        });
+      }}
+    >
       Report visible recipes
     </button>
   ),
@@ -47,6 +63,9 @@ describe("RecipeBoxView", () => {
       screen.getByRole("button", { name: "Report visible recipes" }),
     );
     expect(screen.getByText("7 recipes")).toBeInTheDocument();
+    expect(screen.getByText("2 cuisines")).toBeInTheDocument();
+    expect(screen.getByText("18 ingredients")).toBeInTheDocument();
+    expect(screen.getByText("6 tools")).toBeInTheDocument();
 
     mocks.session = {
       data: { user: { id: "user-2" } },
@@ -55,6 +74,7 @@ describe("RecipeBoxView", () => {
     view.rerender(<RecipeBoxView />);
 
     expect(screen.queryByText("7 recipes")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Loading recipe count")).toBeInTheDocument();
+    expect(screen.queryByText("2 cuisines")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Loading recipe stats")).toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/recipe-box-view.test.tsx
+++ b/ui/tests/components/recipes/recipe-box-view.test.tsx
@@ -7,6 +7,12 @@ const mocks = vi.hoisted(() => ({
     data: { user: { id: "user-1" } },
     isPending: false,
   },
+  visibleRecipeCount: 7,
+  catalogStats: {
+    cuisineCount: 2,
+    ingredientCount: 18,
+    equipmentCount: 6,
+  },
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -32,12 +38,8 @@ vi.mock("@/components/recipes/recipe-collection", () => ({
     <button
       type="button"
       onClick={() => {
-        onDietVisibleCountChange?.(7);
-        onCatalogStatsChange?.({
-          cuisineCount: 2,
-          ingredientCount: 18,
-          equipmentCount: 6,
-        });
+        onDietVisibleCountChange?.(mocks.visibleRecipeCount);
+        onCatalogStatsChange?.(mocks.catalogStats);
       }}
     >
       Report visible recipes
@@ -52,6 +54,12 @@ describe("RecipeBoxView", () => {
     mocks.session = {
       data: { user: { id: "user-1" } },
       isPending: false,
+    };
+    mocks.visibleRecipeCount = 7;
+    mocks.catalogStats = {
+      cuisineCount: 2,
+      ingredientCount: 18,
+      equipmentCount: 6,
     };
   });
 
@@ -76,5 +84,43 @@ describe("RecipeBoxView", () => {
     expect(screen.queryByText("7 recipes")).not.toBeInTheDocument();
     expect(screen.queryByText("2 cuisines")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Loading recipe stats")).toBeInTheDocument();
+  });
+
+  it("hides a zero cuisine count while showing populated stats", async () => {
+    const user = userEvent.setup();
+    mocks.catalogStats = {
+      cuisineCount: 0,
+      ingredientCount: 18,
+      equipmentCount: 6,
+    };
+
+    render(<RecipeBoxView />);
+    await user.click(
+      screen.getByRole("button", { name: "Report visible recipes" }),
+    );
+
+    expect(screen.queryByText("0 cuisines")).not.toBeInTheDocument();
+    expect(screen.getByText("18 ingredients")).toBeInTheDocument();
+    expect(screen.getByText("6 tools")).toBeInTheDocument();
+  });
+
+  it("shows only the recipe count when every catalog stat is zero", async () => {
+    const user = userEvent.setup();
+    mocks.visibleRecipeCount = 0;
+    mocks.catalogStats = {
+      cuisineCount: 0,
+      ingredientCount: 0,
+      equipmentCount: 0,
+    };
+
+    render(<RecipeBoxView />);
+    await user.click(
+      screen.getByRole("button", { name: "Report visible recipes" }),
+    );
+
+    expect(screen.getByText("0 recipes")).toBeInTheDocument();
+    expect(screen.queryByText("0 cuisines")).not.toBeInTheDocument();
+    expect(screen.queryByText("0 ingredients")).not.toBeInTheDocument();
+    expect(screen.queryByText("0 tools")).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/recipe-collection.test.tsx
+++ b/ui/tests/components/recipes/recipe-collection.test.tsx
@@ -20,16 +20,23 @@ vi.mock("@/lib/api/saved-recipes", () => ({
 }));
 
 vi.mock("@/lib/domain/recipe/recipeDraft", () => ({
-  savedRecipeCard: (record: { slug: string; title: string }) => ({
+  savedRecipeCard: (record: {
+    slug: string;
+    title: string;
+    cuisine?: string[];
+    ingredientNames?: string[];
+    ingredientSlugs?: string[];
+    cookware?: string[];
+  }) => ({
     ...record,
     description: "Saved recipe",
     date: "2026-07-19",
-    cuisine: [],
+    cuisine: record.cuisine ?? [],
     tags: [],
     servings: 2,
-    ingredientNames: [],
-    ingredientSlugs: [],
-    cookware: [],
+    ingredientNames: record.ingredientNames ?? [],
+    ingredientSlugs: record.ingredientSlugs ?? [],
+    cookware: record.cookware ?? [],
   }),
 }));
 
@@ -128,5 +135,37 @@ describe("RecipeCollection", () => {
     expect(
       await screen.findByText("Recipes: Selected starter"),
     ).toBeInTheDocument();
+  });
+
+  it("reports unique catalog stats from the loaded recipe box", async () => {
+    const onCatalogStatsChange = vi.fn();
+    mocks.fetchRecipeBoxRecipes.mockResolvedValue({
+      recipes: [
+        {
+          slug: "pasta",
+          title: "Pasta",
+          cuisine: ["Italian"],
+          ingredientNames: ["tomato", "pasta"],
+          cookware: ["pot", "spoon"],
+        },
+        {
+          slug: "soup",
+          title: "Soup",
+          cuisine: ["Italian", "French"],
+          ingredientNames: ["tomato", "stock"],
+          cookware: ["pot", "ladle"],
+        },
+      ],
+      box: { completed: true, recipeSlugs: [] },
+    });
+
+    render(<RecipeCollection onCatalogStatsChange={onCatalogStatsChange} />);
+
+    await screen.findByText("Recipes: Pasta, Soup");
+    expect(onCatalogStatsChange).toHaveBeenCalledWith({
+      cuisineCount: 2,
+      ingredientCount: 3,
+      equipmentCount: 3,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- derive unique cuisine, ingredient, and equipment totals from the dynamically loaded recipe box
- restore the catalog stats alongside the diet-visible recipe count in the recipe box header
- prevent stale stats from appearing while switching accounts
- add coverage for unique aggregation and header rendering

## Testing

- `mise //ui:check` (633 tests passed, type-check and formatting/lint checks passed)
