### PR TITLE
Unify database recipe routes and fix navigation 404s

### DIFF
--- a/functions/lib/public-recipes.ts
+++ b/functions/lib/public-recipes.ts
@@ -13,11 +13,16 @@ export type StoredRecipe = {
   title: string;
   description: string | null;
   body: string | null;
+  visibility: "public" | "private" | "household";
   createdAt?: string;
   updatedAt?: string;
 };
 
 export type RecipePayload = SavedRecipePayload;
+export type LoadedRecipe = {
+  record: StoredRecipe;
+  payload: RecipePayload;
+};
 
 const API_TIMEOUT_MS = 5_000;
 const PAGE_LIMIT = 100;
@@ -31,6 +36,12 @@ function isOptionalString(value: unknown): value is string | undefined {
   return value === undefined || typeof value === "string";
 }
 
+function isRecipeVisibility(
+  value: unknown,
+): value is StoredRecipe["visibility"] {
+  return value === "public" || value === "private" || value === "household";
+}
+
 function isStoredRecipe(value: unknown): value is StoredRecipe {
   return (
     isRecord(value) &&
@@ -38,6 +49,7 @@ function isStoredRecipe(value: unknown): value is StoredRecipe {
     typeof value.title === "string" &&
     (value.description === null || typeof value.description === "string") &&
     (value.body === null || typeof value.body === "string") &&
+    isRecipeVisibility(value.visibility) &&
     isOptionalString(value.createdAt) &&
     isOptionalString(value.updatedAt)
   );
@@ -67,17 +79,38 @@ export function decodeRecipePayload(record: StoredRecipe): RecipePayload | null 
   }
 }
 
