### PR TITLE
Allow opt-in previews for dependency PRs

### DIFF
--- a/.github/workflows/preview-environment.yml
+++ b/.github/workflows/preview-environment.yml
@@ -17,11 +17,20 @@ jobs:
   # Decide whether this PR needs a database-backed backend preview.
   detect:
     # On label events, only react to the preview:* labels so unrelated label
-    # changes don't rebuild the preview.
+    # changes don't rebuild the preview. Dependency-bot PRs stay skipped by
+    # default, but preview:frontend-only is an explicit, low-cost QA opt-in.
     if: >
       github.event.pull_request.head.repo.full_name == github.repository
-      && github.event.pull_request.user.login != 'renovate[bot]'
-      && github.event.pull_request.user.login != 'dependabot[bot]'
+      && (
+        (
+          github.event.pull_request.user.login != 'renovate[bot]'
+          && github.event.pull_request.user.login != 'dependabot[bot]'
+        )
+        || (
+          github.event.action == 'labeled'
+          && github.event.label.name == 'preview:frontend-only'
+        )
+      )
       && (
         (github.event.action != 'labeled' && github.event.action != 'unlabeled')
         || startsWith(github.event.label.name, 'preview:')


### PR DESCRIPTION
## Summary

- keep automatic previews disabled for Renovate and Dependabot PRs
- allow an explicit `preview:frontend-only` label to trigger the static frontend preview
- continue preventing dependency-bot PRs from provisioning backend or database resources

## Why

Dependency upgrades that affect rendered UI, such as Recharts, need an intentional QA path. The current job-level condition skips bot PRs even when a maintainer adds a preview label.

## Validation

- `mise //:lint:actions`
- `mise //:lint:yaml`
- `mise //:security:actions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview environment handling for automated dependency update requests.
  * Front-end-only previews can now still be requested explicitly using the appropriate preview label.
  * Existing preview label controls remain unchanged for other requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->