### PR TITLE
Run AI review at pull request review boundaries

### DIFF
--- a/.agents/skills/complete-pr-review-loop/SKILL.md
+++ b/.agents/skills/complete-pr-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: complete-pr-review-loop
-description: Publish completed repository work as a draft pull request and shepherd it through CI, preview QA, SonarQube, third-party reviewers, and the custom AI reviewer until no substantive issue remains. Use when implementation is complete and changes should be delivered through a PR, or when asked to open, finish, monitor, or settle a PR. Continue through both draft and ready-for-review phases instead of stopping after the first push.
+description: Shepherd completed work from a draft PR through CI, preview QA, SonarQube, third-party reviews, and custom AI review until no substantive issue remains. Use after implementation or when asked to publish, monitor, or settle a PR.
 ---
 
 # Complete the PR review loop

--- a/.agents/skills/complete-pr-review-loop/SKILL.md
+++ b/.agents/skills/complete-pr-review-loop/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: complete-pr-review-loop
+description: Publish completed repository work as a draft pull request and shepherd it through CI, preview QA, SonarQube, third-party reviewers, and the custom AI reviewer until no substantive issue remains. Use when implementation is complete and changes should be delivered through a PR, or when asked to open, finish, monitor, or settle a PR. Continue through both draft and ready-for-review phases instead of stopping after the first push.
+---
+
+# Complete the PR review loop
+
+Read [the shared review-loop workflow](references/review-loop.md) completely,
+then follow it until its completion gate is satisfied.

--- a/.agents/skills/complete-pr-review-loop/agents/openai.yaml
+++ b/.agents/skills/complete-pr-review-loop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Complete PR Review Loop"
+  short_description: "Shepherd a PR until every review settles"
+  default_prompt: "Use $complete-pr-review-loop to publish the completed changes and shepherd the pull request until all checks and reviews settle."

--- a/.agents/skills/complete-pr-review-loop/references/review-loop.md
+++ b/.agents/skills/complete-pr-review-loop/references/review-loop.md
@@ -1,193 +1,103 @@
 # Complete the PR review loop
 
-Own the pull request from the first draft push until every current-head signal is
-settled. Leave the settled PR ready for human merge; do not merge it unless the
-user explicitly asks.
+Own completed work from draft PR to a settled, ready-for-review PR. Do not merge
+unless the user explicitly asks.
 
-## Working rules
+## Publish the draft
 
-- Use the repository's GitHub integration when it exposes the required data and
-  actions; otherwise use `gh` and GitHub's REST or GraphQL API.
-- Preserve unrelated user changes. Commit only the intended work.
-- Keep the branch based on the current `origin/main` before publishing, unless
-  the task requires another base.
-- Never treat a result from an older head SHA as evidence about the current
-  code. Record the PR number and head SHA at the start of every iteration.
-- After every push, restart the checks-and-review loop for the new head.
-- Stay with pending checks and reviewers: poll or watch them rather than handing
-  the user a partially reviewed PR.
-- Do not make speculative changes just to silence a tool. Classify every
-  finding as a true issue, worthwhile nit, duplicate/stale finding, or false
-  positive, and retain the evidence for that classification.
+1. Sync with the intended base, inspect the diff, and run relevant local checks
+   from `AGENTS.md`.
+2. Commit only the intended work, push it, and open or reuse a draft PR.
+3. Give the PR an accurate summary, validation notes, and QA requirements.
 
-## Phase 1: publish a draft
+If deployed QA needs sign-in, seeded data, the API Worker, or ingestion, add
+`preview:backend`. Comment exactly `/preview-backend` to request or retry it.
+Otherwise let the preview workflow infer whether a backend is needed.
 
-1. Run the relevant local validation from `AGENTS.md`.
-2. Review the complete diff and repository status.
-3. Commit the intended changes with a focused message and push the branch.
-4. Open a **draft** PR with an accurate title and body. Include the problem,
-   solution, validation, and any QA constraints.
-5. Confirm the PR is still a draft before beginning remote triage. Opening it
-   ready would trigger the custom AI review too early.
+## Wait efficiently
 
-If a PR already exists, reuse it. Do not open a duplicate.
+CI and reviewers normally take several minutes. After a push or PR state change,
+schedule a wait, timer, or completion notification and yield. Prefer one
+consolidated inspection after roughly 3–5 minutes over a live CLI watcher that
+redraws status every few seconds. Back off further for services known to take
+longer.
 