+export async function decodeRecipeResponse(
+  response: Response,
+): Promise<LoadedRecipe | null> {
+  if (!response.ok) return null;
+  try {
+    const result: unknown = await response.json();
+    if (!isStoredRecipe(result)) return null;
+    const payload = decodeRecipePayload(result);
+    return payload ? { record: result, payload } : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function loadPublicRecipe(
   env: PublicRecipeEnv,
   slug: string,
-): Promise<{ record: StoredRecipe; payload: RecipePayload } | null> {
+): Promise<LoadedRecipe | null> {
   if (!env.RECIPE_API_URL) return null;
-  const result = await fetchApiJson(
-    new URL(`/recipes/${slug}`, env.RECIPE_API_URL),
-  );
-  if (!isStoredRecipe(result)) return null;
-  const payload = decodeRecipePayload(result);
-  return payload ? { record: result, payload } : null;
+  try {
+    const response = await fetch(
+      new URL(`/recipes/${slug}`, env.RECIPE_API_URL),
+      {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+      },
+    );
+    const loaded = await decodeRecipeResponse(response);
+    return loaded?.record.visibility === "public" ? loaded : null;
+  } catch {
+    return null;
+  }
 }
 
 export async function listPublicRecipes(
@@ -94,7 +127,12 @@ export async function listPublicRecipes(
     if (cursor) apiUrl.searchParams.set("cursor", cursor);
     const result = await fetchApiJson(apiUrl);
     if (!isRecord(result) || !Array.isArray(result.items)) return null;
-    recipes.push(...result.items.filter(isStoredRecipe));
+    recipes.push(
+      ...result.items.filter(
+        (item): item is StoredRecipe =>
+          isStoredRecipe(item) && item.visibility === "public",
+      ),
+    );
 
     const nextCursor = result.nextCursor;
     if (nextCursor === null) return recipes;

--- a/functions/lib/recipe-asset.ts
+++ b/functions/lib/recipe-asset.ts
@@ -6,13 +6,16 @@ export interface RecipeAssetContext {
   env: PublicRecipeEnv & { ASSETS: { fetch: typeof fetch } };
 }
 
-export function rewrittenRecipeAssetHeaders(asset: Response): Headers {
+export function rewrittenRecipeAssetHeaders(
+  asset: Response,
+  cacheControl = "public, max-age=60, s-maxage=300",
+): Headers {
   const headers = new Headers(asset.headers);
   headers.delete("content-length");
   headers.delete("content-encoding");
   headers.delete("etag");
   headers.delete("last-modified");
-  headers.set("cache-control", "public, max-age=60, s-maxage=300");
+  headers.set("cache-control", cacheControl);
   return headers;
 }
 

--- a/functions/recipes/[[path]].ts
+++ b/functions/recipes/[[path]].ts
@@ -6,14 +6,18 @@ import {
 } from "recipe-domain/serialization";
 import { isRecipeAppRouteSlug } from "recipe-domain/slugs";
 import {
+  proxyRecipeApiRequest,
+  type RecipeApiProxyEnv,
+} from "../api/auth/routing";
+import {
+  decodeRecipeResponse,
   loadPublicRecipe,
-  type PublicRecipeEnv,
   type RecipePayload,
   recipeMarkdown,
 } from "../lib/public-recipes";
 import { rewrittenRecipeAssetHeaders } from "../lib/recipe-asset";
 
-interface Env extends PublicRecipeEnv {
+interface Env extends RecipeApiProxyEnv {
   ASSETS: { fetch: typeof fetch };
 }
 
@@ -76,9 +80,18 @@ export const onRequest = async (context: Context): Promise<Response> => {
   }
 
   if (!extension) {
-    const loaded = await loadPublicRecipe(context.env, slug);
+    const apiRequest = new Request(context.request.url, {
+      method: "GET",
+      headers: context.request.headers,
+    });
+    const apiResponse = await proxyRecipeApiRequest(
+      { request: apiRequest, env: context.env },
+      "Recipe pages are available on the canonical PR preview URL only",
+    );
+    const loaded = await decodeRecipeResponse(apiResponse);
     if (!loaded) return new Response("Not found", { status: 404 });
     if (
+      loaded.record.visibility === "public" &&
       (context.request.headers.get("accept") ?? "").includes("text/markdown")
     ) {
       return textResponse(recipeMarkdown(loaded.payload), "text/markdown");
@@ -98,17 +111,18 @@ export const onRequest = async (context: Context): Promise<Response> => {
       loaded.payload.recipe.description ||
       loaded.record.description ||
       loaded.payload.recipe.title;
-    const canonicalHref = escapeHtmlAttribute(
-      `${url.origin}/recipes/${slug}`,
-    );
-    const headMarkup =
-      `<link rel="canonical" href="${canonicalHref}">` +
-      `<script type="application/ld+json">${recipeJsonLd(
-        loaded.payload,
-        url,
-        slug,
-      ).trim()}</script>`;
-    const html = (await asset.text())
+    const isPublic = loaded.record.visibility === "public";
+    const headMarkup = isPublic
+      ? `<link rel="canonical" href="${escapeHtmlAttribute(
+          `${url.origin}/recipes/${slug}`,
+        )}">` +
+        `<script type="application/ld+json">${recipeJsonLd(
+          loaded.payload,
+          url,
+          slug,
+        ).trim()}</script>`
+      : "";
+    let html = (await asset.text())
       .replace(
         /<title>[\s\S]*?<\/title>/,
         `<title>${escapeHtmlText(loaded.payload.recipe.title)}</title>`,
@@ -117,9 +131,16 @@ export const onRequest = async (context: Context): Promise<Response> => {
         /<meta name="description" content="[^"]*"\s*\/?>/i,
         `<meta name="description" content="${escapeHtmlAttribute(description)}">`,
       )
-      .replace(/<meta name="robots"[^>]*>/i, "")
       .replace("</head>", `${headMarkup}</head>`);
-    const headers = rewrittenRecipeAssetHeaders(asset);
+    if (isPublic) {
+      html = html.replace(/<meta name="robots"[^>]*>/i, "");
+    }
+    const headers = rewrittenRecipeAssetHeaders(
+      asset,
+      isPublic
+        ? "public, max-age=60, s-maxage=300"
+        : "private, no-store",
+    );
     return new Response(html, { status: asset.status, headers });
   }
 

--- a/functions/recipes/[[path]].ts
+++ b/functions/recipes/[[path]].ts
@@ -96,6 +96,7 @@ export const onRequest = async (context: Context): Promise<Response> => {
     ) {
       return textResponse(recipeMarkdown(loaded.payload), "text/markdown");
     }
+    const isPublic = loaded.record.visibility === "public";
     const assetUrl = new URL("/recipes/saved.html", url);
     const assetHeaders = new Headers(context.request.headers);
     assetHeaders.delete("if-none-match");
@@ -106,12 +107,20 @@ export const onRequest = async (context: Context): Promise<Response> => {
         headers: assetHeaders,
       }),
     );
-    if (!asset.ok || context.request.method === "HEAD") return asset;
+    if (!asset.ok) return asset;
+    const headers = rewrittenRecipeAssetHeaders(
+      asset,
+      isPublic
+        ? "public, max-age=60, s-maxage=300"
+        : "private, no-store",
+    );
+    if (context.request.method === "HEAD") {
+      return new Response(null, { status: asset.status, headers });
+    }
     const description =
       loaded.payload.recipe.description ||
       loaded.record.description ||
       loaded.payload.recipe.title;
-    const isPublic = loaded.record.visibility === "public";
     const headMarkup = isPublic
       ? `<link rel="canonical" href="${escapeHtmlAttribute(
           `${url.origin}/recipes/${slug}`,
@@ -135,12 +144,6 @@ export const onRequest = async (context: Context): Promise<Response> => {
     if (isPublic) {
       html = html.replace(/<meta name="robots"[^>]*>/i, "");
     }
-    const headers = rewrittenRecipeAssetHeaders(
-      asset,
-      isPublic
-        ? "public, max-age=60, s-maxage=300"
-        : "private, no-store",
-    );
     return new Response(html, { status: asset.status, headers });
   }
 

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/recipes/photo-recipe-import";
 import { RecipeContent } from "@/components/recipes/recipe-content";
 import { RecipeLoadError } from "@/components/recipes/recipe-load-state";
+import { navigateToRecipePage } from "@/components/recipes/recipe-page-link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useCooklangRecipe } from "@/hooks/use-cooklang-recipe";
@@ -40,7 +41,6 @@ import {
   normalizeRecipeSource,
   parseSavedRecipePayload,
   type SavedRecipeApiRecord,
-  savedRecipeHref,
   serializeSavedRecipe,
 } from "@/lib/domain/recipe/recipeDraft";
 import { recipeSaveReturnPath } from "@/lib/generic/safe-return-path";
@@ -398,7 +398,7 @@ export function AddRecipeView({
       }
       const saved = (await response.json()) as { slug: string };
       if (initialRecipe) {
-        router.push(savedRecipeHref({ slug: saved.slug, visibility }));
+        navigateToRecipePage(saved);
         return;
       }
       const returnTo = new URLSearchParams(window.location.search).get(
@@ -409,9 +409,11 @@ export function AddRecipeView({
         saved.slug,
         window.location.origin,
       );
-      router.push(
-        safeReturnTo ?? `/recipes/saved?slug=${encodeURIComponent(saved.slug)}`,
-      );
+      if (safeReturnTo) {
+        router.push(safeReturnTo);
+      } else {
+        navigateToRecipePage(saved);
+      }
     } catch (error) {
       setSaveError(
         error instanceof Error

--- a/ui/components/recipes/auth-button.tsx
+++ b/ui/components/recipes/auth-button.tsx
@@ -31,6 +31,15 @@ type PreviewScenario = {
   description: string;
 };
 
+export function redirectAfterSignOut(
+  _context?: unknown,
+  replace: (url: string) => void = window.location.replace.bind(
+    window.location,
+  ),
+) {
+  replace("/recipes");
+}
+
 function authPrompt(
   isPreview: boolean,
   previewBackendDisabled: boolean,
@@ -194,7 +203,7 @@ export function AuthButton({
     setError(null);
     try {
       const result = await authClient.signOut({
-        fetchOptions: { onSuccess: () => window.location.reload() },
+        fetchOptions: { onSuccess: redirectAfterSignOut },
       });
       if (result?.error) {
         setError(result.error.message ?? "Sign-out failed. Please try again.");

--- a/ui/components/recipes/discover-feed.tsx
+++ b/ui/components/recipes/discover-feed.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Globe2, Home, LoaderCircle, UtensilsCrossed } from "lucide-react";
-import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { RecipeThumb } from "@/components/recipes/recipe-card";
+import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import { Button } from "@/components/ui/button";
 import {
   type DiscoverFeedItem,
@@ -68,8 +68,8 @@ function FeedCard({ item }: Readonly<{ item: DiscoverFeedItem }>) {
           </time>
         </div>
       </header>
-      <Link
-        href={`/recipes/saved?slug=${encodeURIComponent(item.recipe.slug)}`}
+      <RecipePageLink
+        href={`/recipes/${encodeURIComponent(item.recipe.slug)}`}
         className="group flex gap-4 border-t border-[var(--line)] p-4 transition-colors hover:bg-[var(--paper-warm)]/60 sm:p-5"
       >
         {recipe ? (
@@ -92,7 +92,7 @@ function FeedCard({ item }: Readonly<{ item: DiscoverFeedItem }>) {
             </p>
           ) : null}
         </div>
-      </Link>
+      </RecipePageLink>
     </article>
   );
 }

--- a/ui/components/recipes/logged-out-landing.tsx
+++ b/ui/components/recipes/logged-out-landing.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { AuthButton } from "@/components/recipes/auth-button";
 import { RecipeThumb, recipeMetaLabel } from "@/components/recipes/recipe-card";
 import { RecipeList } from "@/components/recipes/recipe-list";
+import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import type { RecipeCardView } from "@/lib/api/recipes";
 
 const steps = [
@@ -98,7 +99,7 @@ export function LoggedOutLanding({
             </div>
             <div className="mt-2 divide-y divide-dashed divide-[var(--line)]">
               {previewRecipes.map((recipe, index) => (
-                <Link
+                <RecipePageLink
                   key={recipe.slug}
                   href={`/recipes/${recipe.slug}`}
                   className="group flex items-center gap-4 py-4"
@@ -116,7 +117,7 @@ export function LoggedOutLanding({
                     </p>
                   </div>
                   <ArrowRight className="size-4 shrink-0 text-[var(--ink-3)] transition-transform group-hover:translate-x-1 group-hover:text-[var(--terracotta)]" />
-                </Link>
+                </RecipePageLink>
               ))}
             </div>
             <Link

--- a/ui/components/recipes/logged-out-landing.tsx
+++ b/ui/components/recipes/logged-out-landing.tsx
@@ -11,6 +11,7 @@ import { RecipeThumb, recipeMetaLabel } from "@/components/recipes/recipe-card";
 import { RecipeList } from "@/components/recipes/recipe-list";
 import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import type { RecipeCardView } from "@/lib/api/recipes";
+import { recipePageHref } from "@/lib/domain/recipe/recipeDraft";
 
 const steps = [
   {
@@ -101,7 +102,7 @@ export function LoggedOutLanding({
               {previewRecipes.map((recipe, index) => (
                 <RecipePageLink
                   key={recipe.slug}
-                  href={`/recipes/${recipe.slug}`}
+                  href={recipePageHref(recipe)}
                   className="group flex items-center gap-4 py-4"
                 >
                   <RecipeThumb recipe={recipe} size={72} />

--- a/ui/components/recipes/public-cooks-view.tsx
+++ b/ui/components/recipes/public-cooks-view.tsx
@@ -6,6 +6,7 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { RecipeAvatar } from "@/components/recipes/recipe-avatar";
 import { RecipeThumb } from "@/components/recipes/recipe-card";
+import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import { Button } from "@/components/ui/button";
 import {
   getPublicCook,
@@ -78,9 +79,9 @@ function CookProfile({ cook }: Readonly<{ cook: PublicCookProfile }>) {
         {cook.activity.map((item) => {
           const recipe = savedRecipeCard(item.recipe);
           return (
-            <Link
+            <RecipePageLink
               key={`${item.recipe.slug}-${item.createdAt}`}
-              href={`/recipes/saved?slug=${encodeURIComponent(item.recipe.slug)}`}
+              href={`/recipes/${encodeURIComponent(item.recipe.slug)}`}
               className="group flex items-center gap-4 rounded-xl border border-[var(--line-strong)] bg-[var(--card)] p-4 shadow-[var(--paper-shadow)]"
             >
               {recipe ? (
@@ -96,7 +97,7 @@ function CookProfile({ cook }: Readonly<{ cook: PublicCookProfile }>) {
                   {item.recipe.title}
                 </h2>
               </div>
-            </Link>
+            </RecipePageLink>
           );
         })}
       </div>

--- a/ui/components/recipes/recipe-card.tsx
+++ b/ui/components/recipes/recipe-card.tsx
@@ -1,7 +1,7 @@
 import { Check, ChefHat, Plus } from "lucide-react";
-import Link from "next/link";
 import type { ReactNode } from "react";
 import { DietWarning } from "@/components/recipes/diet-notice";
+import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import type { DietMatch } from "@/lib/domain/diet";
@@ -124,7 +124,7 @@ export function RecipeMatchCard({
           className="absolute inset-0 cursor-pointer rounded-lg focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--ring)]/50"
         />
       ) : (
-        <Link
+        <RecipePageLink
           href={recipe.href ?? `/recipes/${recipe.slug}`}
           aria-label={`Open ${recipe.title}`}
           className="absolute inset-0 rounded-lg focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--ring)]/50"

--- a/ui/components/recipes/recipe-card.tsx
+++ b/ui/components/recipes/recipe-card.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import type { DietMatch } from "@/lib/domain/diet";
 import type { KitchenRecipeMatch } from "@/lib/domain/recipe/kitchen";
+import { recipePageHref } from "@/lib/domain/recipe/recipeDraft";
 import { cn } from "@/lib/generic/styles";
 import { getImageUrl } from "@/lib/integrations/cloudflare-images";
 
@@ -125,7 +126,7 @@ export function RecipeMatchCard({
         />
       ) : (
         <RecipePageLink
-          href={recipe.href ?? `/recipes/${recipe.slug}`}
+          href={recipe.href ?? recipePageHref(recipe)}
           aria-label={`Open ${recipe.title}`}
           className="absolute inset-0 rounded-lg focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--ring)]/50"
         />

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -8,7 +8,6 @@ import {
   Timer,
   UtensilsCrossed,
 } from "lucide-react";
-import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   memo,
@@ -21,6 +20,7 @@ import {
 } from "react";
 import { DietListNotice, DietWarning } from "@/components/recipes/diet-notice";
 import { useDiet } from "@/components/recipes/diet-provider";
+import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -235,7 +235,7 @@ const RecipeCard = memo(function RecipeCard({
   return (
     <Card className="h-full flex flex-col overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] gap-0 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]">
       {recipe.image && (
-        <Link href={href} className="block">
+        <RecipePageLink href={href} className="block">
           <div className="relative w-full h-48 bg-muted overflow-hidden">
             {/* biome-ignore lint/performance/noImgElement: Need native img for srcset control with SSG */}
             <img
@@ -251,14 +251,14 @@ const RecipeCard = memo(function RecipeCard({
               fetchPriority={index < 3 ? "high" : "auto"}
             />
           </div>
-        </Link>
+        </RecipePageLink>
       )}
       <CardHeader className="pt-4 pb-2 gap-1">
-        <Link href={href}>
+        <RecipePageLink href={href}>
           <CardTitle className="rt-display text-2xl leading-tight hover:text-[var(--terracotta)] transition-colors">
             {recipe.title}
           </CardTitle>
-        </Link>
+        </RecipePageLink>
         {recipe.saved && (
           <span className="rt-mono w-fit rounded-full bg-[var(--butter-soft)] px-2 py-0.5 text-[0.625rem] text-[var(--terracotta-deep)]">
             Your recipe

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -41,7 +41,10 @@ import {
   buildDietRecipeMatches,
   type DietMatch,
 } from "@/lib/domain/diet";
-import type { RecipeGridItem } from "@/lib/domain/recipe/recipeDraft";
+import {
+  type RecipeGridItem,
+  recipePageHref,
+} from "@/lib/domain/recipe/recipeDraft";
 import { formatRecipeTime } from "@/lib/domain/recipe/time";
 import { formatDate } from "@/lib/generic/date";
 import { cycleFilterFromCard } from "@/lib/generic/filter-cycle";
@@ -231,7 +234,7 @@ const RecipeCard = memo(function RecipeCard({
   onToggleTotalTime,
   dietMatch,
 }: RecipeCardProps) {
-  const href = recipe.href ?? `/recipes/${recipe.slug}`;
+  const href = recipe.href ?? recipePageHref(recipe);
   return (
     <Card className="h-full flex flex-col overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] gap-0 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]">
       {recipe.image && (

--- a/ui/components/recipes/recipe-page-link.tsx
+++ b/ui/components/recipes/recipe-page-link.tsx
@@ -10,7 +10,17 @@ type RecipePageLinkProps = Omit<ComponentPropsWithoutRef<"a">, "href"> & {
   href: string;
 };
 
-const RECIPE_PATH = /^\/recipes\/([a-z0-9]+(?:-[a-z0-9]+)*)$/;
+const RECIPE_PATH = /^\/recipes\/([^/]+)$/;
+
+function decodedRecipeSlug(href: string): string | null {
+  const segment = RECIPE_PATH.exec(href)?.[1];
+  if (!segment) return null;
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
 
 /**
  * Recipe detail pages are resolved by a Cloudflare Pages Function rather than
@@ -21,7 +31,7 @@ export function RecipePageLink({
   href,
   ...props
 }: Readonly<RecipePageLinkProps>) {
-  const slug = RECIPE_PATH.exec(href)?.[1];
+  const slug = decodedRecipeSlug(href);
   if (slug && !isRecipeAppRouteSlug(slug)) {
     return <a href={href} {...props} />;
   }

--- a/ui/components/recipes/recipe-page-link.tsx
+++ b/ui/components/recipes/recipe-page-link.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import type { ComponentPropsWithoutRef } from "react";
+
+type RecipePageLinkProps = Omit<ComponentPropsWithoutRef<"a">, "href"> & {
+  href: string;
+};
+
+const PUBLIC_RECIPE_PATH = /^\/recipes\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Public recipe pages are resolved by a Cloudflare Pages Function rather than
+ * Next's static route manifest. They therefore need a document navigation;
+ * Next's client router would otherwise resolve the runtime URL as a 404.
+ */
+export function RecipePageLink({
+  href,
+  ...props
+}: Readonly<RecipePageLinkProps>) {
+  if (PUBLIC_RECIPE_PATH.test(href)) {
+    return <a href={href} {...props} />;
+  }
+  return <Link href={href} {...props} />;
+}

--- a/ui/components/recipes/recipe-page-link.tsx
+++ b/ui/components/recipes/recipe-page-link.tsx
@@ -1,14 +1,19 @@
 import Link from "next/link";
 import type { ComponentPropsWithoutRef } from "react";
+import { isRecipeAppRouteSlug } from "recipe-domain/slugs";
+import {
+  recipePageHref,
+  type SavedRecipeApiRecord,
+} from "@/lib/domain/recipe/recipeDraft";
 
 type RecipePageLinkProps = Omit<ComponentPropsWithoutRef<"a">, "href"> & {
   href: string;
 };
 
-const PUBLIC_RECIPE_PATH = /^\/recipes\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const RECIPE_PATH = /^\/recipes\/([a-z0-9]+(?:-[a-z0-9]+)*)$/;
 
 /**
- * Public recipe pages are resolved by a Cloudflare Pages Function rather than
+ * Recipe detail pages are resolved by a Cloudflare Pages Function rather than
  * Next's static route manifest. They therefore need a document navigation;
  * Next's client router would otherwise resolve the runtime URL as a 404.
  */
@@ -16,8 +21,21 @@ export function RecipePageLink({
   href,
   ...props
 }: Readonly<RecipePageLinkProps>) {
-  if (PUBLIC_RECIPE_PATH.test(href)) {
+  const slug = RECIPE_PATH.exec(href)?.[1];
+  if (slug && !isRecipeAppRouteSlug(slug)) {
     return <a href={href} {...props} />;
   }
   return <Link href={href} {...props} />;
+}
+
+export function navigateToRecipePage(
+  recipe: Pick<SavedRecipeApiRecord, "slug">,
+) {
+  window.location.assign(recipePageHref(recipe));
+}
+
+export function replaceWithRecipePage(
+  recipe: Pick<SavedRecipeApiRecord, "slug">,
+) {
+  window.location.replace(recipePageHref(recipe));
 }

--- a/ui/components/recipes/recipe-pagination.tsx
+++ b/ui/components/recipes/recipe-pagination.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import type { RecipeCardView } from "@/lib/api/recipes";
+import { recipePageHref } from "@/lib/domain/recipe/recipeDraft";
 import { cn } from "@/lib/generic/styles";
 
 interface RecipePaginationProps {
@@ -35,7 +36,7 @@ export function RecipePagination({
       >
         {prevRecipe ? (
           <RecipePageLink
-            href={`/recipes/${prevRecipe.slug}`}
+            href={recipePageHref(prevRecipe)}
             className="block min-w-0"
           >
             <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">
@@ -57,7 +58,7 @@ export function RecipePagination({
 
         {nextRecipe ? (
           <RecipePageLink
-            href={`/recipes/${nextRecipe.slug}`}
+            href={recipePageHref(nextRecipe)}
             className="block min-w-0"
           >
             <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">

--- a/ui/components/recipes/recipe-pagination.tsx
+++ b/ui/components/recipes/recipe-pagination.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeft, ArrowRight } from "lucide-react";
-import Link from "next/link";
+import { RecipePageLink } from "@/components/recipes/recipe-page-link";
 import type { RecipeCardView } from "@/lib/api/recipes";
 import { cn } from "@/lib/generic/styles";
 
@@ -34,7 +34,10 @@ export function RecipePagination({
         )}
       >
         {prevRecipe ? (
-          <Link href={`/recipes/${prevRecipe.slug}`} className="block min-w-0">
+          <RecipePageLink
+            href={`/recipes/${prevRecipe.slug}`}
+            className="block min-w-0"
+          >
             <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">
               <ArrowLeft
                 aria-hidden="true"
@@ -49,11 +52,14 @@ export function RecipePagination({
                 </div>
               </div>
             </div>
-          </Link>
+          </RecipePageLink>
         ) : null}
 
         {nextRecipe ? (
-          <Link href={`/recipes/${nextRecipe.slug}`} className="block min-w-0">
+          <RecipePageLink
+            href={`/recipes/${nextRecipe.slug}`}
+            className="block min-w-0"
+          >
             <div className="flex h-full min-w-0 items-center gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3 transition-colors hover:bg-muted/40">
               <ArrowRight
                 aria-hidden="true"
@@ -68,7 +74,7 @@ export function RecipePagination({
                 </div>
               </div>
             </div>
-          </Link>
+          </RecipePageLink>
         ) : null}
       </div>
     </nav>

--- a/ui/components/recipes/saved-recipe-view.tsx
+++ b/ui/components/recipes/saved-recipe-view.tsx
@@ -38,7 +38,8 @@ export function SavedRecipeView() {
     const pathSlug = /^\/recipes\/([a-z0-9]+(?:-[a-z0-9]+)*)\/?$/.exec(
       pathname,
     )?.[1];
-    const slug = searchSlug ?? pathSlug;
+    const slug =
+      pathname === "/recipes/saved" ? searchSlug : (searchSlug ?? pathSlug);
     if (
       !slug ||
       slug.length > 120 ||
@@ -47,8 +48,8 @@ export function SavedRecipeView() {
       setState({ status: "error", message: "No saved recipe was selected." });
       return;
     }
-    if (pathname === "/recipes/saved") {
-      replaceWithRecipePage({ slug });
+    if (pathname === "/recipes/saved" && searchSlug) {
+      replaceWithRecipePage({ slug: searchSlug });
       return;
     }
     const controller = new AbortController();

--- a/ui/components/recipes/saved-recipe-view.tsx
+++ b/ui/components/recipes/saved-recipe-view.tsx
@@ -11,6 +11,7 @@ import {
   RecipeLoadError,
   RecipeLoading,
 } from "@/components/recipes/recipe-load-state";
+import { replaceWithRecipePage } from "@/components/recipes/recipe-page-link";
 import { Button } from "@/components/ui/button";
 import {
   parseSavedRecipe,
@@ -44,6 +45,10 @@ export function SavedRecipeView() {
       !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)
     ) {
       setState({ status: "error", message: "No saved recipe was selected." });
+      return;
+    }
+    if (pathname === "/recipes/saved") {
+      replaceWithRecipePage({ slug });
       return;
     }
     const controller = new AbortController();

--- a/ui/lib/api/recipes.ts
+++ b/ui/lib/api/recipes.ts
@@ -8,9 +8,9 @@ import type {
 import {
   parseSavedRecipe,
   type RecipeGridItem,
+  recipePageHref,
   type SavedRecipeApiRecord,
   savedRecipeCard,
-  savedRecipeHref,
 } from "@/lib/domain/recipe/recipeDraft";
 import type { RecipeDetailView } from "@/lib/domain/recipe/recipeViews";
 
@@ -80,7 +80,7 @@ export function buildKitchenCatalog(records: SavedRecipeApiRecord[]): {
     }
     return {
       slug: recipe.slug,
-      href: savedRecipeHref(record),
+      href: recipePageHref(record),
       title: recipe.title,
       cuisine: recipe.cuisine,
       totalTime: recipe.totalTime,

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -165,13 +165,10 @@ export type RecipeGridItem = RecipeCardView & {
   saved?: boolean;
 };
 
-export function savedRecipeHref(
-  record: Pick<SavedRecipeApiRecord, "slug" | "visibility">,
+export function recipePageHref(
+  record: Pick<SavedRecipeApiRecord, "slug">,
 ): string {
-  const slug = encodeURIComponent(record.slug);
-  return record.visibility === "public"
-    ? `/recipes/${slug}`
-    : `/recipes/saved?slug=${slug}`;
+  return `/recipes/${encodeURIComponent(record.slug)}`;
 }
 
 export function savedRecipeCard(
@@ -197,7 +194,7 @@ export function savedRecipeCard(
     ...recipe,
     ingredientNames,
     ingredientSlugs,
-    href: savedRecipeHref(record),
+    href: recipePageHref(record),
     saved: true,
   };
 }

--- a/ui/tests/components/recipes/add-recipe-view.test.tsx
+++ b/ui/tests/components/recipes/add-recipe-view.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getHouseholds: vi.fn(),
+  navigateToRecipePage: vi.fn(),
   routerPush: vi.fn(),
   useCooklangRecipe: vi.fn(),
   useSession: vi.fn(),
@@ -19,6 +20,10 @@ vi.mock("@/lib/auth-client", () => ({
 
 vi.mock("@/lib/api/households", () => ({
   getHouseholds: mocks.getHouseholds,
+}));
+
+vi.mock("@/components/recipes/recipe-page-link", () => ({
+  navigateToRecipePage: mocks.navigateToRecipePage,
 }));
 
 vi.mock("@/hooks/use-cooklang-recipe", () => ({
@@ -188,9 +193,9 @@ describe("AddRecipeView visibility", () => {
     ]);
     expect(JSON.parse(requestBody.body).recipe.canonical).toBe(canonical);
     expect(JSON.parse(requestBody.body).recipe.date).toBe("2025-05-04");
-    expect(mocks.routerPush).toHaveBeenCalledWith(
-      "/recipes/saved?slug=weeknight-rice",
-    );
+    expect(mocks.navigateToRecipePage).toHaveBeenCalledWith({
+      slug: "weeknight-rice",
+    });
   });
 
   it("disables editing when the saved recipe body is unreadable", () => {

--- a/ui/tests/components/recipes/auth-button.test.tsx
+++ b/ui/tests/components/recipes/auth-button.test.tsx
@@ -25,7 +25,10 @@ vi.mock("@/lib/preview-environment", () => ({
   isPreviewDeployment: mocks.isPreviewDeployment,
 }));
 
-import { AuthButton } from "@/components/recipes/auth-button";
+import {
+  AuthButton,
+  redirectAfterSignOut,
+} from "@/components/recipes/auth-button";
 
 describe("AuthButton", () => {
   beforeEach(() => {
@@ -257,7 +260,17 @@ describe("AuthButton", () => {
 
     await user.click(screen.getByRole("button", { name: "Sign out" }));
 
-    expect(mocks.signOut).toHaveBeenCalledOnce();
+    expect(mocks.signOut).toHaveBeenCalledWith({
+      fetchOptions: { onSuccess: redirectAfterSignOut },
+    });
+  });
+
+  it("redirects successful sign-out to the recipe home", () => {
+    const replace = vi.fn();
+
+    redirectAfterSignOut(undefined, replace);
+
+    expect(replace).toHaveBeenCalledWith("/recipes");
   });
 
   it("shows an error when sign out fails", async () => {

--- a/ui/tests/components/recipes/recipe-page-link.test.tsx
+++ b/ui/tests/components/recipes/recipe-page-link.test.tsx
@@ -32,6 +32,18 @@ describe("RecipePageLink", () => {
     expect(link).not.toHaveAttribute("data-next-link");
   });
 
+  it("uses a document navigation for encoded runtime recipe slugs", () => {
+    render(
+      <RecipePageLink href="/recipes/weeknight%20rice">
+        Weeknight Rice
+      </RecipePageLink>,
+    );
+
+    const link = screen.getByRole("link", { name: "Weeknight Rice" });
+    expect(link).toHaveAttribute("href", "/recipes/weeknight%20rice");
+    expect(link).not.toHaveAttribute("data-next-link");
+  });
+
   it("keeps static application routes on Next client navigation", () => {
     render(<RecipePageLink href="/recipes/discover">Discover</RecipePageLink>);
 

--- a/ui/tests/components/recipes/recipe-page-link.test.tsx
+++ b/ui/tests/components/recipes/recipe-page-link.test.tsx
@@ -33,14 +33,10 @@ describe("RecipePageLink", () => {
   });
 
   it("keeps static application routes on Next client navigation", () => {
-    render(
-      <RecipePageLink href="/recipes/saved?slug=weeknight-rice">
-        Weeknight Rice
-      </RecipePageLink>,
-    );
+    render(<RecipePageLink href="/recipes/discover">Discover</RecipePageLink>);
 
-    const link = screen.getByRole("link", { name: "Weeknight Rice" });
-    expect(link).toHaveAttribute("href", "/recipes/saved?slug=weeknight-rice");
+    const link = screen.getByRole("link", { name: "Discover" });
+    expect(link).toHaveAttribute("href", "/recipes/discover");
     expect(link).toHaveAttribute("data-next-link");
   });
 });

--- a/ui/tests/components/recipes/recipe-page-link.test.tsx
+++ b/ui/tests/components/recipes/recipe-page-link.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: ReactNode;
+    href: string;
+  }) => (
+    <a href={href} data-next-link="" {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import { RecipePageLink } from "@/components/recipes/recipe-page-link";
+
+describe("RecipePageLink", () => {
+  it("uses a document navigation for runtime public recipe pages", () => {
+    render(
+      <RecipePageLink href="/recipes/weeknight-rice">
+        Weeknight Rice
+      </RecipePageLink>,
+    );
+
+    const link = screen.getByRole("link", { name: "Weeknight Rice" });
+    expect(link).toHaveAttribute("href", "/recipes/weeknight-rice");
+    expect(link).not.toHaveAttribute("data-next-link");
+  });
+
+  it("keeps static application routes on Next client navigation", () => {
+    render(
+      <RecipePageLink href="/recipes/saved?slug=weeknight-rice">
+        Weeknight Rice
+      </RecipePageLink>,
+    );
+
+    const link = screen.getByRole("link", { name: "Weeknight Rice" });
+    expect(link).toHaveAttribute("href", "/recipes/saved?slug=weeknight-rice");
+    expect(link).toHaveAttribute("data-next-link");
+  });
+});

--- a/ui/tests/components/recipes/saved-recipe-view.test.tsx
+++ b/ui/tests/components/recipes/saved-recipe-view.test.tsx
@@ -62,6 +62,7 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
   navigation.pathname = "/recipes/first-soup";
   navigation.search = "";
+  navigation.replaceWithRecipePage.mockReset();
   vi.restoreAllMocks();
 });
 
@@ -113,6 +114,19 @@ describe("SavedRecipeView", () => {
     expect(navigation.replaceWithRecipePage).toHaveBeenCalledWith({
       slug: "first-soup",
     });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect the saved-recipe route without a slug", async () => {
+    globalThis.fetch = vi.fn();
+    navigation.pathname = "/recipes/saved";
+
+    render(<SavedRecipeView />);
+
+    expect(
+      await screen.findByText("No saved recipe was selected."),
+    ).toBeInTheDocument();
+    expect(navigation.replaceWithRecipePage).not.toHaveBeenCalled();
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });

--- a/ui/tests/components/recipes/saved-recipe-view.test.tsx
+++ b/ui/tests/components/recipes/saved-recipe-view.test.tsx
@@ -1,11 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const navigation = vi.hoisted(() => ({ pathname: "/recipes/first-soup" }));
+const navigation = vi.hoisted(() => ({
+  pathname: "/recipes/first-soup",
+  replaceWithRecipePage: vi.fn(),
+  search: "",
+}));
 
 vi.mock("next/navigation", () => ({
   usePathname: () => navigation.pathname,
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => new URLSearchParams(navigation.search),
+}));
+
+vi.mock("@/components/recipes/recipe-page-link", () => ({
+  replaceWithRecipePage: navigation.replaceWithRecipePage,
 }));
 
 vi.mock("@/components/recipes/recipe-content", () => ({
@@ -53,6 +61,7 @@ function record(slug: string, title: string, owned = false) {
 afterEach(() => {
   globalThis.fetch = originalFetch;
   navigation.pathname = "/recipes/first-soup";
+  navigation.search = "";
   vi.restoreAllMocks();
 });
 
@@ -92,5 +101,18 @@ describe("SavedRecipeView", () => {
       "href",
       "/recipes/edit?slug=first-soup",
     );
+  });
+
+  it("redirects the legacy saved-recipe URL to the unified recipe path", () => {
+    globalThis.fetch = vi.fn();
+    navigation.pathname = "/recipes/saved";
+    navigation.search = "slug=first-soup";
+
+    render(<SavedRecipeView />);
+
+    expect(navigation.replaceWithRecipePage).toHaveBeenCalledWith({
+      slug: "first-soup",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });

--- a/ui/tests/functions/recipe-pages.test.ts
+++ b/ui/tests/functions/recipe-pages.test.ts
@@ -68,6 +68,7 @@ describe("dynamic recipe pages", () => {
         title: "Lentil Soup",
         description: "A useful soup.",
         body: JSON.stringify(payload),
+        visibility: "public",
       }),
     ) as typeof fetch;
 
@@ -88,6 +89,7 @@ describe("dynamic recipe pages", () => {
         title: "Lentil Soup",
         description: "A useful soup.",
         body: JSON.stringify(payload),
+        visibility: "public",
       }),
     ) as typeof fetch;
 
@@ -134,6 +136,7 @@ describe("dynamic recipe pages", () => {
         title: "Lentil Soup",
         description: "A useful soup.",
         body: JSON.stringify(detailedPayload),
+        visibility: "public",
       }),
     ) as typeof fetch;
 
@@ -163,6 +166,7 @@ describe("dynamic recipe pages", () => {
         title: "Lentil Soup",
         description: "A useful soup.",
         body: JSON.stringify(payload),
+        visibility: "public",
       }),
     ) as typeof fetch;
     const assetFetch = vi.fn(
@@ -189,6 +193,71 @@ describe("dynamic recipe pages", () => {
     expect(html).not.toContain("noindex");
   });
 
+  it.each(["private", "household"] as const)(
+    "serves an authorized %s recipe at its canonical path without indexing it",
+    async (visibility) => {
+      const apiFetch = vi.fn(async (request: Request) => {
+        expect(request.url).toBe(
+          "https://recipe-api.example.test/recipes/lentil-soup",
+        );
+        expect(request.headers.get("cookie")).toBe(
+          "better-auth.session_token=valid",
+        );
+        return Response.json({
+          slug: "lentil-soup",
+          title: "Lentil Soup",
+          description: "A useful soup.",
+          body: JSON.stringify(payload),
+          visibility,
+        });
+      });
+      globalThis.fetch = apiFetch as unknown as typeof fetch;
+      const assetFetch = vi.fn(
+        async () =>
+          new Response(
+            '<html><head><title>Saved Recipe</title><meta name="description" content="Saved"><meta name="robots" content="noindex, nofollow"></head><body></body></html>',
+          ),
+      ) as typeof fetch;
+
+      const response = await onRequest(
+        context(
+          "https://robbiepalmer.me/recipes/lentil-soup",
+          {
+            accept: "text/html",
+            cookie: "better-auth.session_token=valid",
+          },
+          assetFetch,
+        ),
+      );
+      const html = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("private, no-store");
+      expect(html).toContain("<title>Lentil Soup</title>");
+      expect(html).toContain('name="robots" content="noindex, nofollow"');
+      expect(html).not.toContain('rel="canonical"');
+      expect(html).not.toContain('type="application/ld+json"');
+    },
+  );
+
+  it("returns 404 when the visitor cannot read the requested recipe", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("Not found", { status: 404 }),
+    ) as typeof fetch;
+    const assetFetch = vi.fn() as unknown as typeof fetch;
+
+    const response = await onRequest(
+      context(
+        "https://robbiepalmer.me/recipes/private-soup",
+        { accept: "text/html" },
+        assetFetch,
+      ),
+    );
+
+    expect(response.status).toBe(404);
+    expect(assetFetch).not.toHaveBeenCalled();
+  });
+
   it("escapes HTML metadata and preserves the static asset response", async () => {
     const escapedPayload = structuredClone(payload);
     escapedPayload.recipe.title = '<Soup & "Stuff">';
@@ -199,6 +268,7 @@ describe("dynamic recipe pages", () => {
         title: escapedPayload.recipe.title,
         description: 'Stored "description" & <detail>',
         body: JSON.stringify(escapedPayload),
+        visibility: "public",
       }),
     ) as typeof fetch;
     const assetFetchMock = vi.fn(
@@ -255,6 +325,7 @@ describe("dynamic recipe pages", () => {
         title: "Lentil Soup",
         description: null,
         body: JSON.stringify(payload),
+        visibility: "public",
       }),
     ) as typeof fetch;
     const failedAsset = new Response("asset unavailable", { status: 503 });

--- a/ui/tests/functions/recipe-pages.test.ts
+++ b/ui/tests/functions/recipe-pages.test.ts
@@ -318,7 +318,7 @@ describe("dynamic recipe pages", () => {
     expect(html).toContain(String.raw`\u003cSoup & \"Stuff\">`);
   });
 
-  it("returns the static asset unchanged for HEAD and asset failures", async () => {
+  it("rewrites HEAD headers and returns asset failures unchanged", async () => {
     globalThis.fetch = vi.fn(async () =>
       Response.json({
         slug: "lentil-soup",
@@ -338,6 +338,15 @@ describe("dynamic recipe pages", () => {
     );
     expect(failedResponse).toBe(failedAsset);
 
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({
+        slug: "lentil-soup",
+        title: "Lentil Soup",
+        description: null,
+        body: JSON.stringify(payload),
+        visibility: "private",
+      }),
+    ) as typeof fetch;
     const headAsset = new Response(null, { headers: { etag: "cached" } });
     const headResponse = await onRequest(
       context(
@@ -347,7 +356,9 @@ describe("dynamic recipe pages", () => {
         "HEAD",
       ),
     );
-    expect(headResponse).toBe(headAsset);
+    expect(headResponse.status).toBe(200);
+    expect(headResponse.headers.get("cache-control")).toBe("private, no-store");
+    expect(headResponse.headers.has("etag")).toBe(false);
   });
 
   it("returns not found when the public recipe cannot be decoded", async () => {

--- a/ui/tests/lib/api/recipes.test.ts
+++ b/ui/tests/lib/api/recipes.test.ts
@@ -75,7 +75,7 @@ describe("saved recipe API adapters", () => {
     expect(catalog.recipes).toEqual([
       expect.objectContaining({
         slug: "lentil-soup",
-        href: "/recipes/saved?slug=lentil-soup",
+        href: "/recipes/lentil-soup",
         title: "Lentil Soup",
         totalTime: 15,
         ingredients: [

--- a/ui/tests/lib/domain/recipe/recipeDraft.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeDraft.test.ts
@@ -91,21 +91,15 @@ describe("savedRecipeCard", () => {
     };
   }
 
-  it("uses the indexable route for public recipes", () => {
-    expect(savedRecipeCard(record("public"))).toMatchObject({
-      href: "/recipes/weeknight-rice",
-      image: "recipes/weeknight-rice-2026-07-22",
-      imageAlt: "A bowl of rice",
-      canonical: "https://example.test/weeknight-rice",
-    });
-  });
-
-  it.each(["private", "household"] as const)(
-    "uses the authenticated route for %s recipes",
+  it.each(["public", "private", "household"] as const)(
+    "uses the unified recipe route for %s recipes",
     (visibility) => {
-      expect(savedRecipeCard(record(visibility))?.href).toBe(
-        "/recipes/saved?slug=weeknight-rice",
-      );
+      expect(savedRecipeCard(record(visibility))).toMatchObject({
+        href: "/recipes/weeknight-rice",
+        image: "recipes/weeknight-rice-2026-07-22",
+        imageAlt: "A bowl of rice",
+        canonical: "https://example.test/weeknight-rice",
+      });
     },
   );
 


### PR DESCRIPTION
## What changed

- use `/recipes/<slug>` as the single user-facing URL for public, private, and household recipes
- forward the incoming session through the Cloudflare Pages Function so the edge can authorize database-backed private and household recipes
- keep public responses indexable and cacheable with canonical metadata and JSON-LD
- serve authorized private and household responses with `noindex` and `private, no-store`
- return HTTP 404 when a recipe is missing or the visitor cannot read it
- update recipe box, kitchen, discover, cook profile, pagination, creation, and editing flows to use the unified URL
- redirect legacy `/recipes/saved?slug=…` visits to the unified recipe path
- use full document navigation for runtime recipe paths while preserving Next.js client navigation for reserved application routes

## Root cause

All recipes are now database-backed, but navigation still used two historical entry paths. Public recipes used the runtime `/recipes/<slug>` route while private and household recipes used the statically exported `/recipes/saved?slug=<slug>` viewer. In addition, `next/link` attempted to resolve runtime recipe paths through Next.js's static route manifest, producing a client-side 404 even though the Cloudflare Pages Function could serve the URL directly.

## Impact

Every recipe now has one consistent URL and viewer. Public sharing and SEO behavior remain intact, authenticated private and household access is supported at the same path, and unauthorized requests remain indistinguishable from missing recipes.

## Validation

- `mise //ui:test` — 87 files, 654 tests passed
- `mise //ui:test:integration` — 5 files, 22 tests passed
- `mise //ui:typecheck`
- `mise //ui:format:check`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`
- live anonymous recipe API and runtime public recipe page confirmed HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent recipe page linking across recipe cards, feeds, profiles and pagination via a shared link component.
  * Added legacy saved-recipe redirect to canonical recipe pages, including improved handling for `/recipes/saved` with search parameters.
* **Bug Fixes**
  * Improved public vs restricted recipe handling for rendering and HTML metadata, including stricter response validation and no-indexing for non-public pages.
  * Updated recipe caching headers and HEAD responses to match recipe visibility.
  * Refined post-save and sign-out navigation to use canonical recipe routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->