### PR TITLE
Combine paid and free AI review scouts

### DIFF
--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -1,15 +1,17 @@
 # AI code review
 
 This directory contains the repository's custom multi-model pull-request
-reviewer. The free models currently advertised by OpenCode Zen independently
-produce structured findings. A paid OpenRouter merger only deduplicates those
-findings and reconciles them with resolved GitHub review threads; it does not
-judge correctness.
+reviewer. Two paid OpenRouter scouts and the retained free models advertised by
+OpenCode Zen independently produce structured findings. A paid OpenRouter merger
+only deduplicates those findings and reconciles them with resolved GitHub review
+threads; it does not judge correctness. Free-scout findings are real review
+inputs rather than shadow telemetry, so their downstream outcomes can inform
+future performance analytics.
 
 ## Setup
 
 1. Add `OPENROUTER_API_KEY` as an Actions repository secret and set a suitable
-   credit limit on the key. It is used only by the merger.
+   credit limit on the key. It is used by the paid scouts and merger.
 2. Open or update a non-draft pull request from a branch in this repository as
    an owner, member, or collaborator. Every commit is reviewed automatically.
 3. Fork pull requests never run automatically. An owner, member, or collaborator
@@ -19,16 +21,18 @@ Outside contributors cannot trigger a paid run themselves.
 
 Optional Actions repository variables:
 
+- `AI_REVIEW_MODELS`: comma-separated paid OpenRouter scout models. Defaults to
+  `moonshotai/kimi-k2.6,deepseek/deepseek-v4-pro`.
 - `AI_REVIEW_OPENCODE_MODELS`: comma-separated free OpenCode model IDs. When it
   is unset, the reviewer discovers eligible IDs ending in `-free` plus
-  `big-pickle` from the live OpenCode catalogue. Laguna S 2.1, Ling 3.0 Flash,
-  and North Mini Code are excluded after the first live run showed that retaining
-  them would require reduced reasoning or add rate-limited noise. The override is
-  limited to 12 enabled free IDs.
+  `big-pickle` from the live OpenCode catalogue. DeepSeek V4 Flash, MiMo V2.5,
+  Laguna S 2.1, Ling 3.0 Flash, and North Mini Code are excluded after live runs
+  showed that they provided no useful incremental coverage or failed too often.
+  The override is limited to six enabled free IDs.
 - `AI_REVIEW_MERGER_MODEL`: defaults to `anthropic/claude-sonnet-4.6`.
 - `AI_REVIEW_IGNORED_AUTHORS`: comma-separated PR authors to skip. Defaults to
   `renovate[bot],dependabot[bot]`.
-- `AI_REVIEW_ZDR=true`: restricts OpenRouter merger routing to
+- `AI_REVIEW_ZDR=true`: restricts paid OpenRouter scout and merger routing to
   zero-data-retention providers. It does not change OpenCode scout routing.
 
 OpenCode currently accepts anonymous requests for its free models. An
@@ -40,8 +44,8 @@ need to install the CLI or SDK on each runner.
 
 ## Security and behavior
 
-The workflow needs the merger's OpenRouter secret, but code in a pull request is
-untrusted. `pull_request_target` makes the secret available. Automatic reviews
+The workflow needs the OpenRouter secret, but code in a pull request is untrusted.
+`pull_request_target` makes the secret available. Automatic reviews
 check out the PR's exact base commit. Manual comment and dispatch runs check out
 the protected default branch for comments. Maintainer-only manual dispatches
 check out their explicitly selected ref so reviewer changes can be tested before
@@ -59,13 +63,14 @@ cumulative scorecard fields are intended to support removing scouts that are
 noisy or not cost-effective.
 
 Free-model availability is refreshed from OpenCode at the start of every run.
-Models removed from the catalogue are skipped. The four currently retained
-scouts run concurrently in one batch and retry transient errors such as rate
-limits. DeepSeek receives a 16,000-token completion budget, and Nemotron receives
-a 180-second timeout for one further evaluation. Any successful scout is enough
-to continue to reconciliation. If every scout is unavailable, rate-limited, or
-invalid, the workflow publishes an explicit no-coverage warning and does not
-spend money on the merger; the stable `review` check is skipped.
+Models removed from the catalogue are skipped. The four default scouts—Kimi
+K2.6, DeepSeek V4 Pro, Big Pickle, and Nemotron 3 Ultra Free—run concurrently.
+Transient failures such as rate limits are retried, Nemotron receives a
+180-second timeout, and individual failures do not block the remaining scouts.
+Any successful scout is enough to continue to reconciliation. If every scout is
+unavailable, rate-limited, or invalid, the workflow publishes an explicit
+no-coverage warning and does not spend money on the merger; the stable `review`
+check is skipped.
 
 When OpenRouter reports exhausted account credits or an exhausted API-key
 spending limit, the stable `review` check is also marked as skipped.

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -20,8 +20,11 @@ Outside contributors cannot trigger a paid run themselves.
 Optional Actions repository variables:
 
 - `AI_REVIEW_OPENCODE_MODELS`: comma-separated free OpenCode model IDs. When it
-  is unset, the reviewer discovers all IDs ending in `-free` plus `big-pickle`
-  from the live OpenCode catalogue. The override is limited to 12 free IDs.
+  is unset, the reviewer discovers eligible IDs ending in `-free` plus
+  `big-pickle` from the live OpenCode catalogue. Laguna S 2.1, Ling 3.0 Flash,
+  and North Mini Code are excluded after the first live run showed that retaining
+  them would require reduced reasoning or add rate-limited noise. The override is
+  limited to 12 enabled free IDs.
 - `AI_REVIEW_MERGER_MODEL`: defaults to `anthropic/claude-sonnet-4.6`.
 - `AI_REVIEW_IGNORED_AUTHORS`: comma-separated PR authors to skip. Defaults to
   `renovate[bot],dependabot[bot]`.
@@ -56,11 +59,13 @@ cumulative scorecard fields are intended to support removing scouts that are
 noisy or not cost-effective.
 
 Free-model availability is refreshed from OpenCode at the start of every run.
-Models removed from the catalogue are skipped. Scouts run with concurrency
-limited to three, and retry transient errors such as rate limits. Any successful
-scout is enough to continue to reconciliation. If every scout is unavailable,
-rate-limited, or invalid, the workflow publishes an explicit no-coverage warning
-and does not spend money on the merger; the stable `review` check is skipped.
+Models removed from the catalogue are skipped. The four currently retained
+scouts run concurrently in one batch and retry transient errors such as rate
+limits. DeepSeek receives a 16,000-token completion budget, and Nemotron receives
+a 180-second timeout for one further evaluation. Any successful scout is enough
+to continue to reconciliation. If every scout is unavailable, rate-limited, or
+invalid, the workflow publishes an explicit no-coverage warning and does not
+spend money on the merger; the stable `review` check is skipped.
 
 When OpenRouter reports exhausted account credits or an exhausted API-key
 spending limit, the stable `review` check is also marked as skipped.

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -66,11 +66,11 @@ Free-model availability is refreshed from OpenCode at the start of every run.
 Models removed from the catalogue are skipped. The four default scouts—Kimi
 K2.6, DeepSeek V4 Pro, Big Pickle, and Nemotron 3 Ultra Free—run concurrently.
 Transient failures such as rate limits are retried, Nemotron receives a
-180-second timeout, and DeepSeek V4 Pro receives a 16,000-token completion
-budget. Individual failures do not block the remaining scouts. Any successful
-scout is enough to continue to reconciliation. If every scout is unavailable,
-rate-limited, or invalid, the workflow publishes an explicit no-coverage warning
-and does not spend money on the merger; the stable `review` check is skipped.
+180-second timeout, and individual failures do not block the remaining scouts.
+Any successful scout is enough to continue to reconciliation. If every scout is
+unavailable, rate-limited, or invalid, the workflow publishes an explicit
+no-coverage warning and does not spend money on the merger; the stable `review`
+check is skipped.
 
 When OpenRouter reports exhausted account credits or an exhausted API-key
 spending limit, the stable `review` check is also marked as skipped.

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -66,11 +66,11 @@ Free-model availability is refreshed from OpenCode at the start of every run.
 Models removed from the catalogue are skipped. The four default scouts—Kimi
 K2.6, DeepSeek V4 Pro, Big Pickle, and Nemotron 3 Ultra Free—run concurrently.
 Transient failures such as rate limits are retried, Nemotron receives a
