### PR TITLE
Add PostHog distributed tracing across the recipe stack

### DIFF
--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -197,20 +197,33 @@ jobs:
         env:
           DATABASE_URL: ${{ steps.neon.outputs.db_url_pooled }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          POSTHOG_KEY: ${{ vars.POSTHOG_KEY }}
         run: |
           : "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY is required}"
+          : "${POSTHOG_KEY:?POSTHOG_KEY is required}"
           API_SECRETS_FILE="$RUNNER_TEMP/preview-api-secrets.json"
           INGEST_SECRETS_FILE="$RUNNER_TEMP/preview-ingest-secrets.json"
           jq -n \
             --arg database_url "$DATABASE_URL" \
             --arg auth_secret "$BETTER_AUTH_SECRET" \
             --arg preview_password "$PREVIEW_AUTH_PASSWORD" \
-            '{DATABASE_URL: $database_url, BETTER_AUTH_SECRET: $auth_secret, PREVIEW_AUTH_PASSWORD: $preview_password}' \
+            --arg posthog_key "$POSTHOG_KEY" \
+            '{
+              DATABASE_URL: $database_url,
+              BETTER_AUTH_SECRET: $auth_secret,
+              PREVIEW_AUTH_PASSWORD: $preview_password,
+              POSTHOG_KEY: $posthog_key
+            }' \
             > "$API_SECRETS_FILE"
           jq -n \
             --arg database_url "$DATABASE_URL" \
             --arg openrouter_api_key "$OPENROUTER_API_KEY" \
-            '{DATABASE_URL: $database_url, OPENROUTER_API_KEY: $openrouter_api_key}' \
+            --arg posthog_key "$POSTHOG_KEY" \
+            '{
+              DATABASE_URL: $database_url,
+              OPENROUTER_API_KEY: $openrouter_api_key,
+              POSTHOG_KEY: $posthog_key
+            }' \
             > "$INGEST_SECRETS_FILE"
           echo "api_secrets_file=$API_SECRETS_FILE" >> "$GITHUB_OUTPUT"
           echo "ingest_secrets_file=$INGEST_SECRETS_FILE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/recipe-api-cd.yml
+++ b/.github/workflows/recipe-api-cd.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "workers/recipe-api/**"
+      - "packages/observability/**"
       - "packages/recipe-db/**"
       - ".github/workflows/recipe-api-cd.yml"
   workflow_dispatch:
@@ -63,6 +64,7 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET || secrets.GCP_OAUTH_CLIENT_SECRET }}
           GITHUB_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID_GITHUB }}
           GITHUB_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET_GITHUB }}
+          POSTHOG_KEY: ${{ vars.POSTHOG_KEY }}
         run: |
           set -euo pipefail
           : "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET is required}"
@@ -70,6 +72,7 @@ jobs:
           : "${GOOGLE_CLIENT_SECRET:?GOOGLE_CLIENT_SECRET or GCP_OAUTH_CLIENT_SECRET is required}"
           : "${GITHUB_CLIENT_ID:?OAUTH_CLIENT_ID_GITHUB is required}"
           : "${GITHUB_CLIENT_SECRET:?OAUTH_CLIENT_SECRET_GITHUB is required}"
+          : "${POSTHOG_KEY:?POSTHOG_KEY is required}"
 
           SECRETS_FILE="$RUNNER_TEMP/recipe-api-worker-secrets.json"
           jq -n \
@@ -78,12 +81,14 @@ jobs:
             --arg google_client_secret "$GOOGLE_CLIENT_SECRET" \
             --arg github_client_id "$GITHUB_CLIENT_ID" \
             --arg github_client_secret "$GITHUB_CLIENT_SECRET" \
+            --arg posthog_key "$POSTHOG_KEY" \
             '{
               BETTER_AUTH_SECRET: $better_auth_secret,
               GOOGLE_CLIENT_ID: $google_client_id,
               GOOGLE_CLIENT_SECRET: $google_client_secret,
               GITHUB_CLIENT_ID: $github_client_id,
-              GITHUB_CLIENT_SECRET: $github_client_secret
+              GITHUB_CLIENT_SECRET: $github_client_secret,
+              POSTHOG_KEY: $posthog_key
             }' \
             > "$SECRETS_FILE"
           echo "WORKER_SECRETS_FILE=$SECRETS_FILE" >> "$GITHUB_ENV"

--- a/.github/workflows/recipe-ingest-cd.yml
+++ b/.github/workflows/recipe-ingest-cd.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "workers/recipe-ingest/**"
+      - "packages/observability/**"
       - "packages/recipe-parsing/**"
       - "packages/recipe-db/**"
       - "packages/recipe-domain/**"
@@ -50,14 +51,20 @@ jobs:
       - name: Create Worker secrets file
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          POSTHOG_KEY: ${{ vars.POSTHOG_KEY }}
         run: |
           set -euo pipefail
           : "${OPENROUTER_API_KEY:?OPENROUTER_API_KEY is required}"
+          : "${POSTHOG_KEY:?POSTHOG_KEY is required}"
 
           SECRETS_FILE="$RUNNER_TEMP/recipe-ingest-worker-secrets.json"
           jq -n \
             --arg openrouter_api_key "$OPENROUTER_API_KEY" \
-            '{ OPENROUTER_API_KEY: $openrouter_api_key }' \
+            --arg posthog_key "$POSTHOG_KEY" \
+            '{
+              OPENROUTER_API_KEY: $openrouter_api_key,
+              POSTHOG_KEY: $posthog_key
+            }' \
             > "$SECRETS_FILE"
           echo "WORKER_SECRETS_FILE=$SECRETS_FILE" >> "$GITHUB_ENV"
 

--- a/.github/workflows/sonarqube-ci.yml
+++ b/.github/workflows/sonarqube-ci.yml
@@ -55,6 +55,7 @@ jobs:
           path: |
             ai-review/coverage/lcov.info
             ui/coverage/lcov.info
+            packages/observability/coverage/lcov.info
             packages/recipe-parsing/coverage/lcov.info
             ml-pipelines/recipe-parsing/coverage/lcov.info
             workers/recipe-api/coverage/lcov.info