-## Request a backend preview when QA needs it
+When a reviewer is rate-limited:
 
-The preview workflow normally infers backend needs from changed paths. Force a
-backend preview when deployed QA requires sign-in, seeded data, the API Worker,
-or ingestion behavior even if path detection would choose frontend-only.
+- estimate whether another review is likely to add material value given the
+  change risk and existing coverage;
+- if yes, schedule one timer or monitor for the cooldown expiry, then resume the
+  inspection instead of busy-polling; or
+- if no, record the limitation and why the remaining review is not worth
+  waiting for.
 
-- Add the `preview:backend` label when configuring the PR before or during a
-  preview run.
-- Comment exactly `/preview-backend` to add the label and rerun an eligible
-  completed preview for the current head.
-- Remove a conflicting `preview:frontend-only` label.
-- Wait for `Preview Environment` to finish, then use the URL in its rolling
-  `<!-- preview-environment -->` comment for QA.
+## Inspect and repair
 
-Do not mark preview QA complete from a deployment for an older head.
+Once activity settles, take one current-state snapshot:
 
-## Inspect one review iteration
+- CI conclusions and failure details;
+- review comments, change requests, and unresolved threads;
+- SonarQube gate and actionable findings;
+- preview result and any required QA; and
+- rolling bot comments that may have been edited in place.
 
-For the current head SHA, collect all of the following:
+Treat results as stale after a new push, but do not repeatedly prove the head
+SHA when GitHub already associates completed checks and decorations with the
+current PR state. Query the public SonarQube API when its decoration is missing,
+failing, stale-looking, or lacks enough detail. Use:
 
-1. GitHub checks and Actions jobs, including skipped or cancelled jobs.
-2. Failed-step logs and check annotations, not just the check title.
-3. Formal reviews, review state, inline threads, and thread-resolution state.
-4. All top-level PR comments, including bot comments that may be edited in
-   place.
-5. The current SonarQube analysis, quality gate, issues, and security hotspots.
-6. The preview deployment result and any required hands-on QA.
+- host `https://sonarcloud.io`;
+- project key `Robbie-Palmer_personal-site`; and
+- PR issues, hotspots, and quality-gate endpoints as needed.
 
-`gh pr view` alone does not expose enough inline-thread state. Use GitHub
-GraphQL's `reviewThreads` connection when needed, and inspect unresolved and
-outdated threads explicitly. Re-fetch comments after checks finish because
-review bots can post late or overwrite a rolling comment.
+Only compare SonarQube's analyzed commit with the PR head when a recent push or
+conflicting evidence creates a real staleness risk.
 
-## Inspect SonarQube through its public API
-
-Use the public project data rather than relying only on GitHub's SonarQube
-decoration:
-
-- Host: `https://sonarcloud.io`
-- Project key: `Robbie-Palmer_personal-site`
-
-First query:
-
-```text
-GET /api/project_pull_requests/list?project=Robbie-Palmer_personal-site
-```
-
-Select the entry whose `key` is the PR number and require its `commit.sha` to
-equal the current GitHub head SHA. If it is absent or stale, wait for analysis
-and query again.
-
-For the matching analysis, query:
-
-```text
-GET /api/qualitygates/project_status?projectKey=Robbie-Palmer_personal-site&pullRequest=<PR>
-GET /api/issues/search?componentKeys=Robbie-Palmer_personal-site&pullRequest=<PR>&resolved=false&ps=500
-GET /api/hotspots/search?projectKey=Robbie-Palmer_personal-site&pullRequest=<PR>&status=TO_REVIEW&ps=500
-```
-
-Use URL-encoded query parameters and paginate if a response exceeds its page
-size. Inspect each issue's rule, severity, type, message, component, line, and
-status, plus every failed quality-gate condition. Fix true issues and let a new
-analysis clear them. For a false positive, preserve a concise technical
-rationale; do not weaken code or tests merely to change the metric. If clearing
-a false-positive gate requires SonarQube permissions unavailable to the agent,
-report that exact blocker instead of claiming the gate is settled.
-
-## Triage and repair
-
-For every current finding:
-
-- Reproduce or inspect the cited behavior against the current diff and
-  surrounding code.
-- Fix true correctness, security, reliability, maintainability, test, or
-  documentation issues.
-- Add regression coverage when it materially protects the fix.
-- Address reasonable nits when cheap and consistent with repository style, but
-  do not churn code for subjective preferences.
-- Reply with a specific rationale when rejecting a false positive or stale
-  finding.
-- Resolve an inline thread only after its concern is fixed or explicitly
-  dispositioned. Do not hide unresolved human objections.
-- Treat failing CI as a real issue until logs demonstrate an infrastructure or
-  unrelated failure. Retry only genuinely transient failures.
-
-Run relevant local checks after repairs. Then commit and push the repair batch
-and begin a new iteration from the new head SHA. Prefer coherent batches over a
-separate commit for every bot comment.
+For each finding, decide whether it is a true issue, worthwhile nit,
+duplicate/stale observation, or false positive. Fix true issues, add useful
+regression coverage, and give concise evidence for rejected findings. Avoid
+churn merely to satisfy a reviewer. Batch coherent fixes, validate, commit,
+push, and return to the wait step.
 
 ## Settle the draft phase
 