-180-second timeout, and individual failures do not block the remaining scouts.
-Any successful scout is enough to continue to reconciliation. If every scout is
-unavailable, rate-limited, or invalid, the workflow publishes an explicit
-no-coverage warning and does not spend money on the merger; the stable `review`
-check is skipped.
+180-second timeout, and DeepSeek V4 Pro receives a 16,000-token completion
+budget. Individual failures do not block the remaining scouts. Any successful
+scout is enough to continue to reconciliation. If every scout is unavailable,
+rate-limited, or invalid, the workflow publishes an explicit no-coverage warning
+and does not spend money on the merger; the stable `review` check is skipped.
 
 When OpenRouter reports exhausted account credits or an exhausted API-key
 spending limit, the stable `review` check is also marked as skipped.

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -1,14 +1,15 @@
 # AI code review
 
 This directory contains the repository's custom multi-model pull-request
-reviewer. Two OpenRouter models independently produce structured findings. A
-merger model only deduplicates those findings and reconciles them with resolved
-GitHub review threads; it does not judge correctness.
+reviewer. The free models currently advertised by OpenCode Zen independently
+produce structured findings. A paid OpenRouter merger only deduplicates those
+findings and reconciles them with resolved GitHub review threads; it does not
+judge correctness.
 
 ## Setup
 
 1. Add `OPENROUTER_API_KEY` as an Actions repository secret and set a suitable
-   credit limit on the key.
+   credit limit on the key. It is used only by the merger.
 2. Open or update a non-draft pull request from a branch in this repository as
    an owner, member, or collaborator. Every commit is reviewed automatically.
 3. Fork pull requests never run automatically. An owner, member, or collaborator
@@ -18,17 +19,25 @@ Outside contributors cannot trigger a paid run themselves.
 
 Optional Actions repository variables:
 
-- `AI_REVIEW_MODELS`: comma-separated scout models. Defaults to
-  `moonshotai/kimi-k2.6,deepseek/deepseek-v4-pro`.
+- `AI_REVIEW_OPENCODE_MODELS`: comma-separated free OpenCode model IDs. When it
+  is unset, the reviewer discovers all IDs ending in `-free` plus `big-pickle`
+  from the live OpenCode catalogue. The override is limited to 12 free IDs.
 - `AI_REVIEW_MERGER_MODEL`: defaults to `anthropic/claude-sonnet-4.6`.
 - `AI_REVIEW_IGNORED_AUTHORS`: comma-separated PR authors to skip. Defaults to
   `renovate[bot],dependabot[bot]`.
-- `AI_REVIEW_ZDR=true`: restricts routing to zero-data-retention providers. ZDR
-  is not required by default.
+- `AI_REVIEW_ZDR=true`: restricts OpenRouter merger routing to
+  zero-data-retention providers. It does not change OpenCode scout routing.
+
+OpenCode currently accepts anonymous requests for its free models. An
+`OPENCODE_API_KEY` Actions secret may be added if OpenCode requires
+authentication in the future; it is optional today. The TypeScript OpenCode SDK
+controls an OpenCode server, while Zen exposes these models through an
+OpenAI-compatible API, so the workflow calls the Zen API directly and does not
+need to install the CLI or SDK on each runner.
 
 ## Security and behavior
 
-The workflow needs the OpenRouter secret, but code in a pull request is
+The workflow needs the merger's OpenRouter secret, but code in a pull request is
 untrusted. `pull_request_target` makes the secret available. Automatic reviews
 check out the PR's exact base commit. Manual comment and dispatch runs check out
 the protected default branch for comments. Maintainer-only manual dispatches
@@ -46,15 +55,26 @@ per-model cost, model failures, and incomplete-coverage warnings. These
 cumulative scorecard fields are intended to support removing scouts that are
 noisy or not cost-effective.
 
+Free-model availability is refreshed from OpenCode at the start of every run.
+Models removed from the catalogue are skipped. Scouts run with concurrency
+limited to three, and retry transient errors such as rate limits. Any successful
+scout is enough to continue to reconciliation. If every scout is unavailable,
+rate-limited, or invalid, the workflow publishes an explicit no-coverage warning
+and does not spend money on the merger; the stable `review` check is skipped.
+
 When OpenRouter reports exhausted account credits or an exhausted API-key
-spending limit, the stable `review` check is marked as skipped. Authentication,
-provider, reviewer, and workflow failures continue to fail the check.
+spending limit, the stable `review` check is also marked as skipped.
+Authentication, merger, reviewer, and workflow failures continue to fail the
+check.
 
 Scout responses allow up to 8,000 output tokens because reasoning tokens count
 against the same limit and thinking models can otherwise exhaust the budget
-before emitting their final structured response. The default Kimi K2.6 scout
-explicitly disables reasoning because this workflow needs a small structured
-response rather than long-horizon agentic thinking.
+before emitting their final structured response.
+
+OpenCode describes the free models as limited-time feedback programmes. Prompts
+and outputs may be collected or used to improve those models, depending on the
+model's terms. Do not use this scout path for private or sensitive repositories
+without reviewing the current OpenCode privacy terms.
 
 ## Testing reviewer changes
 

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -88,7 +88,7 @@ test("credit exhaustion only matches payment and key-limit failures", () => {
   assert.equal(isCreditExhaustion(new Error("All scout models failed")), false);
 });
 