--- a/.mise.toml
+++ b/.mise.toml
@@ -275,6 +275,7 @@ description = "Generate all LCOV reports imported by SonarQube Cloud"
 depends = [
     "//ai-review:test:coverage",
     "//ui:test:coverage",
+    "//packages/observability:test:coverage",
     "//packages/recipe-parsing:test:coverage",
     "//ml-pipelines/recipe-parsing:test:coverage",
     "//workers/recipe-api:test:coverage",

--- a/.mise.toml
+++ b/.mise.toml
@@ -10,6 +10,7 @@ config_roots = [
     "ml-pipelines/recipe-dataset",
     "ml-pipelines/recipe-parsing",
     "packages/recipe-db",
+    "packages/observability",
     "packages/recipe-parsing",
     "ai-review",
     "workers/recipe-api",
@@ -148,7 +149,7 @@ if [ "${PERSONAL_SITE_DOPPLER_WRAPPED:-}" != "1" ]; then
     -- doppler run \
       --project "${DOPPLER_PROJECT:-personal-site}" \
       --config "${DOPPLER_RECIPE_API_CONFIG:-dev_recipe_api}" \
-      --preserve-env=NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH,CF_IMAGES_ACCOUNT_HASH,POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_KEY,POSTHOG_HOST,NEXT_PUBLIC_POSTHOG_HOST,POSTHOG_API_HOST,POSTHOG_ASSETS_HOST,RECIPE_API_URL,RECIPE_API_PREVIEW_ORIGIN_TEMPLATE,CF_PAGES_HOST \
+      --preserve-env=NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH,CF_IMAGES_ACCOUNT_HASH,POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_KEY,POSTHOG_HOST,NEXT_PUBLIC_POSTHOG_HOST,POSTHOG_OTLP_BASE_URL,POSTHOG_API_HOST,POSTHOG_ASSETS_HOST,RECIPE_API_URL,RECIPE_API_PREVIEW_ORIGIN_TEMPLATE,CF_PAGES_HOST \
       -- "$0" "$@"
 fi
 

--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -145,7 +145,8 @@ Create GitHub environments named `preview-recipe-api` and `preview-site-ui`.
 Populate them from Doppler by running `scripts/sync-doppler-github-envs.sh`;
 do not use the Doppler GitHub sync integration on the free plan.
 
-`preview-recipe-api` receives values from `stg_recipe_api`.
+`preview-recipe-api` receives deployment and database values from
+`stg_recipe_api`, plus the shared PostHog runtime values from `stg_pages_env`.
 
 `preview-recipe-api` receives these environment secrets:
 
@@ -171,6 +172,8 @@ openssl rand -base64 48
 | `CLOUDFLARE_PAGES_HOST` | `personal-site-bu5.pages.dev` |
 | `CF_ACCESS_TEAM_DOMAIN` | `https://your-team.cloudflareaccess.com` |
 | `CF_ACCESS_AUD` | Audience tag from the Pages preview Access application |
+| `POSTHOG_KEY` | Public, write-only project token used for OTLP export |
+| `POSTHOG_HOST` | PostHog application host |
 
 `preview-site-ui` receives values from `stg_site_ui` and `stg_pages_env`.
 
@@ -196,11 +199,10 @@ Project-scoped), so it can manage branches in that project and nothing else.
 Keep it in the `preview-recipe-api` environment only and rotate it if GitHub
 reports any exposure.
 
-`POSTHOG_KEY` and `POSTHOG_HOST` are currently omitted, so previews run without
-browser analytics. The UI build only requires `CF_IMAGES_ACCOUNT_HASH`; the
-PostHog client no-ops when its key is unset. Preview API and ingestion Worker
-logs are still retained in Cloudflare Workers Logs and exported through the
-account-level `posthog-logs` observability destination.
+`POSTHOG_KEY` and `POSTHOG_HOST` are shared through `stg_pages_env` because the
+same public project token correlates browser analytics, Pages requests, API
+requests, and ingestion workflow spans. Preview Worker logs also remain
+available in Cloudflare Workers Logs.
 
 ### 6. Smoke-test a preview
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -36,10 +36,10 @@ Configs are split by environment and runtime/control boundary:
 | `dev_recipe_api` | Local recipe Worker/API/DB/OAuth config | None |
 | `dev_infra` | Local Terraform/provider credentials | None |
 | `dev_bootstrap_infra` | Local bootstrap Terraform credentials | None |
-| `stg_pages_env` | Shared PR preview Cloudflare Pages env vars | `preview-site-ui` |
+| `stg_pages_env` | Shared PR preview runtime env vars | `preview-site-ui`, `preview-recipe-api` |
 | `stg_site_ui` | PR preview UI deploy credentials | `preview-site-ui` |
 | `stg_recipe_api` | PR preview Worker/API automation config | `preview-recipe-api` |
-| `prd_pages_env` | Shared production Cloudflare Pages env vars | `production-site-ui` |
+| `prd_pages_env` | Shared production runtime env vars | `production-site-ui`, `production-recipe-api`, `production-recipe-ingest` |
 | `prd_site_ui` | Production UI deploy credentials | `production-site-ui`, `production-recipe-api`, `production-recipe-ingest` |
 | `prd_recipe_api` | Production Worker/API/DB/OAuth config | `production-recipe-api` |
 | `prd_recipe_ingest` | Production recipe ingest Worker LLM config | `production-recipe-ingest` |
@@ -180,10 +180,10 @@ The GitHub environments are runtime/job boundaries, not provider names:
 
 | GitHub environment | Doppler configs | Used by |
 | --- | --- | --- |
-| `preview-recipe-api` | `stg_recipe_api` | PR preview Worker/database jobs and preview cleanup |
+| `preview-recipe-api` | `stg_recipe_api`, `stg_pages_env` | PR preview Worker/database jobs and preview cleanup |
 | `preview-site-ui` | `stg_site_ui`, `stg_pages_env` | PR preview Pages build/deploy and preview comment |
-| `production-recipe-api` | `prd_recipe_api`, `prd_site_ui` | Production recipe API deploy |
-| `production-recipe-ingest` | `prd_recipe_ingest`, `prd_site_ui` | Production recipe ingest Worker deploy |
+| `production-recipe-api` | `prd_recipe_api`, `prd_site_ui`, `prd_pages_env` | Production recipe API deploy |
+| `production-recipe-ingest` | `prd_recipe_ingest`, `prd_site_ui`, `prd_pages_env` | Production recipe ingest Worker deploy |
 | `production-site-ui` | `prd_site_ui`, `prd_pages_env` | Production UI CI/CD and Cloudflare Images health check |
 | `production-infra` | `prd_infra` | Terraform CI/CD |
 | `production-infra-bootstrap` | `prd_bootstrap_infra` | Manual bootstrap Terraform |
@@ -215,7 +215,7 @@ sync only those environments; omit them to sync every mapped environment.
 - `CF_ACCESS_AUD`
 - `NEON_PROJECT_ID`
 
-`stg_pages_env` should own preview UI build/runtime config:
+`stg_pages_env` should own shared preview runtime config:
 
 - `CF_IMAGES_ACCOUNT_HASH`
 - `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH`
@@ -251,7 +251,7 @@ spend-limited `OPENROUTER_API_KEY` so recipe imports can be QA'd end to end.
 
 - `OPENROUTER_API_KEY`
 
-`prd_pages_env` should own production UI build/runtime config:
+`prd_pages_env` should own shared production runtime config:
 
 - `CF_IMAGES_ACCOUNT_HASH`
 - `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH`
@@ -268,10 +268,10 @@ spend-limited `OPENROUTER_API_KEY` so recipe imports can be QA'd end to end.
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
 
-The sync script also includes `prd_site_ui` when publishing
-`production-recipe-api` and `production-recipe-ingest`, so Worker deploy jobs
-reuse the shared Cloudflare deploy token without duplicating it into each
-runtime-specific Doppler config.
+The sync script includes `prd_site_ui` and `prd_pages_env` when publishing the
+production recipe environments. Worker deploy jobs therefore reuse the shared
+Cloudflare deploy token and PostHog runtime settings without duplicating them
+into each service-specific Doppler config.
 
 `prd_infra` should own:
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -63,6 +63,19 @@ The client-side PostHog initialization in `ui/instrumentation-client.ts` uses
 - `POSTHOG_ASSETS_HOST` - Override the assets endpoint
   (default: `https://eu-assets.i.posthog.com`)
 
+### API distributed tracing
+
+The root middleware creates an OpenTelemetry server span for `/api/*` Pages
+Function requests. The API proxy injects W3C `traceparent` and `tracestate`
+headers into the request to `recipe-api`, and the browser supplies PostHog
+person/session IDs so correlated backend logs can link to session replay.
+
+Pages Functions export OTLP/protobuf traces and logs directly to PostHog using:
+
+- `POSTHOG_KEY` - the `phc_…` project token
+- `POSTHOG_OTLP_BASE_URL` - regional ingestion origin
+  (default: `https://eu.i.posthog.com`)
+
 ## Future Migration
 
 When migrating to Cloudflare Workers (for SSR support, subdomain routing,

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,3 +1,5 @@
+import { withPostHogRequest } from "observability";
+
 /**
  * Serves the pre-generated Markdown twin of a page from its canonical URL
  * when the client asks for Markdown (via Accept header) or looks like an
@@ -7,12 +9,16 @@
 
 interface Env {
   ASSETS: { fetch: typeof fetch };
+  POSTHOG_KEY?: string;
+  POSTHOG_OTLP_BASE_URL?: string;
+  DEPLOYMENT_ENV?: string;
 }
 
 export interface MarkdownMiddlewareContext {
   request: Request;
   env: Env;
   next: () => Promise<Response>;
+  waitUntil?: (promise: Promise<unknown>) => void;
 }
 
 const AGENT_USER_AGENTS =
@@ -29,7 +35,7 @@ function markdownPathFor(pathname: string): string | null {
   return `${normalized}.md`;
 }
 
-export const onRequest = async (
+const handleRequest = async (
   context: MarkdownMiddlewareContext,
 ): Promise<Response> => {
   const { request } = context;
@@ -80,4 +86,26 @@ export const onRequest = async (
     status: asset.status,
     headers,
   });
+};
+
+export const onRequest = async (
+  context: MarkdownMiddlewareContext,
+): Promise<Response> => {
+  const url = new URL(context.request.url);
+  if (!url.pathname.startsWith("/api/")) {
+    return handleRequest(context);
+  }
+
+  return withPostHogRequest(
+    {
+      env: context.env,
+      serviceName: "recipe-pages",
+      spanName: `${context.request.method} ${url.pathname}`,
+      request: context.request,
+      waitUntil: context.waitUntil
+        ? { waitUntil: context.waitUntil.bind(context) }
+        : undefined,
+    },
+    () => handleRequest(context),
+  );
 };

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,4 +1,8 @@
-import { withPostHogRequest } from "observability";
+import {
+  traceCarrierFromSpan,
+  withPostHogRequest,
+  type TraceCarrier,
+} from "observability";
 
 /**
  * Serves the pre-generated Markdown twin of a page from its canonical URL
@@ -17,6 +21,9 @@ interface Env {
 export interface MarkdownMiddlewareContext {
   request: Request;
   env: Env;
+  data?: {
+    posthogTraceCarrier?: TraceCarrier;
+  };
   next: () => Promise<Response>;
   waitUntil?: (promise: Promise<unknown>) => void;
 }
@@ -106,6 +113,13 @@ export const onRequest = async (
         ? { waitUntil: context.waitUntil.bind(context) }
         : undefined,
     },
-    () => handleRequest(context),
+    (span) => {
+      const traceCarrier = traceCarrierFromSpan(span);
+      if (traceCarrier) {
+        context.data ??= {};
+        context.data.posthogTraceCarrier = traceCarrier;
+      }
+      return handleRequest(context);
+    },
   );
 };

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -1,11 +1,18 @@
+import {
+  injectTraceContext,
+  withPostHogSpan,
+  type PostHogObservabilityEnv,
+} from "observability";
+
 export type AuthProxyRoutingEnv = {
   RECIPE_API_PREVIEW_ORIGIN_TEMPLATE?: string;
   CF_PAGES_HOST?: string;
 };
 
-export type RecipeApiProxyEnv = AuthProxyRoutingEnv & {
-  RECIPE_API_URL?: string;
-};
+export type RecipeApiProxyEnv = AuthProxyRoutingEnv &
+  PostHogObservabilityEnv & {
+    RECIPE_API_URL?: string;
+  };
 
 export type RecipeApiProxyContext = {
   request: Request;
@@ -63,8 +70,12 @@ const FORWARDED_REQUEST_HEADERS = [
   "content-type",
   "cookie",
   "origin",
+  "traceparent",
+  "tracestate",
   "referer",
   "user-agent",
+  "x-posthog-distinct-id",
+  "x-posthog-session-id",
   "x-forwarded-for",
 ] as const;
 
@@ -151,13 +162,26 @@ export async function proxyRecipeApiRequest(
 
   let response: Response;
   try {
-    response = await fetch(
-      new Request(destination, {
-        method: context.request.method,
-        headers,
-        body,
-        redirect: "manual",
-      }),
+    response = await withPostHogSpan(
+      {
+        env: context.env,
+        serviceName: "recipe-pages",
+        spanName: `HTTP ${context.request.method} recipe-api`,
+        attributes: {
+          "http.request.method": context.request.method,
+          "server.address": destinationUrl.hostname,
+          "url.path": destinationPath,
+        },
+      },
+      async () =>
+        fetch(
+          new Request(destination, {
+            method: context.request.method,
+            headers: injectTraceContext(headers),
+            body,
+            redirect: "manual",
+          }),
+        ),
     );
   } catch (error) {
     if (logLabel) {

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -20,6 +20,7 @@ export type RecipeApiProxyEnv = AuthProxyRoutingEnv &
 export type RecipeApiProxyContext = {
   request: Request;
   env: RecipeApiProxyEnv;
+  waitUntil?: (promise: Promise<unknown>) => void;
   data?: {
     posthogTraceCarrier?: TraceCarrier;
   };
@@ -181,6 +182,11 @@ export async function proxyRecipeApiRequest(
           "server.address": destinationUrl.hostname,
           "url.path": destinationPath,
         },
+        waitUntil: context.waitUntil
+          ? {
+              waitUntil: (promise) => context.waitUntil?.(promise),
+            }
+          : undefined,
       },
       async (span) =>
         fetch(

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -118,6 +118,46 @@ export function previewApiBase(
   }
 }
 
+function logProxyRequest(
+  logLabel: string | undefined,
+  request: Request,
+  path: string,
+  destination: string,
+): void {
+  if (!logLabel) return;
+  console.log(
+    JSON.stringify({
+      message: `${logLabel} proxy request`,
+      method: request.method,
+      path,
+      destination,
+    }),
+  );
+}
+
+function logProxyFailure(logLabel: string | undefined, error: unknown): void {
+  if (!logLabel) return;
+  console.error(
+    JSON.stringify({
+      message: `${logLabel} proxy request failed`,
+      error: error instanceof Error ? error.message : String(error),
+    }),
+  );
+}
+
+function logProxyResponse(
+  logLabel: string | undefined,
+  response: Response,
+): void {
+  if (!logLabel) return;
+  console.log(
+    JSON.stringify({
+      message: `${logLabel} proxy response`,
+      status: response.status,
+    }),
+  );
+}
+
 export async function proxyRecipeApiRequest(
   context: RecipeApiProxyContext,
   invalidPreviewMessage: string,
@@ -153,16 +193,12 @@ export async function proxyRecipeApiRequest(
     if (value) headers.set(name, value);
   }
 
-  if (logLabel) {
-    console.log(
-      JSON.stringify({
-        message: `${logLabel} proxy request`,
-        method: context.request.method,
-        path: url.pathname,
-        destination: `${apiBase}${destinationPath}`,
-      }),
-    );
-  }
+  logProxyRequest(
+    logLabel,
+    context.request,
+    url.pathname,
+    `${apiBase}${destinationPath}`,
+  );
 
   const body = ["GET", "HEAD"].includes(context.request.method)
     ? undefined
@@ -204,28 +240,14 @@ export async function proxyRecipeApiRequest(
         ),
     );
   } catch (error) {
-    if (logLabel) {
-      console.error(
-        JSON.stringify({
-          message: `${logLabel} proxy request failed`,
-          error: error instanceof Error ? error.message : String(error),
-        }),
-      );
-    }
+    logProxyFailure(logLabel, error);
     return Response.json(
       { error: "Failed to reach the recipe API" },
       { status: 502 },
     );
   }
 
-  if (logLabel) {
-    console.log(
-      JSON.stringify({
-        message: `${logLabel} proxy response`,
-        status: response.status,
-      }),
-    );
-  }
+  logProxyResponse(logLabel, response);
 
   return response;
 }

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -1,7 +1,10 @@
 import {
   injectTraceContext,
+  traceCarrierFromHeaders,
+  traceCarrierFromSpan,
   withPostHogSpan,
   type PostHogObservabilityEnv,
+  type TraceCarrier,
 } from "observability";
 
 export type AuthProxyRoutingEnv = {
@@ -17,6 +20,9 @@ export type RecipeApiProxyEnv = AuthProxyRoutingEnv &
 export type RecipeApiProxyContext = {
   request: Request;
   env: RecipeApiProxyEnv;
+  data?: {
+    posthogTraceCarrier?: TraceCarrier;
+  };
 };
 
 const MAX_PROXY_PATH_LENGTH = 2_048;
@@ -167,17 +173,23 @@ export async function proxyRecipeApiRequest(
         env: context.env,
         serviceName: "recipe-pages",
         spanName: `HTTP ${context.request.method} recipe-api`,
+        traceCarrier:
+          context.data?.posthogTraceCarrier ??
+          traceCarrierFromHeaders(context.request.headers),
         attributes: {
           "http.request.method": context.request.method,
           "server.address": destinationUrl.hostname,
           "url.path": destinationPath,
         },
       },
-      async () =>
+      async (span) =>
         fetch(
           new Request(destination, {
             method: context.request.method,
-            headers: injectTraceContext(headers),
+            headers: injectTraceContext(
+              headers,
+              traceCarrierFromSpan(span),
+            ),
             body,
             redirect: "manual",
           }),

--- a/functions/api/auth/routing.ts
+++ b/functions/api/auth/routing.ts
@@ -1,5 +1,6 @@
 import {
   injectTraceContext,
+  SpanKind,
   traceCarrierFromHeaders,
   traceCarrierFromSpan,
   withPostHogSpan,
@@ -174,6 +175,7 @@ export async function proxyRecipeApiRequest(
         env: context.env,
         serviceName: "recipe-pages",
         spanName: `HTTP ${context.request.method} recipe-api`,
+        kind: SpanKind.CLIENT,
         traceCarrier:
           context.data?.posthogTraceCarrier ??
           traceCarrierFromHeaders(context.request.headers),

--- a/functions/recipes/[[path]].ts
+++ b/functions/recipes/[[path]].ts
@@ -28,6 +28,7 @@ type Context = {
   request: Request;
   env: Env;
   next: () => Promise<Response>;
+  waitUntil?: (promise: Promise<unknown>) => void;
 };
 
 function textResponse(body: string, contentType: string): Response {
@@ -86,7 +87,13 @@ export const onRequest = async (context: Context): Promise<Response> => {
       headers: context.request.headers,
     });
     const apiResponse = await proxyRecipeApiRequest(
-      { request: apiRequest, env: context.env },
+      {
+        request: apiRequest,
+        env: context.env,
+        waitUntil: context.waitUntil
+          ? (promise) => context.waitUntil?.(promise)
+          : undefined,
+      },
       "Recipe pages are available on the canonical PR preview URL only",
     );
     const loaded = await decodeRecipeResponse(apiResponse);

--- a/infra/README.md
+++ b/infra/README.md
@@ -46,26 +46,31 @@ Secrets and config mirrored from Doppler:
      key — it already ships to browsers via `NEXT_PUBLIC_POSTHOG_KEY`, so it is
      not secret in the usual sense, but it is sourced from Doppler for
      single-source-of-truth config management.
-   - Mapped to `TF_VAR_posthog_key` (Terraform → Pages env var) and to
-     `NEXT_PUBLIC_POSTHOG_KEY` (UI build). It is **also** used — outside both
-     Terraform and Doppler's reach — as the auth header on the `posthog-logs`
-     Workers Observability destination. See [Rotating `POSTHOG_KEY`](#rotating-posthog_key).
+   - Mapped to `TF_VAR_posthog_key` (Terraform → Pages Functions and UI) and
+     deployed as a secret to both recipe Workers for direct OTLP tracing.
+     It is **also** used — outside Terraform's reach — as the auth header on
+     the `posthog-logs` Workers Observability destination. See
+     [Rotating `POSTHOG_KEY`](#rotating-posthog_key).
 7. **`POSTHOG_HOST`**
-   - PostHog ingestion host (`https://eu.posthog.com`).
+   - PostHog application host (`https://eu.posthog.com`).
    - Mapped to `NEXT_PUBLIC_POSTHOG_HOST` for the UI build.
-8. **`MISE_GITHUB_TOKEN`**
+8. **`POSTHOG_OTLP_BASE_URL`** (optional)
+   - Regional OTLP ingestion origin (default: `https://eu.i.posthog.com`).
+   - Mapped to `TF_VAR_posthog_otlp_base_url`; the same default is declared in
+     both Worker Wrangler configs and checked for drift in tests.
+9. **`MISE_GITHUB_TOKEN`**
    - GitHub token used by mise to download tools during Cloudflare Pages builds.
    - Mapped to `TF_VAR_github_token`, which Terraform passes into the Pages
      build configuration (`var.github_token`, required — no default).
-9. **`POSTHOG_API_KEY`**
-   - Create at: PostHog → Settings → Personal API keys
-   - Required scopes:
-     - `dashboard:read`
-     - `dashboard:write`
-     - `insight:read`
-     - `insight:write`
-   - Used by the PostHog Terraform provider
-10. **`POSTHOG_PROJECT_ID`**
+10. **`POSTHOG_API_KEY`**
+    - Create at: PostHog → Settings → Personal API keys
+    - Required scopes:
+      - `dashboard:read`
+      - `dashboard:write`
+      - `insight:read`
+      - `insight:write`
+    - Used by the PostHog Terraform provider
+11. **`POSTHOG_PROJECT_ID`**
     - Find in the PostHog project/environment settings or API URLs
     - Passed as `TF_VAR_posthog_project_id`
     - Mark unmasked in Doppler so the GitHub sync publishes it as an Actions
@@ -188,15 +193,19 @@ creates a project-scoped API key for GitHub branch automation; publish the
 
 ## Rotating `POSTHOG_KEY`
 
-`POSTHOG_KEY` lives in Doppler, but it lands in **three** places — two are
-automated, one is **manual**. The manual one will break silently (logs just
-stop arriving in PostHog, no error) if you forget it, so rotate in this order:
+`POSTHOG_KEY` lives in Doppler. It is used by browser analytics, direct
+OTLP/protobuf trace and correlated-log export from Pages/Workers, and the
+Cloudflare native-log fallback. All direct exporters are automated; the
+Cloudflare observability destination remains manual. Rotate in this order:
 
 1. **Doppler** — update the value. This is the source of truth.
-2. **Pages / UI build** — run `scripts/sync-doppler-github-envs.sh`; the next
-   infra apply / UI build picks it up via
-   `TF_VAR_posthog_key` and `NEXT_PUBLIC_POSTHOG_KEY`. Nothing to do by hand.
-3. **`posthog-logs` Workers Observability destination** (⚠️ **manual**) —
+2. **GitHub environments** — run `scripts/sync-doppler-github-envs.sh`. The
+   next infra apply sets both the browser and Pages Function values; the API
+   and ingestion deploy workflows write the same key as a Worker secret.
+3. **Deploy the three runtimes** — apply Terraform for Pages, then redeploy
+   `recipe-api` and `recipe-ingest`. Direct trace/log export now uses the new
+   key everywhere.
+4. **`posthog-logs` Workers Observability destination** (⚠️ **manual**) —
    Cloudflare Dashboard → Workers & Pages → Observability → Telemetry →
    `posthog-logs` → update the `Authorization: Bearer <phc_…>` header. Neither
    Terraform nor Doppler can reach this: there is a Cloudflare API for
@@ -206,7 +215,31 @@ stop arriving in PostHog, no error) if you forget it, so rotate in this order:
    and it is not a Worker secret or Pages var that the manual GitHub sync
    manages.
 
-This destination is referenced by `workers/recipe-api/wrangler.toml`
-(`[observability.logs]`). In practice, the public `phc_` project key rarely
-rotates, which is why the manual step is an acceptable trade-off — but it is the
-one to remember.
+This destination is referenced by both Worker Wrangler files
+(`[observability.logs]`) and provides platform invocation logs and a fallback
+copy of console output. Application traces and their correlated logs do not
+use it: `packages/observability` sends OTLP/protobuf directly to PostHog because
+Cloudflare's native OTLP exporter currently cannot export PostHog traces.
+
+## PostHog Distributed Tracing
+
+The recipe stack propagates standard W3C `traceparent`/`tracestate` context
+across:
+
+1. `recipe-pages` (the same-origin Pages Function proxy)
+2. `recipe-api` (the Cloudflare API Worker)
+3. `recipe-ingest` (the Cloudflare Workflow and its durable steps)
+
+The browser also adds `posthogDistinctId` and `sessionId` correlation data to
+same-origin API requests, so backend logs can link back to the affected person
+and session replay. The workflow emits a span for each durable ingestion step,
+including extraction, normalization, canonicalization, persistence, and
+finalization.
+
+`posthog_otlp_base_url` selects the regional ingestion origin and defaults to
+`https://eu.i.posthog.com`. Traces go to `/i/v1/traces`; correlated logs go to
+`/i/v1/logs`. Both use the project token, not the PostHog personal API key.
+
+PostHog distributed tracing is currently alpha. Cloudflare's own tracing/export
+features are also evolving, so keep the direct exporter until Cloudflare lists
+PostHog trace export as supported.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -7,6 +7,8 @@ locals {
     NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH = var.cf_images_account_hash
     NEXT_PUBLIC_POSTHOG_KEY            = var.posthog_key
     NEXT_PUBLIC_POSTHOG_HOST           = var.posthog_host
+    POSTHOG_KEY                        = var.posthog_key
+    POSTHOG_OTLP_BASE_URL              = var.posthog_otlp_base_url
     GITHUB_TOKEN                       = var.github_token
     RECIPE_API_URL                     = var.recipe_api_url
     RECIPE_API_PREVIEW_ORIGIN_TEMPLATE = var.recipe_api_preview_origin_template
@@ -44,10 +46,14 @@ resource "cloudflare_pages_project" "personal_site" {
   deployment_configs {
     production {
       environment_variables = local.pages_environment_variables
+      compatibility_date    = "2026-05-28"
+      compatibility_flags   = ["nodejs_compat"]
     }
 
     preview {
       environment_variables = local.pages_environment_variables
+      compatibility_date    = "2026-05-28"
+      compatibility_flags   = ["nodejs_compat"]
     }
   }
 }

--- a/infra/scripts/doppler-terraform-env
+++ b/infra/scripts/doppler-terraform-env
@@ -11,7 +11,7 @@ if [ "${DOPPLER_TERRAFORM_ENV_WRAPPED:-}" != "1" ]; then
     exec doppler run --project "$project" --config "$pages_env_config" -- doppler run \
       --project "$project" \
       --config "$infra_config" \
-      --preserve-env=CF_IMAGES_ACCOUNT_HASH,NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH,POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_KEY,POSTHOG_HOST,NEXT_PUBLIC_POSTHOG_HOST,RECIPE_API_URL,RECIPE_API_PREVIEW_ORIGIN_TEMPLATE,CF_PAGES_HOST \
+      --preserve-env=CF_IMAGES_ACCOUNT_HASH,NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH,POSTHOG_KEY,NEXT_PUBLIC_POSTHOG_KEY,POSTHOG_HOST,NEXT_PUBLIC_POSTHOG_HOST,POSTHOG_OTLP_BASE_URL,RECIPE_API_URL,RECIPE_API_PREVIEW_ORIGIN_TEMPLATE,CF_PAGES_HOST \
       -- bash "$0" "$@"
   elif [ "${CI:-}" != "true" ]; then
     echo "Cannot run Terraform locally: doppler is required." >&2
@@ -35,6 +35,7 @@ set_if_unset TF_VAR_github_token "${MISE_GITHUB_TOKEN:-${GITHUB_TOKEN:-}}"
 set_if_unset TF_VAR_neon_org_id "${NEON_ORG_ID:-}"
 set_if_unset TF_VAR_posthog_host "${POSTHOG_HOST:-${NEXT_PUBLIC_POSTHOG_HOST:-}}"
 set_if_unset TF_VAR_posthog_key "${POSTHOG_KEY:-${NEXT_PUBLIC_POSTHOG_KEY:-}}"
+set_if_unset TF_VAR_posthog_otlp_base_url "${POSTHOG_OTLP_BASE_URL:-}"
 set_if_unset TF_VAR_posthog_project_id "${POSTHOG_PROJECT_ID:-}"
 # POSTHOG_API_KEY is canonical; this fallback can be removed once all Doppler
 # configs have migrated away from POSTHOG_PERSONAL_API_KEY.

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -66,6 +66,17 @@ variable "posthog_host" {
   default     = "https://eu.posthog.com"
 }
 
+variable "posthog_otlp_base_url" {
+  description = "Regional PostHog OTLP ingestion base URL"
+  type        = string
+  default     = "https://eu.i.posthog.com"
+
+  validation {
+    condition     = can(regex("^https://[^/]+$", var.posthog_otlp_base_url))
+    error_message = "posthog_otlp_base_url must be an HTTPS origin with no path."
+  }
+}
+
 variable "posthog_project_id" {
   description = "PostHog project/environment ID used by the Terraform provider"
   type        = string

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -72,8 +72,8 @@ variable "posthog_otlp_base_url" {
   default     = "https://eu.i.posthog.com"
 
   validation {
-    condition     = can(regex("^https://[^/]+$", var.posthog_otlp_base_url))
-    error_message = "posthog_otlp_base_url must be an HTTPS origin with no path."
+    condition     = can(regex("^https://[^/?#]+$", var.posthog_otlp_base_url))
+    error_message = "posthog_otlp_base_url must be an HTTPS origin with no path, query string, or fragment."
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "description": "Personal website mono-repo - root package for repo-wide tooling",
   "dependencies": {
+    "observability": "workspace:*",
     "recipe-domain": "workspace:*"
   },
   "scripts": {

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -1,0 +1,51 @@
+# Recipe observability
+
+Shared OpenTelemetry instrumentation for the recipe site's Cloudflare Pages
+Functions, API Worker, and ingestion Workflow.
+
+The package exports OTLP/protobuf directly to PostHog:
+
+- traces: `${POSTHOG_OTLP_BASE_URL}/i/v1/traces`
+- correlated logs: `${POSTHOG_OTLP_BASE_URL}/i/v1/logs`
+
+Authentication uses `Authorization: Bearer ${POSTHOG_KEY}`, where
+`POSTHOG_KEY` is the public `phc_…` project token.
+
+Direct export is intentional. Cloudflare's native Workers observability
+destination exports OTLP/JSON and currently documents PostHog traces as
+unsupported, while PostHog's distributed-tracing endpoint requires
+OTLP/HTTP protobuf. Native Cloudflare logs remain enabled as a fallback.
+
+## Trace shape
+
+```text
+recipe-pages
+└── HTTP … recipe-api
+    └── recipe-api
+        └── workflow.start recipe-ingest
+            ├── workflow.step start
+            ├── workflow.step extract
+            ├── workflow.step persist-extract
+            ├── workflow.step normalize
+            ├── workflow.step persist-normalize
+            ├── workflow.step canonicalize
+            ├── workflow.step persist-canonicalize
+            └── workflow.step finalize
+```
+
+The Workflow context is serialized into its parameters because that durable
+boundary is not an HTTP request. Every Workflow span/export runs inside its
+`step.do()` callback, where side effects are durable and are not duplicated by
+Workflow engine replays. All HTTP boundaries use W3C Trace Context.
+
+## Verification
+
+After deploying all three runtimes:
+
+1. Start a photo recipe import from the recipe site.
+2. In PostHog Tracing, filter `service.name` to `recipe-pages`, `recipe-api`,
+   or `recipe-ingest`.
+3. Open the trace and confirm its waterfall includes the Pages request, API
+   request, workflow start, and durable step spans.
+4. Open a span's correlated logs and confirm `sessionId`,
+   `posthogDistinctId`, and `recipe.import.job_id` where applicable.

--- a/packages/observability/mise.toml
+++ b/packages/observability/mise.toml
@@ -1,0 +1,17 @@
+[tasks.install]
+description = "Install observability package dependencies"
+run = "pnpm install --frozen-lockfile --filter observability..."
+
+[tasks.typecheck]
+description = "Typecheck the shared observability package"
+depends = ["install"]
+run = "pnpm typecheck"
+
+[tasks.test]
+description = "Run observability package tests"
+depends = ["install"]
+run = "pnpm test"
+
+[tasks.check]
+description = "Run all observability package checks"
+depends = ["typecheck", "test"]

--- a/packages/observability/mise.toml
+++ b/packages/observability/mise.toml
@@ -12,6 +12,11 @@ description = "Run observability package tests"
 depends = ["install"]
 run = "pnpm test"
 
+[tasks."test:coverage"]
+description = "Run observability package tests with coverage"
+depends = ["install"]
+run = "pnpm test:coverage"
+
 [tasks.check]
 description = "Run all observability package checks"
 depends = ["typecheck", "test"]

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
@@ -23,6 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^24",
+    "@vitest/coverage-v8": "^4.1.10",
     "typescript": "^5",
     "vitest": "^4.1.7"
   }

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "observability",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.220.0",
+    "@opentelemetry/context-async-hooks": "^2.0.0",
+    "@opentelemetry/core": "^2.0.0",
+    "@opentelemetry/exporter-logs-otlp-proto": "^0.220.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
+    "@opentelemetry/resources": "^2.0.0",
+    "@opentelemetry/sdk-logs": "^0.220.0",
+    "@opentelemetry/sdk-trace-base": "^2.0.0",
+    "@opentelemetry/semantic-conventions": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24",
+    "typescript": "^5",
+    "vitest": "^4.1.7"
+  }
+}

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.220.0",
-    "@opentelemetry/context-async-hooks": "^2.0.0",
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-logs-otlp-proto": "^0.220.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -200,12 +200,41 @@ function recordFailure(
   );
 }
 
+function reportTelemetryFailure(stage: string, error: unknown): void {
+  try {
+    console.error(
+      JSON.stringify({
+        message: "PostHog telemetry failure",
+        stage,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  } catch {
+    // Telemetry reporting must remain fail-open, including its fallback log.
+  }
+}
+
+function safelyRecordTelemetry(stage: string, operation: () => void): void {
+  try {
+    operation();
+  } catch (error) {
+    reportTelemetryFailure(stage, error);
+  }
+}
+
 async function flushTelemetry(state: TelemetryState): Promise<void> {
-  // Telemetry must never become a new failure mode for the application.
-  await Promise.allSettled([
-    state.traceProvider.forceFlush(),
-    state.logProvider.forceFlush(),
+  const results = await Promise.allSettled([
+    Promise.resolve().then(() => state.traceProvider.forceFlush()),
+    Promise.resolve().then(() => state.logProvider.forceFlush()),
   ]);
+  for (const [index, result] of results.entries()) {
+    if (result.status === "rejected") {
+      reportTelemetryFailure(
+        index === 0 ? "flush traces" : "flush logs",
+        result.reason,
+      );
+    }
+  }
 }
 
 async function flushAfter(
@@ -214,9 +243,37 @@ async function flushAfter(
 ): Promise<void> {
   const flush = flushTelemetry(state);
   if (waitUntil) {
-    waitUntil.waitUntil(flush);
+    try {
+      waitUntil.waitUntil(flush);
+    } catch (error) {
+      reportTelemetryFailure("schedule flush", error);
+    }
   } else {
     await flush;
+  }
+}
+
+async function runWithoutTelemetry<T>(
+  serviceName: string,
+  operation: (span: Span) => Promise<T>,
+): Promise<T> {
+  const span = trace.getTracer(serviceName).startSpan("noop");
+  try {
+    return await operation(span);
+  } finally {
+    safelyRecordTelemetry("end fallback span", () => span.end());
+  }
+}
+
+function safelyGetTelemetry(
+  env: PostHogObservabilityEnv,
+  serviceName: string,
+): TelemetryState | undefined {
+  try {
+    return getTelemetry(env, serviceName);
+  } catch (error) {
+    reportTelemetryFailure("initialize", error);
+    return undefined;
   }
 }
 
@@ -286,60 +343,75 @@ export async function withPostHogRequest<T extends Response>(
   },
   operation: (span: Span) => Promise<T>,
 ): Promise<T> {
-  const state = getTelemetry(options.env, options.serviceName);
+  const state = safelyGetTelemetry(options.env, options.serviceName);
   if (!state) {
-    const span = trace.getTracer(options.serviceName).startSpan("noop");
-    try {
-      return await operation(span);
-    } finally {
-      span.end();
-    }
+    return runWithoutTelemetry(options.serviceName, operation);
   }
 
-  const identity = traceIdentityFromHeaders(options.request.headers);
-  const attributes: Attributes = {
-    "http.request.method": options.request.method,
-    "url.path": new URL(options.request.url).pathname,
-    ...identityAttributes(identity),
-    ...options.attributes,
-  };
-  const parentContext = propagation.extract(
-    ROOT_CONTEXT,
-    options.request.headers,
-    headerGetter,
-  );
-  const tracer = state.traceProvider.getTracer(options.serviceName);
-  const span = tracer.startSpan(
-    options.spanName,
-    { kind: SpanKind.SERVER, attributes },
-    parentContext,
-  );
-  const spanContext = trace.setSpan(parentContext, span);
+  let attributes: Attributes;
+  let span: Span;
+  let spanContext: Context;
+  try {
+    const identity = traceIdentityFromHeaders(options.request.headers);
+    attributes = {
+      "http.request.method": options.request.method,
+      "url.path": new URL(options.request.url).pathname,
+      ...identityAttributes(identity),
+      ...options.attributes,
+    };
+    const parentContext = propagation.extract(
+      ROOT_CONTEXT,
+      options.request.headers,
+      headerGetter,
+    );
+    const tracer = state.traceProvider.getTracer(options.serviceName);
+    span = tracer.startSpan(
+      options.spanName,
+      { kind: SpanKind.SERVER, attributes },
+      parentContext,
+    );
+    spanContext = trace.setSpan(parentContext, span);
+  } catch (error) {
+    reportTelemetryFailure("start request span", error);
+    return runWithoutTelemetry(options.serviceName, operation);
+  }
 
   try {
-    const response = await operation(span);
-    span.setAttribute("http.response.status_code", response.status);
-    if (response.status >= 500) {
-      span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: `HTTP ${response.status}`,
-      });
+    let response: T;
+    try {
+      response = await operation(span);
+    } catch (error) {
+      safelyRecordTelemetry("record request failure", () =>
+        recordFailure(span, state, error, attributes, spanContext),
+      );
+      throw error;
     }
-    emitLog(
-      state,
-      response.status >= 500 ? SeverityNumber.ERROR : SeverityNumber.INFO,
-      response.status >= 500 ? "ERROR" : "INFO",
-      `${options.request.method} ${new URL(options.request.url).pathname}`,
-      { ...attributes, "http.response.status_code": response.status },
-      spanContext,
-    );
+
+    safelyRecordTelemetry("record request success", () => {
+      span.setAttribute("http.response.status_code", response.status);
+      if (response.status >= 500) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: `HTTP ${response.status}`,
+        });
+      }
+      emitLog(
+        state,
+        response.status >= 500 ? SeverityNumber.ERROR : SeverityNumber.INFO,
+        response.status >= 500 ? "ERROR" : "INFO",
+        `${options.request.method} ${new URL(options.request.url).pathname}`,
+        { ...attributes, "http.response.status_code": response.status },
+        spanContext,
+      );
+    });
     return response;
-  } catch (error) {
-    recordFailure(span, state, error, attributes, spanContext);
-    throw error;
   } finally {
-    span.end();
-    await flushAfter(state, options.waitUntil);
+    safelyRecordTelemetry("end request span", () => span.end());
+    try {
+      await flushAfter(state, options.waitUntil);
+    } catch (error) {
+      reportTelemetryFailure("flush request telemetry", error);
+    }
   }
 }
 
@@ -355,53 +427,67 @@ export async function withPostHogSpan<T>(
   },
   operation: (span: Span) => Promise<T>,
 ): Promise<T> {
-  const state = getTelemetry(options.env, options.serviceName);
+  const state = safelyGetTelemetry(options.env, options.serviceName);
   if (!state) {
-    const span = trace.getTracer(options.serviceName).startSpan("noop");
-    try {
-      return await operation(span);
-    } finally {
-      span.end();
-    }
+    return runWithoutTelemetry(options.serviceName, operation);
   }
 
-  const parentContext = options.traceCarrier
-    ? propagation.extract(ROOT_CONTEXT, options.traceCarrier, recordGetter)
-    : ROOT_CONTEXT;
-  const tracer = state.traceProvider.getTracer(options.serviceName);
-  const span = tracer.startSpan(
-    options.spanName,
-    {
-      kind: options.kind ?? SpanKind.INTERNAL,
-      attributes: options.attributes,
-    },
-    parentContext,
-  );
-  const spanContext = trace.setSpan(parentContext, span);
+  let span: Span;
+  let spanContext: Context;
+  try {
+    const parentContext = options.traceCarrier
+      ? propagation.extract(ROOT_CONTEXT, options.traceCarrier, recordGetter)
+      : ROOT_CONTEXT;
+    const tracer = state.traceProvider.getTracer(options.serviceName);
+    span = tracer.startSpan(
+      options.spanName,
+      {
+        kind: options.kind ?? SpanKind.INTERNAL,
+        attributes: options.attributes,
+      },
+      parentContext,
+    );
+    spanContext = trace.setSpan(parentContext, span);
+  } catch (error) {
+    reportTelemetryFailure("start span", error);
+    return runWithoutTelemetry(options.serviceName, operation);
+  }
 
   try {
-    const result = await operation(span);
-    emitLog(
-      state,
-      SeverityNumber.INFO,
-      "INFO",
-      options.spanName,
-      options.attributes ?? {},
-      spanContext,
+    let result: T;
+    try {
+      result = await operation(span);
+    } catch (error) {
+      safelyRecordTelemetry("record span failure", () =>
+        recordFailure(
+          span,
+          state,
+          error,
+          options.attributes ?? {},
+          spanContext,
+        ),
+      );
+      throw error;
+    }
+
+    safelyRecordTelemetry("record span success", () =>
+      emitLog(
+        state,
+        SeverityNumber.INFO,
+        "INFO",
+        options.spanName,
+        options.attributes ?? {},
+        spanContext,
+      ),
     );
     return result;
-  } catch (error) {
-    recordFailure(
-      span,
-      state,
-      error,
-      options.attributes ?? {},
-      spanContext,
-    );
-    throw error;
   } finally {
-    span.end();
-    await flushAfter(state, options.waitUntil);
+    safelyRecordTelemetry("end span", () => span.end());
+    try {
+      await flushAfter(state, options.waitUntil);
+    } catch (error) {
+      reportTelemetryFailure("flush span telemetry", error);
+    }
   }
 }
 

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -81,9 +81,21 @@ const recordGetter = {
 
 function normalizedBaseUrl(env: PostHogObservabilityEnv): string {
   const baseUrl = env.POSTHOG_OTLP_BASE_URL || DEFAULT_OTLP_BASE_URL;
-  let end = baseUrl.length;
-  while (end > 0 && baseUrl.charCodeAt(end - 1) === 47) end -= 1;
-  return baseUrl.slice(0, end);
+  const url = new URL(baseUrl);
+  const hasOnlyTrailingSlashes = Array.from(url.pathname).every(
+    (character) => character === "/",
+  );
+  if (
+    url.protocol !== "https:" ||
+    url.username ||
+    url.password ||
+    !hasOnlyTrailingSlashes ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("POSTHOG_OTLP_BASE_URL must be an HTTPS origin");
+  }
+  return url.origin;
 }
 
 function registerGlobals(

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -80,7 +80,10 @@ const recordGetter = {
 };
 
 function normalizedBaseUrl(env: PostHogObservabilityEnv): string {
-  return (env.POSTHOG_OTLP_BASE_URL || DEFAULT_OTLP_BASE_URL).replace(/\/+$/, "");
+  const baseUrl = env.POSTHOG_OTLP_BASE_URL || DEFAULT_OTLP_BASE_URL;
+  let end = baseUrl.length;
+  while (end > 0 && baseUrl.charCodeAt(end - 1) === 47) end -= 1;
+  return baseUrl.slice(0, end);
 }
 
 function registerGlobals(

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,5 +1,4 @@
 import {
-  context,
   propagation,
   ROOT_CONTEXT,
   SpanKind,
@@ -10,7 +9,6 @@ import {
   type Span,
 } from "@opentelemetry/api";
 import { logs, SeverityNumber } from "@opentelemetry/api-logs";
-import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
@@ -91,9 +89,6 @@ function registerGlobals(
 ): void {
   if (globalsRegistered) return;
 
-  context.setGlobalContextManager(
-    new AsyncLocalStorageContextManager().enable(),
-  );
   propagation.setGlobalPropagator(new W3CTraceContextPropagator());
   trace.setGlobalTracerProvider(traceProvider);
   logs.setGlobalLoggerProvider(logProvider);
@@ -165,7 +160,7 @@ function emitLog(
   severityText: string,
   body: string,
   attributes: Attributes,
-  logContext: Context = context.active(),
+  logContext: Context,
 ): void {
   state.logProvider.getLogger(state.serviceName).emit({
     severityNumber,
@@ -181,17 +176,25 @@ function recordFailure(
   state: TelemetryState,
   error: unknown,
   attributes: Attributes,
+  logContext: Context,
 ): void {
   const message = error instanceof Error ? error.message : String(error);
   const errorType =
     error instanceof Error && error.name ? error.name : "UnknownError";
   span.recordException(error instanceof Error ? error : new Error(message));
   span.setStatus({ code: SpanStatusCode.ERROR, message });
-  emitLog(state, SeverityNumber.ERROR, "ERROR", message, {
-    ...attributes,
-    "error.type": errorType,
-    "error.message": message,
-  });
+  emitLog(
+    state,
+    SeverityNumber.ERROR,
+    "ERROR",
+    message,
+    {
+      ...attributes,
+      "error.type": errorType,
+      "error.message": message,
+    },
+    logContext,
+  );
 }
 
 async function flushTelemetry(state: TelemetryState): Promise<void> {
@@ -221,8 +224,31 @@ export function traceIdentityFromHeaders(headers: Headers): TraceIdentity {
   };
 }
 
-export function injectTraceContext(headers: Headers): Headers {
-  propagation.inject(context.active(), headers, {
+export function traceCarrierFromHeaders(
+  headers: Headers,
+): TraceCarrier | undefined {
+  const traceparent = headers.get("traceparent");
+  if (!traceparent) return undefined;
+
+  const tracestate = headers.get("tracestate");
+  return {
+    traceparent,
+    ...(tracestate ? { tracestate } : {}),
+  };
+}
+
+export function injectTraceContext(
+  headers: Headers,
+  traceCarrier?: TraceCarrier,
+): Headers {
+  if (!traceCarrier) return headers;
+
+  const carrierContext = propagation.extract(
+    ROOT_CONTEXT,
+    traceCarrier,
+    recordGetter,
+  );
+  propagation.inject(carrierContext, headers, {
     set(carrier, key, value) {
       carrier.set(key, value);
     },
@@ -230,9 +256,9 @@ export function injectTraceContext(headers: Headers): Headers {
   return headers;
 }
 
-export function currentTraceCarrier(): TraceCarrier | undefined {
+export function traceCarrierFromSpan(span: Span): TraceCarrier | undefined {
   const carrier: Partial<TraceCarrier> = {};
-  propagation.inject(context.active(), carrier, {
+  propagation.inject(trace.setSpan(ROOT_CONTEXT, span), carrier, {
     set(target, key, value) {
       if (key === "traceparent") target.traceparent = value;
       if (key === "tracestate") target.tracestate = value;
@@ -255,10 +281,17 @@ export async function withPostHogRequest<T extends Response>(
     waitUntil?: WaitUntilContext;
     attributes?: Attributes;
   },
-  operation: () => Promise<T>,
+  operation: (span: Span) => Promise<T>,
 ): Promise<T> {
   const state = getTelemetry(options.env, options.serviceName);
-  if (!state) return operation();
+  if (!state) {
+    const span = trace.getTracer(options.serviceName).startSpan("noop");
+    try {
+      return await operation(span);
+    } finally {
+      span.end();
+    }
+  }
 
   const identity = traceIdentityFromHeaders(options.request.headers);
   const attributes: Attributes = {
@@ -273,38 +306,38 @@ export async function withPostHogRequest<T extends Response>(
     headerGetter,
   );
   const tracer = state.traceProvider.getTracer(options.serviceName);
-
-  return tracer.startActiveSpan(
+  const span = tracer.startSpan(
     options.spanName,
     { kind: SpanKind.SERVER, attributes },
     parentContext,
-    async (span) => {
-      try {
-        const response = await operation();
-        span.setAttribute("http.response.status_code", response.status);
-        if (response.status >= 500) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: `HTTP ${response.status}`,
-          });
-        }
-        emitLog(
-          state,
-          response.status >= 500 ? SeverityNumber.ERROR : SeverityNumber.INFO,
-          response.status >= 500 ? "ERROR" : "INFO",
-          `${options.request.method} ${new URL(options.request.url).pathname}`,
-          { ...attributes, "http.response.status_code": response.status },
-        );
-        return response;
-      } catch (error) {
-        recordFailure(span, state, error, attributes);
-        throw error;
-      } finally {
-        span.end();
-        await flushAfter(state, options.waitUntil);
-      }
-    },
   );
+  const spanContext = trace.setSpan(parentContext, span);
+
+  try {
+    const response = await operation(span);
+    span.setAttribute("http.response.status_code", response.status);
+    if (response.status >= 500) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: `HTTP ${response.status}`,
+      });
+    }
+    emitLog(
+      state,
+      response.status >= 500 ? SeverityNumber.ERROR : SeverityNumber.INFO,
+      response.status >= 500 ? "ERROR" : "INFO",
+      `${options.request.method} ${new URL(options.request.url).pathname}`,
+      { ...attributes, "http.response.status_code": response.status },
+      spanContext,
+    );
+    return response;
+  } catch (error) {
+    recordFailure(span, state, error, attributes, spanContext);
+    throw error;
+  } finally {
+    span.end();
+    await flushAfter(state, options.waitUntil);
+  }
 }
 
 export async function withPostHogSpan<T>(
@@ -331,36 +364,42 @@ export async function withPostHogSpan<T>(
 
   const parentContext = options.traceCarrier
     ? propagation.extract(ROOT_CONTEXT, options.traceCarrier, recordGetter)
-    : context.active();
+    : ROOT_CONTEXT;
   const tracer = state.traceProvider.getTracer(options.serviceName);
-
-  return tracer.startActiveSpan(
+  const span = tracer.startSpan(
     options.spanName,
     {
       kind: options.kind ?? SpanKind.INTERNAL,
       attributes: options.attributes,
     },
     parentContext,
-    async (span) => {
-      try {
-        const result = await operation(span);
-        emitLog(
-          state,
-          SeverityNumber.INFO,
-          "INFO",
-          options.spanName,
-          options.attributes ?? {},
-        );
-        return result;
-      } catch (error) {
-        recordFailure(span, state, error, options.attributes ?? {});
-        throw error;
-      } finally {
-        span.end();
-        await flushAfter(state, options.waitUntil);
-      }
-    },
   );
+  const spanContext = trace.setSpan(parentContext, span);
+
+  try {
+    const result = await operation(span);
+    emitLog(
+      state,
+      SeverityNumber.INFO,
+      "INFO",
+      options.spanName,
+      options.attributes ?? {},
+      spanContext,
+    );
+    return result;
+  } catch (error) {
+    recordFailure(
+      span,
+      state,
+      error,
+      options.attributes ?? {},
+      spanContext,
+    );
+    throw error;
+  } finally {
+    span.end();
+    await flushAfter(state, options.waitUntil);
+  }
 }
 
 export { SpanKind };

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,0 +1,366 @@
+import {
+  context,
+  propagation,
+  ROOT_CONTEXT,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  type Attributes,
+  type Context,
+  type Span,
+} from "@opentelemetry/api";
+import { logs, SeverityNumber } from "@opentelemetry/api-logs";
+import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
+import { W3CTraceContextPropagator } from "@opentelemetry/core";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-proto";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import {
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from "@opentelemetry/sdk-logs";
+import {
+  BasicTracerProvider,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+import {
+  ATTR_DEPLOYMENT_ENVIRONMENT_NAME,
+  ATTR_SERVICE_NAME,
+} from "@opentelemetry/semantic-conventions";
+
+const DEFAULT_OTLP_BASE_URL = "https://eu.i.posthog.com";
+
+export type PostHogObservabilityEnv = {
+  POSTHOG_KEY?: string;
+  POSTHOG_OTLP_BASE_URL?: string;
+  DEPLOYMENT_ENV?: string;
+};
+
+export type TraceCarrier = {
+  traceparent: string;
+  tracestate?: string;
+};
+
+export type TraceIdentity = {
+  posthogDistinctId?: string;
+  sessionId?: string;
+};
+
+type WaitUntilContext = {
+  waitUntil(promise: Promise<unknown>): void;
+};
+
+type TelemetryState = {
+  serviceName: string;
+  traceProvider: BasicTracerProvider;
+  logProvider: LoggerProvider;
+};
+
+let telemetryState: TelemetryState | undefined;
+let globalsRegistered = false;
+
+const headerGetter = {
+  get(carrier: Headers, key: string): string | undefined {
+    return carrier.get(key) ?? undefined;
+  },
+  keys(carrier: Headers): string[] {
+    return Array.from(carrier.keys());
+  },
+};
+
+const recordGetter = {
+  get(carrier: TraceCarrier, key: string): string | undefined {
+    if (key === "traceparent") return carrier.traceparent;
+    if (key === "tracestate") return carrier.tracestate;
+    return undefined;
+  },
+  keys(carrier: TraceCarrier): string[] {
+    return carrier.tracestate
+      ? ["traceparent", "tracestate"]
+      : ["traceparent"];
+  },
+};
+
+function normalizedBaseUrl(env: PostHogObservabilityEnv): string {
+  return (env.POSTHOG_OTLP_BASE_URL || DEFAULT_OTLP_BASE_URL).replace(/\/+$/, "");
+}
+
+function registerGlobals(
+  traceProvider: BasicTracerProvider,
+  logProvider: LoggerProvider,
+): void {
+  if (globalsRegistered) return;
+
+  context.setGlobalContextManager(
+    new AsyncLocalStorageContextManager().enable(),
+  );
+  propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+  trace.setGlobalTracerProvider(traceProvider);
+  logs.setGlobalLoggerProvider(logProvider);
+  globalsRegistered = true;
+}
+
+function getTelemetry(
+  env: PostHogObservabilityEnv,
+  serviceName: string,
+): TelemetryState | undefined {
+  const projectToken = env.POSTHOG_KEY?.trim();
+  if (!projectToken) return undefined;
+
+  if (telemetryState) {
+    if (telemetryState.serviceName !== serviceName) {
+      throw new Error(
+        `OpenTelemetry already initialized for ${telemetryState.serviceName}; cannot reinitialize it for ${serviceName}`,
+      );
+    }
+    return telemetryState;
+  }
+
+  const resource = resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: serviceName,
+    [ATTR_DEPLOYMENT_ENVIRONMENT_NAME]:
+      env.DEPLOYMENT_ENV || "production",
+  });
+  const headers = { Authorization: `Bearer ${projectToken}` };
+  const baseUrl = normalizedBaseUrl(env);
+
+  const traceProvider = new BasicTracerProvider({
+    resource,
+    spanProcessors: [
+      new SimpleSpanProcessor(
+        new OTLPTraceExporter({
+          url: `${baseUrl}/i/v1/traces`,
+          headers,
+        }),
+      ),
+    ],
+  });
+  const logProvider = new LoggerProvider({
+    resource,
+    processors: [
+      new SimpleLogRecordProcessor({
+        exporter: new OTLPLogExporter({
+          url: `${baseUrl}/i/v1/logs`,
+          headers,
+        }),
+      }),
+    ],
+  });
+
+  telemetryState = { serviceName, traceProvider, logProvider };
+  registerGlobals(traceProvider, logProvider);
+  return telemetryState;
+}
+
+function identityAttributes(identity: TraceIdentity): Attributes {
+  return {
+    posthogDistinctId: identity.posthogDistinctId,
+    sessionId: identity.sessionId,
+  };
+}
+
+function emitLog(
+  state: TelemetryState,
+  severityNumber: SeverityNumber,
+  severityText: string,
+  body: string,
+  attributes: Attributes,
+  logContext: Context = context.active(),
+): void {
+  state.logProvider.getLogger(state.serviceName).emit({
+    severityNumber,
+    severityText,
+    body,
+    attributes,
+    context: logContext,
+  });
+}
+
+function recordFailure(
+  span: Span,
+  state: TelemetryState,
+  error: unknown,
+  attributes: Attributes,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  const errorType =
+    error instanceof Error && error.name ? error.name : "UnknownError";
+  span.recordException(error instanceof Error ? error : new Error(message));
+  span.setStatus({ code: SpanStatusCode.ERROR, message });
+  emitLog(state, SeverityNumber.ERROR, "ERROR", message, {
+    ...attributes,
+    "error.type": errorType,
+    "error.message": message,
+  });
+}
+
+async function flushTelemetry(state: TelemetryState): Promise<void> {
+  // Telemetry must never become a new failure mode for the application.
+  await Promise.allSettled([
+    state.traceProvider.forceFlush(),
+    state.logProvider.forceFlush(),
+  ]);
+}
+
+async function flushAfter(
+  state: TelemetryState,
+  waitUntil?: WaitUntilContext,
+): Promise<void> {
+  const flush = flushTelemetry(state);
+  if (waitUntil) {
+    waitUntil.waitUntil(flush);
+  } else {
+    await flush;
+  }
+}
+
+export function traceIdentityFromHeaders(headers: Headers): TraceIdentity {
+  return {
+    posthogDistinctId: headers.get("x-posthog-distinct-id") ?? undefined,
+    sessionId: headers.get("x-posthog-session-id") ?? undefined,
+  };
+}
+
+export function injectTraceContext(headers: Headers): Headers {
+  propagation.inject(context.active(), headers, {
+    set(carrier, key, value) {
+      carrier.set(key, value);
+    },
+  });
+  return headers;
+}
+
+export function currentTraceCarrier(): TraceCarrier | undefined {
+  const carrier: Partial<TraceCarrier> = {};
+  propagation.inject(context.active(), carrier, {
+    set(target, key, value) {
+      if (key === "traceparent") target.traceparent = value;
+      if (key === "tracestate") target.tracestate = value;
+    },
+  });
+  return carrier.traceparent
+    ? {
+        traceparent: carrier.traceparent,
+        ...(carrier.tracestate ? { tracestate: carrier.tracestate } : {}),
+      }
+    : undefined;
+}
+
+export async function withPostHogRequest<T extends Response>(
+  options: {
+    env: PostHogObservabilityEnv;
+    serviceName: string;
+    spanName: string;
+    request: Request;
+    waitUntil?: WaitUntilContext;
+    attributes?: Attributes;
+  },
+  operation: () => Promise<T>,
+): Promise<T> {
+  const state = getTelemetry(options.env, options.serviceName);
+  if (!state) return operation();
+
+  const identity = traceIdentityFromHeaders(options.request.headers);
+  const attributes: Attributes = {
+    "http.request.method": options.request.method,
+    "url.path": new URL(options.request.url).pathname,
+    ...identityAttributes(identity),
+    ...options.attributes,
+  };
+  const parentContext = propagation.extract(
+    ROOT_CONTEXT,
+    options.request.headers,
+    headerGetter,
+  );
+  const tracer = state.traceProvider.getTracer(options.serviceName);
+
+  return tracer.startActiveSpan(
+    options.spanName,
+    { kind: SpanKind.SERVER, attributes },
+    parentContext,
+    async (span) => {
+      try {
+        const response = await operation();
+        span.setAttribute("http.response.status_code", response.status);
+        if (response.status >= 500) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: `HTTP ${response.status}`,
+          });
+        }
+        emitLog(
+          state,
+          response.status >= 500 ? SeverityNumber.ERROR : SeverityNumber.INFO,
+          response.status >= 500 ? "ERROR" : "INFO",
+          `${options.request.method} ${new URL(options.request.url).pathname}`,
+          { ...attributes, "http.response.status_code": response.status },
+        );
+        return response;
+      } catch (error) {
+        recordFailure(span, state, error, attributes);
+        throw error;
+      } finally {
+        span.end();
+        await flushAfter(state, options.waitUntil);
+      }
+    },
+  );
+}
+
+export async function withPostHogSpan<T>(
+  options: {
+    env: PostHogObservabilityEnv;
+    serviceName: string;
+    spanName: string;
+    traceCarrier?: TraceCarrier;
+    kind?: SpanKind;
+    waitUntil?: WaitUntilContext;
+    attributes?: Attributes;
+  },
+  operation: (span: Span) => Promise<T>,
+): Promise<T> {
+  const state = getTelemetry(options.env, options.serviceName);
+  if (!state) {
+    const span = trace.getTracer(options.serviceName).startSpan("noop");
+    try {
+      return await operation(span);
+    } finally {
+      span.end();
+    }
+  }
+
+  const parentContext = options.traceCarrier
+    ? propagation.extract(ROOT_CONTEXT, options.traceCarrier, recordGetter)
+    : context.active();
+  const tracer = state.traceProvider.getTracer(options.serviceName);
+
+  return tracer.startActiveSpan(
+    options.spanName,
+    {
+      kind: options.kind ?? SpanKind.INTERNAL,
+      attributes: options.attributes,
+    },
+    parentContext,
+    async (span) => {
+      try {
+        const result = await operation(span);
+        emitLog(
+          state,
+          SeverityNumber.INFO,
+          "INFO",
+          options.spanName,
+          options.attributes ?? {},
+        );
+        return result;
+      } catch (error) {
+        recordFailure(span, state, error, options.attributes ?? {});
+        throw error;
+      } finally {
+        span.end();
+        await flushAfter(state, options.waitUntil);
+      }
+    },
+  );
+}
+
+export { SpanKind };

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -406,6 +406,38 @@ describe("enabled telemetry", () => {
     );
     consoleError.mockRestore();
   });
+
+  it("uses URL parsing to reject a non-origin OTLP base URL", async () => {
+    vi.resetModules();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const traceExporterCount = exported.traceExporterOptions.length;
+    const freshObservability = await import("../src");
+
+    await expect(
+      freshObservability.withPostHogSpan(
+        {
+          env: {
+            ...enabledEnv,
+            POSTHOG_OTLP_BASE_URL:
+              "https://telemetry.example.test/unexpected-path",
+          },
+          serviceName: "invalid-origin-service",
+          spanName: "invalid origin",
+        },
+        async () => "application result",
+      ),
+    ).resolves.toBe("application result");
+
+    expect(exported.traceExporterOptions).toHaveLength(traceExporterCount);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "POSTHOG_OTLP_BASE_URL must be an HTTPS origin",
+      ),
+    );
+    consoleError.mockRestore();
+  });
 });
 
 describe("traceCarrierFromHeaders", () => {

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -14,11 +14,16 @@ const exported = vi.hoisted(() => ({
   logs: [] as Array<Record<string, unknown>>,
   traceExporterOptions: [] as Array<Record<string, unknown>>,
   logExporterOptions: [] as Array<Record<string, unknown>>,
+  throwTraceExporterOnInit: false,
+  rejectTraceExporterFlush: false,
 }));
 
 vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
   OTLPTraceExporter: class {
     constructor(options: Record<string, unknown>) {
+      if (exported.throwTraceExporterOnInit) {
+        throw new Error("trace exporter setup failed");
+      }
       exported.traceExporterOptions.push(options);
     }
 
@@ -31,7 +36,9 @@ vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
     }
 
     forceFlush() {
-      return Promise.resolve();
+      return exported.rejectTraceExporterFlush
+        ? Promise.reject(new Error("trace exporter flush failed"))
+        : Promise.resolve();
     }
 
     shutdown() {
@@ -306,7 +313,35 @@ describe("enabled telemetry", () => {
     });
   });
 
-  it("rejects reinitialization for a different service", async () => {
+  it("keeps operations successful and reports exporter flush failures", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    exported.rejectTraceExporterFlush = true;
+
+    await expect(
+      withPostHogSpan(
+        {
+          env: enabledEnv,
+          serviceName: "test-service",
+          spanName: "workflow.flush-failure",
+        },
+        async () => "application result",
+      ),
+    ).resolves.toBe("application result");
+
+    exported.rejectTraceExporterFlush = false;
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"stage":"flush traces"'),
+    );
+    consoleError.mockRestore();
+  });
+
+  it("fails open if a bundle requests a different service name", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
     await expect(
       withPostHogSpan(
         {
@@ -316,9 +351,11 @@ describe("enabled telemetry", () => {
         },
         async () => undefined,
       ),
-    ).rejects.toThrow(
-      "OpenTelemetry already initialized for test-service; cannot reinitialize it for other-service",
+    ).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"stage":"initialize"'),
     );
+    consoleError.mockRestore();
   });
 
   it("uses PostHog's EU endpoint and production environment defaults", async () => {
@@ -340,6 +377,34 @@ describe("enabled telemetry", () => {
     expect(exported.logExporterOptions.at(-1)).toMatchObject({
       url: "https://eu.i.posthog.com/i/v1/logs",
     });
+  });
+
+  it("runs the application operation once when telemetry setup fails", async () => {
+    vi.resetModules();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    exported.throwTraceExporterOnInit = true;
+    const operation = vi.fn(async () => new Response("ok"));
+    const freshObservability = await import("../src");
+
+    const response = await freshObservability.withPostHogRequest(
+      {
+        env: enabledEnv,
+        serviceName: "setup-failure-service",
+        spanName: "GET /setup-failure",
+        request: new Request("https://example.test/setup-failure"),
+      },
+      operation,
+    );
+
+    exported.throwTraceExporterOnInit = false;
+    expect(response.status).toBe(200);
+    expect(operation).toHaveBeenCalledOnce();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('"stage":"initialize"'),
+    );
+    consoleError.mockRestore();
   });
 });
 

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { traceIdentityFromHeaders } from "../src";
+import {
+  traceCarrierFromHeaders,
+  traceIdentityFromHeaders,
+} from "../src";
 
 describe("traceIdentityFromHeaders", () => {
   it("reads PostHog person and session correlation headers", () => {
@@ -19,5 +22,23 @@ describe("traceIdentityFromHeaders", () => {
       posthogDistinctId: undefined,
       sessionId: undefined,
     });
+  });
+});
+
+describe("traceCarrierFromHeaders", () => {
+  it("copies W3C trace context for explicit propagation", () => {
+    const headers = new Headers({
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      tracestate: "vendor=value",
+    });
+
+    expect(traceCarrierFromHeaders(headers)).toEqual({
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      tracestate: "vendor=value",
+    });
+  });
+
+  it("omits an absent trace context", () => {
+    expect(traceCarrierFromHeaders(new Headers())).toBeUndefined();
   });
 });

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -28,12 +28,12 @@ describe("traceIdentityFromHeaders", () => {
 describe("traceCarrierFromHeaders", () => {
   it("copies W3C trace context for explicit propagation", () => {
     const headers = new Headers({
-      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0be902b7-01",
       tracestate: "vendor=value",
     });
 
     expect(traceCarrierFromHeaders(headers)).toEqual({
-      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      traceparent: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0be902b7-01",
       tracestate: "vendor=value",
     });
   });

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -288,6 +288,24 @@ describe("enabled telemetry", () => {
     });
   });
 
+  it("exports a successful internal span without optional attributes", async () => {
+    await expect(
+      withPostHogSpan(
+        {
+          env: enabledEnv,
+          serviceName: "test-service",
+          spanName: "workflow.complete",
+        },
+        async () => "complete",
+      ),
+    ).resolves.toBe("complete");
+
+    expect(exported.logs.at(-1)).toMatchObject({
+      body: "workflow.complete",
+      attributes: {},
+    });
+  });
+
   it("rejects reinitialization for a different service", async () => {
     await expect(
       withPostHogSpan(
@@ -301,6 +319,27 @@ describe("enabled telemetry", () => {
     ).rejects.toThrow(
       "OpenTelemetry already initialized for test-service; cannot reinitialize it for other-service",
     );
+  });
+
+  it("uses PostHog's EU endpoint and production environment defaults", async () => {
+    vi.resetModules();
+    const freshObservability = await import("../src");
+
+    await freshObservability.withPostHogSpan(
+      {
+        env: { POSTHOG_KEY: "default-token" },
+        serviceName: "default-service",
+        spanName: "default span",
+      },
+      async () => undefined,
+    );
+
+    expect(exported.traceExporterOptions.at(-1)).toMatchObject({
+      url: "https://eu.i.posthog.com/i/v1/traces",
+    });
+    expect(exported.logExporterOptions.at(-1)).toMatchObject({
+      url: "https://eu.i.posthog.com/i/v1/logs",
+    });
   });
 });
 
@@ -319,5 +358,15 @@ describe("traceCarrierFromHeaders", () => {
 
   it("omits an absent trace context", () => {
     expect(traceCarrierFromHeaders(new Headers())).toBeUndefined();
+  });
+
+  it("supports trace context without optional tracestate", () => {
+    const traceparent =
+      "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0be902b7-01";
+    const carrier = traceCarrierFromHeaders(new Headers({ traceparent }));
+    const headers = new Headers();
+
+    expect(carrier).toEqual({ traceparent });
+    expect(injectTraceContext(headers)).toBe(headers);
   });
 });

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { traceIdentityFromHeaders } from "../src";
+
+describe("traceIdentityFromHeaders", () => {
+  it("reads PostHog person and session correlation headers", () => {
+    const headers = new Headers({
+      "x-posthog-distinct-id": "person-123",
+      "x-posthog-session-id": "session-456",
+    });
+
+    expect(traceIdentityFromHeaders(headers)).toEqual({
+      posthogDistinctId: "person-123",
+      sessionId: "session-456",
+    });
+  });
+
+  it("omits missing correlation values", () => {
+    expect(traceIdentityFromHeaders(new Headers())).toEqual({
+      posthogDistinctId: undefined,
+      sessionId: undefined,
+    });
+  });
+});

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -1,8 +1,74 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  injectTraceContext,
+  SpanKind,
   traceCarrierFromHeaders,
+  traceCarrierFromSpan,
   traceIdentityFromHeaders,
+  withPostHogRequest,
+  withPostHogSpan,
 } from "../src";
+
+const exported = vi.hoisted(() => ({
+  spans: [] as Array<Record<string, unknown>>,
+  logs: [] as Array<Record<string, unknown>>,
+  traceExporterOptions: [] as Array<Record<string, unknown>>,
+  logExporterOptions: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => ({
+  OTLPTraceExporter: class {
+    constructor(options: Record<string, unknown>) {
+      exported.traceExporterOptions.push(options);
+    }
+
+    export(
+      spans: Array<Record<string, unknown>>,
+      callback: (result: { code: number }) => void,
+    ) {
+      exported.spans.push(...spans);
+      callback({ code: 0 });
+    }
+
+    forceFlush() {
+      return Promise.resolve();
+    }
+
+    shutdown() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
+  OTLPLogExporter: class {
+    constructor(options: Record<string, unknown>) {
+      exported.logExporterOptions.push(options);
+    }
+
+    export(
+      logs: Array<Record<string, unknown>>,
+      callback: (result: { code: number }) => void,
+    ) {
+      exported.logs.push(...logs);
+      callback({ code: 0 });
+    }
+
+    forceFlush() {
+      return Promise.resolve();
+    }
+
+    shutdown() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+const enabledEnv = {
+  POSTHOG_KEY: " test-token ",
+  POSTHOG_OTLP_BASE_URL: "https://telemetry.example.test////",
+  DEPLOYMENT_ENV: "test",
+};
 
 describe("traceIdentityFromHeaders", () => {
   it("reads PostHog person and session correlation headers", () => {
@@ -22,6 +88,219 @@ describe("traceIdentityFromHeaders", () => {
       posthogDistinctId: undefined,
       sessionId: undefined,
     });
+  });
+});
+
+describe("disabled telemetry", () => {
+  it("runs request and span operations without exporting", async () => {
+    const requestResponse = await withPostHogRequest(
+      {
+        env: {},
+        serviceName: "test-service",
+        spanName: "GET /disabled",
+        request: new Request("https://example.test/disabled"),
+      },
+      async (span) => {
+        expect(traceCarrierFromSpan(span)).toBeUndefined();
+        return new Response("ok");
+      },
+    );
+    const spanResult = await withPostHogSpan(
+      {
+        env: {},
+        serviceName: "test-service",
+        spanName: "disabled child",
+      },
+      async (span) => traceCarrierFromSpan(span),
+    );
+
+    expect(requestResponse.status).toBe(200);
+    expect(spanResult).toBeUndefined();
+    expect(exported.spans).toHaveLength(0);
+    expect(exported.logs).toHaveLength(0);
+  });
+});
+
+describe("enabled telemetry", () => {
+  it("exports a correlated server span and log", async () => {
+    const deferred: Promise<unknown>[] = [];
+    const request = new Request("https://example.test/recipes?ignored=true", {
+      headers: {
+        traceparent:
+          "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0be902b7-01",
+        "x-posthog-distinct-id": "person-123",
+        "x-posthog-session-id": "session-456",
+      },
+    });
+
+    const response = await withPostHogRequest(
+      {
+        env: enabledEnv,
+        serviceName: "test-service",
+        spanName: "GET /recipes",
+        request,
+        waitUntil: {
+          waitUntil(promise) {
+            deferred.push(promise);
+          },
+        },
+        attributes: { "test.attribute": "value" },
+      },
+      async (span) => {
+        const carrier = traceCarrierFromSpan(span);
+        expect(carrier?.traceparent).toContain(
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+        );
+        const headers = injectTraceContext(new Headers(), carrier);
+        expect(headers.get("traceparent")).toBe(carrier?.traceparent);
+        return Response.json({ ok: true }, { status: 201 });
+      },
+    );
+    await Promise.all(deferred);
+
+    expect(response.status).toBe(201);
+    expect(exported.traceExporterOptions).toEqual([
+      {
+        url: "https://telemetry.example.test/i/v1/traces",
+        headers: { Authorization: "Bearer test-token" },
+      },
+    ]);
+    expect(exported.logExporterOptions).toEqual([
+      {
+        url: "https://telemetry.example.test/i/v1/logs",
+        headers: { Authorization: "Bearer test-token" },
+      },
+    ]);
+
+    const span = exported.spans.at(-1);
+    expect(span).toMatchObject({
+      name: "GET /recipes",
+      kind: SpanKind.SERVER,
+      attributes: {
+        "http.request.method": "GET",
+        "http.response.status_code": 201,
+        "url.path": "/recipes",
+        posthogDistinctId: "person-123",
+        sessionId: "session-456",
+        "test.attribute": "value",
+      },
+    });
+    expect(exported.logs.at(-1)).toMatchObject({
+      body: "GET /recipes",
+      attributes: {
+        "http.response.status_code": 201,
+        "url.path": "/recipes",
+      },
+    });
+  });
+
+  it("marks server errors and thrown failures", async () => {
+    const serverError = await withPostHogRequest(
+      {
+        env: enabledEnv,
+        serviceName: "test-service",
+        spanName: "GET /unavailable",
+        request: new Request("https://example.test/unavailable"),
+      },
+      async () => new Response("unavailable", { status: 503 }),
+    );
+
+    expect(serverError.status).toBe(503);
+    expect(exported.spans.at(-1)?.status).toMatchObject({
+      code: 2,
+      message: "HTTP 503",
+    });
+
+    await expect(
+      withPostHogRequest(
+        {
+          env: enabledEnv,
+          serviceName: "test-service",
+          spanName: "GET /failure",
+          request: new Request("https://example.test/failure"),
+        },
+        async () => {
+          throw new TypeError("request failed");
+        },
+      ),
+    ).rejects.toThrow("request failed");
+
+    expect(exported.spans.at(-1)?.status).toMatchObject({
+      code: 2,
+      message: "request failed",
+    });
+    expect(exported.logs.at(-1)).toMatchObject({
+      body: "request failed",
+      attributes: {
+        "error.type": "TypeError",
+        "error.message": "request failed",
+      },
+    });
+  });
+
+  it("parents child spans explicitly and records failures", async () => {
+    const parentCarrier = {
+      traceparent:
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0be902b7-01",
+      tracestate: "vendor=value",
+    };
+
+    const result = await withPostHogSpan(
+      {
+        env: enabledEnv,
+        serviceName: "test-service",
+        spanName: "workflow.start",
+        traceCarrier: parentCarrier,
+        kind: SpanKind.PRODUCER,
+        attributes: { "recipe.import.job_id": "job-123" },
+      },
+      async (span) => traceCarrierFromSpan(span),
+    );
+
+    expect(result?.traceparent).toContain(
+      "4bf92f3577b34da6a3ce929d0e0e4736",
+    );
+    expect(result?.tracestate).toBe("vendor=value");
+    expect(exported.spans.at(-1)).toMatchObject({
+      name: "workflow.start",
+      kind: SpanKind.PRODUCER,
+      attributes: { "recipe.import.job_id": "job-123" },
+    });
+
+    await expect(
+      withPostHogSpan(
+        {
+          env: enabledEnv,
+          serviceName: "test-service",
+          spanName: "workflow.failure",
+        },
+        async () => {
+          throw "non-error failure";
+        },
+      ),
+    ).rejects.toBe("non-error failure");
+    expect(exported.logs.at(-1)).toMatchObject({
+      body: "non-error failure",
+      attributes: {
+        "error.type": "UnknownError",
+        "error.message": "non-error failure",
+      },
+    });
+  });
+
+  it("rejects reinitialization for a different service", async () => {
+    await expect(
+      withPostHogSpan(
+        {
+          env: enabledEnv,
+          serviceName: "other-service",
+          spanName: "invalid",
+        },
+        async () => undefined,
+      ),
+    ).rejects.toThrow(
+      "OpenTelemetry already initialized for test-service; cannot reinitialize it for other-service",
+    );
   });
 });
 

--- a/packages/observability/tsconfig.json
+++ b/packages/observability/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/observability/vitest.config.ts
+++ b/packages/observability/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", ["lcovonly", { projectRoot: "../.." }]],
+      reportsDirectory: "coverage",
+    },
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,9 +177,6 @@ importers:
       '@opentelemetry/api-logs':
         specifier: ^0.220.0
         version: 0.220.0
-      '@opentelemetry/context-async-hooks':
-        specifier: ^2.0.0
-        version: 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/core':
         specifier: ^2.0.0
         version: 2.10.0(@opentelemetry/api@1.9.1)
@@ -1945,12 +1942,6 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
-
-  '@opentelemetry/context-async-hooks@2.10.0':
-    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
   '@opentelemetry/core@2.10.0':
     resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
@@ -7524,10 +7515,6 @@ snapshots:
       '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.1': {}
-
-  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.13.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       typescript:
         specifier: ^5
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
 
   .:
     dependencies:
+      observability:
+        specifier: workspace:*
+        version: link:packages/observability
       recipe-domain:
         specifier: workspace:*
         version: link:packages/recipe-domain
@@ -165,6 +168,49 @@ importers:
       vite-plugin-wasm:
         specifier: ^3.6.0
         version: 3.6.0(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/observability:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/api-logs':
+        specifier: ^0.220.0
+        version: 0.220.0
+      '@opentelemetry/context-async-hooks':
+        specifier: ^2.0.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core':
+        specifier: ^2.0.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^2.0.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs':
+        specifier: ^0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^2.0.0
+        version: 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.0.0
+        version: 1.43.0
+    devDependencies:
+      '@types/node':
+        specifier: ^24
+        version: 24.13.3
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/recipe-db:
     dependencies:
@@ -511,6 +557,9 @@ importers:
       jose:
         specifier: ^6.1.3
         version: 6.2.3
+      observability:
+        specifier: workspace:*
+        version: link:../../packages/observability
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -557,6 +606,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.0
         version: 0.45.2(@cloudflare/workers-types@5.20260724.1)(@opentelemetry/api@1.9.1)(@types/pg@8.6.1)(kysely@0.29.3)(postgres@3.4.9)
+      observability:
+        specifier: workspace:*
+        version: link:../../packages/observability
       postgres:
         specifier: ^3.4.5
         version: 3.4.9
@@ -1894,14 +1946,50 @@ packages:
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@2.10.0':
     resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/core@2.9.0':
+    resolution: {integrity: sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.220.0':
+    resolution: {integrity: sha512-8LZAxdJ0ENDAFwr4j0oY35mHBltiSzvlhdQAPGiC7p9VnxtuSq4SW1gfBAdW6t6hiQG6OwUl8w7KHaOdJPKHWg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.220.0':
+    resolution: {integrity: sha512-voTAD8XgJxlK7zLkXh8EzMB09zrQr3tyY/BsnDTlDiQU/UdK58MZ63A3mUjdEDrxMjCVmBHU3WQJhRmQe+Dvzg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.220.0':
     resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.220.0':
+    resolution: {integrity: sha512-CXYo8UD5Mn9YbgebO2EL4wejtA+gxLmLiu6HCk2KH2BR7XhFN6/6p1UlCb23DYCjeYkndevLHuejCCN1yx4+OQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.220.0':
+    resolution: {integrity: sha512-lXGrv7KXZ0gNH9SVNUaa6vv6phVYGvJxfXAlMbzbakiXru75f5MZl8Z7oqiMMQD77riVHJCFlQvbZs/VVN2/4A==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -1912,6 +2000,24 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
+  '@opentelemetry/resources@2.9.0':
+    resolution: {integrity: sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.220.0':
+    resolution: {integrity: sha512-WywcTkQtv2iNmt+6y5Kcd4rzvx9bLVsBa2Nwcmg01IUaBTkTow3W4d9KE5vNBpEDtb9tp21WcRBY/lANRrApYA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.9.0':
+    resolution: {integrity: sha512-Xx8RGS4H5XEBl01WuCreMIpiah9cCXMbSkeuIePPdD2cUpq/vUzYmj8E/MK1OsbOc93FuAD4jfn2WOacKwLn7Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@2.10.0':
     resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -1920,6 +2026,12 @@ packages:
 
   '@opentelemetry/sdk-trace@2.10.0':
     resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.9.0':
+    resolution: {integrity: sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -7413,10 +7525,35 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)(supports-color@10.2.2)':
     dependencies:
@@ -7427,11 +7564,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/otlp-exporter-base@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.9.0(@opentelemetry/api@1.9.1)
+
   '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/resources@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7446,6 +7619,13 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.9.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/semantic-conventions@1.43.0': {}

--- a/scripts/sync-doppler-github-envs.sh
+++ b/scripts/sync-doppler-github-envs.sh
@@ -177,10 +177,10 @@ for requested_environment in "${requested_environments[@]}"; do
   fi
 done
 
-sync_requested_env preview-recipe-api stg_recipe_api stg_site_ui
+sync_requested_env preview-recipe-api stg_recipe_api stg_pages_env
 sync_requested_env preview-site-ui stg_site_ui stg_pages_env
-sync_requested_env production-recipe-api prd_recipe_api prd_site_ui
-sync_requested_env production-recipe-ingest prd_recipe_ingest prd_site_ui
+sync_requested_env production-recipe-api prd_recipe_api prd_site_ui prd_pages_env
+sync_requested_env production-recipe-ingest prd_recipe_ingest prd_site_ui prd_pages_env
 sync_requested_env production-site-ui prd_site_ui prd_pages_env
 sync_requested_env production-infra prd_infra
 sync_requested_env production-infra-bootstrap prd_bootstrap_infra

--- a/scripts/sync-doppler-github-envs.sh
+++ b/scripts/sync-doppler-github-envs.sh
@@ -177,7 +177,7 @@ for requested_environment in "${requested_environments[@]}"; do
   fi
 done
 
-sync_requested_env preview-recipe-api stg_recipe_api
+sync_requested_env preview-recipe-api stg_recipe_api stg_site_ui
 sync_requested_env preview-site-ui stg_site_ui stg_pages_env
 sync_requested_env production-recipe-api prd_recipe_api prd_site_ui
 sync_requested_env production-recipe-ingest prd_recipe_ingest prd_site_ui

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,4 +15,4 @@ sonar.test.inclusions=**/tests/**/*
 sonar.exclusions=ui/content/projects/*/designs/**,ui/public/recipe-site-design/standalone.html,**/coverage/**,ui/public/**/*.png
 
 # Coverage is an advisory trend, not a quality-gate condition (ADR 045).
-sonar.javascript.lcov.reportPaths=ai-review/coverage/lcov.info,ui/coverage/lcov.info,packages/recipe-parsing/coverage/lcov.info,ml-pipelines/recipe-parsing/coverage/lcov.info,workers/recipe-api/coverage/lcov.info,workers/recipe-ingest/coverage/lcov.info
+sonar.javascript.lcov.reportPaths=ai-review/coverage/lcov.info,ui/coverage/lcov.info,packages/observability/coverage/lcov.info,packages/recipe-parsing/coverage/lcov.info,ml-pipelines/recipe-parsing/coverage/lcov.info,workers/recipe-api/coverage/lcov.info,workers/recipe-ingest/coverage/lcov.info

--- a/ui/content/projects/recipe-site/adrs/060-direct-otlp-export-to-posthog.mdx
+++ b/ui/content/projects/recipe-site/adrs/060-direct-otlp-export-to-posthog.mdx
@@ -1,0 +1,145 @@
+---
+title: "ADR 060: Direct OTLP Export to PostHog Without a Collector"
+date: "2026-07-25"
+status: "Accepted"
+supersedes: "recipe-site:048-cloudflare-observability-destinations"
+tech_stack: ["PostHog", "OpenTelemetry", "Cloudflare Workers", "Cloudflare Workflows"]
+---
+
+## Summary
+
+Export application traces and their correlated logs directly from the recipe site's Pages
+Functions, API Worker, and ingestion Workflow to PostHog over OTLP/HTTP protobuf. Do not operate an
+OpenTelemetry Collector yet. Continue retaining Cloudflare's built-in logs and native PostHog log
+destination as an independent fallback.
+
+This is an intentionally small-scale serverless decision, not a claim that collectors are
+unnecessary in general. Direct export keeps traces, logs, product events, people, and session
+replays in the PostHog project already chosen by
+[ADR 028](/projects/recipe-site/adrs/028-posthog-analytics) and
+[ADR 047](/projects/recipe-site/adrs/047-posthog-logs). It accepts weaker delivery guarantees and
+PostHog tracing's alpha status to avoid introducing and operating another service or observability
+vendor before the traffic or incident load justifies one.
+
+## Context
+
+A recipe import crosses four independently executed components:
+
+```text
+browser → Pages Function → recipe-api Worker → recipe-ingest Workflow steps
+```
+
+Logs in separate service views cannot reliably identify which stage made one user's import slow or
+fail. The system needs W3C trace-context propagation, a single trace waterfall, logs carrying the
+active trace and span IDs, and PostHog person/session identifiers for movement from an operational
+failure to the affected user's replay and product journey.
+
+An OpenTelemetry Collector is the usual production recommendation because it can batch, retry,
+filter, redact, sample, transform, and fan out telemetry independently of application processes.
+However, the OTel guidance also says
+[direct backend export is reasonable for getting started and at small scale](https://opentelemetry.io/docs/collector/).
+A conventional sidecar assumes a co-scheduled container or host process. Cloudflare Workers instead
+run as short-lived, geographically distributed
+[V8 isolates rather than per-application containers](https://developers.cloudflare.com/workers/reference/how-workers-works/).
+There is therefore no local sidecar deployment unit. Adding a collector means provisioning a
+separate, reachable, highly available
+[collector gateway](https://opentelemetry.io/docs/collector/deploy/gateway/), with its own hosting,
+TLS, authentication, scaling, monitoring, upgrades, and failure modes.
+
+There is also a protocol gap in the otherwise attractive Cloudflare-managed path. PostHog requires
+OTLP/HTTP protobuf for traces, while Cloudflare's destination export does not support OTLP binary
+and [lists PostHog trace export as unsupported](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/).
+Cloudflare can still export logs to PostHog, so that path remains useful as a fallback.
+
+## Decision
+
+Use the shared `packages/observability` OpenTelemetry library in all three server runtimes:
+
+* export traces to the regional PostHog `/i/v1/traces` endpoint and correlated application logs to
+  `/i/v1/logs`, authenticated with the PostHog project token;
+* propagate W3C `traceparent` and `tracestate` over HTTP and serialize them into Workflow parameters
+  across the durable, non-HTTP boundary;
+* add `service.name`, deployment environment, route, recipe-import job ID, `posthogDistinctId`, and
+  `sessionId` where applicable; do not attach request bodies, recipe contents, credentials, or other
+  sensitive payloads;
+* flush request telemetry through `waitUntil()` so export is outside response latency, and perform
+  Workflow exports inside `step.do()` so replay does not duplicate side effects;
+* treat telemetry as best effort: exporter errors must never fail an application request or
+  ingestion job;
+* sample all instrumented spans initially because traffic is low, then introduce explicit sampling
+  before volume becomes material;
+* retain Cloudflare Workers Logs and the existing `posthog-logs` destination for platform and
+  `console` logs when direct application export is unavailable.
+
+[PostHog's tracing documentation](https://posthog.com/docs/distributed-tracing/start-here) explicitly
+supports standard OpenTelemetry clients and colocates traces with logs, product analytics, session
+replay, and error tracking. It also explicitly labels distributed tracing **alpha** and warns that
+the endpoint and setup may change. That maturity risk is accepted because loss of telemetry does not
+affect application correctness, Cloudflare retains a fallback, and OTLP keeps the instrumentation
+portable.
+
+## Alternatives Considered
+
+| Option                                                            | Advantages                                                                                                                                                                                                                | Costs and gaps                                                                                                                                                                                                                                                                                                     | Decision                                                                   |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| **Direct OTLP to PostHog**                                        | No new platform or always-on service; complete application-controlled propagation across Pages, Workers, and Workflows; one investigation surface connected to people, events, replays, and product impact; standard OTLP | PostHog tracing is alpha; each runtime carries exporter code; only best-effort buffering/retry; PostHog outage or isolate termination can lose telemetry; no collector-side redaction, tail sampling, or fan-out                                                                                                   | **Adopt now**                                                              |
+| **OTel Collector gateway → PostHog**                              | Central batching, retries, filtering, redaction, sampling, routing, and backend changes; application exports to one stable endpoint                                                                                       | No true Worker sidecar; requires a separately hosted and monitored gateway; adds network hop, credentials, deployment, cost, and another component that can fail; does not remove PostHog's alpha risk                                                                                                             | Defer until its operational benefits exceed its operational cost           |
+| **Cloudflare logs and traces only**                               | Lowest application complexity; platform-managed capture and retention; no application exporter; Cloudflare-native request details                                                                                         | Cloudflare tracing is itself [open beta](https://developers.cloudflare.com/workers/observability/traces/known-limitations/); external trace propagation is currently incomplete; data is separated from PostHog users, feature flags, funnels, and session replay; Cloudflare cannot export traces to PostHog      | Keep as fallback, not the primary investigation surface                    |
+| **Grafana Cloud (Tempo/Loki), with direct export or a collector** | Established, full-featured logs/traces platform; mature querying, dashboards, alerting, service graphs, sampling, and multi-signal operations; native Cloudflare OTLP endpoints                                           | Adds another account, token set, dashboards, alerts, on-call workflow, billing surface, and vendor to maintain; operational data is not natively connected to the existing PostHog person, replay, experiment, and funnel context; correlation would require duplicated identity attributes and manual cross-links | Reconsider when observability depth or reliability outweighs consolidation |
+| **Self-hosted collector plus Grafana/Tempo/Loki**                 | Maximum control and portability; no SaaS dependency for storage                                                                                                                                                           | Highest operational burden: hosting, upgrades, storage, retention, backups, security, alerting, and availability become part of this personal site's production surface                                                                                                                                            | Reject at current scale                                                    |
+
+Grafana Cloud currently has a useful free allowance, so adopting it would not necessarily create an
+immediate bill. It nevertheless creates a second metered platform and future payment path:
+[logs, traces, and profiles are usage-priced beyond the allowance](https://grafana.com/pricing/).
+PostHog is usage-priced too; cost alone does not decide this. The differentiator is that PostHog
+[links logs to users, replays, analytics, and retention impact](https://posthog.com/docs/logs/start-here),
+whereas Grafana provides the stronger dedicated observability product but would require rebuilding
+that user/product connection.
+
+## Consequences
+
+### Positive
+
+* One trace follows a user action through every recipe-site compute boundary.
+* Trace-local logs can lead directly to the affected PostHog person and session replay.
+* The project avoids operating an always-on gateway or adopting another vendor at low volume.
+* W3C Trace Context and OTLP preserve a migration path to a collector or another backend.
+* Cloudflare-native logs remain available during PostHog or direct-export failures.
+
+### Negative
+
+* PostHog may change tracing behavior or ingestion details before general availability.
+* Delivery is not durable: background execution limits, exporter timeouts, or a PostHog outage may
+  drop spans or logs.
+* Exporter dependencies increase Worker bundle size and application-owned observability code.
+* Full sampling can create avoidable volume and cost if traffic grows unnoticed.
+* Two log paths may contain overlapping entries and have different attributes or arrival times.
+* PostHog is weaker than a mature dedicated observability platform for advanced sampling, service
+  maps, SLOs, alert routing, long retention, and multi-signal infrastructure analysis.
+
+## Guardrails and Verification
+
+* Instrumentation failure must be swallowed, while application errors are recorded and rethrown.
+* CI type-checks and dry-run bundles every instrumented runtime.
+* A deployment smoke test must verify the complete Pages → API → Workflow trace and its correlated
+  logs in PostHog.
+* Periodically verify that Cloudflare fallback logs are still arriving independently.
+* Review telemetry volume and configure billing limits before removing full sampling.
+* Treat identifiers as correlation metadata, not permission checks; never emit secrets or payloads.
+
+## When To Revisit
+
+Introduce a collector gateway or a mature dedicated backend when any of these becomes true:
+
+* missing telemetry during incidents is frequent enough to impair diagnosis;
+* volume requires central batching, tail sampling, filtering, or cost controls;
+* compliance requires central PII redaction, egress policy, or auditable delivery;
+* telemetry must fan out to multiple backends or switch vendors without coordinated application
+  deployments;
+* Grafana Cloud, Honeycomb, or another platform's SLOs, alerting, service graphs, retention, or
+  reliability materially improve incident response;
+* a managed collector/gateway becomes part of the existing platform, eliminating most operational
+  overhead;
+* PostHog tracing changes incompatibly during alpha, remains unreliable, or fails to mature;
+* PostHog tracing reaches general availability, prompting a deliberate review of this temporary
+  risk acceptance.

--- a/ui/content/projects/recipe-site/adrs/062-direct-otlp-export-to-posthog.mdx
+++ b/ui/content/projects/recipe-site/adrs/062-direct-otlp-export-to-posthog.mdx
@@ -1,17 +1,16 @@
 ---
-title: "ADR 060: Direct OTLP Export to PostHog Without a Collector"
+title: "ADR 062: Direct OTLP Export to PostHog Without a Collector"
 date: "2026-07-25"
 status: "Accepted"
 supersedes: "recipe-site:048-cloudflare-observability-destinations"
-tech_stack: ["PostHog", "OpenTelemetry", "Cloudflare Workers", "Cloudflare Workflows"]
+tech_stack: ["PostHog", "OpenTelemetry"]
 ---
 
 ## Summary
 
-Export application traces and their correlated logs directly from the recipe site's Pages
-Functions, API Worker, and ingestion Workflow to PostHog over OTLP/HTTP protobuf. Do not operate an
-OpenTelemetry Collector yet. Continue retaining Cloudflare's built-in logs and native PostHog log
-destination as an independent fallback.
+Export application traces and their correlated logs directly from the recipe site's instrumented
+runtimes to PostHog over OTLP/HTTP protobuf. Do not operate an OpenTelemetry Collector yet. Continue
+retaining Cloudflare's built-in logs and native PostHog log destination as an independent fallback.
 
 This is an intentionally small-scale serverless decision, not a claim that collectors are
 unnecessary in general. Direct export keeps traces, logs, product events, people, and session
@@ -23,16 +22,11 @@ vendor before the traffic or incident load justifies one.
 
 ## Context
 
-A recipe import crosses four independently executed components:
-
-```text
-browser → Pages Function → recipe-api Worker → recipe-ingest Workflow steps
-```
-
-Logs in separate service views cannot reliably identify which stage made one user's import slow or
-fail. The system needs W3C trace-context propagation, a single trace waterfall, logs carrying the
-active trace and span IDs, and PostHog person/session identifiers for movement from an operational
-failure to the affected user's replay and product journey.
+Recipe operations cross independently executed compute boundaries. Logs in separate service views
+cannot reliably identify which stage made one user's operation slow or fail. The system needs W3C
+trace-context propagation, a single trace waterfall, logs carrying the active trace and span IDs,
+and PostHog person/session identifiers for movement from an operational failure to the affected
+user's replay and product journey.
 
 An OpenTelemetry Collector is the usual production recommendation because it can batch, retry,
 filter, redact, sample, transform, and fan out telemetry independently of application processes.
@@ -53,7 +47,7 @@ Cloudflare can still export logs to PostHog, so that path remains useful as a fa
 
 ## Decision
 
-Use the shared `packages/observability` OpenTelemetry library in all three server runtimes:
+Use the shared `packages/observability` OpenTelemetry library in instrumented server runtimes:
 
 * export traces to the regional PostHog `/i/v1/traces` endpoint and correlated application logs to
   `/i/v1/logs`, authenticated with the PostHog project token;
@@ -80,13 +74,13 @@ portable.
 
 ## Alternatives Considered
 
-| Option                                                            | Advantages                                                                                                                                                                                                                | Costs and gaps                                                                                                                                                                                                                                                                                                     | Decision                                                                   |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
-| **Direct OTLP to PostHog**                                        | No new platform or always-on service; complete application-controlled propagation across Pages, Workers, and Workflows; one investigation surface connected to people, events, replays, and product impact; standard OTLP | PostHog tracing is alpha; each runtime carries exporter code; only best-effort buffering/retry; PostHog outage or isolate termination can lose telemetry; no collector-side redaction, tail sampling, or fan-out                                                                                                   | **Adopt now**                                                              |
-| **OTel Collector gateway → PostHog**                              | Central batching, retries, filtering, redaction, sampling, routing, and backend changes; application exports to one stable endpoint                                                                                       | No true Worker sidecar; requires a separately hosted and monitored gateway; adds network hop, credentials, deployment, cost, and another component that can fail; does not remove PostHog's alpha risk                                                                                                             | Defer until its operational benefits exceed its operational cost           |
-| **Cloudflare logs and traces only**                               | Lowest application complexity; platform-managed capture and retention; no application exporter; Cloudflare-native request details                                                                                         | Cloudflare tracing is itself [open beta](https://developers.cloudflare.com/workers/observability/traces/known-limitations/); external trace propagation is currently incomplete; data is separated from PostHog users, feature flags, funnels, and session replay; Cloudflare cannot export traces to PostHog      | Keep as fallback, not the primary investigation surface                    |
-| **Grafana Cloud (Tempo/Loki), with direct export or a collector** | Established, full-featured logs/traces platform; mature querying, dashboards, alerting, service graphs, sampling, and multi-signal operations; native Cloudflare OTLP endpoints                                           | Adds another account, token set, dashboards, alerts, on-call workflow, billing surface, and vendor to maintain; operational data is not natively connected to the existing PostHog person, replay, experiment, and funnel context; correlation would require duplicated identity attributes and manual cross-links | Reconsider when observability depth or reliability outweighs consolidation |
-| **Self-hosted collector plus Grafana/Tempo/Loki**                 | Maximum control and portability; no SaaS dependency for storage                                                                                                                                                           | Highest operational burden: hosting, upgrades, storage, retention, backups, security, alerting, and availability become part of this personal site's production surface                                                                                                                                            | Reject at current scale                                                    |
+| Option                                                            | Advantages                                                                                                                                                                                              | Costs and gaps                                                                                                                                                                                                                                                                                                     | Decision                                                                   |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| **Direct OTLP to PostHog**                                        | No new platform or always-on service; application-controlled propagation across execution boundaries; one investigation surface connected to people, events, replays, and product impact; standard OTLP | PostHog tracing is alpha; each runtime carries exporter code; only best-effort buffering/retry; PostHog outage or isolate termination can lose telemetry; no collector-side redaction, tail sampling, or fan-out                                                                                                   | **Adopt now**                                                              |
+| **OTel Collector gateway → PostHog**                              | Central batching, retries, filtering, redaction, sampling, routing, and backend changes; application exports to one stable endpoint                                                                     | No true Worker sidecar; requires a separately hosted and monitored gateway; adds network hop, credentials, deployment, cost, and another component that can fail; does not remove PostHog's alpha risk                                                                                                             | Defer until its operational benefits exceed its operational cost           |
+| **Cloudflare logs and traces only**                               | Lowest application complexity; platform-managed capture and retention; no application exporter; Cloudflare-native request details                                                                       | Cloudflare tracing is itself [open beta](https://developers.cloudflare.com/workers/observability/traces/known-limitations/); external trace propagation is currently incomplete; data is separated from PostHog users, feature flags, funnels, and session replay; Cloudflare cannot export traces to PostHog      | Keep as fallback, not the primary investigation surface                    |
+| **Grafana Cloud (Tempo/Loki), with direct export or a collector** | Established, full-featured logs/traces platform; mature querying, dashboards, alerting, service graphs, sampling, and multi-signal operations; native Cloudflare OTLP endpoints                         | Adds another account, token set, dashboards, alerts, on-call workflow, billing surface, and vendor to maintain; operational data is not natively connected to the existing PostHog person, replay, experiment, and funnel context; correlation would require duplicated identity attributes and manual cross-links | Reconsider when observability depth or reliability outweighs consolidation |
+| **Self-hosted collector plus Grafana/Tempo/Loki**                 | Maximum control and portability; no SaaS dependency for storage                                                                                                                                         | Highest operational burden: hosting, upgrades, storage, retention, backups, security, alerting, and availability become part of this personal site's production surface                                                                                                                                            | Reject at current scale                                                    |
 
 Grafana Cloud currently has a useful free allowance, so adopting it would not necessarily create an
 immediate bill. It nevertheless creates a second metered platform and future payment path:
@@ -100,7 +94,7 @@ that user/product connection.
 
 ### Positive
 
-* One trace follows a user action through every recipe-site compute boundary.
+* One trace follows a user action through every instrumented compute boundary.
 * Trace-local logs can lead directly to the affected PostHog person and session replay.
 * The project avoids operating an always-on gateway or adopting another vendor at low volume.
 * W3C Trace Context and OTLP preserve a migration path to a collector or another backend.
@@ -121,8 +115,8 @@ that user/product connection.
 
 * Instrumentation failure must be swallowed, while application errors are recorded and rethrown.
 * CI type-checks and dry-run bundles every instrumented runtime.
-* A deployment smoke test must verify the complete Pages → API → Workflow trace and its correlated
-  logs in PostHog.
+* A deployment smoke test must verify a complete end-to-end trace and its correlated logs in
+  PostHog.
 * Periodically verify that Cloudflare fallback logs are still arriving independently.
 * Review telemetry volume and configure billing limits before removing full sampling.
 * Treat identifiers as correlation metadata, not permission checks; never emit secrets or payloads.

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -12,4 +12,30 @@ if (posthogKey) {
     // Turn on debug in development mode
     debug: process.env.NODE_ENV === "development",
   });
+
+  // Attach PostHog identity to same-origin API requests so backend OTLP logs
+  // can link directly to the person and session replay that produced them.
+  const originalFetch = window.fetch.bind(window);
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    const requestUrl = new URL(
+      input instanceof Request ? input.url : input.toString(),
+      window.location.origin,
+    );
+    if (
+      requestUrl.origin !== window.location.origin ||
+      !requestUrl.pathname.startsWith("/api/")
+    ) {
+      return originalFetch(input, init);
+    }
+
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    const distinctId = posthog.get_distinct_id();
+    const sessionId = posthog.get_session_id();
+    if (distinctId) headers.set("x-posthog-distinct-id", distinctId);
+    if (sessionId) headers.set("x-posthog-session-id", sessionId);
+
+    return originalFetch(input, { ...init, headers });
+  };
 }

--- a/ui/instrumentation-client.ts
+++ b/ui/instrumentation-client.ts
@@ -2,6 +2,19 @@ import posthog from "posthog-js";
 
 const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 
+function setIdentityHeader(
+  headers: Headers,
+  name: string,
+  identity: () => string,
+): void {
+  try {
+    const value = identity();
+    if (value) headers.set(name, value);
+  } catch {
+    // Correlation is best-effort and must never break the application request.
+  }
+}
+
 if (posthogKey) {
   posthog.init(posthogKey, {
     api_host: "/ingest",
@@ -31,10 +44,12 @@ if (posthogKey) {
     const headers = new Headers(
       init?.headers ?? (input instanceof Request ? input.headers : undefined),
     );
-    const distinctId = posthog.get_distinct_id();
-    const sessionId = posthog.get_session_id();
-    if (distinctId) headers.set("x-posthog-distinct-id", distinctId);
-    if (sessionId) headers.set("x-posthog-session-id", sessionId);
+    setIdentityHeader(headers, "x-posthog-distinct-id", () =>
+      posthog.get_distinct_id(),
+    );
+    setIdentityHeader(headers, "x-posthog-session-id", () =>
+      posthog.get_session_id(),
+    );
 
     return originalFetch(input, { ...init, headers });
   };

--- a/ui/tests/functions/markdown-middleware.test.ts
+++ b/ui/tests/functions/markdown-middleware.test.ts
@@ -15,6 +15,18 @@ function createContext(
 }
 
 describe("Markdown content-negotiation middleware", () => {
+  it("wraps API requests and continues to the route handler", async () => {
+    const context = createContext(
+      new Request("https://robbiepalmer.me/api/recipes"),
+      vi.fn() as unknown as typeof fetch,
+    );
+
+    const response = await onRequest(context);
+
+    expect(await response.text()).toBe("next");
+    expect(context.next).toHaveBeenCalledOnce();
+  });
+
   it("returns a bodyless 304 for a conditional Markdown asset request", async () => {
     const assetFetch = vi.fn(
       async () => new Response(null, { status: 304, headers: { etag: "v1" } }),

--- a/ui/tests/functions/recipe-imports-proxy.test.ts
+++ b/ui/tests/functions/recipe-imports-proxy.test.ts
@@ -2,10 +2,24 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RecipeApiProxyContext } from "../../../functions/api/auth/routing";
 import { onRequest } from "../../../functions/api/recipe-imports/[[path]]";
 
+const withPostHogSpanMock = vi.hoisted(() =>
+  vi.fn(
+    async (_options: unknown, operation: (span: unknown) => Promise<unknown>) =>
+      operation({}),
+  ),
+);
+
+vi.mock("observability", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("observability")>()),
+  traceCarrierFromSpan: () => undefined,
+  withPostHogSpan: withPostHogSpanMock,
+}));
+
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  withPostHogSpanMock.mockClear();
   vi.restoreAllMocks();
 });
 
@@ -31,5 +45,27 @@ describe("recipe imports proxy", () => {
       "https://recipe-api.example.test/recipe-imports/123?fresh=1",
     );
     expect(forwarded.headers.get("cookie")).toBe("session=test");
+  });
+
+  it("defers telemetry export through the Pages execution context", async () => {
+    const pending: Promise<unknown>[] = [];
+    globalThis.fetch = vi.fn(async () => new Response("ok"));
+    const context: RecipeApiProxyContext = {
+      request: new Request("https://robbiepalmer.me/api/recipe-imports/123"),
+      env: {
+        RECIPE_API_URL: "https://recipe-api.example.test",
+      },
+      waitUntil: (promise) => pending.push(promise),
+    };
+
+    const response = await onRequest(context);
+
+    expect(response.status).toBe(200);
+    const spanOptions = withPostHogSpanMock.mock.calls.at(-1)?.[0] as {
+      waitUntil?: { waitUntil: (promise: Promise<unknown>) => void };
+    };
+    spanOptions.waitUntil?.waitUntil(Promise.resolve());
+    expect(pending).toHaveLength(1);
+    await Promise.all(pending);
   });
 });

--- a/ui/tests/functions/recipe-imports-proxy.test.ts
+++ b/ui/tests/functions/recipe-imports-proxy.test.ts
@@ -1,3 +1,4 @@
+import { SpanKind } from "observability";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RecipeApiProxyContext } from "../../../functions/api/auth/routing";
 import { onRequest } from "../../../functions/api/recipe-imports/[[path]]";
@@ -62,8 +63,10 @@ describe("recipe imports proxy", () => {
 
     expect(response.status).toBe(200);
     const spanOptions = withPostHogSpanMock.mock.calls.at(-1)?.[0] as {
+      kind?: SpanKind;
       waitUntil?: { waitUntil: (promise: Promise<unknown>) => void };
     };
+    expect(spanOptions.kind).toBe(SpanKind.CLIENT);
     spanOptions.waitUntil?.waitUntil(Promise.resolve());
     expect(pending).toHaveLength(1);
     await Promise.all(pending);

--- a/ui/tests/instrumentation-client.test.ts
+++ b/ui/tests/instrumentation-client.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const posthog = vi.hoisted(() => ({
+  init: vi.fn(),
+  get_distinct_id: vi.fn(() => "person-123"),
+  get_session_id: vi.fn(() => "session-456"),
+}));
+
+vi.mock("posthog-js", () => ({ default: posthog }));
+
+describe("PostHog browser instrumentation", () => {
+  let originalFetch: typeof window.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    posthog.init.mockClear();
+    posthog.get_distinct_id.mockClear();
+    posthog.get_session_id.mockClear();
+    originalFetch = window.fetch;
+  });
+
+  afterEach(() => {
+    window.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("does not initialize without a project token", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "");
+
+    await import("../instrumentation-client");
+
+    expect(posthog.init).not.toHaveBeenCalled();
+  });
+
+  it("adds PostHog identity to same-origin API requests only", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://eu.posthog.com");
+    vi.stubEnv("NODE_ENV", "development");
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("ok"),
+    );
+    window.fetch = fetchMock as typeof window.fetch;
+
+    await import("../instrumentation-client");
+
+    expect(posthog.init).toHaveBeenCalledWith("phc_test", {
+      api_host: "/ingest",
+      ui_host: "https://eu.posthog.com",
+      defaults: "2025-11-30",
+      capture_exceptions: true,
+      debug: true,
+    });
+
+    await window.fetch("/api/recipes", {
+      headers: { "x-existing": "value" },
+    });
+    const apiInit = fetchMock.mock.calls[0]?.[1];
+    const apiHeaders = new Headers(apiInit?.headers);
+    expect(apiHeaders.get("x-existing")).toBe("value");
+    expect(apiHeaders.get("x-posthog-distinct-id")).toBe("person-123");
+    expect(apiHeaders.get("x-posthog-session-id")).toBe("session-456");
+
+    await window.fetch("https://example.test/api/recipes");
+    expect(fetchMock.mock.calls[1]).toEqual([
+      "https://example.test/api/recipes",
+      undefined,
+    ]);
+  });
+
+  it("preserves Request headers and omits unavailable identity values", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    posthog.get_distinct_id.mockReturnValueOnce("");
+    posthog.get_session_id.mockReturnValueOnce("");
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("ok"),
+    );
+    window.fetch = fetchMock as typeof window.fetch;
+
+    await import("../instrumentation-client");
+    await window.fetch(
+      new Request(`${window.location.origin}/api/recipes`, {
+        headers: { "x-existing": "value" },
+      }),
+    );
+
+    const apiHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(apiHeaders.get("x-existing")).toBe("value");
+    expect(apiHeaders.has("x-posthog-distinct-id")).toBe(false);
+    expect(apiHeaders.has("x-posthog-session-id")).toBe(false);
+  });
+});

--- a/ui/tests/instrumentation-client.test.ts
+++ b/ui/tests/instrumentation-client.test.ts
@@ -91,4 +91,24 @@ describe("PostHog browser instrumentation", () => {
     expect(apiHeaders.has("x-posthog-distinct-id")).toBe(false);
     expect(apiHeaders.has("x-posthog-session-id")).toBe(false);
   });
+
+  it("keeps API requests working when an identity lookup fails", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    posthog.get_distinct_id.mockImplementationOnce(() => {
+      throw new Error("PostHog is not ready");
+    });
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("ok"),
+    );
+    window.fetch = fetchMock as typeof window.fetch;
+
+    await import("../instrumentation-client");
+    const response = await window.fetch("/api/recipes");
+
+    expect(response.status).toBe(200);
+    const apiHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(apiHeaders.has("x-posthog-distinct-id")).toBe(false);
+    expect(apiHeaders.get("x-posthog-session-id")).toBe("session-456");
+  });
 });

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -24,6 +24,7 @@
     "hono": "^4.7.11",
     "ipaddr.js": "^2.4.0",
     "jose": "^6.1.3",
