### PR TITLE
Backfill existing recipe cookware to the canonical registry

### DIFF
--- a/packages/recipe-parsing/src/lib/cooklang-token-rewrite.ts
+++ b/packages/recipe-parsing/src/lib/cooklang-token-rewrite.ts
@@ -1,0 +1,80 @@
+import {
+	type EquipmentCanonicalizationDecision,
+	equipmentDisplayName,
+} from "./equipment-canonicalization.js";
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+export function normalizeTokenName(value: string): string {
+	return value
+		.trim()
+		.replace(/[-\s]+/gu, "-")
+		.toLowerCase();
+}
+
+export function canonicalCookwareReplacements(
+	decisions: EquipmentCanonicalizationDecision[],
+): Map<string, string> {
+	const replacements = new Map<string, string>();
+	for (const decision of decisions) {
+		const displayName = equipmentDisplayName(decision.canonicalSlug);
+		if (decision.originalName !== displayName) {
+			replacements.set(normalizeTokenName(decision.originalName), displayName);
+		}
+	}
+	return replacements;
+}
+
+export function applyCanonicalTokens(
+	body: string,
+	marker: "@" | "#",
+	replacements: Map<string, string>,
+): string {
+	if (replacements.size === 0) return body;
+
+	const alternatives = [...replacements.keys()]
+		.sort((left, right) => right.length - left.length)
+		.map((slug) =>
+			slug
+				.split(/[-\s]+/u)
+				.map(escapeRegExp)
+				.join(String.raw`[\s-]+`),
+		);
+	// A token may already carry an alias, either because the recipe was written
+	// that way or because a previous pass added one. Only its registered name is
+	// rewritten; the words it displays are left as they are.
+	const token = new RegExp(
+		String.raw`${escapeRegExp(marker)}(?:${alternatives.join("|")})(\|[^{}|\n]*)?(?=\{|[.,;:()!?]|$|\s(?![^@#~{}\n]*\{))`,
+		"giu",
+	);
+
+	return body.replace(
+		token,
+		(match: string, aliasPart: string | undefined, offset: number) => {
+			const authoredName = match.slice(
+				1,
+				aliasPart ? -aliasPart.length : undefined,
+			);
+			const canonicalName = replacements.get(normalizeTokenName(authoredName));
+			if (!canonicalName) return match;
+
+			// Cooklang reads `name|alias` as the registered name plus the words to
+			// show, so the step keeps the wording the recipe used while the recipe
+			// itself records the canonical one. Wording that differs only in spacing
+			// or case is not worth preserving.
+			const displayName = canonicalName.replaceAll("-", " ");
+			const authoredAlias = aliasPart?.slice(1) || authoredName;
+			const alias =
+				normalizeTokenName(authoredAlias) === normalizeTokenName(displayName)
+					? undefined
+					: authoredAlias;
+
+			const rewritten = alias ? `${displayName}|${alias}` : displayName;
+			const alreadyBraced = body[offset + match.length] === "{";
+			const needsBraces = !alreadyBraced && /[\s|]/u.test(rewritten);
+			return `${marker}${rewritten}${needsBraces ? "{}" : ""}`;
+		},
+	);
+}

