### PR TITLE
Add local recipe file imports

### DIFF
--- a/packages/recipe-parsing/src/lib/recipe-file.ts
+++ b/packages/recipe-parsing/src/lib/recipe-file.ts
@@ -1,0 +1,159 @@
+import { CooklangParser } from "@cooklang/cooklang";
+import { deriveRecipeFromCooklang } from "./cooklang.js";
+import type { SchemaOrgRecipeFileImport } from "./schema-org.js";
+import { parseSchemaOrgRecipeJson } from "./schema-org.js";
+
+export type RecipeFileFormat = "cooklang" | "schema-org";
+
+export type RecipeFileImport = SchemaOrgRecipeFileImport;
+
+const parser = new CooklangParser();
+
+function fileFormat(filename: string): RecipeFileFormat | undefined {
+  const extension = filename.toLowerCase().split(".").pop();
+  if (extension === "cook" || extension === "cooklang") return "cooklang";
+  if (extension === "json" || extension === "jsonld") return "schema-org";
+  return undefined;
+}
+
+function cooklangBody(source: string): string {
+  const normalized = source.replace(/^\uFEFF/, "");
+  const frontmatter = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/.exec(
+    normalized,
+  );
+  return (frontmatter ? normalized.slice(frontmatter[0].length) : normalized).trim();
+}
+
+function metadataValue(
+  metadata: Map<unknown, unknown>,
+  key: string,
+): unknown {
+  const normalizedKey = key.toLowerCase();
+  for (const [candidate, value] of metadata) {
+    if (String(candidate).toLowerCase() === normalizedKey) return value;
+  }
+  return undefined;
+}
+
+function positiveNumber(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseFloat(value)
+        : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : undefined;
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseFloat(value)
+        : Number.NaN;
+  return Number.isFinite(parsed) && parsed >= 0
+    ? Math.round(parsed)
+    : undefined;
+}
+
+function cuisineLabels(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+  return typeof value === "string"
+    ? value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : [];
+}
+
+function fallbackTitle(filename: string): string {
+  const basename = filename.replace(/\.[^.]+$/, "").replace(/[-_]+/g, " ").trim();
+  return basename || "Imported recipe";
+}
+
+function httpUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseCooklangRecipeFile(
+  source: string,
+  filename: string,
+): RecipeFileImport | null {
+  const body = cooklangBody(source);
+  if (!body) return null;
+
+  const [parsed] = parser.parse(source.replace(/^\uFEFF/, ""));
+  const title = (parsed.title?.trim() || fallbackTitle(filename)).slice(0, 120);
+  const description = (
+    parsed.description?.trim() ||
+    `Recipe for ${title}, imported from a Cooklang file.`
+  ).slice(0, 500);
+  const servings = positiveNumber(parsed.servings) ?? 1;
+  const parsedTime =
+    parsed.time && typeof parsed.time === "object" ? parsed.time : undefined;
+  const prepTime =
+    nonNegativeNumber(metadataValue(parsed.rawMetadata, "prepTime")) ??
+    nonNegativeNumber(parsedTime?.prep_time);
+  const cookTime =
+    nonNegativeNumber(metadataValue(parsed.rawMetadata, "cookTime")) ??
+    nonNegativeNumber(parsedTime?.cook_time);
+  const cuisine = cuisineLabels(parsed.cuisine);
+  const derived = deriveRecipeFromCooklang({
+    frontmatter: {
+      title,
+      description,
+      servings,
+      cuisine,
+      prepTime,
+      cookTime,
+      tags: [],
+    },
+    body,
+    diagnostics: [],
+  });
+  if (!derived.derived) return null;
+
+  const canonical = httpUrl(metadataValue(parsed.rawMetadata, "canonical"));
+  return {
+    title,
+    description,
+    cuisine: cuisine.join(", "),
+    servings,
+    prepTime,
+    cookTime,
+    source: body,
+    ...(canonical ? { url: canonical } : {}),
+  };
+}
+
+export async function parseRecipeFile(
+  filename: string,
+  source: string,
+): Promise<RecipeFileImport | null> {
+  try {
+    const format = fileFormat(filename);
+    if (format === "cooklang") {
+      return parseCooklangRecipeFile(source, filename);
+    }
+    if (format === "schema-org") {
+      return parseSchemaOrgRecipeJson(source);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/recipe-parsing/src/lib/recipe-file.ts
+++ b/packages/recipe-parsing/src/lib/recipe-file.ts
@@ -148,7 +148,7 @@ export async function parseRecipeFile(
       return parseCooklangRecipeFile(source, filename);
     }
     if (format === "schema-org") {
-      return parseSchemaOrgRecipeJson(source);
+      return await parseSchemaOrgRecipeJson(source);
     }
     return null;
   } catch {

--- a/packages/recipe-parsing/src/lib/recipe-file.ts
+++ b/packages/recipe-parsing/src/lib/recipe-file.ts
@@ -36,23 +36,19 @@ function metadataValue(
   return undefined;
 }
 
+function numericValue(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") return Number.parseFloat(value);
+  return Number.NaN;
+}
+
 function positiveNumber(value: unknown): number | undefined {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string"
-        ? Number.parseFloat(value)
-        : Number.NaN;
+  const parsed = numericValue(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : undefined;
 }
 
 function nonNegativeNumber(value: unknown): number | undefined {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string"
-        ? Number.parseFloat(value)
-        : Number.NaN;
+  const parsed = numericValue(value);
   return Number.isFinite(parsed) && parsed >= 0
     ? Math.round(parsed)
     : undefined;

--- a/packages/recipe-parsing/src/lib/recipe-file.ts
+++ b/packages/recipe-parsing/src/lib/recipe-file.ts
@@ -16,11 +16,12 @@ function fileFormat(filename: string): RecipeFileFormat | undefined {
   return undefined;
 }
 
-function cooklangBody(source: string): string {
+function cooklangBody(source: string): string | undefined {
   const normalized = source.replace(/^\uFEFF/, "");
   const frontmatter = /^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*(?:\r?\n|$)/.exec(
     normalized,
   );
+  if (normalized.startsWith("---") && !frontmatter) return undefined;
   return (frontmatter ? normalized.slice(frontmatter[0].length) : normalized).trim();
 }
 
@@ -97,6 +98,7 @@ function parseCooklangRecipeFile(
   if (!body) return null;
 
   const [parsed] = parser.parse(source.replace(/^\uFEFF/, ""));
+  if (!parsed) return null;
   const title = (parsed.title?.trim() || fallbackTitle(filename)).slice(0, 120);
   const description = (
     parsed.description?.trim() ||

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -13,8 +13,66 @@ export type SchemaOrgRecipeImport = {
   source: string;
 };
 
+export type SchemaOrgRecipeFileImport = SchemaOrgRecipeImport & {
+  url?: string;
+};
+
 function servings(value: string): string {
   return /\d+(?:\.\d+)?/.exec(value)?.[0] ?? "1";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRecipeType(value: unknown): boolean {
+  const types = Array.isArray(value) ? value : [value];
+  return types.some(
+    (type) =>
+      typeof type === "string" && /(?:^|\/)Recipe\/?$/i.test(type.trim()),
+  );
+}
+
+function findRecipeObject(value: unknown): Record<string, unknown> | undefined {
+  const pending: unknown[] = [value];
+  while (pending.length > 0) {
+    const candidate = pending.pop();
+    if (Array.isArray(candidate)) {
+      for (let index = candidate.length - 1; index >= 0; index--) {
+        pending.push(candidate[index]);
+      }
+      continue;
+    }
+    if (!isRecord(candidate)) continue;
+    if (isRecipeType(candidate["@type"])) return candidate;
+    const children = Object.values(candidate);
+    for (let index = children.length - 1; index >= 0; index--) {
+      pending.push(children[index]);
+    }
+  }
+  return undefined;
+}
+
+function httpUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function recipeCanonicalUrl(
+  recipe: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!recipe) return undefined;
+  const directUrl = httpUrl(recipe.url);
+  if (directUrl) return directUrl;
+  if (isRecord(recipe.isBasedOn)) return httpUrl(recipe.isBasedOn.url);
+  return httpUrl(recipe.isBasedOn);
 }
 
 function unwrapJsonLd(source: string): string {
@@ -40,13 +98,15 @@ function normalizeRecipeMarkup(html: string, url: string): string {
 
     try {
       const data: unknown = JSON.parse(source);
-      const visit = (value: unknown): void => {
+      const pending: unknown[] = [data];
+      while (pending.length > 0) {
+        const value = pending.pop();
         if (Array.isArray(value)) {
-          for (const entry of value) visit(entry);
-          return;
+          pending.push(...value);
+          continue;
         }
-        if (!value || typeof value !== "object") return;
-        const object = value as Record<string, unknown>;
+        if (!isRecord(value)) continue;
+        const object = value;
         const types = Array.isArray(object["@type"])
           ? object["@type"]
           : [object["@type"]];
@@ -67,9 +127,8 @@ function normalizeRecipeMarkup(html: string, url: string): string {
           object.image ??= url;
           object.recipeYield ??= "1 serving";
         }
-        for (const child of Object.values(object)) visit(child);
-      };
-      visit(data);
+        pending.push(...Object.values(object));
+      }
       $(element).text(JSON.stringify(data));
     } catch {
       // recipe-scrapers can recover some malformed JSON-LD itself.
@@ -133,4 +192,29 @@ export async function parseSchemaOrgRecipeHtml(
     cookTime: cooklang.frontmatter.cookTime,
     source: cooklang.body,
   };
+}
+
+/**
+ * Parse a standalone schema.org JSON-LD document. Recipe apps commonly
+ * exchange either a single Recipe object, a top-level array, or an @graph.
+ */
+export async function parseSchemaOrgRecipeJson(
+  source: string,
+): Promise<SchemaOrgRecipeFileImport | null> {
+  let data: unknown;
+  try {
+    data = JSON.parse(source);
+  } catch {
+    return null;
+  }
+
+  const recipeObject = findRecipeObject(data);
+  if (!recipeObject) return null;
+  const url = recipeCanonicalUrl(recipeObject);
+  const safeJson = JSON.stringify(data).replaceAll("<", String.raw`\u003c`);
+  const parsed = await parseSchemaOrgRecipeHtml(
+    `<script type="application/ld+json">${safeJson}</script>`,
+    url ?? "https://example.com/imported-recipe",
+  );
+  return parsed ? { ...parsed, ...(url ? { url } : {}) } : null;
 }

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -95,6 +95,40 @@ function unwrapJsonLd(source: string): string {
   return cleaned;
 }
 
+function normalizeRecipeObject(object: Record<string, unknown>, url: string) {
+  const types = Array.isArray(object["@type"])
+    ? object["@type"]
+    : [object["@type"]];
+  const recipeIndex = types.findIndex(
+    (type) => typeof type === "string" && /(?:^|\/)Recipe\/?$/i.test(type),
+  );
+  if (recipeIndex < 0) return;
+
+  object["@type"] = [
+    "Recipe",
+    ...types.filter((type, index) => index !== recipeIndex && type !== "Recipe"),
+  ];
+  object.author ??= "Imported recipe";
+  const recipeName = typeof object.name === "string" ? object.name : "this dish";
+  object.description ??= `Recipe for ${recipeName}, imported from the web.`;
+  object.image ??= url;
+  object.recipeYield ??= "1 serving";
+}
+
+function normalizeJsonLdData(data: unknown, url: string) {
+  const pending: unknown[] = [data];
+  while (pending.length > 0) {
+    const value = pending.pop();
+    if (Array.isArray(value)) {
+      for (const child of value) pending.push(child);
+      continue;
+    }
+    if (!isRecord(value)) continue;
+    normalizeRecipeObject(value, url);
+    for (const child of Object.values(value)) pending.push(child);
+  }
+}
+
 function normalizeRecipeMarkup(html: string, url: string): string {
   const $ = cheerio.load(html);
   $("script[type='application/ld+json']").each((_, element) => {
@@ -104,37 +138,7 @@ function normalizeRecipeMarkup(html: string, url: string): string {
 
     try {
       const data: unknown = JSON.parse(source);
-      const pending: unknown[] = [data];
-      while (pending.length > 0) {
-        const value = pending.pop();
-        if (Array.isArray(value)) {
-          for (const child of value) pending.push(child);
-          continue;
-        }
-        if (!isRecord(value)) continue;
-        const object = value;
-        const types = Array.isArray(object["@type"])
-          ? object["@type"]
-          : [object["@type"]];
-        const recipeIndex = types.findIndex(
-          (type) => typeof type === "string" && /(?:^|\/)Recipe\/?$/i.test(type),
-        );
-        if (recipeIndex >= 0) {
-          object["@type"] = [
-            "Recipe",
-            ...types.filter(
-              (type, index) => index !== recipeIndex && type !== "Recipe",
-            ),
-          ];
-          object.author ??= "Imported recipe";
-          const recipeName =
-            typeof object.name === "string" ? object.name : "this dish";
-          object.description ??= `Recipe for ${recipeName}, imported from the web.`;
-          object.image ??= url;
-          object.recipeYield ??= "1 serving";
-        }
-        for (const child of Object.values(object)) pending.push(child);
-      }
+      normalizeJsonLdData(data, url);
       $(element).text(JSON.stringify(data));
     } catch {
       // recipe-scrapers can recover some malformed JSON-LD itself.

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -71,8 +71,14 @@ function recipeCanonicalUrl(
   if (!recipe) return undefined;
   const directUrl = httpUrl(recipe.url);
   if (directUrl) return directUrl;
-  if (isRecord(recipe.isBasedOn)) return httpUrl(recipe.isBasedOn.url);
-  return httpUrl(recipe.isBasedOn);
+  const candidates = Array.isArray(recipe.isBasedOn)
+    ? recipe.isBasedOn
+    : [recipe.isBasedOn];
+  for (const candidate of candidates) {
+    const url = isRecord(candidate) ? httpUrl(candidate.url) : httpUrl(candidate);
+    if (url) return url;
+  }
+  return undefined;
 }
 
 function unwrapJsonLd(source: string): string {

--- a/packages/recipe-parsing/src/lib/schema-org.ts
+++ b/packages/recipe-parsing/src/lib/schema-org.ts
@@ -108,7 +108,7 @@ function normalizeRecipeMarkup(html: string, url: string): string {
       while (pending.length > 0) {
         const value = pending.pop();
         if (Array.isArray(value)) {
-          pending.push(...value);
+          for (const child of value) pending.push(child);
           continue;
         }
         if (!isRecord(value)) continue;
@@ -133,7 +133,7 @@ function normalizeRecipeMarkup(html: string, url: string): string {
           object.image ??= url;
           object.recipeYield ??= "1 serving";
         }
-        pending.push(...Object.values(object));
+        for (const child of Object.values(object)) pending.push(child);
       }
       $(element).text(JSON.stringify(data));
     } catch {

--- a/packages/recipe-parsing/tests/lib/recipe-file.test.ts
+++ b/packages/recipe-parsing/tests/lib/recipe-file.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { parseRecipeFile } from "../../src/lib/recipe-file.js";
+
+describe("parseRecipeFile", () => {
+  it("imports Cooklang frontmatter and body into an editable draft", async () => {
+    const source = `---
+title: "Weeknight pasta"
+description: "A quick dinner."
+cuisine: ["Italian"]
+servings: 2
+prepTime: 5
+cookTime: 20
+canonical: "https://recipes.example.test/weeknight-pasta"
+---
+@pasta{200%g}
+@tomatoes{400%g}
+
+Boil the pasta, then stir in the tomatoes.`;
+
+    await expect(
+      parseRecipeFile("weeknight-pasta.cook", source),
+    ).resolves.toEqual({
+      title: "Weeknight pasta",
+      description: "A quick dinner.",
+      cuisine: "Italian",
+      servings: 2,
+      prepTime: 5,
+      cookTime: 20,
+      url: "https://recipes.example.test/weeknight-pasta",
+      source:
+        "@pasta{200%g}\n@tomatoes{400%g}\n\nBoil the pasta, then stir in the tomatoes.",
+    });
+  });
+
+  it("uses the filename and editable defaults when metadata is absent", async () => {
+    await expect(
+      parseRecipeFile(
+        "lemon-rice.cooklang",
+        "@rice{200%g}\n\nCook the rice with @lemon{1}.",
+      ),
+    ).resolves.toMatchObject({
+      title: "lemon rice",
+      description: "Recipe for lemon rice, imported from a Cooklang file.",
+      cuisine: "",
+      servings: 1,
+    });
+  });
+
+  it("rejects unsupported and incomplete files", async () => {
+    await expect(parseRecipeFile("recipe.txt", "Cook.")).resolves.toBeNull();
+    await expect(
+      parseRecipeFile("recipe.cook", "There are no ingredients here."),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/recipe-parsing/tests/lib/recipe-file.test.ts
+++ b/packages/recipe-parsing/tests/lib/recipe-file.test.ts
@@ -46,6 +46,30 @@ Boil the pasta, then stir in the tomatoes.`;
     });
   });
 
+  it.each(["json", "jsonld"])(
+    "routes .%s files through the schema.org importer",
+    async (extension) => {
+      const source = JSON.stringify({
+        "@type": "Recipe",
+        name: "Tomato pasta",
+        url: "https://recipes.example.test/tomato-pasta",
+        recipeYield: "2 servings",
+        recipeIngredient: ["200 g pasta", "400 g tomatoes"],
+        recipeInstructions: ["Boil the pasta.", "Add the tomatoes."],
+      });
+
+      await expect(
+        parseRecipeFile(`tomato-pasta.${extension}`, source),
+      ).resolves.toMatchObject({
+        title: "Tomato pasta",
+        servings: 2,
+        url: "https://recipes.example.test/tomato-pasta",
+        source:
+          "@pasta{200%g}\n@tomatoes{400%g}\n\nBoil the pasta.\n\nAdd the tomatoes.",
+      });
+    },
+  );
+
   it("rejects unsupported and incomplete files", async () => {
     await expect(parseRecipeFile("recipe.txt", "Cook.")).resolves.toBeNull();
     await expect(

--- a/packages/recipe-parsing/tests/lib/recipe-file.test.ts
+++ b/packages/recipe-parsing/tests/lib/recipe-file.test.ts
@@ -51,5 +51,11 @@ Boil the pasta, then stir in the tomatoes.`;
     await expect(
       parseRecipeFile("recipe.cook", "There are no ingredients here."),
     ).resolves.toBeNull();
+    await expect(
+      parseRecipeFile(
+        "recipe.cook",
+        "---\ntitle: Unclosed metadata\n@rice{200%g}\n\nCook the rice.",
+      ),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/recipe-parsing/tests/lib/schema-org.test.ts
+++ b/packages/recipe-parsing/tests/lib/schema-org.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseSchemaOrgRecipeHtml } from "../../src/lib/schema-org.js";
+import {
+  parseSchemaOrgRecipeHtml,
+  parseSchemaOrgRecipeJson,
+} from "../../src/lib/schema-org.js";
 
 describe("parseSchemaOrgRecipeHtml", () => {
   it("imports a Recipe from a JSON-LD graph into Cooklang source", async () => {
@@ -63,5 +66,38 @@ describe("parseSchemaOrgRecipeHtml", () => {
   it("rejects pages without a complete Recipe", async () => {
     await expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Article"}</script>`)).resolves.toBeNull();
     await expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Recipe","name":"Empty"}</script>`)).resolves.toBeNull();
+  });
+
+  it("imports standalone JSON-LD and preserves its canonical URL", async () => {
+    const source = JSON.stringify({
+      "@context": "https://schema.org",
+      "@graph": [
+        { "@type": "WebPage", name: "Dinner" },
+        {
+          "@type": "Recipe",
+          name: "Tomato pasta",
+          url: "https://recipes.example.test/tomato-pasta",
+          description: "A quick dinner.",
+          recipeYield: "2 servings",
+          recipeIngredient: ["200 g pasta", "400 g tomatoes"],
+          recipeInstructions: ["Boil the pasta.", "Add the tomatoes."],
+        },
+      ],
+    });
+
+    await expect(parseSchemaOrgRecipeJson(source)).resolves.toMatchObject({
+      title: "Tomato pasta",
+      servings: 2,
+      url: "https://recipes.example.test/tomato-pasta",
+      source:
+        "@pasta{200%g}\n@tomatoes{400%g}\n\nBoil the pasta.\n\nAdd the tomatoes.",
+    });
+  });
+
+  it("rejects malformed standalone JSON-LD", async () => {
+    await expect(parseSchemaOrgRecipeJson("{")).resolves.toBeNull();
+    await expect(
+      parseSchemaOrgRecipeJson(JSON.stringify({ "@type": "Article" })),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/recipe-parsing/tests/lib/schema-org.test.ts
+++ b/packages/recipe-parsing/tests/lib/schema-org.test.ts
@@ -67,7 +67,9 @@ describe("parseSchemaOrgRecipeHtml", () => {
     await expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Article"}</script>`)).resolves.toBeNull();
     await expect(parseSchemaOrgRecipeHtml(`<script type="application/ld+json">{"@type":"Recipe","name":"Empty"}</script>`)).resolves.toBeNull();
   });
+});
 
+describe("parseSchemaOrgRecipeJson", () => {
   it("imports standalone JSON-LD and preserves its canonical URL", async () => {
     const source = JSON.stringify({
       "@context": "https://schema.org",

--- a/packages/recipe-parsing/tests/lib/schema-org.test.ts
+++ b/packages/recipe-parsing/tests/lib/schema-org.test.ts
@@ -94,6 +94,24 @@ describe("parseSchemaOrgRecipeHtml", () => {
     });
   });
 
+  it("uses the first valid canonical URL from an isBasedOn array", async () => {
+    const source = JSON.stringify({
+      "@type": "Recipe",
+      name: "Tomato pasta",
+      isBasedOn: [
+        "not a URL",
+        { url: "https://recipes.example.test/original-pasta" },
+      ],
+      recipeIngredient: ["200 g pasta"],
+      recipeInstructions: ["Boil the pasta."],
+    });
+
+    await expect(parseSchemaOrgRecipeJson(source)).resolves.toMatchObject({
+      title: "Tomato pasta",
+      url: "https://recipes.example.test/original-pasta",
+    });
+  });
+
   it("rejects malformed standalone JSON-LD", async () => {
     await expect(parseSchemaOrgRecipeJson("{")).resolves.toBeNull();
     await expect(

--- a/ui/app/recipes/add/page.tsx
+++ b/ui/app/recipes/add/page.tsx
@@ -4,7 +4,7 @@ import { AddRecipeView } from "@/components/recipes/add-recipe-view";
 export const metadata: Metadata = {
   title: "Add Recipe",
   description:
-    "Add a recipe using Cooklang, import schema.org Recipe data, or scan recipe photos.",
+    "Add a recipe manually, import a URL or local Cooklang or schema.org file, or scan a recipe photo.",
   robots: { index: false, follow: false },
 };
 

--- a/ui/app/recipes/add/page.tsx
+++ b/ui/app/recipes/add/page.tsx
@@ -4,7 +4,7 @@ import { AddRecipeView } from "@/components/recipes/add-recipe-view";
 export const metadata: Metadata = {
   title: "Add Recipe",
   description:
-    "Add a recipe manually, import a URL or local Cooklang or schema.org file, or scan a recipe photo.",
+    "Add a recipe manually, import a URL, upload a local Cooklang or schema.org file, or scan a recipe photo.",
   robots: { index: false, follow: false },
 };
 

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -6,6 +6,7 @@ import {
   ArrowLeft,
   Camera,
   FileText,
+  FileUp,
   Globe2,
   Home,
   Loader2,
@@ -54,7 +55,7 @@ Meanwhile, warm @olive oil{2%tbsp} in a #frying pan{}. Add @garlic{2%cloves} and
 
 Stir in @chopped tomatoes{400%g} and simmer for ~{15%minutes}. Drain the pasta, toss it through the sauce, and serve.`;
 
-type AddMethod = "write" | "url" | "photo";
+type AddMethod = "write" | "url" | "photo" | "file";
 type RecipeVisibility = "private" | "household" | "public";
 
 type ImportedRecipe = {
@@ -65,7 +66,7 @@ type ImportedRecipe = {
   prepTime?: number;
   cookTime?: number;
   source: string;
-  url: string;
+  url?: string;
 };
 
 async function invalidateSavedRecipeQueries({
@@ -112,6 +113,8 @@ async function invalidateSavedRecipeQueries({
   }
   await Promise.all(invalidations);
 }
+
+const MAX_RECIPE_FILE_LENGTH = 100_000;
 
 function RecipeEditorGate({
   unreadable,
@@ -209,14 +212,18 @@ export function AddRecipeView({
   const titleId = useId();
   const descriptionId = useId();
   const cuisineId = useId();
+  const recipeFileId = useId();
   const router = useRouter();
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const sessionUserId = session?.user.id;
   const queryClient = useQueryClient();
   const [method, setMethod] = useState<AddMethod>("write");
   const [recipeUrl, setRecipeUrl] = useState("");
+  const [recipeFile, setRecipeFile] = useState<File | null>(null);
   const [importing, setImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
+  const [urlImportSuccess, setUrlImportSuccess] = useState(false);
+  const [importedFileName, setImportedFileName] = useState<string | null>(null);
   const [importedUrl, setImportedUrl] = useState<string | null>(
     initialPayload?.recipe.canonical ?? null,
   );
@@ -325,6 +332,17 @@ export function AddRecipeView({
   ]);
   const preview = previewResult.recipe;
 
+  const applyImportedRecipe = useCallback((recipe: ImportedRecipe) => {
+    setTitle(recipe.title);
+    setDescription(recipe.description);
+    setCuisine(recipe.cuisine);
+    setServings(recipe.servings);
+    setPrepTime(recipe.prepTime);
+    setCookTime(recipe.cookTime);
+    setSource(recipe.source);
+    setImportedUrl(recipe.url ?? null);
+  }, []);
+
   async function importRecipeUrl() {
     if (!recipeUrl.trim() || importing) return;
     importRequestRef.current?.controller.abort();
@@ -335,6 +353,7 @@ export function AddRecipeView({
     importRequestRef.current = request;
     setImporting(true);
     setImportError(null);
+    setUrlImportSuccess(false);
     try {
       const response = await fetch("/api/recipes/import-url", {
         method: "POST",
@@ -354,15 +373,10 @@ export function AddRecipeView({
         );
       }
       if (importRequestRef.current?.id !== request.id) return;
-      setTitle(body.title);
-      setDescription(body.description);
-      setCuisine(body.cuisine);
-      setServings(body.servings);
-      setPrepTime(body.prepTime);
-      setCookTime(body.cookTime);
-      setSource(body.source);
-      setRecipeUrl(body.url);
-      setImportedUrl(body.url);
+      applyImportedRecipe(body);
+      setRecipeUrl(body.url ?? recipeUrl.trim());
+      setUrlImportSuccess(true);
+      setImportedFileName(null);
     } catch (error) {
       if (
         request.controller.signal.aborted ||
@@ -374,6 +388,63 @@ export function AddRecipeView({
         error instanceof Error
           ? error.message
           : "The recipe could not be imported.",
+      );
+    } finally {
+      if (importRequestRef.current?.id === request.id) {
+        importRequestRef.current = null;
+        setImporting(false);
+      }
+    }
+  }
+
+  async function importRecipeFile() {
+    if (!recipeFile || importing) return;
+    importRequestRef.current?.controller.abort();
+    const request = {
+      id: ++nextImportRequestIdRef.current,
+      controller: new AbortController(),
+    };
+    importRequestRef.current = request;
+    setImporting(true);
+    setImportError(null);
+    setImportedFileName(null);
+    try {
+      const content = await recipeFile.text();
+      if (content.length > MAX_RECIPE_FILE_LENGTH) {
+        throw new Error("Choose a recipe file smaller than 100 KB.");
+      }
+      const response = await fetch("/api/recipes/import-file", {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ filename: recipeFile.name, content }),
+        signal: request.controller.signal,
+      });
+      const body = (await response.json().catch(() => null)) as
+        | ImportedRecipe
+        | { error?: string }
+        | null;
+      if (!response.ok || !body || !("source" in body)) {
+        throw new Error(
+          (body && "error" in body && body.error) ||
+            "The recipe file could not be imported.",
+        );
+      }
+      if (importRequestRef.current?.id !== request.id) return;
+      applyImportedRecipe(body);
+      setImportedFileName(recipeFile.name);
+      setUrlImportSuccess(false);
+    } catch (error) {
+      if (
+        request.controller.signal.aborted ||
+        importRequestRef.current?.id !== request.id
+      ) {
+        return;
+      }
+      setImportError(
+        error instanceof Error
+          ? error.message
+          : "The recipe file could not be imported.",
       );
     } finally {
       if (importRequestRef.current?.id === request.id) {
@@ -399,6 +470,8 @@ export function AddRecipeView({
     setCookTime(draft.recipe.cookTime);
     setSource(body);
     setImportedUrl(null);
+    setUrlImportSuccess(false);
+    setImportedFileName(null);
   }, []);
 
   async function saveRecipe() {
@@ -498,7 +571,7 @@ export function AddRecipeView({
           <p className="rt-body mt-2 text-[var(--ink-2)]">
             {editing
               ? "Update the Cooklang recipe and review every change in the live preview."
-              : "Write with Cooklang, import a webpage, or scan a recipe photo. Every method feeds the same editable preview."}
+              : "Enter a recipe manually, import a webpage or local file, or scan a recipe photo. Every method feeds the same editable preview."}
           </p>
         </div>
         <Button
@@ -526,7 +599,7 @@ export function AddRecipeView({
           <div className="grid gap-4">
             {!editing && (
               <fieldset
-                className="grid grid-cols-3 rounded-lg border border-[var(--line-strong)] bg-[var(--paper-warm)] p-1"
+                className="grid grid-cols-2 rounded-lg border border-[var(--line-strong)] bg-[var(--paper-warm)] p-1 sm:grid-cols-4"
                 aria-label="Choose how to add a recipe"
               >
                 <button
@@ -542,11 +615,15 @@ export function AddRecipeView({
                       : "text-[var(--ink-3)] hover:text-[var(--ink)]"
                   }`}
                 >
-                  <PenLine className="size-4" /> Write with Cooklang
+                  <PenLine className="size-4" /> Manual entry
                 </button>
                 <button
                   type="button"
-                  onClick={() => setMethod("url")}
+                  onClick={() => {
+                    invalidateImportRequest();
+                    setImportError(null);
+                    setMethod("url");
+                  }}
                   aria-pressed={method === "url"}
                   className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
                     method === "url"
@@ -554,7 +631,7 @@ export function AddRecipeView({
                       : "text-[var(--ink-3)] hover:text-[var(--ink)]"
                   }`}
                 >
-                  <Globe2 className="size-4" /> Import from URL
+                  <Globe2 className="size-4" /> Import URL
                 </button>
                 <button
                   type="button"
@@ -570,6 +647,22 @@ export function AddRecipeView({
                   }`}
                 >
                   <Camera className="size-4" /> Scan photo
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    invalidateImportRequest();
+                    setImportError(null);
+                    setMethod("file");
+                  }}
+                  aria-pressed={method === "file"}
+                  className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-2 py-2 text-sm transition-colors ${
+                    method === "file"
+                      ? "bg-[var(--card)] text-[var(--ink)] shadow-sm"
+                      : "text-[var(--ink-3)] hover:text-[var(--ink)]"
+                  }`}
+                >
+                  <FileUp className="size-4" /> Upload file
                 </button>
               </fieldset>
             )}
@@ -627,9 +720,63 @@ export function AddRecipeView({
                     {importError}
                   </p>
                 )}
-                {importedUrl && !importError && (
+                {urlImportSuccess && !importError && (
                   <output className="text-sm text-[var(--sage)]">
                     Imported successfully. You can edit any field before saving.
+                  </output>
+                )}
+              </div>
+            )}
+
+            {!editing && method === "file" && (
+              <div className="grid gap-2 rounded-lg border border-dashed border-[var(--line-strong)] bg-[var(--paper-warm)] p-3">
+                <label htmlFor={recipeFileId} className="grid gap-1.5">
+                  <span className="rt-mono text-[var(--ink-3)]">
+                    Recipe file
+                  </span>
+                  <Input
+                    id={recipeFileId}
+                    type="file"
+                    accept=".cook,.cooklang,.json,.jsonld,application/json,application/ld+json"
+                    onChange={(event) => {
+                      invalidateImportRequest();
+                      setRecipeFile(event.target.files?.[0] ?? null);
+                      setImportError(null);
+                      setImportedFileName(null);
+                    }}
+                    className="border-[var(--line-strong)] bg-[var(--paper)] file:mr-3 file:font-medium"
+                  />
+                </label>
+                <Button
+                  type="button"
+                  onClick={() => void importRecipeFile()}
+                  disabled={!recipeFile || importing}
+                  className="justify-self-start bg-[var(--terracotta)] text-white hover:bg-[var(--terracotta-deep)]"
+                >
+                  {importing ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <FileUp className="size-4" />
+                  )}
+                  {importing ? "Importing…" : "Import recipe"}
+                </Button>
+                <p className="text-xs text-[var(--ink-3)]">
+                  Upload Cooklang (.cook or .cooklang) or schema.org Recipe
+                  JSON-LD (.json or .jsonld), up to 100 KB.
+                </p>
+                {importError && (
+                  <p
+                    role="alert"
+                    className="flex items-start gap-1.5 text-sm text-destructive"
+                  >
+                    <AlertCircle className="mt-0.5 size-4 shrink-0" />
+                    {importError}
+                  </p>
+                )}
+                {importedFileName && !importError && (
+                  <output className="text-sm text-[var(--sage)]">
+                    Imported {importedFileName}. You can edit any field before
+                    saving.
                   </output>
                 )}
               </div>
@@ -747,7 +894,7 @@ export function AddRecipeView({
               <div>
                 <p className="rt-mono text-[var(--ink-3)]">Recipe text</p>
                 <p className="text-xs text-[var(--ink-3)]">
-                  {method === "url" || method === "photo"
+                  {method === "url" || method === "photo" || method === "file"
                     ? "Imported as editable Cooklang. Adjust anything before saving."
                     : "Use @ingredients, #cookware and ~timers directly in each step."}
                 </p>
@@ -767,6 +914,8 @@ export function AddRecipeView({
                     setCookTime(25);
                     setSource(EXAMPLE_RECIPE);
                     setImportedUrl(null);
+                    setUrlImportSuccess(false);
+                    setImportedFileName(null);
                   }}
                 >
                   <Sparkles /> Try example
@@ -808,8 +957,8 @@ export function AddRecipeView({
               </h2>
               <p className="rt-body mt-2 max-w-md text-[var(--ink-3)]">
                 Add a name and write your steps with inline Cooklang—or use the
-                example, URL importer, or a recipe photo to see ingredients and
-                timers come alive.
+                example, URL importer, local file importer, or a recipe photo to
+                see ingredients and timers come alive.
               </p>
               {(parse.error || previewResult.error) && (
                 <p role="alert" className="mt-4 text-sm text-destructive">

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -116,6 +116,8 @@ async function invalidateSavedRecipeQueries({
 
 const MAX_RECIPE_FILE_LENGTH = 100_000;
 
+class RecipeFileImportError extends Error {}
+
 function RecipeEditorGate({
   unreadable,
   pending,
@@ -409,10 +411,12 @@ export function AddRecipeView({
     setImportError(null);
     setImportedFileName(null);
     try {
-      const content = await recipeFile.text();
-      if (content.length > MAX_RECIPE_FILE_LENGTH) {
-        throw new Error("Choose a recipe file smaller than 100 KB.");
+      if (recipeFile.size > MAX_RECIPE_FILE_LENGTH) {
+        throw new RecipeFileImportError(
+          "Choose a recipe file smaller than 100 KB.",
+        );
       }
+      const content = await recipeFile.text();
       const response = await fetch("/api/recipes/import-file", {
         method: "POST",
         credentials: "include",
@@ -425,7 +429,7 @@ export function AddRecipeView({
         | { error?: string }
         | null;
       if (!response.ok || !body || !("source" in body)) {
-        throw new Error(
+        throw new RecipeFileImportError(
           (body && "error" in body && body.error) ||
             "The recipe file could not be imported.",
         );
@@ -442,7 +446,7 @@ export function AddRecipeView({
         return;
       }
       setImportError(
-        error instanceof Error
+        error instanceof RecipeFileImportError
           ? error.message
           : "The recipe file could not be imported.",
       );
@@ -458,6 +462,14 @@ export function AddRecipeView({
     importRequestRef.current?.controller.abort();
     importRequestRef.current = null;
     setImporting(false);
+  }
+
+  function selectMethod(nextMethod: AddMethod) {
+    invalidateImportRequest();
+    setImportError(null);
+    setImportedFileName(null);
+    setUrlImportSuccess(false);
+    setMethod(nextMethod);
   }
 
   const applyPhotoDraft = useCallback((draft: PhotoRecipeImportDraft) => {
@@ -604,10 +616,7 @@ export function AddRecipeView({
               >
                 <button
                   type="button"
-                  onClick={() => {
-                    invalidateImportRequest();
-                    setMethod("write");
-                  }}
+                  onClick={() => selectMethod("write")}
                   aria-pressed={method === "write"}
                   className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
                     method === "write"
@@ -619,11 +628,7 @@ export function AddRecipeView({
                 </button>
                 <button
                   type="button"
-                  onClick={() => {
-                    invalidateImportRequest();
-                    setImportError(null);
-                    setMethod("url");
-                  }}
+                  onClick={() => selectMethod("url")}
                   aria-pressed={method === "url"}
                   className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors ${
                     method === "url"
@@ -635,10 +640,7 @@ export function AddRecipeView({
                 </button>
                 <button
                   type="button"
-                  onClick={() => {
-                    invalidateImportRequest();
-                    setMethod("photo");
-                  }}
+                  onClick={() => selectMethod("photo")}
                   aria-pressed={method === "photo"}
                   className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-2 py-2 text-sm transition-colors ${
                     method === "photo"
@@ -650,11 +652,7 @@ export function AddRecipeView({
                 </button>
                 <button
                   type="button"
-                  onClick={() => {
-                    invalidateImportRequest();
-                    setImportError(null);
-                    setMethod("file");
-                  }}
+                  onClick={() => selectMethod("file")}
                   aria-pressed={method === "file"}
                   className={`rt-mono inline-flex items-center justify-center gap-2 rounded-md px-2 py-2 text-sm transition-colors ${
                     method === "file"

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -202,6 +202,22 @@ function NumberField({
   );
 }
 
+function recipeEditorCopy(editing: boolean) {
+  return editing
+    ? {
+        action: "Save changes",
+        description:
+          "Update the Cooklang recipe and review every change in the live preview.",
+        heading: "Edit",
+      }
+    : {
+        action: "Save recipe",
+        description:
+          "Enter a recipe manually, import a webpage or local file, or scan a recipe photo. Every method feeds the same editable preview.",
+        heading: "Add a",
+      };
+}
+
 export function AddRecipeView({
   initialRecipe,
 }: Readonly<{ initialRecipe?: SavedRecipeApiRecord }>) {
@@ -210,6 +226,7 @@ export function AddRecipeView({
     [initialRecipe],
   );
   const editing = Boolean(initialRecipe);
+  const editorCopy = recipeEditorCopy(editing);
   const unreadableRecipe = editing && !initialPayload;
   const titleId = useId();
   const descriptionId = useId();
@@ -577,13 +594,11 @@ export function AddRecipeView({
             <ArrowLeft className="size-3.5" /> Recipe box
           </Link>
           <h1 className="rt-display mt-2 text-5xl sm:text-6xl">
-            {editing ? "Edit" : "Add a"}{" "}
+            {editorCopy.heading}{" "}
             <span className="text-[var(--terracotta)]">recipe</span>
           </h1>
           <p className="rt-body mt-2 text-[var(--ink-2)]">
-            {editing
-              ? "Update the Cooklang recipe and review every change in the live preview."
-              : "Enter a recipe manually, import a webpage or local file, or scan a recipe photo. Every method feeds the same editable preview."}
+            {editorCopy.description}
           </p>
         </div>
         <Button
@@ -592,7 +607,7 @@ export function AddRecipeView({
           className="rounded-full bg-[var(--ink)] px-5 text-[var(--paper)] hover:bg-[var(--terracotta-deep)]"
         >
           {saving ? <Loader2 className="animate-spin" /> : <Save />}{" "}
-          {editing ? "Save changes" : "Save recipe"}
+          {editorCopy.action}
         </Button>
       </div>
 

--- a/ui/tests/components/recipes/add-recipe-view.test.tsx
+++ b/ui/tests/components/recipes/add-recipe-view.test.tsx
@@ -170,7 +170,7 @@ describe("AddRecipeView visibility", () => {
       screen.getByRole("button", { name: "Private", pressed: true }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Import from URL" }),
+      screen.queryByRole("button", { name: "Import URL" }),
     ).not.toBeInTheDocument();
 
     fireEvent.click(
@@ -225,5 +225,63 @@ describe("AddRecipeView visibility", () => {
     expect(
       screen.queryByRole("button", { name: "Save changes" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("imports a local schema.org file into the editable fields", async () => {
+    mocks.getHouseholds.mockResolvedValue([]);
+    const content = JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "Recipe",
+      name: "Tomato pasta",
+      recipeIngredient: ["200 g pasta"],
+      recipeInstructions: ["Boil the pasta."],
+    });
+    const file = new File([content], "tomato-pasta.json", {
+      type: "application/ld+json",
+    });
+    Object.defineProperty(file, "text", {
+      value: vi.fn().mockResolvedValue(content),
+    });
+    globalThis.fetch = vi.fn(async (input) => {
+      if (String(input) !== "/api/recipes/import-file") {
+        throw new Error(`Unexpected request: ${String(input)}`);
+      }
+      return Response.json({
+        title: "Tomato pasta",
+        description: "A quick dinner.",
+        cuisine: "Italian",
+        servings: 2,
+        prepTime: 5,
+        cookTime: 20,
+        source: "@pasta{200%g}\n\nBoil the pasta.",
+      });
+    }) as typeof fetch;
+
+    render(<AddRecipeView />);
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    fireEvent.change(screen.getByLabelText("Recipe file"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import recipe" }));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Recipe name")).toHaveValue("Tomato pasta"),
+    );
+    expect(screen.getByLabelText("Short description")).toHaveValue(
+      "A quick dinner.",
+    );
+    expect(screen.getByLabelText("Cuisine")).toHaveValue("Italian");
+    expect(screen.getByLabelText("Servings")).toHaveValue(2);
+    expect(
+      screen.getByText(
+        "Imported tomato-pasta.json. You can edit any field before saving.",
+      ),
+    ).toBeInTheDocument();
+
+    const [, request] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+    expect(JSON.parse(String(request?.body))).toEqual({
+      filename: "tomato-pasta.json",
+      content,
+    });
   });
 });

--- a/ui/tests/components/recipes/add-recipe-view.test.tsx
+++ b/ui/tests/components/recipes/add-recipe-view.test.tsx
@@ -284,4 +284,77 @@ describe("AddRecipeView visibility", () => {
       content,
     });
   });
+
+  it("rejects oversized files before reading or uploading them", async () => {
+    mocks.getHouseholds.mockResolvedValue([]);
+    const file = new File(["recipe"], "large.cook");
+    const text = vi.fn();
+    Object.defineProperties(file, {
+      size: { value: 100_001 },
+      text: { value: text },
+    });
+    globalThis.fetch = vi.fn();
+
+    render(<AddRecipeView />);
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    fireEvent.change(screen.getByLabelText("Recipe file"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import recipe" }));
+
+    expect(
+      await screen.findByText("Choose a recipe file smaller than 100 KB."),
+    ).toBeInTheDocument();
+    expect(text).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("clears file import feedback when switching methods", async () => {
+    mocks.getHouseholds.mockResolvedValue([]);
+    const file = new File(["@rice{1%cup}\n\nCook."], "rice.cook");
+    Object.defineProperty(file, "text", {
+      value: vi.fn().mockResolvedValue("@rice{1%cup}\n\nCook."),
+    });
+    globalThis.fetch = vi.fn(async () =>
+      Response.json({
+        title: "Rice",
+        description: "Rice.",
+        cuisine: "",
+        servings: 1,
+        source: "@rice{1%cup}\n\nCook.",
+      }),
+    ) as typeof fetch;
+
+    render(<AddRecipeView />);
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    fireEvent.change(screen.getByLabelText("Recipe file"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import recipe" }));
+    expect(await screen.findByText(/Imported rice\.cook/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Import URL" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    expect(screen.queryByText(/Imported rice\.cook/)).not.toBeInTheDocument();
+  });
+
+  it("shows a generic message for unexpected file import failures", async () => {
+    mocks.getHouseholds.mockResolvedValue([]);
+    const file = new File(["recipe"], "recipe.cook");
+    Object.defineProperty(file, "text", {
+      value: vi.fn().mockRejectedValue(new Error("internal detail")),
+    });
+
+    render(<AddRecipeView />);
+    fireEvent.click(screen.getByRole("button", { name: "Upload file" }));
+    fireEvent.change(screen.getByLabelText("Recipe file"), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import recipe" }));
+
+    expect(
+      await screen.findByText("The recipe file could not be imported."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("internal detail")).not.toBeInTheDocument();
+  });
 });

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -255,7 +255,13 @@ const importRecipeFileBodySchema = z
         /\.(?:cook|cooklang|json|jsonld)$/i,
         "Use a .cook, .cooklang, .json, or .jsonld file",
       ),
-    content: z.string().min(1).max(100_000),
+    content: z
+      .string()
+      .min(1)
+      .refine(
+        (value) => new TextEncoder().encode(value).byteLength <= 100_000,
+        "File content must be 100 KB or smaller",
+      ),
   })
   .strict();
 

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -28,6 +28,7 @@ import {
   LOWERCASE_KEBAB_CASE_PATTERN,
   RECIPE_SLUG_MAX_LENGTH,
 } from "recipe-domain/slugs";
+import { parseRecipeFile } from "recipe-parsing/recipe-file";
 import { parseSchemaOrgRecipeHtml } from "recipe-parsing/schema-org";
 import { createAuth } from "./auth";
 import { verifyCloudflareAccess } from "./cloudflare-access";
@@ -228,6 +229,7 @@ const NOTIFICATION_PAGE_SIZE = 100;
 
 const HOUSEHOLD_INVITE_RATE_LIMIT = { max: 10, windowSeconds: 60 * 60 };
 const RECIPE_URL_IMPORT_RATE_LIMIT = { max: 20, windowSeconds: 60 * 60 };
+const RECIPE_FILE_IMPORT_RATE_LIMIT = { max: 20, windowSeconds: 60 * 60 };
 const RECIPE_PHOTO_IMPORT_RATE_LIMIT = { max: 20, windowSeconds: 60 * 60 };
 
 const createRecipeBodySchema = z.object({
@@ -240,6 +242,21 @@ const createRecipeBodySchema = z.object({
 
 const importRecipeUrlBodySchema = z
   .object({ url: z.string().trim().min(1).max(2_048) })
+  .strict();
+
+const importRecipeFileBodySchema = z
+  .object({
+    filename: z
+      .string()
+      .trim()
+      .min(1)
+      .max(255)
+      .regex(
+        /\.(?:cook|cooklang|json|jsonld)$/i,
+        "Use a .cook, .cooklang, .json, or .jsonld file",
+      ),
+    content: z.string().min(1).max(100_000),
+  })
   .strict();
 
 const updateRecipeBodySchema = z
@@ -2701,6 +2718,54 @@ app.post("/recipes/import-url", async (c) => {
         error instanceof RecipeUrlImportError
           ? c.json({ error: error.message }, error.status)
           : undefined,
+    },
+  );
+});
+
+app.post("/recipes/import-file", async (c) => {
+  const csrfFailure = validateCsrf(c);
+  if (csrfFailure) return csrfFailure;
+
+  return withRecipeSession(
+    c,
+    "mutation",
+    "POST /recipes/import-file failed",
+    async ({ db, session }) => {
+      const body = await parseJsonBody(c, importRecipeFileBodySchema);
+      if (!body.success) return body.response;
+
+      const importLimit = await enforceRateLimit(
+        db,
+        `recipe-file-import:${session.user.id}`,
+        RECIPE_FILE_IMPORT_RATE_LIMIT,
+      );
+      if (!importLimit.allowed) {
+        return rateLimitedResponse(c, importLimit.retryAfter);
+      }
+
+      const recipe = await parseRecipeFile(
+        body.data.filename,
+        body.data.content,
+      );
+      if (!recipe) {
+        return c.json(
+          {
+            error:
+              "No complete recipe was found in that file. Cooklang files need ingredients and instructions; schema.org files need a Recipe with a name, ingredients, and instructions.",
+          },
+          422,
+        );
+      }
+      if (recipe.source.length > 10_000) {
+        return c.json(
+          {
+            error:
+              "That recipe is too long to import. The Cooklang draft exceeds 10,000 characters.",
+          },
+          422,
+        );
+      }
+      return c.json(recipe);
     },
   );
 });

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -2099,6 +2099,108 @@ describe("POST /recipes/import-url", () => {
   });
 });
 
+describe("POST /recipes/import-file", () => {
+  it("requires authentication before parsing the file", async () => {
+    const res = await app.request(
+      "/recipes/import-file",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          filename: "pasta.cook",
+          content: "@pasta{200%g}\n\nBoil the pasta.",
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns an editable draft from a local Cooklang file", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+    const content = `---
+title: "Tomato pasta"
+description: "A quick dinner."
+cuisine: ["Italian"]
+servings: 2
+prepTime: 5
+cookTime: 20
+---
+@pasta{200%g}
+@tomatoes{400%g}
+
+Boil the pasta, then add the tomatoes.`;
+
+    const res = await app.request(
+      "/recipes/import-file",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({ filename: "pasta.cook", content }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      title: "Tomato pasta",
+      description: "A quick dinner.",
+      cuisine: "Italian",
+      servings: 2,
+      prepTime: 5,
+      cookTime: 20,
+      source:
+        "@pasta{200%g}\n@tomatoes{400%g}\n\nBoil the pasta, then add the tomatoes.",
+    });
+  });
+
+  it("validates the supported file extensions", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/recipes/import-file",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          filename: "pasta.txt",
+          content: "@pasta{200%g}\n\nBoil the pasta.",
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: "Invalid request body",
+      details: [
+        expect.objectContaining({
+          path: ["filename"],
+          message: "Use a .cook, .cooklang, .json, or .jsonld file",
+        }),
+      ],
+    });
+  });
+});
+
 describe("profile diet preferences", () => {
   it("requires authentication before returning a diet profile", async () => {
     const res = await app.request("/api/profile/diet", {}, env);

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -2200,6 +2200,66 @@ Boil the pasta, then add the tomatoes.`;
     });
   });
 
+  it("reports files without a complete recipe", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/recipes/import-file",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          filename: "article.json",
+          content: JSON.stringify({ "@type": "Article" }),
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({
+      error:
+        "No complete recipe was found in that file. Cooklang files need ingredients and instructions; schema.org files need a Recipe with a name, ingredients, and instructions.",
+    });
+  });
+
+  it("reports imported drafts longer than 10,000 characters", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/recipes/import-file",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          filename: "long-recipe.cook",
+          content: `@rice{1%cup}\n\n${"Cook the rice. ".repeat(800)}`,
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({
+      error:
+        "That recipe is too long to import. The Cooklang draft exceeds 10,000 characters.",
+    });
+  });
+
   it("rejects file content larger than 100 KB when encoded", async () => {
     authzMock.session = sessionFor({
       id: "owner-user",

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -2199,6 +2199,41 @@ Boil the pasta, then add the tomatoes.`;
       ],
     });
   });
+
+  it("rejects file content larger than 100 KB when encoded", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+
+    const res = await app.request(
+      "/recipes/import-file",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "http://localhost:3000",
+        },
+        body: JSON.stringify({
+          filename: "pasta.cook",
+          content: "é".repeat(50_001),
+        }),
+      },
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: "Invalid request body",
+      details: [
+        expect.objectContaining({
+          path: ["content"],
+          message: "File content must be 100 KB or smaller",
+        }),
+      ],
+    });
+  });
 });
 
 describe("profile diet preferences", () => {


### PR DESCRIPTION
## What changed

- add local Cooklang (`.cook` and `.cooklang`) recipe imports
- add schema.org Recipe JSON-LD (`.json` and `.jsonld`) imports
- expose an authenticated, rate-limited recipe-file import API endpoint
- add an upload-file method to the recipe editor with validation and import feedback
- preserve canonical recipe URLs when supplied by imported files

## Why

Recipes stored in portable local formats previously had to be copied into the editor manually. This adds a direct import path while keeping the resulting Cooklang draft fully editable before saving.

## Validation

- `mise //packages/recipe-parsing:check` — 81 tests passed
- `mise //workers/recipe-api:check` — 166 tests passed; type and migration checks passed
- `mise //ui:check` — 652 tests passed; type, lint, and format checks passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added local recipe file importing for Cooklang and schema.org JSON/JSON-LD files.
  - Added an “Upload file” option to the recipe editor.
  - Imported recipes now populate editable fields and preserve canonical URLs when available.
  - Added clear success and error feedback for file imports.

- **Bug Fixes**
  - Added validation for supported file types and a 100 KB size limit.
  - Invalid, incomplete, malformed, or unsupported recipe files are rejected safely.
  - Updated Add Recipe guidance to describe the available import methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->