+    "observability": "workspace:*",
     "postgres": "^3.4.5",
     "recipe-db": "workspace:*",
     "recipe-domain": "workspace:*",

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -3191,6 +3191,7 @@ app.post("/recipe-imports", async (c) => {
             spanName: "workflow.start recipe-ingest",
             traceCarrier: traceCarrierFromHeaders(c.req.raw.headers),
             attributes: { "recipe.import.job_id": job.id },
+            waitUntil: c.executionCtx,
           },
           async (span) => {
             const traceContext = traceCarrierFromSpan(span);

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -1,6 +1,8 @@
 import { Hono, type Context } from "hono";
 import {
-  currentTraceCarrier,
+  injectTraceContext,
+  traceCarrierFromHeaders,
+  traceCarrierFromSpan,
   withPostHogRequest,
   withPostHogSpan,
 } from "observability";
@@ -3187,10 +3189,11 @@ app.post("/recipe-imports", async (c) => {
             env: c.env,
             serviceName: "recipe-api",
             spanName: "workflow.start recipe-ingest",
+            traceCarrier: traceCarrierFromHeaders(c.req.raw.headers),
             attributes: { "recipe.import.job_id": job.id },
           },
-          async () => {
-            const traceContext = currentTraceCarrier();
+          async (span) => {
+            const traceContext = traceCarrierFromSpan(span);
             await workflow.create({
               id: job.id,
               params: {
@@ -3340,7 +3343,13 @@ export default {
         request,
         waitUntil: ctx,
       },
-      async () => app.fetch(request, env, ctx),
+      async (span) => {
+        const headers = injectTraceContext(
+          new Headers(request.headers),
+          traceCarrierFromSpan(span),
+        );
+        return app.fetch(new Request(request, { headers }), env, ctx);
+      },
     ),
   scheduled: (_event, env, ctx) => {
     ctx.waitUntil(cleanupRateLimits(env));

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -1,5 +1,10 @@
 import { Hono, type Context } from "hono";
 import {
+  currentTraceCarrier,
+  withPostHogRequest,
+  withPostHogSpan,
+} from "observability";
+import {
   and,
   count,
   desc,
@@ -68,6 +73,8 @@ export type Bindings = {
   HYPERDRIVE?: Hyperdrive;
   DATABASE_URL?: string;
   DEPLOYMENT_ENV?: string;
+  POSTHOG_KEY?: string;
+  POSTHOG_OTLP_BASE_URL?: string;
   BETTER_AUTH_URL: string;
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
@@ -3175,7 +3182,24 @@ app.post("/recipe-imports", async (c) => {
             ),
           ),
         );
-        await workflow.create({ id: job.id, params: { jobId: job.id } });
+        await withPostHogSpan(
+          {
+            env: c.env,
+            serviceName: "recipe-api",
+            spanName: "workflow.start recipe-ingest",
+            attributes: { "recipe.import.job_id": job.id },
+          },
+          async () => {
+            const traceContext = currentTraceCarrier();
+            await workflow.create({
+              id: job.id,
+              params: {
+                jobId: job.id,
+                ...(traceContext ? { traceContext } : {}),
+              },
+            });
+          },
+        );
       } catch (error) {
         console.error("POST /recipe-imports failed to start workflow", error);
         // Best-effort cleanup so partially uploaded images don't accumulate.
@@ -3307,7 +3331,17 @@ async function cleanupRateLimits(env: Bindings): Promise<void> {
 }
 
 export default {
-  fetch: app.fetch,
+  fetch: (request, env, ctx) =>
+    withPostHogRequest(
+      {
+        env,
+        serviceName: "recipe-api",
+        spanName: `${request.method} ${new URL(request.url).pathname}`,
+        request,
+        waitUntil: ctx,
+      },
+      async () => app.fetch(request, env, ctx),
+    ),
   scheduled: (_event, env, ctx) => {
     ctx.waitUntil(cleanupRateLimits(env));
   },

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -1457,6 +1457,21 @@ describe("GET /health", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ status: "ok" });
   });
+
+  it("runs through the Worker fetch handler", async () => {
+    const ctx = {
+      waitUntil: vi.fn(),
+    } as unknown as ExecutionContext;
+
+    const res = await handler.fetch(
+      new Request("https://recipe-api.example.test/health"),
+      env,
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "ok" });
+  });
 });
 
 describe("GET /recipes", () => {

--- a/workers/recipe-api/tests/integration/database.test.ts
+++ b/workers/recipe-api/tests/integration/database.test.ts
@@ -573,6 +573,9 @@ describe("recipe API PostgreSQL integration", () => {
         body: form,
       },
       importEnv,
+      {
+        waitUntil: vi.fn(),
+      } as unknown as ExecutionContext,
     );
     expect(importResponse.status).toBe(202);
     const importJob = await json<{ id: string }>(importResponse);

--- a/workers/recipe-api/wrangler.preview.toml
+++ b/workers/recipe-api/wrangler.preview.toml
@@ -13,11 +13,16 @@ enabled = true
 enabled = true
 destinations = ["posthog-logs"]
 
+[vars]
+DEPLOYMENT_ENV = "preview"
+POSTHOG_OTLP_BASE_URL = "https://eu.i.posthog.com"
+
 [secrets]
 required = [
   "DATABASE_URL",
   "BETTER_AUTH_SECRET",
   "PREVIEW_AUTH_PASSWORD",
+  "POSTHOG_KEY",
 ]
 
 # The preview workflow injects the isolated Neon branch's pooled DATABASE_URL

--- a/workers/recipe-api/wrangler.toml
+++ b/workers/recipe-api/wrangler.toml
@@ -3,8 +3,10 @@ main = "src/index.ts"
 compatibility_date = "2026-05-28"
 compatibility_flags = ["nodejs_compat"]
 
-# Export Worker logs to PostHog via OTLP. The "posthog-logs" destination
-# (endpoint + auth header) is configured in the Cloudflare dashboard, not here.
+# Retain native Worker logs and export them to PostHog as a platform fallback.
+# Application traces and their correlated logs are exported directly as
+# OTLP/protobuf because Cloudflare's OTLP/JSON trace export is incompatible
+# with PostHog's tracing endpoint.
 [observability]
 enabled = true
 
@@ -13,6 +15,8 @@ enabled = true
 destinations = ["posthog-logs"]
 
 [vars]
+DEPLOYMENT_ENV = "production"
+POSTHOG_OTLP_BASE_URL = "https://eu.i.posthog.com"
 # Browser-facing URL used to build OAuth callbacks in production.
 # The local dev script overrides this with http://localhost:3000.
 BETTER_AUTH_URL = "https://robbiepalmer.me"
@@ -24,6 +28,7 @@ required = [
   "GOOGLE_CLIENT_SECRET",
   "GITHUB_CLIENT_ID",
   "GITHUB_CLIENT_SECRET",
+  "POSTHOG_KEY",
 ]
 
 # Daily sweep of stale rate-limit counters (src/index.ts scheduled handler).

--- a/workers/recipe-ingest/package.json
+++ b/workers/recipe-ingest/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.0",
+    "observability": "workspace:*",
     "postgres": "^3.4.5",
     "recipe-db": "workspace:*",
     "recipe-parsing": "workspace:*"

--- a/workers/recipe-ingest/src/env.ts
+++ b/workers/recipe-ingest/src/env.ts
@@ -4,6 +4,9 @@ export type Env = {
   ARTIFACTS: R2Bucket;
   RECIPE_INGEST_WORKFLOW: Workflow;
   OPENROUTER_API_KEY: string;
+  POSTHOG_KEY?: string;
+  POSTHOG_OTLP_BASE_URL?: string;
+  DEPLOYMENT_ENV?: string;
   EXTRACT_MODEL?: string;
   EXTRACT_TIMEOUT_MS?: string;
   EXTRACT_RETRIES?: string;

--- a/workers/recipe-ingest/src/index.ts
+++ b/workers/recipe-ingest/src/index.ts
@@ -326,6 +326,14 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
         buildCategoryMap(canonicalIngredients.ingredients),
       );
       if (unresolvedIngredients.length > 0) {
+        const requestIngredientDisambiguation = () =>
+          disambiguateIngredients({
+            apiKey: env.OPENROUTER_API_KEY,
+            unresolvedItems: unresolvedIngredients,
+            recipeContext: extractRecipeContext(entry, decisions),
+            model: canonicalizeParams.model,
+            requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
+          });
         const choices = await step.do(
           "disambiguate-ingredients",
           llmStepConfig(canonicalizeParams),
@@ -337,14 +345,7 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
                   jobId,
                   stage: "canonicalize",
                   model: canonicalizeParams.model,
-                  call: () =>
-                    disambiguateIngredients({
-                      apiKey: env.OPENROUTER_API_KEY,
-                      unresolvedItems: unresolvedIngredients,
-                      recipeContext: extractRecipeContext(entry, decisions),
-                      model: canonicalizeParams.model,
-                      requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
-                    }),
+                  call: requestIngredientDisambiguation,
                 }),
               ),
             ),
@@ -357,6 +358,17 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
         buildCategoryMap(canonicalEquipment.equipment),
       );
       if (unresolvedEquipment.length > 0) {
+        const requestEquipmentDisambiguation = () =>
+          disambiguateEquipment({
+            apiKey: env.OPENROUTER_API_KEY,
+            unresolvedItems: unresolvedEquipment,
+            equipmentContext: extractEquipmentContext(
+              entry,
+              cookwareDecisions,
+            ),
+            model: canonicalizeParams.model,
+            requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
+          });
         const choices = await step.do(
           "disambiguate-equipment",
           llmStepConfig(canonicalizeParams),
@@ -368,17 +380,7 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
                   jobId,
                   stage: "canonicalize",
                   model: canonicalizeParams.model,
-                  call: () =>
-                    disambiguateEquipment({
-                      apiKey: env.OPENROUTER_API_KEY,
-                      unresolvedItems: unresolvedEquipment,
-                      equipmentContext: extractEquipmentContext(
-                        entry,
-                        cookwareDecisions,
-                      ),
-                      model: canonicalizeParams.model,
-                      requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
-                    }),
+                  call: requestEquipmentDisambiguation,
                 }),
               ),
             ),

--- a/workers/recipe-ingest/src/index.ts
+++ b/workers/recipe-ingest/src/index.ts
@@ -379,7 +379,6 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
                       model: canonicalizeParams.model,
                       requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
                     }),
