### PR TITLE
Add social share buttons to blog posts

### DIFF
--- a/ui/app/(site)/blog/[slug]/page.tsx
+++ b/ui/app/(site)/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { DebtInvestmentChart } from "@/components/blog/how-to-build-wealth/debt-
 import { FinancialIndependenceChart } from "@/components/blog/how-to-build-wealth/financial-independence-chart";
 import { LisaComparisonChart } from "@/components/blog/how-to-build-wealth/lisa-comparison-chart";
 import { PensionReturnsChart } from "@/components/blog/how-to-build-wealth/pension-returns-chart";
+import { ShareButtons } from "@/components/blog/share-buttons";
 import { Markdown } from "@/components/markdown";
 import { Mermaid } from "@/components/mermaid";
 import { Badge } from "@/components/ui/badge";
@@ -118,6 +119,14 @@ export default async function BlogPostPage(props: Readonly<PageProps>) {
                 </Badge>
               </Link>
             ))}
+          </div>
+
+          <div className="sm:ml-auto">
+            <ShareButtons
+              slug={slug}
+              title={post.title}
+              url={`${siteConfig.url}/blog/${slug}`}
+            />
           </div>
         </div>
       </header>

--- a/ui/components/blog/share-buttons.tsx
+++ b/ui/components/blog/share-buttons.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Linkedin } from "lucide-react";
+import Link from "next/link";
+import posthog from "posthog-js";
+import type { ReactNode } from "react";
+import { siX, siYcombinator } from "simple-icons";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  getShareUrl,
+  type SharePlatform,
+} from "@/lib/integrations/social-share";
+
+function BrandIcon({ path }: Readonly<{ path: string }>) {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="size-4">
+      <path d={path} fill="currentColor" />
+    </svg>
+  );
+}
+
+const SHARE_TARGETS: ReadonlyArray<{
+  platform: SharePlatform;
+  label: string;
+  icon: ReactNode;
+}> = [
+  { platform: "x", label: "Share on X", icon: <BrandIcon path={siX.path} /> },
+  {
+    platform: "linkedin",
+    label: "Share on LinkedIn",
+    icon: <Linkedin className="size-4" />,
+  },
+  {
+    platform: "hackernews",
+    label: "Share on Hacker News",
+    icon: <BrandIcon path={siYcombinator.path} />,
+  },
+];
+
+interface ShareButtonsProps {
+  slug: string;
+  title: string;
+  url: string;
+}
+
+export function ShareButtons({
+  slug,
+  title,
+  url,
+}: Readonly<ShareButtonsProps>) {
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-1 text-muted-foreground">
+        <span className="text-sm mr-1">Share</span>
+        {SHARE_TARGETS.map(({ platform, label, icon }) => (
+          <Tooltip key={platform}>
+            <TooltipTrigger asChild>
+              <Button
+                asChild
+                variant="ghost"
+                size="icon-sm"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <Link
+                  href={getShareUrl(platform, { url, title })}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={label}
+                  onClick={() =>
+                    posthog.capture("blog_post_shared", {
+                      platform,
+                      slug,
+                      url,
+                    })
+                  }
+                >
+                  {icon}
+                </Link>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+          </Tooltip>
+        ))}
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/ui/components/blog/share-buttons.tsx
+++ b/ui/components/blog/share-buttons.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Linkedin } from "lucide-react";
 import Link from "next/link";
 import posthog from "posthog-js";
 import type { ReactNode } from "react";
@@ -16,6 +15,11 @@ import {
   getShareUrl,
   type SharePlatform,
 } from "@/lib/integrations/social-share";