--- a/packages/recipe-parsing/tests/lib/cooklang-token-rewrite.test.ts
+++ b/packages/recipe-parsing/tests/lib/cooklang-token-rewrite.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyCanonicalTokens,
+	canonicalCookwareReplacements,
+	normalizeTokenName,
+} from "../../src/lib/cooklang-token-rewrite.js";
+import type { EquipmentCanonicalizationDecision } from "../../src/lib/equipment-canonicalization.js";
+
+function decision(
+	originalName: string,
+	canonicalSlug: string,
+): EquipmentCanonicalizationDecision {
+	return {
+		originalName,
+		canonicalSlug,
+		baseSlug: normalizeTokenName(originalName),
+		method: "exact",
+		candidates: [],
+	} as EquipmentCanonicalizationDecision;
+}
+
+describe("normalizeTokenName", () => {
+	it("lowercases, trims, and collapses separators to a slug", () => {
+		expect(normalizeTokenName("  Baking   Tray ")).toBe("baking-tray");
+		expect(normalizeTokenName("tin-foil")).toBe("tin-foil");
+		expect(normalizeTokenName("Frying Pan")).toBe("frying-pan");
+	});
+});
+
+describe("canonicalCookwareReplacements", () => {
+	it("maps a divergent name to its canonical display name", () => {
+		const replacements = canonicalCookwareReplacements([
+			decision("forks", "fork"),
+		]);
+		expect(replacements.get("forks")).toBe("fork");
+	});
+
+	it("omits a decision whose name already equals its canonical display", () => {
+		const replacements = canonicalCookwareReplacements([
+			decision("fork", "fork"),
+		]);
+		expect(replacements.size).toBe(0);
+	});
+});
+
+describe("applyCanonicalTokens", () => {
+	it("returns the body untouched when there are no replacements", () => {
+		const body = "Serve on a #plate{}.";
+		expect(applyCanonicalTokens(body, "#", new Map())).toBe(body);
+	});
+
+	it("rewrites a bare token and keeps the authored wording as the alias", () => {
+		expect(
+			applyCanonicalTokens(
+				"Fry in a #skillet{}.",
+				"#",
+				new Map([["skillet", "frying pan"]]),
+			),
+		).toBe("Fry in a #frying pan|skillet{}.");
+	});
+
+	it("preserves the authored casing of the alias", () => {
+		expect(
+			applyCanonicalTokens(
+				"Fry in a #Skillet{}.",
+				"#",
+				new Map([["skillet", "frying pan"]]),
+			),
+		).toBe("Fry in a #frying pan|Skillet{}.");
+	});
+
+	it("drops the alias when it differs from the canonical name only in case", () => {
+		expect(
+			applyCanonicalTokens(
+				"Fry in a #Frying Pan{}.",
+				"#",
+				new Map([["frying-pan", "frying pan"]]),
+			),
+		).toBe("Fry in a #frying pan{}.");
+	});
+
+	it("rewrites only the registered name of a token that already has an alias", () => {
+		expect(
+			applyCanonicalTokens(
+				"Roast on a #sheet pan|my tray{}.",
+				"#",
+				new Map([["sheet-pan", "baking tray"]]),
+			),
+		).toBe("Roast on a #baking tray|my tray{}.");
+	});
+
+	it("matches a token terminated by punctuation and adds no braces for a bare single word", () => {
+		expect(
+			applyCanonicalTokens(
+				"Serve on a #Plate.",
+				"#",
+				new Map([["plate", "plate"]]),
+			),
+		).toBe("Serve on a #plate.");
+	});
+
+	it("adds braces when an aliased single-word token is terminated by punctuation", () => {
+		expect(
+			applyCanonicalTokens(
+				"Serve with two #forks.",
+				"#",
+				new Map([["forks", "fork"]]),
+			),
+		).toBe("Serve with two #fork|forks{}.");
+	});
+
+	it("rewrites ingredient tokens with the @ marker", () => {
+		expect(
+			applyCanonicalTokens(
+				"Add @capsicum{}.",
+				"@",
+				new Map([["capsicum", "bell pepper"]]),
+			),
+		).toBe("Add @bell pepper|capsicum{}.");
+	});
+
+	it("matches a longer name before its shorter substring", () => {
+		expect(
+			applyCanonicalTokens(
+				"Use a #frying pan{} and a #pan{}.",
+				"#",
+				new Map([
+					["pan", "pot"],
+					["frying-pan", "frying pan"],
+				]),
+			),
+		).toBe("Use a #frying pan{} and a #pot|pan{}.");
+	});
+
+	it("leaves a token whose name is not in the replacements", () => {
+		const body = "Use a #whisk{}.";
+		expect(applyCanonicalTokens(body, "#", new Map([["forks", "fork"]]))).toBe(
+			body,
+		);
+	});
+});

--- a/workers/recipe-api/mise.toml
+++ b/workers/recipe-api/mise.toml
@@ -46,6 +46,11 @@ description = "Seed deterministic preview users and data"
 depends = ["install"]
 run = "pnpm preview:seed"
 
+[tasks."db:backfill:cookware"]
+description = "Canonicalize existing recipe cookware against the equipment registry (read-only; pass -- --apply to write)"
+depends = ["install"]
+run = "pnpm backfill:cookware"
+
 [tasks."db:studio"]
 description = "Open Drizzle Studio for DATABASE_URL"
 depends = ["install"]