-                  }),
                 }),
               ),
             ),

--- a/workers/recipe-ingest/src/index.ts
+++ b/workers/recipe-ingest/src/index.ts
@@ -5,6 +5,12 @@ import {
   type WorkflowStepConfig,
 } from "cloudflare:workers";
 import { NonRetryableError } from "cloudflare:workflows";
+import {
+  SpanKind,
+  withPostHogRequest,
+  withPostHogSpan,
+  type TraceCarrier,
+} from "observability";
 import { canonicalEquipment } from "recipe-parsing/canonical-equipment-data";
 import { canonicalIngredients } from "recipe-parsing/canonical-ingredients-data";
 import {
@@ -50,6 +56,7 @@ import { stageParams, type StageParams } from "./params";
 
 export type IngestParams = {
   jobId: string;
+  traceContext?: TraceCarrier;
 };
 
 function llmStepConfig(params: StageParams): WorkflowStepConfig {
@@ -69,65 +76,96 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
     event: WorkflowEvent<IngestParams>,
     step: WorkflowStep,
   ): Promise<void> {
+    await this.runTraced(event, step);
+  }
+
+  private async runTraced(
+    event: WorkflowEvent<IngestParams>,
+    step: WorkflowStep,
+  ): Promise<void> {
     const { jobId } = event.payload;
     const env = this.env;
+    const traceStep = <T>(
+      name: string,
+      operation: () => Promise<T>,
+    ): Promise<T> =>
+      withPostHogSpan(
+        {
+          env,
+          serviceName: "recipe-ingest",
+          spanName: `workflow.step ${name}`,
+          traceCarrier: event.payload.traceContext,
+          kind: SpanKind.CONSUMER,
+          attributes: {
+            "recipe.import.job_id": jobId,
+            "cloudflare.workflow.instance_id": event.instanceId,
+            "cloudflare.workflow.step": name,
+          },
+        },
+        operation,
+      );
 
     try {
-      const sourceKeys = await step.do("start", async () => {
-        const keys = await listSourceImageKeys(env, jobId);
-        if (keys.length === 0) {
-          throw new NonRetryableError(
-            `No source images found for job ${jobId}`,
+      const sourceKeys = await step.do("start", async () =>
+        traceStep("start", async () => {
+          const keys = await listSourceImageKeys(env, jobId);
+          if (keys.length === 0) {
+            throw new NonRetryableError(
+              `No source images found for job ${jobId}`,
+            );
+          }
+          await withDb(env, (db) =>
+            markJobRunning(db, jobId, event.instanceId),
           );
-        }
-        await withDb(env, (db) =>
-          markJobRunning(db, jobId, event.instanceId),
-        );
-        return keys;
-      });
+          return keys;
+        }),
+      );
 
       const extractParams = stageParams(env, "extract");
       const extraction = await step.do(
         "extract",
         llmStepConfig(extractParams),
-        async (): Promise<ExtractionRecipe> => {
-          const imageDataUrls = await loadImageDataUrls(env, sourceKeys);
-          return runLlmCall({
-            env,
-            jobId,
-            stage: "extract",
-            model: extractParams.model,
-            call: () =>
-              extractRecipeFromImages({
-                apiKey: env.OPENROUTER_API_KEY,
-                imageDataUrls,
-                model: extractParams.model,
-                requestTimeoutMs: extractParams.requestTimeoutMs,
-              }),
-          });
-        },
+        async (): Promise<ExtractionRecipe> =>
+          traceStep("extract", async () => {
+            const imageDataUrls = await loadImageDataUrls(env, sourceKeys);
+            return runLlmCall({
+              env,
+              jobId,
+              stage: "extract",
+              model: extractParams.model,
+              call: () =>
+                extractRecipeFromImages({
+                  apiKey: env.OPENROUTER_API_KEY,
+                  imageDataUrls,
+                  model: extractParams.model,
+                  requestTimeoutMs: extractParams.requestTimeoutMs,
+                }),
+            });
+          }),
       );
 
-      await step.do("persist-extract", async () => {
-        await withDb(env, async (db) => {
-          await writeArtifact({
-            env,
-            db,
-            jobId,
-            stage: "extract",
-            kind: "extraction",
-            filename: "extraction.json",
-            payload: extraction,
-            model: extractParams.model,
+      await step.do("persist-extract", async () =>
+        traceStep("persist-extract", async () => {
+          await withDb(env, async (db) => {
+            await writeArtifact({
+              env,
+              db,
+              jobId,
+              stage: "extract",
+              kind: "extraction",
+              filename: "extraction.json",
+              payload: extraction,
+              model: extractParams.model,
+            });
+            await updateJobStage(
+              db,
+              jobId,
+              "normalize",
+              "Tidying the recipe into a draft",
+            );
           });
-          await updateJobStage(
-            db,
-            jobId,
-            "normalize",
-            "Tidying the recipe into a draft",
-          );
-        });
-      });
+        }),
+      );
 
       const normalizeParams = stageParams(env, "normalize");
       let cooklang: CooklangRecipe;
@@ -135,89 +173,94 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
         cooklang = await step.do(
           "normalize",
           llmStepConfig(normalizeParams),
-          async (): Promise<CooklangRecipe> => {
-            const llmCooklang = await runLlmCall({
-              env,
-              jobId,
-              stage: "normalize",
-              model: normalizeParams.model,
-              call: () =>
-                normalizeExtractionToCooklang({
-                  apiKey: env.OPENROUTER_API_KEY,
-                  extracted: extraction,
-                  model: normalizeParams.model,
-                  requestTimeoutMs: normalizeParams.requestTimeoutMs,
-                }),
-            });
+          async (): Promise<CooklangRecipe> =>
+            traceStep("normalize", async () => {
+              const llmCooklang = await runLlmCall({
+                env,
+                jobId,
+                stage: "normalize",
+                model: normalizeParams.model,
+                call: () =>
+                  normalizeExtractionToCooklang({
+                    apiKey: env.OPENROUTER_API_KEY,
+                    extracted: extraction,
+                    model: normalizeParams.model,
+                    requestTimeoutMs: normalizeParams.requestTimeoutMs,
+                  }),
+              });
 
-            // Always re-derive from the body to ensure slug normalization is applied.
-            const derived = deriveRecipeFromCooklang({
-              ...llmCooklang,
-              derived: undefined,
-            });
-            if (derived.derived) {
-              return derived;
-            }
+              // Always re-derive from the body to ensure slug normalization is applied.
+              const derived = deriveRecipeFromCooklang({
+                ...llmCooklang,
+                derived: undefined,
+              });
+              if (derived.derived) {
+                return derived;
+              }
 
-            // LLM produced Cooklang but derivation failed — deterministic draft fallback.
-            const draft = buildCooklangDraftFromExtraction(extraction);
-            if (draft.derived) {
-              return {
-                ...derived,
-                derived: draft.derived,
-                diagnostics: [
-                  ...derived.diagnostics,
-                  "LLM cooklang derivation failed; using deterministic draft.",
-                ],
-              };
-            }
-            throw new NonRetryableError(derived.diagnostics.join(" | "));
-          },
+              // LLM produced Cooklang but derivation failed — deterministic draft fallback.
+              const draft = buildCooklangDraftFromExtraction(extraction);
+              if (draft.derived) {
+                return {
+                  ...derived,
+                  derived: draft.derived,
+                  diagnostics: [
+                    ...derived.diagnostics,
+                    "LLM cooklang derivation failed; using deterministic draft.",
+                  ],
+                };
+              }
+              throw new NonRetryableError(derived.diagnostics.join(" | "));
+            }),
         );
       } catch (normalizeError) {
         // Normalization failed outright — fall back to the deterministic draft,
         // mirroring the evaluation pipeline's behaviour.
-        cooklang = await step.do("normalize-fallback", async () => {
-          const draft = buildCooklangDraftFromExtraction(extraction);
-          if (!draft.derived) {
-            throw new NonRetryableError(
-              "Normalization failed and deterministic draft could not produce a recipe",
-            );
-          }
-          return {
-            ...draft,
-            diagnostics: [
-              ...draft.diagnostics,
-              `Normalization LLM failed; using deterministic draft. (${
-                normalizeError instanceof Error
-                  ? normalizeError.message
-                  : String(normalizeError)
-              })`,
-            ],
-          };
-        });
+        cooklang = await step.do("normalize-fallback", async () =>
+          traceStep("normalize-fallback", async () => {
+            const draft = buildCooklangDraftFromExtraction(extraction);
+            if (!draft.derived) {
+              throw new NonRetryableError(
+                "Normalization failed and deterministic draft could not produce a recipe",
+              );
+            }
+            return {
+              ...draft,
+              diagnostics: [
+                ...draft.diagnostics,
+                `Normalization LLM failed; using deterministic draft. (${
+                  normalizeError instanceof Error
+                    ? normalizeError.message
+                    : String(normalizeError)
+                })`,
+              ],
+            };
+          }),
+        );
       }
 
-      await step.do("persist-normalize", async () => {
-        await withDb(env, async (db) => {
-          await writeArtifact({
-            env,
-            db,
-            jobId,
-            stage: "normalize",
-            kind: "cooklang",
-            filename: "cooklang.json",
-            payload: cooklang,
-            model: normalizeParams.model,
+      await step.do("persist-normalize", async () =>
+        traceStep("persist-normalize", async () => {
+          await withDb(env, async (db) => {
+            await writeArtifact({
+              env,
+              db,
+              jobId,
+              stage: "normalize",
+              kind: "cooklang",
+              filename: "cooklang.json",
+              payload: cooklang,
+              model: normalizeParams.model,
+            });
+            await updateJobStage(
+              db,
+              jobId,
+              "canonicalize",
+              "Matching ingredients to the pantry",
+            );
           });
-          await updateJobStage(
-            db,
-            jobId,
-            "canonicalize",
-            "Matching ingredients to the pantry",
-          );
-        });
-      });
+        }),
+      );
 
       const canonicalizeParams = stageParams(env, "canonicalize");
 
@@ -225,32 +268,33 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
       // LLM retry budget. The two disambiguation steps below own the retries.
       const { entry, decisions, cookwareDecisions } = await step.do(
         "canonicalize",
-        async () => {
-          const recipe = cooklang.derived;
-          if (!recipe) {
-            throw new NonRetryableError(
-              "Normalized recipe missing derived output",
-            );
-          }
+        async () =>
+          traceStep("canonicalize", async () => {
+            const recipe = cooklang.derived;
+            if (!recipe) {
+              throw new NonRetryableError(
+                "Normalized recipe missing derived output",
+              );
+            }
 
-          const ingredientOntology = buildOntology(
-            canonicalIngredients.ingredients,
-            "ingredient",
-          );
-          const equipmentOntology = buildOntology(
-            canonicalEquipment.equipment,
-            "equipment",
-          );
-          return canonicalizePredictionEntry(
-            { images: sourceKeys, predicted: recipe },
-            {
-              ingredients: ingredientOntology,
-              ingredientIndex: buildOntologyIndex(ingredientOntology),
-              equipment: equipmentOntology,
-              equipmentIndex: buildOntologyIndex(equipmentOntology),
-            },
-          );
-        },
+            const ingredientOntology = buildOntology(
+              canonicalIngredients.ingredients,
+              "ingredient",
+            );
+            const equipmentOntology = buildOntology(
+              canonicalEquipment.equipment,
+              "equipment",
+            );
+            return canonicalizePredictionEntry(
+              { images: sourceKeys, predicted: recipe },
+              {
+                ingredients: ingredientOntology,
+                ingredientIndex: buildOntologyIndex(ingredientOntology),
+                equipment: equipmentOntology,
+                equipmentIndex: buildOntologyIndex(equipmentOntology),
+              },
+            );
+          }),
       );
 
       // Each registry is disambiguated in its own step so retrying one provider
@@ -285,21 +329,23 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
           "disambiguate-ingredients",
           llmStepConfig(canonicalizeParams),
           (ctx) =>
-            bestEffortDisambiguation(ctx, () =>
-              runLlmCall({
-                env,
-                jobId,
-                stage: "canonicalize",
-                model: canonicalizeParams.model,
-                call: () =>
-                  disambiguateIngredients({
-                    apiKey: env.OPENROUTER_API_KEY,
-                    unresolvedItems: unresolvedIngredients,
-                    recipeContext: extractRecipeContext(entry, decisions),
-                    model: canonicalizeParams.model,
-                    requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
-                  }),
-              }),
+            traceStep("disambiguate-ingredients", () =>
+              bestEffortDisambiguation(ctx, () =>
+                runLlmCall({
+                  env,
+                  jobId,
+                  stage: "canonicalize",
+                  model: canonicalizeParams.model,
+                  call: () =>
+                    disambiguateIngredients({
+                      apiKey: env.OPENROUTER_API_KEY,
+                      unresolvedItems: unresolvedIngredients,
+                      recipeContext: extractRecipeContext(entry, decisions),
+                      model: canonicalizeParams.model,
+                      requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
+                    }),
+                }),
+              ),
             ),
         );
         applyDisambiguationChoices(decisions, unresolvedIngredients, choices);
@@ -314,24 +360,27 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
           "disambiguate-equipment",
           llmStepConfig(canonicalizeParams),
           (ctx) =>
-            bestEffortDisambiguation(ctx, () =>
-              runLlmCall({
-                env,
-                jobId,
-                stage: "canonicalize",
-                model: canonicalizeParams.model,
-                call: () =>
-                  disambiguateEquipment({
-                    apiKey: env.OPENROUTER_API_KEY,
-                    unresolvedItems: unresolvedEquipment,
-                    equipmentContext: extractEquipmentContext(
-                      entry,
-                      cookwareDecisions,
-                    ),
-                    model: canonicalizeParams.model,
-                    requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
+            traceStep("disambiguate-equipment", () =>
+              bestEffortDisambiguation(ctx, () =>
+                runLlmCall({
+                  env,
+                  jobId,
+                  stage: "canonicalize",
+                  model: canonicalizeParams.model,
+                  call: () =>
+                    disambiguateEquipment({
+                      apiKey: env.OPENROUTER_API_KEY,
+                      unresolvedItems: unresolvedEquipment,
+                      equipmentContext: extractEquipmentContext(
+                        entry,
+                        cookwareDecisions,
+                      ),
+                      model: canonicalizeParams.model,
+                      requestTimeoutMs: canonicalizeParams.requestTimeoutMs,
+                    }),
                   }),
-              }),
+                }),
+              ),
             ),
         );
         applyDisambiguationChoices(
@@ -351,46 +400,50 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
         cookwareDecisions,
       };
 
-      await step.do("persist-canonicalize", async () => {
-        await withDb(env, async (db) => {
-          await writeArtifact({
-            env,
-            db,
-            jobId,
-            stage: "canonicalize",
-            kind: "canonicalization-decisions",
-            filename: "decisions.json",
-            payload: {
-              decisions: canonical.decisions,
-              cookwareDecisions: canonical.cookwareDecisions,
-            },
-            model: canonicalizeParams.model,
+      await step.do("persist-canonicalize", async () =>
+        traceStep("persist-canonicalize", async () => {
+          await withDb(env, async (db) => {
+            await writeArtifact({
+              env,
+              db,
+              jobId,
+              stage: "canonicalize",
+              kind: "canonicalization-decisions",
+              filename: "decisions.json",
+              payload: {
+                decisions: canonical.decisions,
+                cookwareDecisions: canonical.cookwareDecisions,
+              },
+              model: canonicalizeParams.model,
+            });
+            await updateJobStage(db, jobId, "finalize", "Preparing your draft");
           });
-          await updateJobStage(db, jobId, "finalize", "Preparing your draft");
-        });
-      });
+        }),
+      );
 
-      await step.do("finalize", async () => {
-        const draft = buildFinalDraft(
-          sourceKeys,
-          cooklang,
-          canonical.recipe,
-          canonical.cookwareDecisions,
-        );
-        await withDb(env, async (db) => {
-          await writeArtifact({
-            env,
-            db,
-            jobId,
-            stage: "finalize",
-            kind: "draft",
-            filename: "draft.json",
-            payload: draft,
-            preview: draft,
+      await step.do("finalize", async () =>
+        traceStep("finalize", async () => {
+          const draft = buildFinalDraft(
+            sourceKeys,
+            cooklang,
+            canonical.recipe,
+            canonical.cookwareDecisions,
+          );
+          await withDb(env, async (db) => {
+            await writeArtifact({
+              env,
+              db,
+              jobId,
+              stage: "finalize",
+              kind: "draft",
+              filename: "draft.json",
+              payload: draft,
+              preview: draft,
+            });
+            await markJobSucceeded(db, jobId);
           });
-          await markJobSucceeded(db, jobId);
-        });
-      });
+        }),
+      );
     } catch (error) {
       const errorType =
         error instanceof Error && error.name ? error.name : "IngestError";
@@ -401,22 +454,35 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
         errorType,
         errorMessage,
       });
-      await step.do("mark-failed", async () => {
-        await withDb(env, (db) =>
-          markJobFailed(db, jobId, errorType, errorMessage),
-        );
-      });
+      await step.do("mark-failed", async () =>
+        traceStep("mark-failed", async () => {
+          await withDb(env, (db) =>
+            markJobFailed(db, jobId, errorType, errorMessage),
+          );
+        }),
+      );
       throw error;
     }
   }
 }
 
 export default {
-  async fetch(request: Request): Promise<Response> {
-    const url = new URL(request.url);
-    if (url.pathname === "/health") {
-      return Response.json({ status: "ok", service: "recipe-ingest" });
-    }
-    return new Response("Not found", { status: 404 });
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    return withPostHogRequest(
+      {
+        env,
+        serviceName: "recipe-ingest",
+        spanName: `${request.method} ${new URL(request.url).pathname}`,
+        request,
+        waitUntil: ctx,
+      },
+      async () => {
+        const url = new URL(request.url);
+        if (url.pathname === "/health") {
+          return Response.json({ status: "ok", service: "recipe-ingest" });
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    );
   },
 };

--- a/workers/recipe-ingest/src/index.ts
+++ b/workers/recipe-ingest/src/index.ts
@@ -96,6 +96,7 @@ export class RecipeIngestWorkflow extends WorkflowEntrypoint<Env, IngestParams> 
           spanName: `workflow.step ${name}`,
           traceCarrier: event.payload.traceContext,
           kind: SpanKind.CONSUMER,
+          waitUntil: this.ctx,
           attributes: {
             "recipe.import.job_id": jobId,
             "cloudflare.workflow.instance_id": event.instanceId,

--- a/workers/recipe-ingest/tests/config-parity.test.ts
+++ b/workers/recipe-ingest/tests/config-parity.test.ts
@@ -36,6 +36,7 @@ type WranglerConfig = {
     enabled?: boolean;
     logs?: { enabled?: boolean; destinations?: string[] };
   };
+  secrets?: { required?: string[] };
 };
 
 type StageParamsYaml = Record<
@@ -128,6 +129,21 @@ describe("shared infrastructure bindings", () => {
         enabled: true,
         logs: { enabled: true, destinations: ["posthog-logs"] },
       });
+    }
+  });
+
+  it("production and preview workers configure direct PostHog tracing", () => {
+    const posthogOtlpBaseUrl = terraformDefault("posthog_otlp_base_url");
+
+    for (const config of [
+      apiWrangler,
+      ingestWrangler,
+      apiPreviewWrangler,
+      ingestPreviewWrangler,
+    ]) {
+      expect(config.vars?.POSTHOG_OTLP_BASE_URL).toBe(posthogOtlpBaseUrl);
+      expect(config.vars?.DEPLOYMENT_ENV).toMatch(/^(production|preview)$/);
+      expect(config.secrets?.required).toContain("POSTHOG_KEY");
     }
   });
 

--- a/workers/recipe-ingest/tests/config-parity.test.ts
+++ b/workers/recipe-ingest/tests/config-parity.test.ts
@@ -61,7 +61,7 @@ const pipelineParams = parseYaml(
 ) as StageParamsYaml;
 const terraformVariables = readRepoFile("infra/variables.tf");
 
-function terraformDefault(variableName: string): string {
+function terraformVariableBlock(variableName: string): string {
   // Slice out the variable's block (up to the next top-level declaration)
   // before matching, so nested blocks at any depth can't derail the search.
   const blockStart = terraformVariables.indexOf(`variable "${variableName}" {`);
@@ -76,6 +76,11 @@ function terraformDefault(variableName: string): string {
     blockStart,
     blockEnd === -1 ? undefined : blockEnd,
   );
+  return block;
+}
+
+function terraformDefault(variableName: string): string {
+  const block = terraformVariableBlock(variableName);
   const match = /default\s*=\s*"([^"]+)"/.exec(block);
   if (!match?.[1]) {
     throw new Error(`No default found for Terraform variable ${variableName}`);
@@ -118,6 +123,21 @@ describe("LLM stage parameters", () => {
 });
 
 describe("shared infrastructure bindings", () => {
+  it.each([
+    ["https://eu.i.posthog.com", true],
+    ["https://localhost:4318", true],
+    ["http://eu.i.posthog.com", false],
+    ["https://eu.i.posthog.com/i/v1", false],
+    ["https://eu.i.posthog.com?region=eu", false],
+    ["https://eu.i.posthog.com#traces", false],
+  ])("validates the PostHog OTLP origin %s", (value, expected) => {
+    const block = terraformVariableBlock("posthog_otlp_base_url");
+    const pattern = /condition\s*=\s*can\(regex\("([^"]+)"/.exec(block)?.[1];
+    if (!pattern) throw new Error("PostHog OTLP validation regex not found");
+
+    expect(new RegExp(pattern).test(value)).toBe(expected);
+  });
+
   it("production and preview workers retain and export logs", () => {
     for (const config of [
       apiWrangler,
@@ -135,14 +155,14 @@ describe("shared infrastructure bindings", () => {
   it("production and preview workers configure direct PostHog tracing", () => {
     const posthogOtlpBaseUrl = terraformDefault("posthog_otlp_base_url");
 
-    for (const config of [
-      apiWrangler,
-      ingestWrangler,
-      apiPreviewWrangler,
-      ingestPreviewWrangler,
+    for (const { config, expectedEnvironment } of [
+      { config: apiWrangler, expectedEnvironment: "production" },
+      { config: ingestWrangler, expectedEnvironment: "production" },
+      { config: apiPreviewWrangler, expectedEnvironment: "preview" },
+      { config: ingestPreviewWrangler, expectedEnvironment: "preview" },
     ]) {
       expect(config.vars?.POSTHOG_OTLP_BASE_URL).toBe(posthogOtlpBaseUrl);
-      expect(config.vars?.DEPLOYMENT_ENV).toMatch(/^(production|preview)$/);
+      expect(config.vars?.DEPLOYMENT_ENV).toBe(expectedEnvironment);
       expect(config.secrets?.required).toContain("POSTHOG_KEY");
     }
   });

--- a/workers/recipe-ingest/tests/index.test.ts
+++ b/workers/recipe-ingest/tests/index.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Env } from "../src/env";
+
+vi.mock("cloudflare:workers", () => ({
+  WorkflowEntrypoint: class {},
+}));
+
+vi.mock("cloudflare:workflows", () => ({
+  NonRetryableError: class extends Error {},
+}));
+
+import handler from "../src/index";
+
+const ctx = {
+  waitUntil: vi.fn(),
+} as unknown as ExecutionContext;
+const env = {} as Env;
+
+describe("recipe ingest Worker", () => {
+  it("returns its health response through the tracing wrapper", async () => {
+    const response = await handler.fetch(
+      new Request("https://recipe-ingest.example.test/health"),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "ok",
+      service: "recipe-ingest",
+    });
+  });
+
+  it("returns not found for unknown paths", async () => {
+    const response = await handler.fetch(
+      new Request("https://recipe-ingest.example.test/unknown"),
+      env,
+      ctx,
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/workers/recipe-ingest/wrangler.preview.toml
+++ b/workers/recipe-ingest/wrangler.preview.toml
@@ -14,6 +14,8 @@ enabled = true
 destinations = ["posthog-logs"]
 
 [vars]
+DEPLOYMENT_ENV = "preview"
+POSTHOG_OTLP_BASE_URL = "https://eu.i.posthog.com"
 EXTRACT_MODEL = "google/gemini-3-flash-preview"
 EXTRACT_TIMEOUT_MS = "30000"
 EXTRACT_RETRIES = "2"
@@ -25,7 +27,7 @@ CANONICALIZE_TIMEOUT_MS = "15000"
 CANONICALIZE_RETRIES = "1"
 
 [secrets]
-required = ["DATABASE_URL", "OPENROUTER_API_KEY"]
+required = ["DATABASE_URL", "OPENROUTER_API_KEY", "POSTHOG_KEY"]
 
 [[workflows]]
 name = "__PREVIEW_INGEST_NAME__"

--- a/workers/recipe-ingest/wrangler.toml
+++ b/workers/recipe-ingest/wrangler.toml
@@ -3,8 +3,10 @@ main = "src/index.ts"
 compatibility_date = "2026-05-28"
 compatibility_flags = ["nodejs_compat"]
 
-# Export Worker logs to PostHog via OTLP. The "posthog-logs" destination
-# (endpoint + auth header) is configured in the Cloudflare dashboard, not here.
+# Retain native Worker logs and export them to PostHog as a platform fallback.
+# Application traces and their correlated logs are exported directly as
+# OTLP/protobuf because Cloudflare's OTLP/JSON trace export is incompatible
+# with PostHog's tracing endpoint.
 [observability]
 enabled = true
 
@@ -13,6 +15,8 @@ enabled = true
 destinations = ["posthog-logs"]
 
 [vars]
+DEPLOYMENT_ENV = "production"
+POSTHOG_OTLP_BASE_URL = "https://eu.i.posthog.com"
 # Stage parameters mirror ml-pipelines/recipe-parsing/params.yaml so production
 # runs the same models/timeouts the evaluation pipeline scores.
 EXTRACT_MODEL = "google/gemini-3-flash-preview"
@@ -26,7 +30,7 @@ CANONICALIZE_TIMEOUT_MS = "15000"
 CANONICALIZE_RETRIES = "1"
 
 [secrets]
-required = ["OPENROUTER_API_KEY"]
+required = ["OPENROUTER_API_KEY", "POSTHOG_KEY"]
 
 [[workflows]]
 name = "recipe-ingest"


### PR DESCRIPTION
## Summary

- add a shared OpenTelemetry package that exports OTLP/HTTP protobuf traces and correlated logs directly to PostHog
- propagate W3C trace context from the recipe UI through Pages Functions and `recipe-api` into durable `recipe-ingest` Workflow steps
- attach PostHog person and session identifiers so backend failures can be connected to product analytics and session replay
- configure Terraform, Wrangler, Doppler, preview environments, and deployment workflows for the PostHog OTLP endpoint and project token
- retain Cloudflare-native logs as an independent fallback
- add ADR 060 documenting direct export without a collector, including Cloudflare-only and Grafana Cloud alternatives and explicit revisit triggers

## Why

A recipe image import crosses the browser, a Pages Function, an API Worker, and a durable Cloudflare Workflow. Separate logs do not show which stage made one user's request slow or fail.

Cloudflare currently supports PostHog log export but not PostHog trace export, and its observability destination does not support the OTLP binary format PostHog tracing requires. Application-owned OTLP export closes that gap while preserving the user, session replay, and product context already held in PostHog.

A collector gateway is intentionally deferred at the current traffic level. Cloudflare Workers have no co-scheduled sidecar primitive, so a collector would be a separate service to host and operate. ADR 060 records the weaker delivery guarantees and PostHog tracing's alpha status as accepted, revisitable tradeoffs.

## Implementation notes

- request telemetry flushes through `waitUntil()` and never changes application success or failure
- Workflow exports run inside `step.do()` callbacks so replay does not duplicate telemetry side effects
- the Workflow boundary serializes W3C trace context because it is not an HTTP hop
- instrumentation excludes request bodies, recipe contents, credentials, and other sensitive payloads
- Terraform was planned but not applied; deployments were not performed

## Validation

- observability package tests and typecheck: passed
- `recipe-api`: 163 tests and typecheck passed
- `recipe-ingest`: 19 tests and typecheck passed
- UI: 709 tests, static checks, and production build passed
- API Worker, ingestion Worker, and Pages Functions Wrangler dry-runs passed
- Terraform validate, format, TFLint, and plan passed (`0 add, 1 change, 0 destroy`)
- GitHub Actions lint, Markdown/MDX lint, Knip, typo checks, and gitleaks passed
- production content build generated 288 static pages, including ADR 060 and its Markdown/text twins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rolled out PostHog-based distributed tracing with correlated logs across the site, API, and recipe workflow steps.
  - Added support for a regional OTLP base URL and propagated trace context through requests.
- **Bug Fixes**
  - Improved API-path handling in middleware and added coverage to confirm health-check responses.
- **Documentation**
  - Published/expanded guidance on telemetry setup, trace propagation, environment variables, and secret rotation.
- **Tests**
  - Expanded automated tests for telemetry exporting, trace/header propagation, worker behaviour, and configuration parity.
- **Chores**
  - Updated CI/CD workflows and Sonar coverage to include observability changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->