-Remain in draft until all of these are true for the same head:
+Keep the PR in draft until:
 
-- Every relevant check is terminal and required checks pass.
-- Any skipped check is expected and understood.
-- The SonarQube PR entry matches the head SHA, its quality gate passes, and no
-  unresolved true issue or hotspot remains.
-- Draft-visible third-party reviewers have no unaddressed true issue or active
-  change request.
-- Required preview QA passes.
-- A final refresh finds no late actionable comment.
-- The worktree is clean and all intended commits are pushed.
+- required checks pass and expected skips are understood;
+- SonarQube passes with no unresolved true issue or hotspot;
+- draft-visible reviewers have no unresolved true issue or active change
+  request;
+- required preview QA passes; and
+- the worktree is clean and pushed.
 
-Then move the PR to ready for review. This transition intentionally triggers
-the custom AI review and may trigger reviewers that ignore drafts.
+Refresh once for late feedback, then mark the PR ready for review.
 
-## Phase 2: settle ready-for-review feedback
+## Settle the ready phase
 
-After marking the PR ready:
+Wait for ready-only reviewers and the automatic custom AI review, then repeat
+the same inspect, repair, and wait cycle.
 
-1. Wait for all current-head CI and reviewer activity, including the automatic
-   custom AI review.
-2. Run the complete inspection, triage, repair, commit, and push loop again.
-3. Re-check third-party reviewer comments after each push until they contain no
-   unresolved true issue.
-4. Address every substantive finding from the initial custom AI review, either
-   with a fix or a concrete false-positive/stale rationale.
+The custom reviewer overwrites one top-level comment containing
+`<!-- ai-code-review -->`. Re-fetch that comment after each completed run
+instead of relying on an older copy.
 
-The custom AI reviewer maintains one top-level comment containing
-`<!-- ai-code-review -->` and overwrites that same comment on later runs. Never
-rely on a cached copy. After each `AI code review` run completes, fetch all PR
-comments again, locate the marker, and read the entire current body.
-
-## Request follow-up custom AI reviews
-
-Once third-party feedback and the initial custom review are settled:
-
-1. Determine whether the head changed after the most recent completed custom AI
-   review.
-2. If it changed, comment exactly `/ai-review` once to request a fresh review.
-3. Wait for the matching `AI code review` workflow run to finish.
-4. Re-fetch the overwritten marker comment and triage its new contents.
-5. Fix substantive true findings, push one coherent batch, settle CI and
-   third-party feedback again, then request another custom review if the head
-   changed.
-
-Do not request another paid review when the head has not changed. Stop the
-custom-review cycle when its current comment has no substantive true issue and
-only nitpicks, duplicates, stale observations, or false positives remain.
-Record concise dispositions for rejected findings. If the review is skipped
-because of exhausted credits or no model coverage, report that limitation
-truthfully rather than treating it as a clean review.
+After third-party feedback and the initial custom review are settled, request
+another review with exactly `/ai-review` only if the head changed after the
+latest completed custom review. Repeat after substantive fixes. Do not pay for
+another run when the head is unchanged, or when only nitpicks, duplicates,
+stale observations, or false positives remain. Record their dispositions. If a
+run has no model coverage or exhausted credits, report that limitation rather
+than calling it clean.
 
 ## Completion gate
 
-Finish only when the PR is ready for review and, for one current head SHA:
+Finish when the PR is ready for review and the current state has:
 