--- a/workers/recipe-api/package.json
+++ b/workers/recipe-api/package.json
@@ -15,7 +15,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
-    "preview:seed": "tsx scripts/seed-preview.ts"
+    "preview:seed": "tsx scripts/seed-preview.ts",
+    "backfill:cookware": "tsx scripts/canonicalize-cookware.ts"
   },
   "dependencies": {
     "better-auth": "^1.6.19",

--- a/workers/recipe-api/scripts/canonicalize-cookware-recipe.ts
+++ b/workers/recipe-api/scripts/canonicalize-cookware-recipe.ts
@@ -3,6 +3,7 @@ import {
 	SavedRecipePayloadSchema,
 } from "recipe-domain";
 import { canonicalEquipment } from "recipe-parsing/canonical-equipment-data";
+import { extractCookwareFromBody } from "recipe-parsing/cooklang";
 import {
 	applyCanonicalTokens,
 	canonicalCookwareReplacements,
@@ -24,16 +25,6 @@ export interface CookwareCanonicalization {
 	cookwareAfter: string[];
 }
 
-function canonicalNames(names: string[]): string[] {
-	return [
-		...new Set(
-			canonicalizeCookwareList(names, equipment, equipmentIndex).cookware.map(
-				(name) => name.trim().toLowerCase(),
-			),
-		),
-	];
-}
-
 function sameList(left: string[], right: string[]): boolean {
 	return (
 		left.length === right.length &&
@@ -43,24 +34,22 @@ function sameList(left: string[], right: string[]): boolean {
 
 /**
  * Resolves a recipe's cookware against the canonical equipment registry. The
- * structured equipment list moves to the canonical name; the cooklang source
- * keeps the authored wording as a `#canonical|authored{}` alias so the prose
- * reads exactly as before. The transform is idempotent — a body that already
- * uses canonical names comes back unchanged.
+ * registered names come from the cooklang source itself, so the rewrite and the
+ * structured equipment list stay in step: the source keeps each authored
+ * wording as a `#canonical|authored{}` alias while the equipment list and the
+ * cooklang tokens both carry the canonical name. Deriving from the source is
+ * what keeps a token that already has an alias (`#baking dish|casserole{}`)
+ * consistent — the registered name is what gets rewritten, not the alias. The
+ * transform is idempotent; a body already on canonical names comes back
+ * unchanged.
  */
 export function canonicalizeSavedRecipeCookware(
 	payload: SavedRecipePayload,
 ): CookwareCanonicalization {
 	const { recipe } = payload;
 
-	// The display values are the wording each cookware token shows in the prose
-	// ("skillet", "large frying pan"); their registered names come from
-	// canonicalizing them. Fall back to the stored equipment list for older
-	// records saved without an instruction SDK.
-	const authoredNames =
-		recipe.instructionSdk?.cookwareDisplayValues ?? recipe.cookware;
-	const { decisions } = canonicalizeCookwareList(
-		authoredNames,
+	const { cookware, decisions } = canonicalizeCookwareList(
+		extractCookwareFromBody(payload.source),
 		equipment,
 		equipmentIndex,
 	);
@@ -68,7 +57,9 @@ export function canonicalizeSavedRecipeCookware(
 
 	const nextSource = applyCanonicalTokens(payload.source, "#", replacements);
 	const nextCookBody = applyCanonicalTokens(recipe.cookBody, "#", replacements);
-	const nextCookware = canonicalNames(recipe.cookware);
+	const nextCookware = [
+		...new Set(cookware.map((name) => name.trim().toLowerCase())),
+	];
 
 	const changed =
 		nextSource !== payload.source ||

--- a/workers/recipe-api/scripts/canonicalize-cookware-recipe.ts
+++ b/workers/recipe-api/scripts/canonicalize-cookware-recipe.ts
@@ -1,0 +1,91 @@
+import {
+	type SavedRecipePayload,
+	SavedRecipePayloadSchema,
+} from "recipe-domain";
+import { canonicalEquipment } from "recipe-parsing/canonical-equipment-data";
+import {
+	applyCanonicalTokens,
+	canonicalCookwareReplacements,
+} from "recipe-parsing/cooklang-token-rewrite";
+import { canonicalizeCookwareList } from "recipe-parsing/equipment-canonicalization";
+import {
+	buildOntology,
+	buildOntologyIndex,
+} from "recipe-parsing/slug-matching";
+
+const equipment = buildOntology(canonicalEquipment.equipment, "equipment");
+const equipmentIndex = buildOntologyIndex(equipment);
+
+export interface CookwareCanonicalization {
+	payload: SavedRecipePayload;
+	changed: boolean;
+	replacements: Map<string, string>;
+	cookwareBefore: string[];
+	cookwareAfter: string[];
+}
+
+function canonicalNames(names: string[]): string[] {
+	return [
+		...new Set(
+			canonicalizeCookwareList(names, equipment, equipmentIndex).cookware.map(
+				(name) => name.trim().toLowerCase(),
+			),
+		),
+	];
+}
+
+function sameList(left: string[], right: string[]): boolean {
+	return (
+		left.length === right.length &&
+		left.every((value, index) => value === right[index])
+	);
+}
+
+/**
+ * Resolves a recipe's cookware against the canonical equipment registry. The
+ * structured equipment list moves to the canonical name; the cooklang source
+ * keeps the authored wording as a `#canonical|authored{}` alias so the prose
+ * reads exactly as before. The transform is idempotent — a body that already
+ * uses canonical names comes back unchanged.
+ */
+export function canonicalizeSavedRecipeCookware(
+	payload: SavedRecipePayload,
+): CookwareCanonicalization {
+	const { recipe } = payload;
+
+	// The display values are the wording each cookware token shows in the prose
+	// ("skillet", "large frying pan"); their registered names come from
+	// canonicalizing them. Fall back to the stored equipment list for older
+	// records saved without an instruction SDK.
+	const authoredNames =
+		recipe.instructionSdk?.cookwareDisplayValues ?? recipe.cookware;
+	const { decisions } = canonicalizeCookwareList(
+		authoredNames,
+		equipment,
+		equipmentIndex,
+	);
+	const replacements = canonicalCookwareReplacements(decisions);
+
+	const nextSource = applyCanonicalTokens(payload.source, "#", replacements);
+	const nextCookBody = applyCanonicalTokens(recipe.cookBody, "#", replacements);
+	const nextCookware = canonicalNames(recipe.cookware);
+
+	const changed =
+		nextSource !== payload.source ||
+		nextCookBody !== recipe.cookBody ||
+		!sameList(nextCookware, recipe.cookware);
+
+	return {
+		payload: changed
+			? SavedRecipePayloadSchema.parse({
+					...payload,
+					source: nextSource,
+					recipe: { ...recipe, cookBody: nextCookBody, cookware: nextCookware },
+				})
+			: payload,
+		changed,
+		replacements,
+		cookwareBefore: recipe.cookware,
+		cookwareAfter: nextCookware,
+	};
+}

--- a/workers/recipe-api/scripts/canonicalize-cookware.ts
+++ b/workers/recipe-api/scripts/canonicalize-cookware.ts
@@ -1,0 +1,75 @@
+import { eq } from "drizzle-orm";
+import { createDb, schema } from "recipe-db";
+import { SavedRecipePayloadSchema } from "recipe-domain";
+import { canonicalizeSavedRecipeCookware } from "./canonicalize-cookware-recipe";
+
+// Existing recipes predate the canonical equipment registry, so their equipment
+// filters carry the wording each recipe happened to use — "fork" and "forks",
+// "baking dish" and "baking tin" and "baking tray". This backfill resolves each
+// recipe's cookware the same way the ingest pipeline now does, moving the
+// structured equipment list to the canonical name while keeping the authored
+// wording in the prose. Runs read-only by default; pass --apply to write.
+
+const APPLY = process.argv.includes("--apply");
+
+function requiredEnv(name: string): string {
+	const value = process.env[name];
+	if (!value) throw new Error(`${name} is required`);
+	return value;
+}
+
+const { db, client } = createDb(requiredEnv("DATABASE_URL"));
+
+let scanned = 0;
+let skipped = 0;
+let changed = 0;
+
+try {
+	const recipes = await db
+		.select({
+			id: schema.recipe.id,
+			slug: schema.recipe.slug,
+			body: schema.recipe.body,
+		})
+		.from(schema.recipe);
+
+	for (const record of recipes) {
+		scanned += 1;
+		if (!record.body) continue;
+
+		const parsed = SavedRecipePayloadSchema.safeParse(JSON.parse(record.body));
+		if (!parsed.success) {
+			skipped += 1;
+			console.warn(`skip ${record.slug}: body is not a valid saved recipe`);
+			continue;
+		}
+
+		const result = canonicalizeSavedRecipeCookware(parsed.data);
+		if (!result.changed) continue;
+
+		changed += 1;
+		console.log(`\n${record.slug}`);
+		console.log(
+			`  equipment: [${result.cookwareBefore.join(", ")}] -> [${result.cookwareAfter.join(", ")}]`,
+		);
+		for (const [authored, canonical] of result.replacements) {
+			console.log(`  token: #${authored} -> #${canonical}|${authored}`);
+		}
+
+		if (!APPLY) continue;
+
+		await db
+			.update(schema.recipe)
+			.set({ body: JSON.stringify(result.payload) })
+			.where(eq(schema.recipe.id, record.id));
+	}
+
+	console.log(
+		`\n${APPLY ? "Updated" : "Would update"} ${changed} of ${scanned} recipes (${skipped} skipped).`,
+	);
+	if (!APPLY && changed > 0) {
+		console.log("Re-run with --apply to write these changes.");
+	}
+} finally {
+	await client.end({ timeout: 5 });
+}

--- a/workers/recipe-api/scripts/canonicalize-cookware.ts
+++ b/workers/recipe-api/scripts/canonicalize-cookware.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { createDb, schema } from "recipe-db";
 import { SavedRecipePayloadSchema } from "recipe-domain";
 import { canonicalizeSavedRecipeCookware } from "./canonicalize-cookware-recipe";
@@ -23,6 +23,7 @@ const { db, client } = createDb(requiredEnv("DATABASE_URL"));
 let scanned = 0;
 let skipped = 0;
 let changed = 0;
+let conflicts = 0;
 
 try {
 	const recipes = await db
@@ -37,7 +38,16 @@ try {
 		scanned += 1;
 		if (!record.body) continue;
 
-		const parsed = SavedRecipePayloadSchema.safeParse(JSON.parse(record.body));
+		let json: unknown;
+		try {
+			json = JSON.parse(record.body);
+		} catch {
+			skipped += 1;
+			console.warn(`skip ${record.slug}: body is not valid JSON`);
+			continue;
+		}
+
+		const parsed = SavedRecipePayloadSchema.safeParse(json);
 		if (!parsed.success) {
 			skipped += 1;
 			console.warn(`skip ${record.slug}: body is not a valid saved recipe`);
@@ -58,14 +68,30 @@ try {
 
 		if (!APPLY) continue;
 
-		await db
+		// Guard against a recipe edited between the scan and this write: match the
+		// body we transformed, so a concurrent edit is reported rather than
+		// silently overwritten with our stale copy.
+		const written = await db
 			.update(schema.recipe)
 			.set({ body: JSON.stringify(result.payload) })
-			.where(eq(schema.recipe.id, record.id));
+			.where(
+				and(
+					eq(schema.recipe.id, record.id),
+					eq(schema.recipe.body, record.body),
+				),
+			)
+			.returning({ id: schema.recipe.id });
+		if (written.length === 0) {
+			conflicts += 1;
+			changed -= 1;
+			console.warn(
+				`  conflict: ${record.slug} changed since the scan; skipped`,
+			);
+		}
 	}
 
 	console.log(
-		`\n${APPLY ? "Updated" : "Would update"} ${changed} of ${scanned} recipes (${skipped} skipped).`,
+		`\n${APPLY ? "Updated" : "Would update"} ${changed} of ${scanned} recipes (${skipped} skipped${conflicts > 0 ? `, ${conflicts} conflicts` : ""}).`,
 	);
 	if (!APPLY && changed > 0) {
 		console.log("Re-run with --apply to write these changes.");

--- a/workers/recipe-api/tests/canonicalize-cookware.test.ts
+++ b/workers/recipe-api/tests/canonicalize-cookware.test.ts
@@ -1,0 +1,123 @@
+import { SavedRecipePayloadSchema } from "recipe-domain";
+import { describe, expect, it } from "vitest";
+import { canonicalizeSavedRecipeCookware } from "../scripts/canonicalize-cookware-recipe";
+
+function payload(options: {
+	source: string;
+	cookware: string[];
+	cookwareDisplayValues?: string[];
+}) {
+	return SavedRecipePayloadSchema.parse({
+		version: 1,
+		source: options.source,
+		recipe: {
+			title: "Test Recipe",
+			description: "A recipe for testing.",
+			date: "2026-07-15",
+			cuisine: [],
+			servings: 2,
+			tags: [],
+			cookBody: options.source,
+			cookware: options.cookware,
+			ingredientGroups: [{ items: [{ ingredient: "salt", amount: 1 }] }],
+			instructions: ["Do the thing."],
+			...(options.cookwareDisplayValues
+				? {
+						instructionSdk: {
+							sections: [],
+							ingredientNames: [],
+							ingredientDisplayValues: [],
+							ingredientAmounts: [],
+							ingredientUnits: [],
+							cookwareDisplayValues: options.cookwareDisplayValues,
+							inlineQuantityDisplayValues: [],
+							timerDisplayValues: [],
+							timerDurationSeconds: [],
+						},
+					}
+				: {}),
+		},
+	});
+}
+
+describe("canonicalizeSavedRecipeCookware", () => {
+	it("collapses a plural to its canonical singular and keeps the prose", () => {
+		const result = canonicalizeSavedRecipeCookware(
+			payload({
+				source: "Serve with two #forks{}.",
+				cookware: ["forks"],
+			}),
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.cookwareAfter).toEqual(["fork"]);
+		expect(result.payload.source).toBe("Serve with two #fork|forks{}.");
+		expect(result.payload.recipe.cookBody).toBe(
+			"Serve with two #fork|forks{}.",
+		);
+	});
+
+	it("merges divergent spellings into one canonical entry", () => {
+		const result = canonicalizeSavedRecipeCookware(
+			payload({
+				source: "Grab a #fork{} and a #forks{}.",
+				cookware: ["fork", "forks"],
+			}),
+		);
+
+		expect(result.cookwareAfter).toEqual(["fork"]);
+		expect(result.payload.source).toBe("Grab a #fork{} and a #fork|forks{}.");
+	});
+
+	it("resolves an alias to its canonical equipment name", () => {
+		const result = canonicalizeSavedRecipeCookware(
+			payload({
+				source: "Bake in a #baking dish{}.",
+				cookware: ["baking dish"],
+			}),
+		);
+
+		expect(result.cookwareAfter).toEqual(["oven dish"]);
+		expect(result.payload.source).toBe("Bake in a #oven dish|baking dish{}.");
+	});
+
+	it("collapses baking dish, tin, and tray duplicates across recipes", () => {
+		const names = (source: string, cookware: string[]) =>
+			canonicalizeSavedRecipeCookware(payload({ source, cookware }))
+				.cookwareAfter;
+
+		expect(names("Use a #baking dish{}.", ["baking dish"])).toEqual([
+			"oven dish",
+		]);
+		expect(names("Use a #baking sheet{}.", ["baking sheet"])).toEqual([
+			"baking tray",
+		]);
+		expect(names("Use a #sheet pan{}.", ["sheet pan"])).toEqual([
+			"baking tray",
+		]);
+	});
+
+	it("prefers the instruction SDK display wording as the authored alias", () => {
+		const result = canonicalizeSavedRecipeCookware(
+			payload({
+				source: "Fry in a #skillet{}.",
+				cookware: ["skillet"],
+				cookwareDisplayValues: ["skillet"],
+			}),
+		);
+
+		expect(result.cookwareAfter).toEqual(["frying pan"]);
+		expect(result.payload.source).toBe("Fry in a #frying pan|skillet{}.");
+	});
+
+	it("leaves an already-canonical recipe untouched", () => {
+		const input = payload({
+			source: "Fry in a #frying pan|skillet{}.",
+			cookware: ["frying pan"],
+		});
+		const result = canonicalizeSavedRecipeCookware(input);
+
+		expect(result.changed).toBe(false);
+		expect(result.payload).toBe(input);
+	});
+});

--- a/workers/recipe-api/tests/canonicalize-cookware.test.ts
+++ b/workers/recipe-api/tests/canonicalize-cookware.test.ts
@@ -2,11 +2,7 @@ import { SavedRecipePayloadSchema } from "recipe-domain";
 import { describe, expect, it } from "vitest";
 import { canonicalizeSavedRecipeCookware } from "../scripts/canonicalize-cookware-recipe";
 
-function payload(options: {
-	source: string;
-	cookware: string[];
-	cookwareDisplayValues?: string[];
-}) {
+function payload(options: { source: string; cookware: string[] }) {
 	return SavedRecipePayloadSchema.parse({
 		version: 1,
 		source: options.source,
@@ -21,21 +17,6 @@ function payload(options: {
 			cookware: options.cookware,
 			ingredientGroups: [{ items: [{ ingredient: "salt", amount: 1 }] }],
 			instructions: ["Do the thing."],
-			...(options.cookwareDisplayValues
-				? {
-						instructionSdk: {
-							sections: [],
-							ingredientNames: [],
-							ingredientDisplayValues: [],
-							ingredientAmounts: [],
-							ingredientUnits: [],
-							cookwareDisplayValues: options.cookwareDisplayValues,
-							inlineQuantityDisplayValues: [],
-							timerDisplayValues: [],
-							timerDurationSeconds: [],
-						},
-					}
-				: {}),
 		},
 	});
 }
@@ -97,17 +78,19 @@ describe("canonicalizeSavedRecipeCookware", () => {
 		]);
 	});
 
-	it("prefers the instruction SDK display wording as the authored alias", () => {
+	it("rewrites the registered name of a token that already carries an alias", () => {
+		// Registered name "baking dish" is non-canonical; the authored alias
+		// "casserole" is the prose. Only the registered name should move, keeping
+		// the source and the equipment list on the same canonical value.
 		const result = canonicalizeSavedRecipeCookware(
 			payload({
-				source: "Fry in a #skillet{}.",
-				cookware: ["skillet"],
-				cookwareDisplayValues: ["skillet"],
+				source: "Bake in a #baking dish|casserole{}.",
+				cookware: ["baking dish"],
 			}),
 		);
 
-		expect(result.cookwareAfter).toEqual(["frying pan"]);
-		expect(result.payload.source).toBe("Fry in a #frying pan|skillet{}.");
+		expect(result.cookwareAfter).toEqual(["oven dish"]);
+		expect(result.payload.source).toBe("Bake in a #oven dish|casserole{}.");
 	});
 
 	it("leaves an already-canonical recipe untouched", () => {

--- a/workers/recipe-api/tsconfig.json
+++ b/workers/recipe-api/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
     "noUncheckedIndexedAccess": true,

--- a/workers/recipe-ingest/src/draft.ts
+++ b/workers/recipe-ingest/src/draft.ts
@@ -1,145 +1,77 @@
 import { recipeToCooklang } from "recipe-parsing/cooklang";
 import {
-  equipmentDisplayName,
-  type EquipmentCanonicalizationDecision,
-} from "recipe-parsing/equipment-canonicalization";
+	applyCanonicalTokens,
+	canonicalCookwareReplacements,
+	normalizeTokenName,
+} from "recipe-parsing/cooklang-token-rewrite";
+import type { EquipmentCanonicalizationDecision } from "recipe-parsing/equipment-canonicalization";
 import type { Recipe } from "recipe-parsing/schemas/ground-truth";
 import type { CooklangRecipe } from "recipe-parsing/schemas/stage-artifacts";
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-}
-
 function canonicalIngredientReplacements(
-  original: Recipe,
-  finalized: Recipe,
+	original: Recipe,
+	finalized: Recipe,
 ): Map<string, string> {
-  const replacements = new Map<string, string>();
-  for (
-    let groupIndex = 0;
-    groupIndex < original.ingredientGroups.length;
-    groupIndex++
-  ) {
-    const originalGroup = original.ingredientGroups[groupIndex];
-    const finalizedGroup = finalized.ingredientGroups[groupIndex];
-    if (!originalGroup || !finalizedGroup) continue;
+	const replacements = new Map<string, string>();
+	for (
+		let groupIndex = 0;
+		groupIndex < original.ingredientGroups.length;
+		groupIndex++
+	) {
+		const originalGroup = original.ingredientGroups[groupIndex];
+		const finalizedGroup = finalized.ingredientGroups[groupIndex];
+		if (!originalGroup || !finalizedGroup) continue;
 
-    for (
-      let itemIndex = 0;
-      itemIndex < originalGroup.items.length;
-      itemIndex++
-    ) {
-      const originalIngredient = originalGroup.items[itemIndex]?.ingredient;
-      const finalizedIngredient = finalizedGroup.items[itemIndex]?.ingredient;
-      if (
-        originalIngredient &&
-        finalizedIngredient &&
-        originalIngredient !== finalizedIngredient
-      ) {
-        replacements.set(
-          normalizeTokenName(originalIngredient),
-          finalizedIngredient,
-        );
-      }
-    }
-  }
-  return replacements;
-}
-
-function canonicalCookwareReplacements(
-  decisions: EquipmentCanonicalizationDecision[],
-): Map<string, string> {
-  const replacements = new Map<string, string>();
-  for (const decision of decisions) {
-    const displayName = equipmentDisplayName(decision.canonicalSlug);
-    if (decision.originalName !== displayName) {
-      replacements.set(normalizeTokenName(decision.originalName), displayName);
-    }
-  }
-  return replacements;
-}
-
-function normalizeTokenName(value: string): string {
-  return value.trim().replace(/[-\s]+/gu, "-").toLowerCase();
-}
-
-function applyCanonicalTokens(
-  body: string,
-  marker: "@" | "#",
-  replacements: Map<string, string>,
-): string {
-  if (replacements.size === 0) return body;
-
-  const alternatives = [...replacements.keys()]
-    .sort((left, right) => right.length - left.length)
-    .map((slug) =>
-      slug
-        .split(/[-\s]+/u)
-        .map(escapeRegExp)
-        .join(String.raw`[\s-]+`),
-    );
-  // A token may already carry an alias, either because the recipe was written
-  // that way or because a previous pass added one. Only its registered name is
-  // rewritten; the words it displays are left as they are.
-  const token = new RegExp(
-    String.raw`${escapeRegExp(marker)}(?:${alternatives.join("|")})(\|[^{}|\n]*)?(?=\{|[.,;:()!?]|$|\s(?![^@#~{}\n]*\{))`,
-    "giu",
-  );
-
-  return body.replace(
-    token,
-    (match: string, aliasPart: string | undefined, offset: number) => {
-      const authoredName = match.slice(1, aliasPart ? -aliasPart.length : undefined);
-      const canonicalName = replacements.get(normalizeTokenName(authoredName));
-      if (!canonicalName) return match;
-
-      // Cooklang reads `name|alias` as the registered name plus the words to
-      // show, so the step keeps the wording the recipe used while the recipe
-      // itself records the canonical one. Wording that differs only in spacing
-      // or case is not worth preserving.
-      const displayName = canonicalName.replaceAll("-", " ");
-      const authoredAlias = aliasPart?.slice(1) || authoredName;
-      const alias =
-        normalizeTokenName(authoredAlias) === normalizeTokenName(displayName)
-          ? undefined
-          : authoredAlias;
-
-      const rewritten = alias ? `${displayName}|${alias}` : displayName;
-      const alreadyBraced = body[offset + match.length] === "{";
-      const needsBraces = !alreadyBraced && /[\s|]/u.test(rewritten);
-      return `${marker}${rewritten}${needsBraces ? "{}" : ""}`;
-    },
-  );
+		for (
+			let itemIndex = 0;
+			itemIndex < originalGroup.items.length;
+			itemIndex++
+		) {
+			const originalIngredient = originalGroup.items[itemIndex]?.ingredient;
+			const finalizedIngredient = finalizedGroup.items[itemIndex]?.ingredient;
+			if (
+				originalIngredient &&
+				finalizedIngredient &&
+				originalIngredient !== finalizedIngredient
+			) {
+				replacements.set(
+					normalizeTokenName(originalIngredient),
+					finalizedIngredient,
+				);
+			}
+		}
+	}
+	return replacements;
 }
 
 export function buildFinalDraft(
-  sourceImageKeys: string[],
-  normalizedCooklang: CooklangRecipe,
-  recipe: Recipe,
-  cookwareDecisions: EquipmentCanonicalizationDecision[],
+	sourceImageKeys: string[],
+	normalizedCooklang: CooklangRecipe,
+	recipe: Recipe,
+	cookwareDecisions: EquipmentCanonicalizationDecision[],
 ) {
-  const canonicalCooklang = recipeToCooklang(recipe);
-  const originalRecipe = normalizedCooklang.derived;
-  const ingredientBody = originalRecipe
-    ? applyCanonicalTokens(
-        normalizedCooklang.body,
-        "@",
-        canonicalIngredientReplacements(originalRecipe, recipe),
-      )
-    : normalizedCooklang.body;
-  const body = applyCanonicalTokens(
-    ingredientBody,
-    "#",
-    canonicalCookwareReplacements(cookwareDecisions),
-  );
+	const canonicalCooklang = recipeToCooklang(recipe);
+	const originalRecipe = normalizedCooklang.derived;
+	const ingredientBody = originalRecipe
+		? applyCanonicalTokens(
+				normalizedCooklang.body,
+				"@",
+				canonicalIngredientReplacements(originalRecipe, recipe),
+			)
+		: normalizedCooklang.body;
+	const body = applyCanonicalTokens(
+		ingredientBody,
+		"#",
+		canonicalCookwareReplacements(cookwareDecisions),
+	);
 
-  return {
-    sourceImageKeys,
-    cooklang: {
-      frontmatter: canonicalCooklang.frontmatter,
-      body,
-      diagnostics: normalizedCooklang.diagnostics,
-    },
-    recipe,
-  };
+	return {
+		sourceImageKeys,
+		cooklang: {
+			frontmatter: canonicalCooklang.frontmatter,
+			body,
+			diagnostics: normalizedCooklang.diagnostics,
+		},
+		recipe,
+	};
 }


### PR DESCRIPTION
## Why

Recipes created before the canonical equipment registry (#793) keep the wording each one happened to use, so the equipment **filters are full of near-duplicates** — `fork` beside `forks`, `baking dish`/`baking tin`/`baking tray`, `tin foil` beside `foil`. The ingest pipeline now resolves cookware against the registry, but nothing back-filled the recipes already saved.

## What

A read-only-by-default backfill that reuses the **same deterministic canonicalization the ingest path uses** (registry + `EQUIPMENT_ALIASES`, no LLM):

- **`packages/recipe-parsing/src/lib/cooklang-token-rewrite.ts`** — the `#canonical|authored{}` token rewriter, factored out of `workers/recipe-ingest/src/draft.ts` so the ingest worker and the backfill share one implementation. `draft.ts` now imports it (behaviour unchanged).
- **`workers/recipe-api/scripts/canonicalize-cookware-recipe.ts`** — the pure, side-effect-free transform: moves `recipe.cookware` to the canonical name while the cooklang `source`/`cookBody` keep the authored wording as the alias. Idempotent.
- **`workers/recipe-api/scripts/canonicalize-cookware.ts`** — the DB runner. Read-only by default (prints a per-recipe diff); writes only with `--apply`.
- **`tests/canonicalize-cookware.test.ts`** — covers `forks`→`fork`, merging duplicates, `baking dish`→`oven dish`, `baking sheet`/`sheet pan`→`baking tray`, prose preserved, and idempotence.
- Support: `db:backfill:cookware` mise task + npm script; recipe-api tsconfig `module` `ES2022`→`ESNext` (matching the ingest worker) so the JSON import-attribute typechecks.

The structured equipment list becomes canonical; the prose is untouched because the authored wording is preserved as the cooklang alias.

## Running it

```bash
doppler run --project personal-site --config dev_recipe_api -- \
  mise //workers/recipe-api:db:backfill:cookware            # dry-run
# ... -- --apply   to write
```

## Dry run (dev database)

48 recipes scanned, **6 would change**, 0 skipped:

| Recipe | Change |
| --- | --- |
| `slow-cooker-teriyaki-chicken` | `forks` → `fork` |
| `bruschetta-chicken` | `baking dish` → `oven dish` |
| `buttermilk-cornflake-chicken-burgers` | `tray` → `baking tray` |
| `chicken-gyros-with-tzatziki` | `tin foil` → `foil` (merges with existing `foil`) |
| `piri-piri-chicken-burger` | `tenderizer` → `tenderiser` |
| `breakfast-flatbreads` | `plates` → `plate` |

## Verification

- `mise //workers/recipe-api:typecheck`, `//workers/recipe-ingest:typecheck`, `//packages/recipe-parsing:typecheck`
- `mise //workers/recipe-api:test` (176), `//workers/recipe-ingest:test` (29)
- Biome + knip clean

## Note

The `--apply` run against production data is a manual step, to be run once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardised cookware and ingredient names across recipes for more consistent display and references.
  - Preserved authored aliases where appropriate while updating registered names to their canonical forms.
  - Updated recipe content and cookware lists together, including support for older saved recipes.
  - Prevented duplicate entries caused by alternate spellings, plurals, and recognised aliases.

- **Maintenance**
  - Added a safe preview process for standardising existing recipes, with changes applied only when explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->