-test("free OpenCode model discovery includes free suffixes and the stealth exception", () => {
+test("OpenCode model discovery includes eligible free models and excludes noisy scouts", () => {
   assert.deepEqual(
     selectFreeScoutModels({
       data: [
@@ -96,6 +96,9 @@ test("free OpenCode model discovery includes free suffixes and the stealth excep
         { id: "deepseek-v4-flash-free" },
         { id: "big-pickle" },
         { id: "deepseek-v4-flash-free" },
+        { id: "laguna-s-2.1-free" },
+        { id: "ling-3.0-flash-free" },
+        { id: "north-mini-code-free" },
       ],
     }),
     ["deepseek-v4-flash-free", "big-pickle"],

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -106,6 +106,7 @@ test("OpenCode model discovery keeps live supplementary scouts and excludes fail
     }),
     ["big-pickle", "nemotron-3-ultra-free"],
   );
+  assert.deepEqual(selectFreeScoutModels({ data: [] }), []);
   assert.throws(() => selectFreeScoutModels({ models: [] }), /no data array/);
 });
 

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -88,7 +88,7 @@ test("credit exhaustion only matches payment and key-limit failures", () => {
   assert.equal(isCreditExhaustion(new Error("All scout models failed")), false);
 });
 
-test("OpenCode model discovery includes eligible free models and excludes noisy scouts", () => {
+test("OpenCode model discovery keeps live supplementary scouts and excludes failed ones", () => {
   assert.deepEqual(
     selectFreeScoutModels({
       data: [
@@ -96,12 +96,14 @@ test("OpenCode model discovery includes eligible free models and excludes noisy 
         { id: "deepseek-v4-flash-free" },
         { id: "big-pickle" },
         { id: "deepseek-v4-flash-free" },
+        { id: "mimo-v2.5-free" },
+        { id: "nemotron-3-ultra-free" },
         { id: "laguna-s-2.1-free" },
         { id: "ling-3.0-flash-free" },
         { id: "north-mini-code-free" },
       ],
     }),
-    ["deepseek-v4-flash-free", "big-pickle"],
+    ["big-pickle", "nemotron-3-ultra-free"],
   );
   assert.throws(() => selectFreeScoutModels({ models: [] }), /no data array/);
 });

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   completionContent,
+  duplicateScoutModels,
   ignored,
   isCreditExhaustion,
   markdownText,
@@ -106,6 +107,14 @@ test("OpenCode model discovery keeps live supplementary scouts and excludes fail
     ["big-pickle", "nemotron-3-ultra-free"],
   );
   assert.throws(() => selectFreeScoutModels({ models: [] }), /no data array/);
+});
+
+test("duplicate scout model IDs are detected across providers", () => {
+  assert.deepEqual(
+    duplicateScoutModels(["provider/model-a", "big-pickle"], ["big-pickle", "free-model"]),
+    ["big-pickle"],
+  );
+  assert.deepEqual(duplicateScoutModels(["provider/model-a"], ["free-model"]), []);
 });
 
 test("workflow skips its stable check when no scout provides coverage", () => {

--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -8,7 +8,9 @@ import {
   markdownText,
   parseModelPayload,
   renderComment,
+  selectFreeScoutModels,
   validateFindings,
+  workflowStatusForCoverage,
 } from "./ai-review.ts";
 
 const finding = {
@@ -86,6 +88,26 @@ test("credit exhaustion only matches payment and key-limit failures", () => {
   assert.equal(isCreditExhaustion(new Error("All scout models failed")), false);
 });
 
+test("free OpenCode model discovery includes free suffixes and the stealth exception", () => {
+  assert.deepEqual(
+    selectFreeScoutModels({
+      data: [
+        { id: "paid-model" },
+        { id: "deepseek-v4-flash-free" },
+        { id: "big-pickle" },
+        { id: "deepseek-v4-flash-free" },
+      ],
+    }),
+    ["deepseek-v4-flash-free", "big-pickle"],
+  );
+  assert.throws(() => selectFreeScoutModels({ models: [] }), /no data array/);
+});
+
+test("workflow skips its stable check when no scout provides coverage", () => {
+  assert.equal(workflowStatusForCoverage(0), "no_coverage");
+  assert.equal(workflowStatusForCoverage(1), "success");
+});
+
 test("model payload accepts a single JSON fence but rejects prose", () => {
   assert.deepEqual(parseModelPayload('```json\n{"findings":[]}\n```'), { findings: [] });
   assert.deepEqual(parseModelPayload('```json\n{"findings":[]}```'), { findings: [] });
@@ -153,4 +175,24 @@ test("historical scorecard schema drift cannot produce NaN", () => {
     },
   });
   assert.doesNotMatch(body, /NaN/);
+});
+
+test("rendered comment makes total scout failure explicit", () => {
+  const body = renderComment({
+    result: { summary: "No coverage", findings: [] },
+    headSha: "a".repeat(40),
+    models: ["free-a", "free-b"],
+    merger: "paid-merger",
+    failed: ["free-a", "free-b"],
+    candidateCounts: {},
+    invalidCounts: {},
+    outOfScopeCounts: {},
+    modelCosts: {},
+    mergerCost: 0,
+    omitted: [],
+    runCost: 0,
+    previousState: { runs: 0, total_usd: 0 },
+  });
+  assert.match(body, /No findings were evaluated because every scout failed/);
+  assert.doesNotMatch(body, /No open findings reported/);
 });

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 type JsonObject = Record<string, unknown>;
 type Severity = "critical" | "high" | "medium" | "low";
 type FindingStatus = "open" | "resolved";
+type WorkflowStatus = "success" | "credits" | "no_coverage" | "failure";
 
 export interface Finding {
   severity: Severity;
@@ -25,6 +26,7 @@ interface MergedFinding extends Finding {
 interface Settings {
   githubToken: string;
   openRouterKey: string;
+  openCodeKey?: string;
   repository: string;
   prNumber: number;
   scouts: string[];
@@ -52,13 +54,6 @@ interface ModelResult {
   cost: number;
 }
 
-interface ReasoningSettings {
-  enabled: boolean;
-  // OpenRouter's unified reasoning API supports excluding reasoning text while
-  // still controlling whether the model reasons internally.
-  exclude: boolean;
-}
-
 interface ModelStats {
   runs: number;
   candidates: number;
@@ -78,11 +73,16 @@ interface ReviewState {
 const MARKER = "<!-- ai-code-review -->";
 const COST_PATTERN = /<!-- ai-review-cost:(\{[^\n]*\}) -->/;
 const BOT_LOGINS = new Set(["github-actions[bot]"]);
-const DEFAULT_SCOUTS = [
-  "moonshotai/kimi-k2.6",
-  "deepseek/deepseek-v4-pro",
+const KNOWN_FREE_SCOUTS = [
+  "big-pickle",
+  "deepseek-v4-flash-free",
+  "mimo-v2.5-free",
+  "laguna-s-2.1-free",
+  "ling-3.0-flash-free",
+  "north-mini-code-free",
+  "nemotron-3-ultra-free",
 ];
-const REASONING_DISABLED_MODELS = new Set(["moonshotai/kimi-k2.6"]);
+const FREE_SCOUT_EXCEPTIONS = new Set(["big-pickle"]);
 const DEFAULT_MERGER = "anthropic/claude-sonnet-4.6";
 const DEFAULT_IGNORED_AUTHORS = ["renovate[bot]", "dependabot[bot]"];
 const IGNORED_FILENAMES = new Set([
@@ -156,6 +156,8 @@ const MERGED_FINDINGS_LIMIT = 100;
 // and DeepSeek have exhausted a 4,000-token budget before emitting final JSON.
 const SCOUT_MAX_TOKENS = 8_000;
 const MERGER_MAX_TOKENS = 6_000;
+const SCOUT_CONCURRENCY = 3;
+const MAX_SCOUTS = 12;
 const HTTP_TIMEOUT_MS = 300_000;
 const RETRIES = 3;
 
@@ -243,17 +245,24 @@ function csv(value: string | undefined, fallback: string[]): string[] {
     ?.split(",")
     .map((item) => item.trim())
     .filter(Boolean);
-  return values?.length ? values : fallback;
+  return values?.length ? [...new Set(values)] : fallback;
 }
 
 function settingsFromEnv(): Settings {
-  const scouts = csv(process.env.AI_REVIEW_MODELS, DEFAULT_SCOUTS);
-  if (scouts.length < 1 || scouts.length > 6) {
-    throw new Error("AI_REVIEW_MODELS must contain between one and six model IDs");
+  const scouts = csv(process.env.AI_REVIEW_OPENCODE_MODELS, []);
+  if (scouts.length > MAX_SCOUTS) {
+    throw new Error(`AI_REVIEW_OPENCODE_MODELS must contain at most ${MAX_SCOUTS} model IDs`);
+  }
+  const paidScouts = scouts.filter((model) => !isFreeScoutModelId(model));
+  if (paidScouts.length) {
+    throw new Error(
+      `AI_REVIEW_OPENCODE_MODELS only accepts free OpenCode model IDs; rejected: ${paidScouts.join(", ")}`,
+    );
   }
   return {
     githubToken: env("GITHUB_TOKEN"),
     openRouterKey: env("OPENROUTER_API_KEY"),
+    openCodeKey: process.env.OPENCODE_API_KEY?.trim() || undefined,
     repository: env("GITHUB_REPOSITORY"),
     prNumber: Number.parseInt(env("PR_NUMBER"), 10),
     scouts,
@@ -263,6 +272,24 @@ function settingsFromEnv(): Settings {
     ),
     requireZdr: ["1", "true", "yes", "on"].includes(process.env.AI_REVIEW_ZDR?.trim().toLowerCase() ?? ""),
   };
+}
+
+function isFreeScoutModelId(model: string): boolean {
+  return model.endsWith("-free") || FREE_SCOUT_EXCEPTIONS.has(model);
+}
+
+export function selectFreeScoutModels(payload: unknown): string[] {
+  if (!isObject(payload) || !Array.isArray(payload.data)) {
+    throw new Error("OpenCode model catalogue has no data array");
+  }
+  return [
+    ...new Set(
+      payload.data
+        .filter(isObject)
+        .map((model) => String(model.id ?? ""))
+        .filter(isFreeScoutModelId),
+    ),
+  ].slice(0, MAX_SCOUTS);
 }
 
 function sleep(milliseconds: number): Promise<void> {
@@ -279,18 +306,30 @@ export function isCreditExhaustion(error: unknown): boolean {
   );
 }
 
-function setWorkflowStatus(status: "success" | "credits" | "failure"): void {
+function setWorkflowStatus(status: WorkflowStatus): void {
   const output = process.env.GITHUB_OUTPUT;
   if (output) appendFileSync(output, `status=${status}\n`, "utf8");
+}
+
+export function workflowStatusForCoverage(successfulScouts: number): "success" | "no_coverage" {
+  return successfulScouts > 0 ? "success" : "no_coverage";
 }
 
 class JsonClient {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
+  private readonly timeoutMs: number;
+  private readonly retries: number;
 
-  constructor(baseUrl: string, headers: Record<string, string>) {
+  constructor(
+    baseUrl: string,
+    headers: Record<string, string>,
+    options: { timeoutMs?: number; retries?: number } = {},
+  ) {
     this.baseUrl = baseUrl;
     this.headers = headers;
+    this.timeoutMs = options.timeoutMs ?? HTTP_TIMEOUT_MS;
+    this.retries = options.retries ?? RETRIES;
   }
 
   async request<T>(
@@ -301,13 +340,13 @@ class JsonClient {
     const url = new URL(`${this.baseUrl.replace(/\/$/, "")}${path}`);
     for (const [key, value] of Object.entries(options.query ?? {})) url.searchParams.set(key, String(value));
     let lastError: Error | undefined;
-    for (let attempt = 0; attempt < RETRIES; attempt += 1) {
+    for (let attempt = 0; attempt < this.retries; attempt += 1) {
       try {
         const response = await fetch(url, {
           method,
           headers: { ...this.headers, ...(options.accept ? { Accept: options.accept } : {}) },
           body: options.body === undefined ? undefined : JSON.stringify(options.body),
-          signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+          signal: AbortSignal.timeout(this.timeoutMs),
         });
         if (response.ok) {
           const raw = await response.text();
@@ -315,7 +354,7 @@ class JsonClient {
         }
         const detail = (await response.text()).slice(0, 1_000);
         const retryable = [408, 409, 429, 500, 502, 503, 504].includes(response.status);
-        if (!retryable || attempt === RETRIES - 1) {
+        if (!retryable || attempt === this.retries - 1) {
           throw new Error(`${method} ${path} failed (${response.status}): ${detail}`);
         }
         const retryAfter = Number.parseInt(response.headers.get("retry-after") ?? "", 10);
@@ -323,7 +362,7 @@ class JsonClient {
         await sleep(Math.min(delay + Math.random() * 1_000, 15_000));
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-        if (attempt === RETRIES - 1 || /failed \(4\d\d\)/.test(lastError.message)) throw lastError;
+        if (attempt === this.retries - 1 || /failed \(4\d\d\)/.test(lastError.message)) throw lastError;
         await sleep(2 ** attempt * 1_000 + Math.random() * 1_000);
       }
     }
@@ -420,6 +459,7 @@ export function validateFindings(
 
 class Reviewer {
   private readonly github: JsonClient;
+  private readonly openCode: JsonClient;
   private readonly openRouter: JsonClient;
   private readonly settings: Settings;
 
@@ -432,6 +472,14 @@ class Reviewer {
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
     });
+    this.openCode = new JsonClient(
+      "https://opencode.ai/zen/v1",
+      {
+        ...common,
+        ...(settings.openCodeKey ? { Authorization: `Bearer ${settings.openCodeKey}` } : {}),
+      },
+      { timeoutMs: 120_000, retries: 2 },
+    );
     this.openRouter = new JsonClient("https://openrouter.ai/api/v1", {
       ...common,
       Authorization: `Bearer ${settings.openRouterKey}`,
@@ -537,14 +585,59 @@ class Reviewer {
     return "";
   }
 
-  async callModel(
+  async scoutModels(): Promise<{ models: string[]; unavailable: string[] }> {
+    try {
+      const available = selectFreeScoutModels(await this.openCode.request<JsonObject>("GET", "/models"));
+      if (!this.settings.scouts.length) {
+        if (!available.length) throw new Error("OpenCode currently advertises no free scout models");
+        return { models: available, unavailable: [] };
+      }
+      const availableSet = new Set(available);
+      return {
+        models: this.settings.scouts.filter((model) => availableSet.has(model)),
+        unavailable: this.settings.scouts.filter((model) => !availableSet.has(model)),
+      };
+    } catch (error) {
+      console.error(`::warning::Could not refresh OpenCode free models; using configured fallback: ${String(error)}`);
+      return {
+        models: this.settings.scouts.length ? this.settings.scouts : KNOWN_FREE_SCOUTS,
+        unavailable: [],
+      };
+    }
+  }
+
+  async callScout(model: string, system: string, user: string): Promise<ModelResult> {
+    const response = await this.openCode.request<JsonObject>("POST", "/chat/completions", {
+      body: {
+        model,
+        temperature: 0,
+        max_tokens: SCOUT_MAX_TOKENS,
+        messages: [
+          {
+            role: "system",
+            content: `${system}\n\nOUTPUT JSON SCHEMA:\n${JSON.stringify(scoutSchema)}`,
+          },
+          { role: "user", content: user },
+        ],
+      },
+    });
+    const choices = response.choices;
+    if (!Array.isArray(choices) || !isObject(choices[0])) throw new Error(`Invalid response from ${model}`);
+    const choice = choices[0];
+    const usage = isObject(response.usage) ? response.usage : {};
+    return {
+      payload: parseModelPayload(completionContent(choice, model)),
+      cost: finiteNumber(response.cost ?? usage.cost),
+    };
+  }
+
+  async callMerger(
     model: string,
     system: string,
     user: string,
     schemaName: string,
     schema: JsonObject,
     maxTokens: number,
-    reasoning?: ReasoningSettings,
   ): Promise<ModelResult> {
     const provider: JsonObject = { require_parameters: true };
     if (this.settings.requireZdr) Object.assign(provider, { zdr: true, data_collection: "deny" });
@@ -554,7 +647,6 @@ class Reviewer {
         temperature: 0,
         max_tokens: maxTokens,
         provider,
-        ...(reasoning ? { reasoning } : {}),
         response_format: { type: "json_schema", json_schema: { name: schemaName, strict: true, schema } },
         messages: [
           { role: "system", content: system },
@@ -722,7 +814,13 @@ export function renderComment(options: {
     markdownText(options.result.summary, 1_000) || "Review complete.",
     "",
   ];
-  if (!open.length) lines.push("No open findings reported.", "");
+  if (!open.length) {
+    const message =
+      options.failed.length === options.models.length
+        ? "No findings were evaluated because every scout failed."
+        : "No open findings reported.";
+    lines.push(message, "");
+  }
   for (const finding of open) {
     const location = `${markdownText(finding.file, 500)}${finding.line && finding.line > 0 ? `:${finding.line}` : ""}`;
     lines.push(
@@ -790,19 +888,19 @@ export function renderComment(options: {
   return lines.join("\n");
 }
 
-async function main(): Promise<void> {
+async function main(): Promise<"success" | "no_coverage"> {
   const settings = settingsFromEnv();
   if (!Number.isInteger(settings.prNumber) || settings.prNumber < 1) throw new Error("PR_NUMBER must be positive");
   const reviewer = new Reviewer(settings);
   const pr = await reviewer.getPr();
   if (pr.state !== "open") {
     console.log(`Skipping PR #${settings.prNumber} because it is ${pr.state}`);
-    return;
+    return "success";
   }
   const author = pr.user.login.toLowerCase();
   if (settings.ignoredAuthors.includes(author)) {
     console.log(`Skipping PR #${settings.prNumber} from ignored author ${author}`);
-    return;
+    return "success";
   }
   const initialHead = pr.head.sha;
   const { diff, paths, omitted } = await reviewer.changedFiles();
@@ -813,43 +911,39 @@ async function main(): Promise<void> {
       existing.id,
       `${MARKER}\n<!-- ai-review-cost:${state} -->\n## AI code review\n\nNo reviewable text changes found.`,
     );
-    return;
+    return "success";
   }
 
   const source = dataPrompt(diff, await reviewer.fileContext(paths, initialHead), await reviewer.guidelines());
-  const settled = await Promise.allSettled(
-    settings.scouts.map(async (model) => ({
-      model,
-      result: await reviewer.callModel(
-        model,
-        scoutSystem,
-        source,
-        "code_review_findings",
-        scoutSchema,
-        SCOUT_MAX_TOKENS,
-        REASONING_DISABLED_MODELS.has(model) ? { enabled: false, exclude: true } : undefined,
-      ),
-    })),
-  );
+  const availability = await reviewer.scoutModels();
+  const scouts = [...availability.models, ...availability.unavailable];
+  const settled: Array<{ model: string; outcome: PromiseSettledResult<ModelResult> }> = [];
+  for (let offset = 0; offset < availability.models.length; offset += SCOUT_CONCURRENCY) {
+    const batch = availability.models.slice(offset, offset + SCOUT_CONCURRENCY);
+    const outcomes = await Promise.allSettled(
+      batch.map((model) => reviewer.callScout(model, scoutSystem, source)),
+    );
+    batch.forEach((model, index) => settled.push({ model, outcome: outcomes[index] }));
+  }
   const candidates: Record<string, Finding[]> = {};
   const costs: Record<string, number> = {};
   const invalidCounts: Record<string, number> = {};
   const outOfScopeCounts: Record<string, number> = {};
   const candidateCounts: Record<string, number> = {};
-  const failed: string[] = [];
-  const creditFailures: string[] = [];
+  const failed = [...availability.unavailable];
+  for (const model of availability.unavailable) {
+    console.error(`::warning::Scout ${model} is no longer present in the OpenCode free-model catalogue`);
+  }
   const allowedFiles = new Set(paths);
-  settled.forEach((outcome, index) => {
-    const model = settings.scouts[index];
+  settled.forEach(({ model, outcome }) => {
     if (outcome.status === "rejected") {
       failed.push(model);
-      if (isCreditExhaustion(outcome.reason)) creditFailures.push(model);
       console.error(`::warning::Scout ${model} failed: ${String(outcome.reason)}`);
       return;
     }
-    costs[model] = outcome.value.result.cost;
+    costs[model] = outcome.value.cost;
     try {
-      const raw = outcome.value.result.payload;
+      const raw = outcome.value.payload;
       const structurallyValid = validateFindings(raw, { merged: false }) as Finding[];
       const accepted = structurallyValid.filter((finding) => allowedFiles.has(finding.file));
       const rawCount = isObject(raw) && Array.isArray(raw.findings) ? raw.findings.length : 0;
@@ -865,31 +959,36 @@ async function main(): Promise<void> {
       console.error(`::warning::Scout ${model} returned invalid payload: ${String(error)}`);
     }
   });
-  if (!Object.keys(candidates).length) {
-    if (creditFailures.length === settings.scouts.length) {
-      throw new Error("OpenRouter credits exhausted for all scout models");
-    }
-    throw new Error("All scout models failed; refusing to publish an empty review");
-  }
 
-  const threads = await reviewer.reviewThreadContext();
-  const mergerPrompt = `<DATA kind=scout-candidates>\n${JSON.stringify(candidates)}\n</DATA>
+  let merged: ModelResult;
+  if (Object.keys(candidates).length) {
+    const threads = await reviewer.reviewThreadContext();
+    const mergerPrompt = `<DATA kind=scout-candidates>\n${JSON.stringify(candidates)}\n</DATA>
 <DATA kind=github-review-threads>\n${threads}\n</DATA>`;
-  const merged = await reviewer.callModel(
-    settings.merger,
-    mergerSystem,
-    mergerPrompt,
-    "merged_code_review",
-    mergerSchema,
-    MERGER_MAX_TOKENS,
-  );
+    merged = await reviewer.callMerger(
+      settings.merger,
+      mergerSystem,
+      mergerPrompt,
+      "merged_code_review",
+      mergerSchema,
+      MERGER_MAX_TOKENS,
+    );
+  } else {
+    merged = {
+      payload: {
+        summary: "All OpenCode scouts failed or were unavailable, so this run has no review coverage.",
+        findings: [],
+      },
+      cost: 0,
+    };
+  }
   merged.payload.findings = (validateFindings(merged.payload, {
     merged: true,
     allowedFiles,
   }) as MergedFinding[])
     .map((finding) => ({
       ...finding,
-      source_models: [...new Set(finding.source_models.filter((model) => settings.scouts.includes(model)))],
+      source_models: [...new Set(finding.source_models.filter((model) => scouts.includes(model)))],
     }))
     .filter((finding) => finding.source_models.length > 0);
 
@@ -903,7 +1002,7 @@ async function main(): Promise<void> {
     renderComment({
       result: merged.payload,
       headSha: initialHead,
-      models: settings.scouts,
+      models: scouts,
       merger: settings.merger,
       failed,
       candidateCounts,
@@ -917,12 +1016,13 @@ async function main(): Promise<void> {
     }),
   );
   console.log(`Reviewed PR #${settings.prNumber} at ${initialHead.slice(0, 12)}; cost $${runCost.toFixed(4)}`);
+  return workflowStatusForCoverage(Object.keys(candidates).length);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main()
-    .then(() => {
-      setWorkflowStatus("success");
+    .then((status) => {
+      setWorkflowStatus(status);
     })
     .catch((error) => {
       if (isCreditExhaustion(error)) {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -29,7 +29,8 @@ interface Settings {
   openCodeKey?: string;
   repository: string;
   prNumber: number;
-  scouts: string[];
+  openRouterScouts: string[];
+  openCodeScouts: string[];
   merger: string;
   ignoredAuthors: string[];
   requireZdr: boolean;
@@ -54,6 +55,16 @@ interface ModelResult {
   cost: number;
 }
 
+interface ReasoningSettings {
+  enabled: boolean;
+  exclude: boolean;
+}
+
+interface Scout {
+  model: string;
+  provider: "opencode" | "openrouter";
+}
+
 interface ModelStats {
   runs: number;
   candidates: number;
@@ -73,18 +84,23 @@ interface ReviewState {
 const MARKER = "<!-- ai-code-review -->";
 const COST_PATTERN = /<!-- ai-review-cost:(\{[^\n]*\}) -->/;
 const BOT_LOGINS = new Set(["github-actions[bot]"]);
+const DEFAULT_OPENROUTER_SCOUTS = [
+  "moonshotai/kimi-k2.6",
+  "deepseek/deepseek-v4-pro",
+];
 const KNOWN_FREE_SCOUTS = [
   "big-pickle",
-  "deepseek-v4-flash-free",
-  "mimo-v2.5-free",
   "nemotron-3-ultra-free",
 ];
 const FREE_SCOUT_EXCEPTIONS = new Set(["big-pickle"]);
 const EXCLUDED_FREE_SCOUTS = new Set([
+  "deepseek-v4-flash-free",
   "laguna-s-2.1-free",
   "ling-3.0-flash-free",
+  "mimo-v2.5-free",
   "north-mini-code-free",
 ]);
+const REASONING_DISABLED_MODELS = new Set(["moonshotai/kimi-k2.6"]);
 const DEFAULT_MERGER = "anthropic/claude-sonnet-4.6";
 const DEFAULT_IGNORED_AUTHORS = ["renovate[bot]", "dependabot[bot]"];
 const IGNORED_FILENAMES = new Set([
@@ -154,19 +170,17 @@ const MAX_THREAD_CHARS = 40_000;
 const MAX_COMMENT_CHARS = 60_000;
 const SCOUT_FINDINGS_LIMIT = 25;
 const MERGED_FINDINGS_LIMIT = 100;
-// Reasoning tokens count against max_tokens. Most scouts can finish within
-// 8,000 tokens; DeepSeek exhausted that budget in the first live Actions run.
+// Reasoning tokens count against max_tokens. The retained scouts can finish
+// within 8,000 tokens or fail independently without blocking the ensemble.
 const SCOUT_MAX_TOKENS = 8_000;
-const SCOUT_MAX_TOKENS_BY_MODEL: Record<string, number> = {
-  "deepseek-v4-flash-free": 16_000,
-};
 const SCOUT_TIMEOUT_MS = 120_000;
 const SCOUT_TIMEOUT_BY_MODEL: Record<string, number> = {
   "nemotron-3-ultra-free": 180_000,
 };
 const MERGER_MAX_TOKENS = 6_000;
 const SCOUT_CONCURRENCY = 4;
-const MAX_SCOUTS = 12;
+const MAX_OPENROUTER_SCOUTS = 6;
+const MAX_OPENCODE_SCOUTS = 6;
 const HTTP_TIMEOUT_MS = 300_000;
 const RETRIES = 3;
 
@@ -258,11 +272,15 @@ function csv(value: string | undefined, fallback: string[]): string[] {
 }
 
 function settingsFromEnv(): Settings {
-  const scouts = csv(process.env.AI_REVIEW_OPENCODE_MODELS, []);
-  if (scouts.length > MAX_SCOUTS) {
-    throw new Error(`AI_REVIEW_OPENCODE_MODELS must contain at most ${MAX_SCOUTS} model IDs`);
+  const openRouterScouts = csv(process.env.AI_REVIEW_MODELS, DEFAULT_OPENROUTER_SCOUTS);
+  if (openRouterScouts.length > MAX_OPENROUTER_SCOUTS) {
+    throw new Error(`AI_REVIEW_MODELS must contain at most ${MAX_OPENROUTER_SCOUTS} model IDs`);
   }
-  const rejectedScouts = scouts.filter((model) => !isEligibleFreeScoutModelId(model));
+  const openCodeScouts = csv(process.env.AI_REVIEW_OPENCODE_MODELS, []);
+  if (openCodeScouts.length > MAX_OPENCODE_SCOUTS) {
+    throw new Error(`AI_REVIEW_OPENCODE_MODELS must contain at most ${MAX_OPENCODE_SCOUTS} model IDs`);
+  }
+  const rejectedScouts = openCodeScouts.filter((model) => !isEligibleFreeScoutModelId(model));
   if (rejectedScouts.length) {
     throw new Error(
       `AI_REVIEW_OPENCODE_MODELS only accepts enabled free OpenCode model IDs; rejected: ${rejectedScouts.join(", ")}`,
@@ -274,7 +292,8 @@ function settingsFromEnv(): Settings {
     openCodeKey: process.env.OPENCODE_API_KEY?.trim() || undefined,
     repository: env("GITHUB_REPOSITORY"),
     prNumber: Number.parseInt(env("PR_NUMBER"), 10),
-    scouts,
+    openRouterScouts,
+    openCodeScouts,
     merger: process.env.AI_REVIEW_MERGER_MODEL?.trim() || DEFAULT_MERGER,
     ignoredAuthors: csv(process.env.AI_REVIEW_IGNORED_AUTHORS, DEFAULT_IGNORED_AUTHORS).map((author) =>
       author.toLowerCase(),
@@ -302,7 +321,7 @@ export function selectFreeScoutModels(payload: unknown): string[] {
         .map((model) => String(model.id ?? ""))
         .filter(isEligibleFreeScoutModelId),
     ),
-  ].slice(0, MAX_SCOUTS);
+  ].slice(0, MAX_OPENCODE_SCOUTS);
 }
 
 function sleep(milliseconds: number): Promise<void> {
@@ -603,33 +622,33 @@ class Reviewer {
     return "";
   }
 
-  async scoutModels(): Promise<{ models: string[]; unavailable: string[] }> {
+  async openCodeScoutModels(): Promise<{ models: string[]; unavailable: string[] }> {
     try {
       const available = selectFreeScoutModels(await this.openCode.request<JsonObject>("GET", "/models"));
-      if (!this.settings.scouts.length) {
+      if (!this.settings.openCodeScouts.length) {
         if (!available.length) throw new Error("OpenCode currently advertises no free scout models");
         return { models: available, unavailable: [] };
       }
       const availableSet = new Set(available);
       return {
-        models: this.settings.scouts.filter((model) => availableSet.has(model)),
-        unavailable: this.settings.scouts.filter((model) => !availableSet.has(model)),
+        models: this.settings.openCodeScouts.filter((model) => availableSet.has(model)),
+        unavailable: this.settings.openCodeScouts.filter((model) => !availableSet.has(model)),
       };
     } catch (error) {
       console.error(`::warning::Could not refresh OpenCode free models; using configured fallback: ${String(error)}`);
       return {
-        models: this.settings.scouts.length ? this.settings.scouts : KNOWN_FREE_SCOUTS,
+        models: this.settings.openCodeScouts.length ? this.settings.openCodeScouts : KNOWN_FREE_SCOUTS,
         unavailable: [],
       };
     }
   }
 
-  async callScout(model: string, system: string, user: string): Promise<ModelResult> {
+  async callOpenCodeScout(model: string, system: string, user: string): Promise<ModelResult> {
     const response = await this.openCode.request<JsonObject>("POST", "/chat/completions", {
       body: {
         model,
         temperature: 0,
-        max_tokens: SCOUT_MAX_TOKENS_BY_MODEL[model] ?? SCOUT_MAX_TOKENS,
+        max_tokens: SCOUT_MAX_TOKENS,
         messages: [
           {
             role: "system",
@@ -646,6 +665,38 @@ class Reviewer {
     const usage = isObject(response.usage) ? response.usage : {};
     return {
       payload: parseModelPayload(completionContent(choice, model)),
+      cost: finiteNumber(response.cost ?? usage.cost),
+    };
+  }
+
+  async callOpenRouterScout(model: string, system: string, user: string): Promise<ModelResult> {
+    const provider: JsonObject = { require_parameters: true };
+    if (this.settings.requireZdr) Object.assign(provider, { zdr: true, data_collection: "deny" });
+    const reasoning: ReasoningSettings | undefined = REASONING_DISABLED_MODELS.has(model)
+      ? { enabled: false, exclude: true }
+      : undefined;
+    const response = await this.openRouter.request<JsonObject>("POST", "/chat/completions", {
+      body: {
+        model,
+        temperature: 0,
+        max_tokens: SCOUT_MAX_TOKENS,
+        provider,
+        ...(reasoning ? { reasoning } : {}),
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "code_review_findings", strict: true, schema: scoutSchema },
+        },
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+      },
+    });
+    const choices = response.choices;
+    if (!Array.isArray(choices) || !isObject(choices[0])) throw new Error(`Invalid response from ${model}`);
+    const usage = isObject(response.usage) ? response.usage : {};
+    return {
+      payload: parseModelPayload(completionContent(choices[0], model)),
       cost: finiteNumber(response.cost ?? usage.cost),
     };
   }
@@ -934,15 +985,23 @@ async function main(): Promise<"success" | "no_coverage"> {
   }
 
   const source = dataPrompt(diff, await reviewer.fileContext(paths, initialHead), await reviewer.guidelines());
-  const availability = await reviewer.scoutModels();
-  const scouts = [...availability.models, ...availability.unavailable];
+  const availability = await reviewer.openCodeScoutModels();
+  const runnableScouts: Scout[] = [
+    ...settings.openRouterScouts.map((model): Scout => ({ model, provider: "openrouter" })),
+    ...availability.models.map((model): Scout => ({ model, provider: "opencode" })),
+  ];
+  const scouts = [...runnableScouts.map(({ model }) => model), ...availability.unavailable];
   const settled: Array<{ model: string; outcome: PromiseSettledResult<ModelResult> }> = [];
-  for (let offset = 0; offset < availability.models.length; offset += SCOUT_CONCURRENCY) {
-    const batch = availability.models.slice(offset, offset + SCOUT_CONCURRENCY);
+  for (let offset = 0; offset < runnableScouts.length; offset += SCOUT_CONCURRENCY) {
+    const batch = runnableScouts.slice(offset, offset + SCOUT_CONCURRENCY);
     const outcomes = await Promise.allSettled(
-      batch.map((model) => reviewer.callScout(model, scoutSystem, source)),
+      batch.map(({ model, provider }) =>
+        provider === "openrouter"
+          ? reviewer.callOpenRouterScout(model, scoutSystem, source)
+          : reviewer.callOpenCodeScout(model, scoutSystem, source),
+      ),
     );
-    batch.forEach((model, index) => settled.push({ model, outcome: outcomes[index] }));
+    batch.forEach(({ model }, index) => settled.push({ model, outcome: outcomes[index] }));
   }
   const candidates: Record<string, Finding[]> = {};
   const costs: Record<string, number> = {};
@@ -995,7 +1054,7 @@ async function main(): Promise<"success" | "no_coverage"> {
   } else {
     merged = {
       payload: {
-        summary: "All OpenCode scouts failed or were unavailable, so this run has no review coverage.",
+        summary: "All scouts failed or were unavailable, so this run has no review coverage.",
         findings: [],
       },
       cost: 0,

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -173,9 +173,6 @@ const MERGED_FINDINGS_LIMIT = 100;
 // Reasoning tokens count against max_tokens. The retained scouts can finish
 // within 8,000 tokens or fail independently without blocking the ensemble.
 const SCOUT_MAX_TOKENS = 8_000;
-const SCOUT_MAX_TOKENS_BY_MODEL: Record<string, number> = {
-  "deepseek/deepseek-v4-pro": 16_000,
-};
 const SCOUT_TIMEOUT_MS = 120_000;
 const SCOUT_TIMEOUT_BY_MODEL: Record<string, number> = {
   "nemotron-3-ultra-free": 180_000,
@@ -682,7 +679,7 @@ class Reviewer {
       body: {
         model,
         temperature: 0,
-        max_tokens: SCOUT_MAX_TOKENS_BY_MODEL[model] ?? SCOUT_MAX_TOKENS,
+        max_tokens: SCOUT_MAX_TOKENS,
         provider,
         ...(reasoning ? { reasoning } : {}),
         response_format: {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -173,6 +173,9 @@ const MERGED_FINDINGS_LIMIT = 100;
 // Reasoning tokens count against max_tokens. The retained scouts can finish
 // within 8,000 tokens or fail independently without blocking the ensemble.
 const SCOUT_MAX_TOKENS = 8_000;
+const SCOUT_MAX_TOKENS_BY_MODEL: Record<string, number> = {
+  "deepseek/deepseek-v4-pro": 16_000,
+};
 const SCOUT_TIMEOUT_MS = 120_000;
 const SCOUT_TIMEOUT_BY_MODEL: Record<string, number> = {
   "nemotron-3-ultra-free": 180_000,
@@ -679,7 +682,7 @@ class Reviewer {
       body: {
         model,
         temperature: 0,
-        max_tokens: SCOUT_MAX_TOKENS,
+        max_tokens: SCOUT_MAX_TOKENS_BY_MODEL[model] ?? SCOUT_MAX_TOKENS,
         provider,
         ...(reasoning ? { reasoning } : {}),
         response_format: {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -628,17 +628,9 @@ class Reviewer {
   }
 
   async openCodeScoutModels(): Promise<{ models: string[]; unavailable: string[] }> {
+    let available: string[];
     try {
-      const available = selectFreeScoutModels(await this.openCode.request<JsonObject>("GET", "/models"));
-      if (!this.settings.openCodeScouts.length) {
-        if (!available.length) throw new Error("OpenCode currently advertises no free scout models");
-        return { models: available, unavailable: [] };
-      }
-      const availableSet = new Set(available);
-      return {
-        models: this.settings.openCodeScouts.filter((model) => availableSet.has(model)),
-        unavailable: this.settings.openCodeScouts.filter((model) => !availableSet.has(model)),
-      };
+      available = selectFreeScoutModels(await this.openCode.request<JsonObject>("GET", "/models"));
     } catch (error) {
       console.error(`::warning::Could not refresh OpenCode free models; using configured fallback: ${String(error)}`);
       return {
@@ -646,6 +638,15 @@ class Reviewer {
         unavailable: [],
       };
     }
+    if (!this.settings.openCodeScouts.length) {
+      if (!available.length) console.error("::warning::OpenCode currently advertises no eligible free scout models");
+      return { models: available, unavailable: [] };
+    }
+    const availableSet = new Set(available);
+    return {
+      models: this.settings.openCodeScouts.filter((model) => availableSet.has(model)),
+      unavailable: this.settings.openCodeScouts.filter((model) => !availableSet.has(model)),
+    };
   }
 
   async callOpenCodeScout(model: string, system: string, user: string): Promise<ModelResult> {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -77,12 +77,14 @@ const KNOWN_FREE_SCOUTS = [
   "big-pickle",
   "deepseek-v4-flash-free",
   "mimo-v2.5-free",
-  "laguna-s-2.1-free",
-  "ling-3.0-flash-free",
-  "north-mini-code-free",
   "nemotron-3-ultra-free",
 ];
 const FREE_SCOUT_EXCEPTIONS = new Set(["big-pickle"]);
+const EXCLUDED_FREE_SCOUTS = new Set([
+  "laguna-s-2.1-free",
+  "ling-3.0-flash-free",
+  "north-mini-code-free",
+]);
 const DEFAULT_MERGER = "anthropic/claude-sonnet-4.6";
 const DEFAULT_IGNORED_AUTHORS = ["renovate[bot]", "dependabot[bot]"];
 const IGNORED_FILENAMES = new Set([
@@ -152,11 +154,18 @@ const MAX_THREAD_CHARS = 40_000;
 const MAX_COMMENT_CHARS = 60_000;
 const SCOUT_FINDINGS_LIMIT = 25;
 const MERGED_FINDINGS_LIMIT = 100;
-// Reasoning tokens count against max_tokens. Kimi always thinks, and both Kimi
-// and DeepSeek have exhausted a 4,000-token budget before emitting final JSON.
+// Reasoning tokens count against max_tokens. Most scouts can finish within
+// 8,000 tokens; DeepSeek exhausted that budget in the first live Actions run.
 const SCOUT_MAX_TOKENS = 8_000;
+const SCOUT_MAX_TOKENS_BY_MODEL: Record<string, number> = {
+  "deepseek-v4-flash-free": 16_000,
+};
+const SCOUT_TIMEOUT_MS = 120_000;
+const SCOUT_TIMEOUT_BY_MODEL: Record<string, number> = {
+  "nemotron-3-ultra-free": 180_000,
+};
 const MERGER_MAX_TOKENS = 6_000;
-const SCOUT_CONCURRENCY = 3;
+const SCOUT_CONCURRENCY = 4;
 const MAX_SCOUTS = 12;
 const HTTP_TIMEOUT_MS = 300_000;
 const RETRIES = 3;
@@ -253,10 +262,10 @@ function settingsFromEnv(): Settings {
   if (scouts.length > MAX_SCOUTS) {
     throw new Error(`AI_REVIEW_OPENCODE_MODELS must contain at most ${MAX_SCOUTS} model IDs`);
   }
-  const paidScouts = scouts.filter((model) => !isFreeScoutModelId(model));
-  if (paidScouts.length) {
+  const rejectedScouts = scouts.filter((model) => !isEligibleFreeScoutModelId(model));
+  if (rejectedScouts.length) {
     throw new Error(
-      `AI_REVIEW_OPENCODE_MODELS only accepts free OpenCode model IDs; rejected: ${paidScouts.join(", ")}`,
+      `AI_REVIEW_OPENCODE_MODELS only accepts enabled free OpenCode model IDs; rejected: ${rejectedScouts.join(", ")}`,
     );
   }
   return {
@@ -278,6 +287,10 @@ function isFreeScoutModelId(model: string): boolean {
   return model.endsWith("-free") || FREE_SCOUT_EXCEPTIONS.has(model);
 }
 
+function isEligibleFreeScoutModelId(model: string): boolean {
+  return isFreeScoutModelId(model) && !EXCLUDED_FREE_SCOUTS.has(model);
+}
+
 export function selectFreeScoutModels(payload: unknown): string[] {
   if (!isObject(payload) || !Array.isArray(payload.data)) {
     throw new Error("OpenCode model catalogue has no data array");
@@ -287,7 +300,7 @@ export function selectFreeScoutModels(payload: unknown): string[] {
       payload.data
         .filter(isObject)
         .map((model) => String(model.id ?? ""))
-        .filter(isFreeScoutModelId),
+        .filter(isEligibleFreeScoutModelId),
     ),
   ].slice(0, MAX_SCOUTS);
 }
@@ -335,7 +348,12 @@ class JsonClient {
   async request<T>(
     method: string,
     path: string,
-    options: { query?: Record<string, string | number>; body?: unknown; accept?: string } = {},
+    options: {
+      query?: Record<string, string | number>;
+      body?: unknown;
+      accept?: string;
+      timeoutMs?: number;
+    } = {},
   ): Promise<T> {
     const url = new URL(`${this.baseUrl.replace(/\/$/, "")}${path}`);
     for (const [key, value] of Object.entries(options.query ?? {})) url.searchParams.set(key, String(value));
@@ -346,7 +364,7 @@ class JsonClient {
           method,
           headers: { ...this.headers, ...(options.accept ? { Accept: options.accept } : {}) },
           body: options.body === undefined ? undefined : JSON.stringify(options.body),
-          signal: AbortSignal.timeout(this.timeoutMs),
+          signal: AbortSignal.timeout(options.timeoutMs ?? this.timeoutMs),
         });
         if (response.ok) {
           const raw = await response.text();
@@ -478,7 +496,7 @@ class Reviewer {
         ...common,
         ...(settings.openCodeKey ? { Authorization: `Bearer ${settings.openCodeKey}` } : {}),
       },
-      { timeoutMs: 120_000, retries: 2 },
+      { timeoutMs: SCOUT_TIMEOUT_MS, retries: 2 },
     );
     this.openRouter = new JsonClient("https://openrouter.ai/api/v1", {
       ...common,
@@ -611,7 +629,7 @@ class Reviewer {
       body: {
         model,
         temperature: 0,
-        max_tokens: SCOUT_MAX_TOKENS,
+        max_tokens: SCOUT_MAX_TOKENS_BY_MODEL[model] ?? SCOUT_MAX_TOKENS,
         messages: [
           {
             role: "system",
@@ -620,6 +638,7 @@ class Reviewer {
           { role: "user", content: user },
         ],
       },
+      timeoutMs: SCOUT_TIMEOUT_BY_MODEL[model] ?? SCOUT_TIMEOUT_MS,
     });
     const choices = response.choices;
     if (!Array.isArray(choices) || !isObject(choices[0])) throw new Error(`Invalid response from ${model}`);

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -324,6 +324,11 @@ export function selectFreeScoutModels(payload: unknown): string[] {
   ].slice(0, MAX_OPENCODE_SCOUTS);
 }
 
+export function duplicateScoutModels(openRouterModels: string[], openCodeModels: string[]): string[] {
+  const openCodeSet = new Set(openCodeModels);
+  return openRouterModels.filter((model) => openCodeSet.has(model));
+}
+
 function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
@@ -986,6 +991,15 @@ async function main(): Promise<"success" | "no_coverage"> {
 
   const source = dataPrompt(diff, await reviewer.fileContext(paths, initialHead), await reviewer.guidelines());
   const availability = await reviewer.openCodeScoutModels();
+  const duplicateModels = duplicateScoutModels(
+    settings.openRouterScouts,
+    [...availability.models, ...availability.unavailable],
+  );
+  if (duplicateModels.length) {
+    throw new Error(
+      `Scout model IDs must be unique across OpenRouter and OpenCode; duplicates: ${duplicateModels.join(", ")}`,
+    );
+  }
   const runnableScouts: Scout[] = [
     ...settings.openRouterScouts.map((model): Scout => ({ model, provider: "openrouter" })),
     ...availability.models.map((model): Scout => ({ model, provider: "opencode" })),

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -69,6 +69,7 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+          AI_REVIEW_MODELS: ${{ vars.AI_REVIEW_MODELS }}
           AI_REVIEW_OPENCODE_MODELS: ${{ vars.AI_REVIEW_OPENCODE_MODELS }}
           AI_REVIEW_MERGER_MODEL: ${{ vars.AI_REVIEW_MERGER_MODEL }}
           AI_REVIEW_IGNORED_AUTHORS: ${{ vars.AI_REVIEW_IGNORED_AUTHORS }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -66,9 +66,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
-          AI_REVIEW_MODELS: ${{ vars.AI_REVIEW_MODELS }}
+          AI_REVIEW_OPENCODE_MODELS: ${{ vars.AI_REVIEW_OPENCODE_MODELS }}
           AI_REVIEW_MERGER_MODEL: ${{ vars.AI_REVIEW_MERGER_MODEL }}
           AI_REVIEW_IGNORED_AUTHORS: ${{ vars.AI_REVIEW_IGNORED_AUTHORS }}
           AI_REVIEW_ZDR: ${{ vars.AI_REVIEW_ZDR }}
@@ -76,13 +77,15 @@ jobs:
 
   # A job can only receive GitHub's "skipped" conclusion when its job-level
   # condition is false. Keep this lightweight sentinel as the stable PR check:
-  # exhausted credits skip it, while genuine execution failures still fail it.
+  # exhausted credits or absent scout coverage skip it, while genuine execution
+  # failures still fail it.
   review:
     needs: run-review
     if: >
       always()
       && needs.run-review.result != 'skipped'
       && needs.run-review.outputs.status != 'credits'
+      && needs.run-review.outputs.status != 'no_coverage'
     runs-on: ubuntu-latest
     steps:
       - name: Report review result

--- a/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
+++ b/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
@@ -14,6 +14,14 @@ Actions architecture consumes too many repeated input tokens. ADR 056 retains
 the scorecard and model agility while moving orchestration and PR memory to
 Cloudflare Workers.
 
+While the Actions implementation remains in service during that migration, its
+paid OpenRouter scouts have been replaced by the free models advertised by
+OpenCode Zen. OpenRouter remains the paid reconciliation layer. Scout
+availability is discovered at run time, individual free-model failures degrade
+coverage rather than failing the review, and a total scout outage publishes an
+explicit no-coverage result, skips the stable review check, and does not invoke
+the paid merger.
+
 # Context
 
 [ADR 009: CodeRabbit](/projects/personal-site/adrs/009-code-rabbit) records why this project uses automated review. [ADR 041: Gemini Code Assist](/projects/personal-site/adrs/041-gemini-code-assist), [ADR 042: Greptile](/projects/personal-site/adrs/042-greptile), [ADR 044: Codex Code Review](/projects/personal-site/adrs/044-codex-code-review), and [ADR 045: Qodo](/projects/personal-site/adrs/045-qodo) record the successive attempts to maintain diverse review coverage. This ADR does not repeat that rationale.

--- a/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
+++ b/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
@@ -2,7 +2,7 @@
 title: "ADR 046: Custom Agentic Code Review"
 date: "2026-06-21"
 status: "Deprecated"
-tech_stack: ["OpenRouter"]
+tech_stack: ["OpenRouter", "OpenCode Zen"]
 ---
 
 # Deprecation
@@ -14,15 +14,16 @@ Actions architecture consumes too many repeated input tokens. ADR 056 retains
 the scorecard and model agility while moving orchestration and PR memory to
 Cloudflare Workers.
 
-While the Actions implementation remains in service during that migration, its
-paid OpenRouter scouts have been replaced by the free models advertised by
-OpenCode Zen. OpenRouter remains the paid reconciliation layer. Scout
-availability is discovered at run time, individual free-model failures degrade
-coverage rather than failing the review, and a total scout outage publishes an
-explicit no-coverage result, skips the stable review check, and does not invoke
-the paid merger. The retained scouts run concurrently; free models that would
-require low or disabled reasoning to complete reliably are excluded rather than
-adding lower-quality candidates to reconciliation.
+While the Actions implementation remains in service during that migration, it
+uses Kimi K2.6 and DeepSeek V4 Pro as paid OpenRouter anchor scouts alongside
+the retained free models advertised by OpenCode Zen. OpenRouter remains the
+paid reconciliation layer. Free-scout availability is discovered at run time,
+individual model failures degrade coverage rather than failing the review, and
+a total scout outage publishes an explicit no-coverage result, skips the stable
+review check, and does not invoke the paid merger. The retained scouts run
+concurrently; unreliable free models are excluded rather than reducing their
+reasoning quality. Retained free scouts submit real candidates to reconciliation
+so their downstream outcomes can feed the planned review data lake.
 
 # Context
 
@@ -47,9 +48,9 @@ This challenges the normal preference to buy rather than build. A focused vendor
 
 I propose evaluating the repository's custom **OpenRouter-based multi-model Pull Request reviewer** as a complement to the existing services.
 
-The current implementation sends each eligible diff to two configurable scout models. The scouts independently return structured findings covering correctness, security, reliability, data loss, concurrency, and material performance. A separate merger model deduplicates findings and reconciles them with resolved GitHub review threads without judging whether a finding is correct.
+The current implementation sends each eligible diff to four scout models by default: two paid OpenRouter anchors and two free OpenCode Zen supplements. The scouts independently return structured findings covering correctness, security, reliability, data loss, concurrency, and material performance. A separate merger model deduplicates findings and reconciles them with resolved GitHub review threads without judging whether a finding is correct.
 
-The scout configuration retains Kimi K2.6 and DeepSeek V4 Pro as the models validated to provide useful review coverage at good value. These exact models are configuration rather than architecture: they should be replaced as stronger or more cost-effective models become available, and OpenRouter fallbacks can preserve a review run when a preferred model or provider is unavailable. A closed-weight merger may be used where it improves reliable orchestration because foundation-model purity is not the objective; useful, diverse, economical review is.
+The scout configuration retains Kimi K2.6 and DeepSeek V4 Pro as the models validated to provide useful review coverage at good value, with Big Pickle and Nemotron 3 Ultra Free adding breadth while their real-world performance is measured. These exact models are configuration rather than architecture: they should be replaced as stronger or more cost-effective models become available, and OpenRouter fallbacks can preserve a review run when a preferred model or provider is unavailable. A closed-weight merger may be used where it improves reliable orchestration because foundation-model purity is not the objective; useful, diverse, economical review is.
 
 The workflow records findings retained from each model, invalid and out-of-scope responses, failures, and cumulative cost. This scorecard makes model selection empirical rather than reputational and creates a continuing evaluation of frontier open-weight models that can inform other projects.
 

--- a/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
+++ b/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
@@ -2,7 +2,7 @@
 title: "ADR 046: Custom Agentic Code Review"
 date: "2026-06-21"
 status: "Deprecated"
-tech_stack: ["OpenRouter", "OpenCode Zen"]
+tech_stack: ["OpenRouter"]
 ---
 
 # Deprecation

--- a/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
+++ b/ui/content/projects/personal-site/adrs/046-custom-agentic-code-review.mdx
@@ -20,7 +20,9 @@ OpenCode Zen. OpenRouter remains the paid reconciliation layer. Scout
 availability is discovered at run time, individual free-model failures degrade
 coverage rather than failing the review, and a total scout outage publishes an
 explicit no-coverage result, skips the stable review check, and does not invoke
-the paid merger.
+the paid merger. The retained scouts run concurrently; free models that would
+require low or disabled reasoning to complete reliably are excluded rather than
+adding lower-quality candidates to reconciliation.
 
 # Context
 


### PR DESCRIPTION
## Summary

- keep the proven paid OpenRouter scouts unchanged: Kimi K2.6 and DeepSeek V4 Pro
- add Big Pickle and Nemotron 3 Ultra Free as live supplementary OpenCode Zen scouts for greater recall
- remove DeepSeek V4 Flash Free and MiMo V2.5 Free after representative live runs showed poor reliability or no useful incremental coverage
- continue excluding Laguna S 2.1, Ling 3.0 Flash, and North Mini Code rather than reducing their reasoning quality
- run the four current scouts concurrently and preserve every valid distinct candidate through the existing reconciliation prompt
- discover eligible free models at run time, retry transient failures, and preserve partial coverage when individual scouts fail
- reject duplicate model IDs across providers before execution so shared result keys cannot overwrite recall or scorecard data
- skip the paid merger and stable review check with an explicit `no_coverage` result only when every scout fails or is unavailable
- retain per-model provenance, candidate counts, failures, costs, and cumulative scorecards so real downstream outcomes can feed future analytics

## Why

The free-only experiment across eight open Pull Requests showed that the OpenCode scouts can add useful breadth, but are not reliable enough to replace the two paid models that have already performed well over sustained use. This hybrid keeps the established paid recall baseline and lets the retained free scouts submit real review comments, rather than shadow output, so the agentic feedback loop and planned data lake can measure their actual value.

This change is intentionally about recall, not precision. The reconciliation prompt is unchanged: it does not judge correctness and continues to preserve every distinct candidate.

## Validation

- branch is current with `origin/main`
- live workflow-dispatch evaluation across eight open Pull Requests
- live hybrid workflow-dispatch test against this PR: https://github.com/Robbie-Palmer/personal-site/actions/runs/30195254538
- Node 24 syntax check
- 13 reviewer unit tests
- YAML and GitHub Actions linting
- Markdown and MDX linting
- zizmor Actions security audit
- repository-wide lint task
- UI check: 93 test files and 710 tests passed
- production UI build
- all GitHub Actions PR checks passing