### PR TITLE
Reset timer dock position and fix backend preview command

### DIFF
--- a/.github/workflows/preview-backend-command.yml
+++ b/.github/workflows/preview-backend-command.yml
@@ -21,7 +21,7 @@ jobs:
       actions: write
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Request and rerun backend preview
         env:

--- a/ui/components/recipes/timer-dock.tsx
+++ b/ui/components/recipes/timer-dock.tsx
@@ -72,6 +72,14 @@ function savePosition(position: DockPosition): void {
   }
 }
 
+function clearPosition(): void {
+  try {
+    localStorage.removeItem(POSITION_KEY);
+  } catch {
+    // localStorage unavailable
+  }
+}
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), Math.max(min, max));
 }
@@ -263,6 +271,16 @@ export function TimerDock() {
     setMounted(true);
     setPosition(loadPosition());
   }, []);
+
+  // A dragged position only belongs to the current batch of timers. Once the
+  // last timer is dismissed, return the idle dock (and the next timer) to its
+  // default corner instead of stranding it at a location that can no longer be
+  // adjusted while idle.
+  useEffect(() => {
+    if (timers.length > 0) return;
+    setPosition(null);
+    clearPosition();
+  }, [timers.length]);
 
   const completedTimers = timers.filter((timer) => timer.state === "completed");
   const completedIdsKey = completedTimerIdsKey(timers);

--- a/ui/tests/components/recipes/timer-dock.test.tsx
+++ b/ui/tests/components/recipes/timer-dock.test.tsx
@@ -1,11 +1,20 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TimerDock } from "@/components/recipes/timer-dock";
-import { CookModeProvider } from "@/contexts/cook-mode-context";
+import { CookModeProvider, useCookMode } from "@/contexts/cook-mode-context";
 import {
   __resetTimerStoreForTests,
   startTimer,
 } from "@/lib/cooking/timerStore";
+
+function OpenCookModeButton() {
+  const { setCookModeOpen } = useCookMode();
+  return (
+    <button type="button" onClick={() => setCookModeOpen(true)}>
+      Open cook mode
+    </button>
+  );
+}
 
 describe("TimerDock", () => {
   beforeEach(() => {
@@ -139,5 +148,43 @@ describe("TimerDock", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Time's up for roast.");
     // The completion must not tear down the open popover or discard the label.
     expect(screen.getByPlaceholderText("e.g. pasta")).toHaveValue("pasta");
+  });
+
+  it("resets a dragged position after the last timer is dismissed", () => {
+    localStorage.setItem(
+      "cooking-timer-dock-pos:v1",
+      JSON.stringify({ right: 72, bottom: 180 }),
+    );
+    startTimer({
+      id: "pasta-timer",
+      label: "pasta",
+      durationSeconds: 600,
+    });
+
+    render(
+      <CookModeProvider>
+        <OpenCookModeButton />
+        <TimerDock />
+      </CookModeProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open cook mode" }));
+    expect(screen.getByRole("region", { name: "Cooking timers" })).toHaveStyle({
+      right: "72px",
+      bottom: "180px",
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand cooking timers (1)" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Dismiss pasta timer" }),
+    );
+
+    expect(localStorage.getItem("cooking-timer-dock-pos:v1")).toBeNull();
+
+    const idleDock = screen.getByRole("region", { name: "Cooking timers" });
+    expect(idleDock.style.right).toBe("");
+    expect(idleDock.style.bottom).toBe("116px");
   });
 });


### PR DESCRIPTION
## Summary

- clear the timer dock's in-memory and persisted drag position when its final timer is dismissed
- return the idle add-timer dock and future timers to the default corner
- add a regression test covering the visible cook-mode flow
- allow `/preview-backend` to apply the `preview:backend` PR label by granting the command workflow pull-request write permission

## Root causes

The dragged bottom-right offset was persisted to local storage and retained after the timer list became empty. The idle dock has no drag handle, so after the final dismissal it remained stranded at the previous dragged location.

The backend-preview command workflow attempted to label a pull request while its job only had `pull-requests: read`, causing GitHub to reject the write with HTTP 403 before preview provisioning could start.

## Validation

- `mise //ui:test` — 93 test files and 710 tests passed
- `mise //ui:test -- tests/components/recipes/timer-dock.test.tsx` — 4 tests passed
- `mise //ui:typecheck` — passed
- changed UI files pass `mise //ui:lint` and `mise //ui:format:check`
- `mise //:lint:actions` — passed
- `mise //:security:actions` — passed with no findings

The repo-wide `mise //ui:check` still reports the existing Biome schema/CLI mismatch (configuration schema 2.5.4, installed CLI 2.5.5); the files changed here pass Biome directly.