### PR TITLE
Improve PR QA developer experience

### DIFF
--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -46,6 +46,10 @@ per-model cost, model failures, and incomplete-coverage warnings. These
 cumulative scorecard fields are intended to support removing scouts that are
 noisy or not cost-effective.
 
+When OpenRouter reports exhausted account credits or an exhausted API-key
+spending limit, the stable `review` check is marked as skipped. Authentication,
+provider, reviewer, and workflow failures continue to fail the check.
+
 Scout responses allow up to 8,000 output tokens because reasoning tokens count
 against the same limit and thinking models can otherwise exhaust the budget
 before emitting their final structured response. The default Kimi K2.6 scout

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   completionContent,
   ignored,
+  isCreditExhaustion,
   markdownText,
   parseModelPayload,
   renderComment,
@@ -59,6 +60,30 @@ test("completion accepts a null finish reason but rejects truncation", () => {
     () => completionContent({ finish_reason: "length", message: { content: "{}" } }, "model"),
     /stopped with length/,
   );
+});
+
+test("credit exhaustion only matches payment and key-limit failures", () => {
+  assert.equal(
+    isCreditExhaustion(
+      new Error(
+        'POST /chat/completions failed (403): {"error":{"message":"Key limit exceeded (monthly limit)"}}',
+      ),
+    ),
+    true,
+  );
+  assert.equal(
+    isCreditExhaustion(
+      new Error('POST /chat/completions failed (402): {"error":{"message":"Insufficient credits"}}'),
+    ),
+    true,
+  );
+  assert.equal(
+    isCreditExhaustion(
+      new Error('POST /chat/completions failed (403): {"error":{"message":"Guardrail blocked request"}}'),
+    ),
+    false,
+  );
+  assert.equal(isCreditExhaustion(new Error("All scout models failed")), false);
 });
 
 test("model payload accepts a single JSON fence but rejects prose", () => {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -1,3 +1,4 @@
+import { appendFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 
@@ -266,6 +267,21 @@ function settingsFromEnv(): Settings {
 
 function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export function isCreditExhaustion(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /OpenRouter credits exhausted/.test(message) ||
+    /failed \(402\)/.test(message) ||
+    (/failed \(403\)/.test(message) &&
+      /(?:key limit exceeded|insufficient credits|out of credits|payment required)/i.test(message))
+  );
+}
+
+function setWorkflowStatus(status: "success" | "credits" | "failure"): void {
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) appendFileSync(output, `status=${status}\n`, "utf8");
 }
 
 class JsonClient {
@@ -821,11 +837,13 @@ async function main(): Promise<void> {
   const outOfScopeCounts: Record<string, number> = {};
   const candidateCounts: Record<string, number> = {};
   const failed: string[] = [];
+  const creditFailures: string[] = [];
   const allowedFiles = new Set(paths);
   settled.forEach((outcome, index) => {
     const model = settings.scouts[index];
     if (outcome.status === "rejected") {
       failed.push(model);
+      if (isCreditExhaustion(outcome.reason)) creditFailures.push(model);
       console.error(`::warning::Scout ${model} failed: ${String(outcome.reason)}`);
       return;
     }
@@ -847,7 +865,12 @@ async function main(): Promise<void> {
       console.error(`::warning::Scout ${model} returned invalid payload: ${String(error)}`);
     }
   });
-  if (!Object.keys(candidates).length) throw new Error("All scout models failed; refusing to publish an empty review");
+  if (!Object.keys(candidates).length) {
+    if (creditFailures.length === settings.scouts.length) {
+      throw new Error("OpenRouter credits exhausted for all scout models");
+    }
+    throw new Error("All scout models failed; refusing to publish an empty review");
+  }
 
   const threads = await reviewer.reviewThreadContext();
   const mergerPrompt = `<DATA kind=scout-candidates>\n${JSON.stringify(candidates)}\n</DATA>
@@ -897,8 +920,18 @@ async function main(): Promise<void> {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch((error) => {
-    console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
-    process.exitCode = 1;
-  });
+  main()
+    .then(() => {
+      setWorkflowStatus("success");
+    })
+    .catch((error) => {
+      if (isCreditExhaustion(error)) {
+        console.log("::notice::AI code review skipped because the OpenRouter API key is out of credits.");
+        setWorkflowStatus("credits");
+        return;
+      }
+      console.error(`::error::${error instanceof Error ? error.message : String(error)}`);
+      setWorkflowStatus("failure");
+      process.exitCode = 1;
+    });
 }

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -14,11 +14,9 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
-  review:
+  run-review:
     if: >-
       (github.event_name == 'pull_request' &&
        github.event.pull_request.draft == false &&
@@ -33,6 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production-ci
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    outputs:
+      status: ${{ steps.review.outputs.status }}
     timeout-minutes: 20
     concurrency:
       group: ai-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
@@ -59,6 +63,7 @@ jobs:
           node --check .github/scripts/ai-review/ai-review.ts
 
       - name: Review pull request
+        id: review
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -69,3 +74,23 @@ jobs:
           AI_REVIEW_IGNORED_AUTHORS: ${{ vars.AI_REVIEW_IGNORED_AUTHORS }}
           AI_REVIEW_ZDR: ${{ vars.AI_REVIEW_ZDR }}
         run: node .github/scripts/ai-review/ai-review.ts
+
+  # A job can only receive GitHub's "skipped" conclusion when its job-level
+  # condition is false. Keep this lightweight sentinel as the stable PR check:
+  # exhausted credits skip it, while genuine execution failures still fail it.
+  review:
+    needs: run-review
+    if: >
+      always()
+      && needs.run-review.result != 'skipped'
+      && needs.run-review.outputs.status != 'credits'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report review result
+        env:
+          REVIEW_STATUS: ${{ needs.run-review.outputs.status }}
+        run: |
+          if [[ "$REVIEW_STATUS" != "success" ]]; then
+            echo "::error::AI reviewer failed before completing successfully."
+            exit 1
+          fi

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -12,8 +12,7 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   run-review:

--- a/.github/workflows/preview-backend-command.yml
+++ b/.github/workflows/preview-backend-command.yml
@@ -1,0 +1,83 @@
+name: Request Backend Preview
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  request:
+    if: >
+      github.event.issue.pull_request
+      && github.event.comment.body == '/preview-backend'
+      && contains(
+        fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+        github.event.comment.author_association
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Request and rerun backend preview
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+
+          if [[ "$(jq -r '.head.repo.full_name' <<< "$pr")" != "$REPO" ]]; then
+            echo "::error::Backend previews are only available for same-repository pull requests."
+            exit 1
+          fi
+
+          author=$(jq -r '.user.login' <<< "$pr")
+          if [[ "$author" == "renovate[bot]" || "$author" == "dependabot[bot]" ]]; then
+            echo "::error::Backend previews are not available for dependency bot pull requests."
+            exit 1
+          fi
+
+          head_sha=$(jq -r '.head.sha' <<< "$pr")
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Pull request #$PR_NUMBER returned an invalid head SHA."
+            exit 1
+          fi
+
+          if jq -e '[.labels[].name] | index("preview:frontend-only") != null' <<< "$pr" >/dev/null; then
+            gh api \
+              --method DELETE \
+              "repos/$REPO/issues/$PR_NUMBER/labels/preview%3Afrontend-only" >/dev/null
+          fi
+          gh api \
+            --method POST \
+            "repos/$REPO/issues/$PR_NUMBER/labels" \
+            -f 'labels[]=preview:backend' >/dev/null
+
+          run_id=$(
+            gh api \
+              --method GET \
+              "repos/$REPO/actions/workflows/preview-environment.yml/runs" \
+              -f event=pull_request \
+              -f head_sha="$head_sha" \
+              -f per_page=1 \
+              --jq '.workflow_runs[0].id'
+          )
+          if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::No preview workflow run was found for pull request #$PR_NUMBER at $head_sha."
+            exit 1
+          fi
+
+          gh api \
+            --method POST \
+            "repos/$REPO/actions/runs/$run_id/rerun"
+          gh api \
+            --method POST \
+            "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=rocket >/dev/null

--- a/.github/workflows/preview-backend-command.yml
+++ b/.github/workflows/preview-backend-command.yml
@@ -59,25 +59,84 @@ jobs:
             --method POST \
             "repos/$REPO/issues/$PR_NUMBER/labels" \
             -f 'labels[]=preview:backend' >/dev/null
-
-          run_id=$(
-            gh api \
-              --method GET \
-              "repos/$REPO/actions/workflows/preview-environment.yml/runs" \
-              -f event=pull_request \
-              -f head_sha="$head_sha" \
-              -f per_page=1 \
-              --jq '.workflow_runs[0].id'
-          )
-          if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
-            echo "::error::No preview workflow run was found for pull request #$PR_NUMBER at $head_sha."
-            exit 1
-          fi
-
-          gh api \
-            --method POST \
-            "repos/$REPO/actions/runs/$run_id/rerun"
           gh api \
             --method POST \
             "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
-            -f content=rocket >/dev/null
+            -f content=eyes >/dev/null
+
+          # A command can arrive while the current preview is still running.
+          # Wait for a completed run whose detect job actually ran, then rerun
+          # that exact PR/SHA execution. This excludes unrelated label events,
+          # other PRs sharing a commit, and ineligible active runs.
+          for _ in {1..60}; do
+            runs=$(
+              gh api \
+                --method GET \
+                "repos/$REPO/actions/workflows/preview-environment.yml/runs" \
+                -f event=pull_request \
+                -f head_sha="$head_sha" \
+                -f per_page=100
+            )
+            run_id=""
+            while IFS=$'\t' read -r candidate_id candidate_status; do
+              jobs=$(
+                gh api \
+                  --method GET \
+                  "repos/$REPO/actions/runs/$candidate_id/jobs" \
+                  -f filter=latest \
+                  -f per_page=100
+              )
+              if ! jq -e \
+                'any(.jobs[]?; .name == "detect" and .conclusion == "success")' \
+                <<< "$jobs" >/dev/null; then
+                continue
+              fi
+              if [[ "$candidate_status" == "completed" ]]; then
+                run_id=$candidate_id
+                break
+              fi
+            done < <(
+              jq -r \
+                --arg sha "$head_sha" \
+                --argjson pr "$PR_NUMBER" \
+                '.workflow_runs[]
+                 | select(.head_sha == $sha)
+                 | select(any(.pull_requests[]?; .number == $pr))
+                 | [.id, .status]
+                 | @tsv' \
+                <<< "$runs"
+            )
+
+            if [[ "$run_id" =~ ^[0-9]+$ ]]; then
+              rerun_error="$RUNNER_TEMP/preview-rerun-error"
+              if gh api \
+                --method POST \
+                "repos/$REPO/actions/runs/$run_id/rerun" \
+                2>"$rerun_error"; then
+                gh api \
+                  --method POST \
+                  "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+                  -f content=rocket >/dev/null
+                exit 0
+              fi
+
+              # A concurrent rerun may have started after selection. Retry
+              # after it completes; surface permanent API errors immediately.
+              run_status=$(
+                gh api \
+                  --method GET \
+                  "repos/$REPO/actions/runs/$run_id" \
+                  --jq '.status'
+              )
+              if [[ "$run_status" == "completed" ]]; then
+                cat "$rerun_error" >&2
+                exit 1
+              fi
+            fi
+
+            echo "::notice::Waiting for an eligible preview run for PR #$PR_NUMBER at $head_sha."
+            sleep 10
+          done
+
+          echo "::error::No completed eligible preview run was found for pull request #$PR_NUMBER at $head_sha within 10 minutes."
+          exit 1

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -5,81 +5,27 @@ on:
   # secrets they need while fork PRs get none.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  issue_comment:
-    types: [created]
 
 permissions:
   contents: read
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number || github.event.issue.number }}
+  group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  context:
-    if: >
-      (
-        github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.full_name == github.repository
-        && github.event.pull_request.user.login != 'renovate[bot]'
-        && github.event.pull_request.user.login != 'dependabot[bot]'
-        && (
-          (github.event.action != 'labeled' && github.event.action != 'unlabeled')
-          || startsWith(github.event.label.name, 'preview:')
-        )
-      ) || (
-        github.event_name == 'issue_comment'
-        && github.event.issue.pull_request
-        && github.event.comment.body == '/preview-backend'
-        && contains(
-          fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
-          github.event.comment.author_association
-        )
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      eligible: ${{ steps.resolve.outputs.eligible }}
-      pr_number: ${{ steps.resolve.outputs.pr_number }}
-      head_sha: ${{ steps.resolve.outputs.head_sha }}
-      force_frontend: ${{ steps.resolve.outputs.force_frontend }}
-      force_backend: ${{ steps.resolve.outputs.force_backend }}
-    steps:
-      - name: Resolve pull request context
-        id: resolve
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          pr=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
-
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          if [[ "$(jq -r '.head.repo.full_name' <<< "$pr")" != "$REPO" ]]; then
-            echo "eligible=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          author=$(jq -r '.user.login' <<< "$pr")
-          if [[ "$author" == "renovate[bot]" || "$author" == "dependabot[bot]" ]]; then
-            echo "eligible=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          {
-            echo "eligible=true"
-            echo "head_sha=$(jq -r '.head.sha' <<< "$pr")"
-            echo "force_frontend=$(jq -r '[.labels[].name] | index("preview:frontend-only") != null' <<< "$pr")"
-            echo "force_backend=$(jq -r '[.labels[].name] | index("preview:backend") != null' <<< "$pr")"
-          } >> "$GITHUB_OUTPUT"
-
   # Decide whether this PR needs a database-backed backend preview.
   detect:
-    needs: context
-    if: needs.context.outputs.eligible == 'true'
+    # On label events, only react to the preview:* labels so unrelated label
+    # changes don't rebuild the preview.
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'renovate[bot]'
+      && github.event.pull_request.user.login != 'dependabot[bot]'
+      && (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+        || startsWith(github.event.label.name, 'preview:')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -91,24 +37,20 @@ jobs:
         id: decide
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          COMMENT_REQUEST: ${{ github.event_name == 'issue_comment' }}
-          FORCE_FRONTEND: ${{ needs.context.outputs.force_frontend }}
-          FORCE_BACKEND: ${{ needs.context.outputs.force_backend }}
         run: |
           set -euo pipefail
-          if [[ "$COMMENT_REQUEST" == "true" ]]; then
-            echo "The /preview-backend command requests a backend preview."
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ "$FORCE_FRONTEND" == "true" ]]; then
+          pr=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+          force_frontend=$(jq -r '[.labels[].name] | index("preview:frontend-only") != null' <<< "$pr")
+          force_backend=$(jq -r '[.labels[].name] | index("preview:backend") != null' <<< "$pr")
+
+          if [[ "$force_frontend" == "true" ]]; then
             echo "Label preview:frontend-only forces frontend-only preview."
             echo "backend=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ "$FORCE_BACKEND" == "true" ]]; then
+          if [[ "$force_backend" == "true" ]]; then
             echo "Label preview:backend forces a backend preview."
             echo "backend=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -123,7 +65,7 @@ jobs:
           fi
 
   backend:
-    needs: [context, detect]
+    needs: detect
     if: needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     environment:
@@ -133,7 +75,7 @@ jobs:
     steps:
       - name: Set preview resource names
         env:
-          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PAGES_HOST: ${{ vars.CLOUDFLARE_PAGES_HOST }}
           PREVIEW_AUTH_SEED: ${{ secrets.PREVIEW_AUTH_SEED }}
         run: |
@@ -169,7 +111,7 @@ jobs:
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          branch: preview-pr-${{ needs.context.outputs.pr_number }}
+          branch: preview-pr-${{ github.event.pull_request.number }}
 
       - name: Wait for previous Neon preview branch deletion
         env:
@@ -197,7 +139,7 @@ jobs:
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          branch_name: preview-pr-${{ needs.context.outputs.pr_number }}
+          branch_name: preview-pr-${{ github.event.pull_request.number }}
           parent_branch: preview-base
           database: recipes
           role: recipes_owner
@@ -215,7 +157,7 @@ jobs:
       # never see the Neon API key.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.context.outputs.head_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -248,7 +190,7 @@ jobs:
         run: mise run //workers/recipe-api:db:seed:preview
         env:
           DATABASE_URL: ${{ steps.neon.outputs.db_url }}
-          BETTER_AUTH_URL: https://pr-${{ needs.context.outputs.pr_number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
+          BETTER_AUTH_URL: https://pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
 
       - name: Create atomic Worker secrets files
         id: worker-secrets
@@ -293,7 +235,7 @@ jobs:
   # backend job. NEXT_PUBLIC_PREVIEW_BACKEND tells the build whether sign-in is
   # backed by a per-PR Worker so the UI can present the right state.
   frontend:
-    needs: [context, detect]
+    needs: detect
     if: needs.detect.result == 'success'
     runs-on: ubuntu-latest
     environment:
@@ -303,7 +245,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ needs.context.outputs.head_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -346,12 +288,12 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DEPLOY_BRANCH: pr-${{ needs.context.outputs.pr_number }}
+          DEPLOY_BRANCH: pr-${{ github.event.pull_request.number }}
           NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ vars.CF_IMAGES_ACCOUNT_HASH }}
           NEXT_PUBLIC_PREVIEW_BACKEND: ${{ needs.detect.outputs.backend }}
 
   comment:
-    needs: [context, detect, backend, frontend]
+    needs: [detect, backend, frontend]
     if: always() && needs.frontend.result == 'success'
     runs-on: ubuntu-latest
     # The preview URL is built from vars.CLOUDFLARE_PAGES_HOST, which is scoped
@@ -367,9 +309,9 @@ jobs:
       - name: Comment preview URL on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          PREVIEW_SITE_URL: https://pr-${{ needs.context.outputs.pr_number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
-          PREVIEW_WORKER_NAME: recipe-api-pr-${{ needs.context.outputs.pr_number }}
-          PREVIEW_BRANCH: preview-pr-${{ needs.context.outputs.pr_number }}
+          PREVIEW_SITE_URL: https://pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
+          PREVIEW_WORKER_NAME: recipe-api-pr-${{ github.event.pull_request.number }}
+          PREVIEW_BRANCH: preview-pr-${{ github.event.pull_request.number }}
           BACKEND_REQUESTED: ${{ needs.detect.outputs.backend }}
           BACKEND_RESULT: ${{ needs.backend.result }}
         with:

--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -5,27 +5,81 @@ on:
   # secrets they need while fork PRs get none.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 concurrency:
-  group: preview-${{ github.event.pull_request.number }}
+  group: preview-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
 
 jobs:
+  context:
+    if: >
+      (
+        github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.event.pull_request.user.login != 'renovate[bot]'
+        && github.event.pull_request.user.login != 'dependabot[bot]'
+        && (
+          (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+          || startsWith(github.event.label.name, 'preview:')
+        )
+      ) || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && github.event.comment.body == '/preview-backend'
+        && contains(
+          fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+          github.event.comment.author_association
+        )
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      eligible: ${{ steps.resolve.outputs.eligible }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      force_frontend: ${{ steps.resolve.outputs.force_frontend }}
+      force_backend: ${{ steps.resolve.outputs.force_backend }}
+    steps:
+      - name: Resolve pull request context
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          if [[ "$(jq -r '.head.repo.full_name' <<< "$pr")" != "$REPO" ]]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          author=$(jq -r '.user.login' <<< "$pr")
+          if [[ "$author" == "renovate[bot]" || "$author" == "dependabot[bot]" ]]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          {
+            echo "eligible=true"
+            echo "head_sha=$(jq -r '.head.sha' <<< "$pr")"
+            echo "force_frontend=$(jq -r '[.labels[].name] | index("preview:frontend-only") != null' <<< "$pr")"
+            echo "force_backend=$(jq -r '[.labels[].name] | index("preview:backend") != null' <<< "$pr")"
+          } >> "$GITHUB_OUTPUT"
+
   # Decide whether this PR needs a database-backed backend preview.
   detect:
-    # On label events, only react to the preview:* labels so unrelated label
-    # changes don't rebuild the preview.
-    if: >
-      github.event.pull_request.head.repo.full_name == github.repository
-      && github.event.pull_request.user.login != 'renovate[bot]'
-      && github.event.pull_request.user.login != 'dependabot[bot]'
-      && (
-        (github.event.action != 'labeled' && github.event.action != 'unlabeled')
-        || startsWith(github.event.label.name, 'preview:')
-      )
+    needs: context
+    if: needs.context.outputs.eligible == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,12 +91,18 @@ jobs:
         id: decide
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
           REPO: ${{ github.repository }}
-          FORCE_FRONTEND: ${{ contains(github.event.pull_request.labels.*.name, 'preview:frontend-only') }}
-          FORCE_BACKEND: ${{ contains(github.event.pull_request.labels.*.name, 'preview:backend') }}
+          COMMENT_REQUEST: ${{ github.event_name == 'issue_comment' }}
+          FORCE_FRONTEND: ${{ needs.context.outputs.force_frontend }}
+          FORCE_BACKEND: ${{ needs.context.outputs.force_backend }}
         run: |
           set -euo pipefail
+          if [[ "$COMMENT_REQUEST" == "true" ]]; then
+            echo "The /preview-backend command requests a backend preview."
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [[ "$FORCE_FRONTEND" == "true" ]]; then
             echo "Label preview:frontend-only forces frontend-only preview."
             echo "backend=false" >> "$GITHUB_OUTPUT"
@@ -63,7 +123,7 @@ jobs:
           fi
 
   backend:
-    needs: detect
+    needs: [context, detect]
     if: needs.detect.outputs.backend == 'true'
     runs-on: ubuntu-latest
     environment:
@@ -73,7 +133,7 @@ jobs:
     steps:
       - name: Set preview resource names
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
           PAGES_HOST: ${{ vars.CLOUDFLARE_PAGES_HOST }}
           PREVIEW_AUTH_SEED: ${{ secrets.PREVIEW_AUTH_SEED }}
         run: |
@@ -109,7 +169,7 @@ jobs:
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          branch: preview-pr-${{ github.event.pull_request.number }}
+          branch: preview-pr-${{ needs.context.outputs.pr_number }}
 
       - name: Wait for previous Neon preview branch deletion
         env:
@@ -137,7 +197,7 @@ jobs:
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           api_key: ${{ secrets.NEON_API_KEY }}
-          branch_name: preview-pr-${{ github.event.pull_request.number }}
+          branch_name: preview-pr-${{ needs.context.outputs.pr_number }}
           parent_branch: preview-base
           database: recipes
           role: recipes_owner
@@ -155,7 +215,7 @@ jobs:
       # never see the Neon API key.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.context.outputs.head_sha }}
           persist-credentials: false
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -188,7 +248,7 @@ jobs:
         run: mise run //workers/recipe-api:db:seed:preview
         env:
           DATABASE_URL: ${{ steps.neon.outputs.db_url }}
-          BETTER_AUTH_URL: https://pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
+          BETTER_AUTH_URL: https://pr-${{ needs.context.outputs.pr_number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
 
       - name: Create atomic Worker secrets files
         id: worker-secrets
@@ -233,7 +293,7 @@ jobs:
   # backend job. NEXT_PUBLIC_PREVIEW_BACKEND tells the build whether sign-in is
   # backed by a per-PR Worker so the UI can present the right state.
   frontend:
-    needs: detect
+    needs: [context, detect]
     if: needs.detect.result == 'success'
     runs-on: ubuntu-latest
     environment:
@@ -243,7 +303,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ needs.context.outputs.head_sha }}
           persist-credentials: false
 
       - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
@@ -286,12 +346,12 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          DEPLOY_BRANCH: pr-${{ github.event.pull_request.number }}
+          DEPLOY_BRANCH: pr-${{ needs.context.outputs.pr_number }}
           NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: ${{ vars.CF_IMAGES_ACCOUNT_HASH }}
           NEXT_PUBLIC_PREVIEW_BACKEND: ${{ needs.detect.outputs.backend }}
 
   comment:
-    needs: [detect, backend, frontend]
+    needs: [context, detect, backend, frontend]
     if: always() && needs.frontend.result == 'success'
     runs-on: ubuntu-latest
     # The preview URL is built from vars.CLOUDFLARE_PAGES_HOST, which is scoped
@@ -307,9 +367,9 @@ jobs:
       - name: Comment preview URL on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          PREVIEW_SITE_URL: https://pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
-          PREVIEW_WORKER_NAME: recipe-api-pr-${{ github.event.pull_request.number }}
-          PREVIEW_BRANCH: preview-pr-${{ github.event.pull_request.number }}
+          PREVIEW_SITE_URL: https://pr-${{ needs.context.outputs.pr_number }}.${{ vars.CLOUDFLARE_PAGES_HOST }}
+          PREVIEW_WORKER_NAME: recipe-api-pr-${{ needs.context.outputs.pr_number }}
+          PREVIEW_BRANCH: preview-pr-${{ needs.context.outputs.pr_number }}
           BACKEND_REQUESTED: ${{ needs.detect.outputs.backend }}
           BACKEND_RESULT: ${{ needs.backend.result }}
         with:
@@ -328,16 +388,22 @@ jobs:
                 'The site is protected by Cloudflare Access. Use the **Sign in** menu to choose a seeded QA scenario.',
               ];
             } else if (requested && !ok) {
-              backendLines = ['**Backend:** ⚠️ provisioning failed — the frontend is deployed, but sign-in is unavailable. Re-run the workflow to retry.'];
+              backendLines = ['**Backend:** ⚠️ provisioning failed — the frontend is deployed, but sign-in is unavailable. Comment `/preview-backend` again to retry.'];
             } else {
-              backendLines = ['**Backend:** frontend-only preview — sign-in is disabled. Add the `preview:backend` label to provision an isolated Worker + database.'];
+              backendLines = [
+                '**Backend:** frontend-only preview — sign-in is disabled.',
+                '',
+                'Need sign-in and seeded QA data? Comment `/preview-backend` on this PR to provision an isolated Worker + database.',
+              ];
             }
 
             const body = [
               marker,
               '### Preview environment',
               '',
-              `**Site:** ${process.env.PREVIEW_SITE_URL}`,
+              `**Personal site:** ${process.env.PREVIEW_SITE_URL}`,
+              `**Recipes:** ${process.env.PREVIEW_SITE_URL}/recipes`,
+              `**AssetTracker:** ${process.env.PREVIEW_SITE_URL}/assettracker`,
               ...backendLines,
             ].join('\n');
 


### PR DESCRIPTION
## What changed

### Preview environments

- Adds direct links for the personal site, Recipes, and AssetTracker to the rolling PR preview comment.
- Adds a mobile-friendly `/preview-backend` PR comment command.
- Handles the command in a non-privileged broker workflow that validates the commenter and PR, applies the backend label, and reruns the matching PR-originated preview workflow.
- Keeps deployment secrets and PR checkout isolated in the existing `pull_request` workflow, pinned to the event-provided immutable head SHA.
- Keeps the existing `preview:backend` and `preview:frontend-only` label behavior.

### AI code review

- Distinguishes OpenRouter credit exhaustion from authentication, provider, and reviewer failures.
- Marks the stable `review` check as skipped when account credits or the API-key spending limit are exhausted.
- Continues to fail the check for genuine execution failures.
- Narrows write permissions to the reviewer execution job.

## Why

GitHub's Android app does not make the backend-preview label flow easy to discover or use. The preview comment is already the natural QA entry point, so it now links directly to every incubated app and documents a command that can be posted from mobile.

A Markdown checkbox on the bot-authored comment would not provide a reliable Actions trigger. The broker uses `issue_comment` without checking out PR code or receiving deployment secrets, then reruns the existing PR-scoped workflow.

The AI reviewer is advisory. Exhausted credits are an unavailable optional service, not a code defect, so that outcome should not present as a failed PR check.

## Validation

- AI reviewer unit tests under Node 24
- AI reviewer syntax check under Node 24
- `mise run //:lint:actions`
- `mise run //:lint:yaml`
- `mise run //:lint:markdown:check`
- `mise run //:security:actions`
- `git diff --check`
- Pre-commit formatting and secret checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/preview-backend` pull request command to request backend preview provisioning and automatically retry the relevant preview workflow.
  * Added clearer preview labelling and validation for backend preview requests.
* **Bug Fixes**
  * AI review checks now skip gracefully when account credits or API spending limits are exhausted, while other review failures remain visible.
  * Improved preview environment detection and status reporting.
* **Documentation**
  * Updated guidance for retrying backend provisioning and viewing preview site links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->