-- CI and the SonarQube gate pass;
-- SonarQube has no unresolved true issue or hotspot;
-- required preview QA passes;
-- no third-party reviewer has an unresolved true issue;
-- the latest applicable custom AI review has no substantive true issue;
-- false positives and intentionally unaddressed nitpicks have explicit,
-  evidence-based dispositions; and
-- there are no uncommitted or unpushed fixes.
+- passing CI and SonarQube;
+- no unresolved true SonarQube, reviewer, or custom-review finding;
+- completed required preview QA;
+- explicit dispositions for remaining nits and false positives; and
+- no uncommitted or unpushed fixes.
 
-Report the PR URL, final head SHA, checks and SonarQube status, QA performed,
-review rounds completed, and any remaining nitpick or false-positive
-dispositions.
+Report the PR URL, final commit, validation and QA status, review rounds, and
+material limitations. Leave the PR for human merge.

--- a/.agents/skills/complete-pr-review-loop/references/review-loop.md
+++ b/.agents/skills/complete-pr-review-loop/references/review-loop.md
@@ -1,0 +1,193 @@
+# Complete the PR review loop
+
+Own the pull request from the first draft push until every current-head signal is
+settled. Leave the settled PR ready for human merge; do not merge it unless the
+user explicitly asks.
+
+## Working rules
+
+- Use the repository's GitHub integration when it exposes the required data and
+  actions; otherwise use `gh` and GitHub's REST or GraphQL API.
+- Preserve unrelated user changes. Commit only the intended work.
+- Keep the branch based on the current `origin/main` before publishing, unless
+  the task requires another base.
+- Never treat a result from an older head SHA as evidence about the current
+  code. Record the PR number and head SHA at the start of every iteration.
+- After every push, restart the checks-and-review loop for the new head.
+- Stay with pending checks and reviewers: poll or watch them rather than handing
+  the user a partially reviewed PR.
+- Do not make speculative changes just to silence a tool. Classify every
+  finding as a true issue, worthwhile nit, duplicate/stale finding, or false
+  positive, and retain the evidence for that classification.
+
+## Phase 1: publish a draft
+
+1. Run the relevant local validation from `AGENTS.md`.
+2. Review the complete diff and repository status.
+3. Commit the intended changes with a focused message and push the branch.
+4. Open a **draft** PR with an accurate title and body. Include the problem,
+   solution, validation, and any QA constraints.
+5. Confirm the PR is still a draft before beginning remote triage. Opening it
+   ready would trigger the custom AI review too early.
+
+If a PR already exists, reuse it. Do not open a duplicate.
+
+## Request a backend preview when QA needs it
+
+The preview workflow normally infers backend needs from changed paths. Force a
+backend preview when deployed QA requires sign-in, seeded data, the API Worker,
+or ingestion behavior even if path detection would choose frontend-only.
+
+- Add the `preview:backend` label when configuring the PR before or during a
+  preview run.
+- Comment exactly `/preview-backend` to add the label and rerun an eligible
+  completed preview for the current head.
+- Remove a conflicting `preview:frontend-only` label.
+- Wait for `Preview Environment` to finish, then use the URL in its rolling
+  `<!-- preview-environment -->` comment for QA.
+
+Do not mark preview QA complete from a deployment for an older head.
+
+## Inspect one review iteration
+
+For the current head SHA, collect all of the following:
+
+1. GitHub checks and Actions jobs, including skipped or cancelled jobs.
+2. Failed-step logs and check annotations, not just the check title.
+3. Formal reviews, review state, inline threads, and thread-resolution state.
+4. All top-level PR comments, including bot comments that may be edited in
+   place.
+5. The current SonarQube analysis, quality gate, issues, and security hotspots.
+6. The preview deployment result and any required hands-on QA.
+
+`gh pr view` alone does not expose enough inline-thread state. Use GitHub
+GraphQL's `reviewThreads` connection when needed, and inspect unresolved and
+outdated threads explicitly. Re-fetch comments after checks finish because
+review bots can post late or overwrite a rolling comment.
+
+## Inspect SonarQube through its public API
+
+Use the public project data rather than relying only on GitHub's SonarQube
+decoration:
+
+- Host: `https://sonarcloud.io`
+- Project key: `Robbie-Palmer_personal-site`
+
+First query:
+
+```text
+GET /api/project_pull_requests/list?project=Robbie-Palmer_personal-site
+```
+
+Select the entry whose `key` is the PR number and require its `commit.sha` to
+equal the current GitHub head SHA. If it is absent or stale, wait for analysis
+and query again.
+
+For the matching analysis, query:
+
+```text
+GET /api/qualitygates/project_status?projectKey=Robbie-Palmer_personal-site&pullRequest=<PR>
+GET /api/issues/search?componentKeys=Robbie-Palmer_personal-site&pullRequest=<PR>&resolved=false&ps=500
+GET /api/hotspots/search?projectKey=Robbie-Palmer_personal-site&pullRequest=<PR>&status=TO_REVIEW&ps=500
+```
+
+Use URL-encoded query parameters and paginate if a response exceeds its page
+size. Inspect each issue's rule, severity, type, message, component, line, and
+status, plus every failed quality-gate condition. Fix true issues and let a new
+analysis clear them. For a false positive, preserve a concise technical
+rationale; do not weaken code or tests merely to change the metric. If clearing
+a false-positive gate requires SonarQube permissions unavailable to the agent,
+report that exact blocker instead of claiming the gate is settled.
+
+## Triage and repair
+
+For every current finding:
+
+- Reproduce or inspect the cited behavior against the current diff and
+  surrounding code.
+- Fix true correctness, security, reliability, maintainability, test, or
+  documentation issues.
+- Add regression coverage when it materially protects the fix.
+- Address reasonable nits when cheap and consistent with repository style, but
+  do not churn code for subjective preferences.
+- Reply with a specific rationale when rejecting a false positive or stale
+  finding.
+- Resolve an inline thread only after its concern is fixed or explicitly
+  dispositioned. Do not hide unresolved human objections.
+- Treat failing CI as a real issue until logs demonstrate an infrastructure or
+  unrelated failure. Retry only genuinely transient failures.
+
+Run relevant local checks after repairs. Then commit and push the repair batch
+and begin a new iteration from the new head SHA. Prefer coherent batches over a
+separate commit for every bot comment.
+
+## Settle the draft phase
+
+Remain in draft until all of these are true for the same head:
+
+- Every relevant check is terminal and required checks pass.
+- Any skipped check is expected and understood.
+- The SonarQube PR entry matches the head SHA, its quality gate passes, and no
+  unresolved true issue or hotspot remains.
+- Draft-visible third-party reviewers have no unaddressed true issue or active
+  change request.
+- Required preview QA passes.
+- A final refresh finds no late actionable comment.
+- The worktree is clean and all intended commits are pushed.
+
+Then move the PR to ready for review. This transition intentionally triggers
+the custom AI review and may trigger reviewers that ignore drafts.
+
+## Phase 2: settle ready-for-review feedback
+
+After marking the PR ready:
+
+1. Wait for all current-head CI and reviewer activity, including the automatic
+   custom AI review.
+2. Run the complete inspection, triage, repair, commit, and push loop again.
+3. Re-check third-party reviewer comments after each push until they contain no
+   unresolved true issue.
+4. Address every substantive finding from the initial custom AI review, either
+   with a fix or a concrete false-positive/stale rationale.
+
+The custom AI reviewer maintains one top-level comment containing
+`<!-- ai-code-review -->` and overwrites that same comment on later runs. Never
+rely on a cached copy. After each `AI code review` run completes, fetch all PR
+comments again, locate the marker, and read the entire current body.
+
+## Request follow-up custom AI reviews
+
+Once third-party feedback and the initial custom review are settled:
+
+1. Determine whether the head changed after the most recent completed custom AI
+   review.
+2. If it changed, comment exactly `/ai-review` once to request a fresh review.
+3. Wait for the matching `AI code review` workflow run to finish.
+4. Re-fetch the overwritten marker comment and triage its new contents.
+5. Fix substantive true findings, push one coherent batch, settle CI and
+   third-party feedback again, then request another custom review if the head
+   changed.
+
+Do not request another paid review when the head has not changed. Stop the
+custom-review cycle when its current comment has no substantive true issue and
+only nitpicks, duplicates, stale observations, or false positives remain.
+Record concise dispositions for rejected findings. If the review is skipped
+because of exhausted credits or no model coverage, report that limitation
+truthfully rather than treating it as a clean review.
+
+## Completion gate
+
+Finish only when the PR is ready for review and, for one current head SHA:
+
+- CI and the SonarQube gate pass;
+- SonarQube has no unresolved true issue or hotspot;
+- required preview QA passes;
+- no third-party reviewer has an unresolved true issue;
+- the latest applicable custom AI review has no substantive true issue;
+- false positives and intentionally unaddressed nitpicks have explicit,
+  evidence-based dispositions; and
+- there are no uncommitted or unpushed fixes.
+
+Report the PR URL, final head SHA, checks and SonarQube status, QA performed,
+review rounds completed, and any remaining nitpick or false-positive
+dispositions.