+
+// simple-icons dropped LinkedIn and lucide's brand icons are deprecated, so the
+// "in" mark is inlined to keep all three glyphs on the same solid 24x24 grid.
+const LINKEDIN_PATH =
+  "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z";
 
 function BrandIcon({ path }: Readonly<{ path: string }>) {
   return (
@@ -34,7 +38,7 @@ const SHARE_TARGETS: ReadonlyArray<{
   {
     platform: "linkedin",
     label: "Share on LinkedIn",
-    icon: <Linkedin className="size-4" />,
+    icon: <BrandIcon path={LINKEDIN_PATH} />,
   },
   {
     platform: "hackernews",

--- a/ui/components/blog/share-buttons.tsx
+++ b/ui/components/blog/share-buttons.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Linkedin } from "lucide-react";
 import Link from "next/link";
 import posthog from "posthog-js";
 import type { ReactNode } from "react";
@@ -15,11 +16,6 @@ import {
   getShareUrl,
   type SharePlatform,
 } from "@/lib/integrations/social-share";
-
-// simple-icons dropped LinkedIn and lucide's brand icons are deprecated, so the
-// "in" mark is inlined to keep all three glyphs on the same solid 24x24 grid.
-const LINKEDIN_PATH =
-  "M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z";
 
 function BrandIcon({ path }: Readonly<{ path: string }>) {
   return (
@@ -38,7 +34,7 @@ const SHARE_TARGETS: ReadonlyArray<{
   {
     platform: "linkedin",
     label: "Share on LinkedIn",
-    icon: <BrandIcon path={LINKEDIN_PATH} />,
+    icon: <Linkedin className="size-4" />,
   },
   {
     platform: "hackernews",

--- a/ui/lib/integrations/social-share.ts
+++ b/ui/lib/integrations/social-share.ts
@@ -10,8 +10,11 @@ export function getShareUrl(
   { url, title }: ShareTarget,
 ): string {
   switch (platform) {
+    // `intent/tweet` rather than `intent/post`: despite the rebrand, only
+    // `tweet` is documented, and `post` bounces between the X app and the
+    // in-app browser on iOS and Android instead of opening the composer.
     case "x":
-      return `https://x.com/intent/post?${new URLSearchParams({
+      return `https://x.com/intent/tweet?${new URLSearchParams({
         url,
         text: title,
       }).toString()}`;

--- a/ui/lib/integrations/social-share.ts
+++ b/ui/lib/integrations/social-share.ts
@@ -1,0 +1,28 @@
+export type SharePlatform = "x" | "linkedin" | "hackernews";
+
+export interface ShareTarget {
+  url: string;
+  title: string;
+}
+
+export function getShareUrl(
+  platform: SharePlatform,
+  { url, title }: ShareTarget,
+): string {
+  switch (platform) {
+    case "x":
+      return `https://x.com/intent/post?${new URLSearchParams({
+        url,
+        text: title,
+      }).toString()}`;
+    case "linkedin":
+      return `https://www.linkedin.com/sharing/share-offsite/?${new URLSearchParams(
+        { url },
+      ).toString()}`;
+    case "hackernews":
+      return `https://news.ycombinator.com/submitlink?${new URLSearchParams({
+        u: url,
+        t: title,
+      }).toString()}`;
+  }
+}

--- a/ui/tests/components/blog/share-buttons.test.tsx
+++ b/ui/tests/components/blog/share-buttons.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "@testing-library/react";
 import posthog from "posthog-js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ShareButtons } from "@/components/blog/share-buttons";
@@ -64,13 +63,19 @@ describe("ShareButtons", () => {
     }
   });
 
-  it("captures a share event with the platform and post", async () => {
+  it.each([
+    ["Share on X", "x"],
+    ["Share on LinkedIn", "linkedin"],
+    ["Share on Hacker News", "hackernews"],
+  ])("captures a share event when %s is clicked", (label, platform) => {
     renderShareButtons();
 
-    await userEvent.click(screen.getByLabelText("Share on Hacker News"));
+    // fireEvent, not userEvent: userEvent's hover opens the Radix tooltip
+    // (delayDuration 0), and the resulting re-render can swallow the click.
+    fireEvent.click(screen.getByLabelText(label));
 
     expect(posthog.capture).toHaveBeenCalledWith("blog_post_shared", {
-      platform: "hackernews",
+      platform,
       slug: post.slug,
       url: post.url,
     });

--- a/ui/tests/components/blog/share-buttons.test.tsx
+++ b/ui/tests/components/blog/share-buttons.test.tsx
@@ -27,7 +27,7 @@ describe("ShareButtons", () => {
 
     expect(screen.getByLabelText("Share on X")).toHaveAttribute(
       "href",
-      "https://x.com/intent/post?url=https%3A%2F%2Frobbiepalmer.me%2Fblog%2Fjust-right-engineering&text=Just+Right+Engineering",
+      "https://x.com/intent/tweet?url=https%3A%2F%2Frobbiepalmer.me%2Fblog%2Fjust-right-engineering&text=Just+Right+Engineering",
     );
   });
 

--- a/ui/tests/components/blog/share-buttons.test.tsx
+++ b/ui/tests/components/blog/share-buttons.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import posthog from "posthog-js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ShareButtons } from "@/components/blog/share-buttons";
+
+vi.mock("posthog-js", () => ({
+  default: { capture: vi.fn() },
+}));
+
+const post = {
+  slug: "just-right-engineering",
+  title: "Just Right Engineering",
+  url: "https://robbiepalmer.me/blog/just-right-engineering",
+};
+
+function renderShareButtons() {
+  render(<ShareButtons {...post} />);
+}
+
+describe("ShareButtons", () => {
+  beforeEach(() => {
+    vi.mocked(posthog.capture).mockReset();
+  });
+
+  it("links to X with the post url and title", () => {
+    renderShareButtons();
+
+    expect(screen.getByLabelText("Share on X")).toHaveAttribute(
+      "href",
+      "https://x.com/intent/post?url=https%3A%2F%2Frobbiepalmer.me%2Fblog%2Fjust-right-engineering&text=Just+Right+Engineering",
+    );
+  });
+
+  it("links to LinkedIn with the post url", () => {
+    renderShareButtons();
+
+    expect(screen.getByLabelText("Share on LinkedIn")).toHaveAttribute(
+      "href",
+      "https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Frobbiepalmer.me%2Fblog%2Fjust-right-engineering",
+    );
+  });
+
+  it("links to Hacker News with the post url and title", () => {
+    renderShareButtons();
+
+    expect(screen.getByLabelText("Share on Hacker News")).toHaveAttribute(
+      "href",
+      "https://news.ycombinator.com/submitlink?u=https%3A%2F%2Frobbiepalmer.me%2Fblog%2Fjust-right-engineering&t=Just+Right+Engineering",
+    );
+  });
+
+  it("opens share targets in a new tab without leaking the referrer opener", () => {
+    renderShareButtons();
+
+    for (const label of [
+      "Share on X",
+      "Share on LinkedIn",
+      "Share on Hacker News",
+    ]) {
+      const link = screen.getByLabelText(label);
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  it("captures a share event with the platform and post", async () => {
+    renderShareButtons();
+
+    await userEvent.click(screen.getByLabelText("Share on Hacker News"));
+
+    expect(posthog.capture).toHaveBeenCalledWith("blog_post_shared", {
+      platform: "hackernews",
+      slug: post.slug,
+      url: post.url,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Every blog post header now carries a subtle share row for **X**, **LinkedIn** and **Hacker News**, placed above the fold alongside the date, reading time and tags.

## Changes

- `ui/lib/integrations/social-share.ts` — pure `getShareUrl(platform, { url, title })` builder for the three share-intent URLs.
- `ui/components/blog/share-buttons.tsx` — ghost icon buttons with tooltips and `aria-label`s, opening in a new tab with `rel="noopener noreferrer"`, and firing a `blog_post_shared` PostHog event (`platform`, `slug`, `url`) to match the `social_link_clicked` convention in `components/footer-links.tsx`.
- `ui/app/(site)/blog/[slug]/page.tsx` — renders the share row in the post header meta line. It is the shared post template, so all 12 posts get it.
- `ui/tests/components/blog/share-buttons.test.tsx` — asserts the exact share URL per platform, the new-tab/rel attributes, and the analytics capture.

## Notes

- **Icons**: `simple-icons` (already a dependency) supplies the X and Y Combinator marks. It no longer ships a LinkedIn icon, so LinkedIn uses lucide's `Linkedin`, which is what the footer already uses.
- **Deprecated `Linkedin` import is intentional.** lucide has deprecated its brand icons and points at simple-icons, which no longer carries LinkedIn, so there is no packaged replacement. Staying on lucide keeps this consistent with `components/footer-links.tsx`. SonarCloud raises two MINOR `typescript:S1874` code smells for this; they are accepted, not oversights — please don't re-flag.
- **Shared URL**: always `https://robbiepalmer.me/blog/<slug>`, even for the three posts with a `canonical` pointing elsewhere. The share button exists to drive traffic to this site; the canonical `<link>` still handles SEO attribution.

## Verification

- `mise //ui:test` — 653 tests pass (87 files)
- `mise //ui:typecheck` — clean
- `mise //ui:lint` — no new diagnostics on touched files
- Production build succeeds; all 12 pages in `out/blog/` contain the three share links with correctly encoded URLs and titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sharing controls to blog post headers.
  - Posts can now be shared directly to X, LinkedIn, and Hacker News.
  - Added hover tooltips with accessible platform labels.
  - Sharing activity is recorded for analytics.

- **Tests**
  - Added coverage to verify share links, security attributes, and sharing activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->