--- a/.claude/skills/complete-pr-review-loop/SKILL.md
+++ b/.claude/skills/complete-pr-review-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: complete-pr-review-loop
-description: Publish completed repository work as a draft pull request and shepherd it through CI, preview QA, SonarQube, third-party reviewers, and the custom AI reviewer until no substantive issue remains. Use when implementation is complete and changes should be delivered through a PR, or when asked to open, finish, monitor, or settle a PR. Continue through both draft and ready-for-review phases instead of stopping after the first push.
+description: Shepherd completed work from a draft PR through CI, preview QA, SonarQube, third-party reviews, and custom AI review until no substantive issue remains. Use after implementation or when asked to publish, monitor, or settle a PR.
 ---
 
 # Complete the PR review loop

--- a/.claude/skills/complete-pr-review-loop/SKILL.md
+++ b/.claude/skills/complete-pr-review-loop/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: complete-pr-review-loop
+description: Publish completed repository work as a draft pull request and shepherd it through CI, preview QA, SonarQube, third-party reviewers, and the custom AI reviewer until no substantive issue remains. Use when implementation is complete and changes should be delivered through a PR, or when asked to open, finish, monitor, or settle a PR. Continue through both draft and ready-for-review phases instead of stopping after the first push.
+---
+
+# Complete the PR review loop
+
+Read [the shared review-loop workflow](../../../.agents/skills/complete-pr-review-loop/references/review-loop.md)
+completely, then follow it until its completion gate is satisfied.

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -12,8 +12,9 @@ future performance analytics.
 
 1. Add `OPENROUTER_API_KEY` as an Actions repository secret and set a suitable
    credit limit on the key. It is used by the paid scouts and merger.
-2. Open or update a non-draft pull request from a branch in this repository as
-   an owner, member, or collaborator. Every commit is reviewed automatically.
+2. Open a non-draft pull request, or mark a draft pull request ready for review,
+   from a branch in this repository as an owner, member, or collaborator. Later
+   commits are not reviewed automatically.
 3. Fork pull requests never run automatically. An owner, member, or collaborator
    must comment exactly `/ai-review` or manually dispatch the workflow.
 

--- a/.github/scripts/ai-review/README.md
+++ b/.github/scripts/ai-review/README.md
@@ -14,7 +14,8 @@ future performance analytics.
    credit limit on the key. It is used by the paid scouts and merger.
 2. Open a non-draft pull request, or mark a draft pull request ready for review,
    from a branch in this repository as an owner, member, or collaborator. Later
-   commits are not reviewed automatically.
+   commits and reopened pull requests are not reviewed automatically; comment
+   exactly `/ai-review` to request another review.
 3. Fork pull requests never run automatically. An owner, member, or collaborator
    must comment exactly `/ai-review` or manually dispatch the workflow.
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,7 +2,7 @@ name: AI code review
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, ready_for_review]
   issue_comment:
     types: [created]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- run the custom AI review automatically only when a non-draft pull request opens or a draft becomes ready for review
- retain explicit `/ai-review` and manual-dispatch review paths while avoiding per-commit runs
- add a shared repository review-loop skill with native Codex and Claude entrypoints
- document the updated trigger behavior

## Validation

- `mise //:lint:actions`
- `mise //:lint:yaml .github/workflows/ai-review.yml .agents/skills/complete-pr-review-loop/agents/openai.yaml`
- `mise //:lint:markdown:check .github/scripts/ai-review/README.md .agents/skills/complete-pr-review-loop/SKILL.md .agents/skills/complete-pr-review-loop/references/review-loop.md .claude/skills/complete-pr-review-loop/SKILL.md`
- `mise //:lint:typos .github/scripts/ai-review/README.md .github/workflows/ai-review.yml .agents/skills/complete-pr-review-loop .claude/skills/complete-pr-review-loop`
- both skill entrypoints pass `quick_validate.py`
- pre-commit Markdown, YAML, and secret checks

## QA

Workflow and documentation changes only. The normal frontend-only preview is sufficient; no backend preview is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added guidance for completing pull requests through validation, reviews, quality checks and preview QA.
  - Added matching workflow guidance for supported agent environments.

- **Documentation**
  - Clarified that subsequent pull request commits require a new AI review request.
  - Documented the full review-loop process, including draft and ready-for-review stages.

- **Chores**
  - Updated automated AI review triggers to run when pull requests are opened or marked ready for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->