### PR TITLE
Add PostHog alerts for recipe services

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -69,7 +69,9 @@ Secrets and config mirrored from Doppler:
       - `dashboard:write`
       - `insight:read`
       - `insight:write`
-    - Used by the PostHog Terraform provider
+      - `logs:read`
+      - `logs:write`
+    - Used by the PostHog Terraform and REST providers
 11. **`POSTHOG_PROJECT_ID`**
     - Find in the PostHog project/environment settings or API URLs
     - Passed as `TF_VAR_posthog_project_id`
@@ -150,10 +152,27 @@ PostHog dashboards and insights are managed in Terraform via the official
 `posthog_resources.json`, with `posthog.tf` converting that data into
 Terraform-managed dashboard and insight resources.
 
+Production log-alert definitions are managed in `posthog_alerts.tf`. PostHog's
+official provider currently supports insight alerts but not the separate Logs
+Alert API, so these use the `Mastercard/restapi` provider until first-class
+support is available. The alerts cover error/fatal logs for `recipe-pages`,
+`recipe-api`, and `recipe-ingest`; application errors recorded on traces also
+emit a correlated error log and are therefore covered by the same alerts.
+
+PostHog log-alert notification destinations are managed in the PostHog UI.
+The API models each Slack, Teams, or webhook destination as a group of internal
+Hog functions and does not expose a stable destination resource that Terraform
+can safely reconcile. After the first apply, attach at least one destination to
+each alert; an alert without a destination records state but sends no
+notification. Editing the alert definition itself in the UI will be reverted
+by Terraform.
+
 ### Managed PostHog Resources
 
 - Existing dashboards in project `123162`
 - Existing insights in project `123162`, including their dashboard attachments
+- Production log alerts for the recipe Pages Function, API Worker, and ingestion
+  Workflow
 
 ### Importing PostHog Resources
 

--- a/infra/posthog_alerts.tf
+++ b/infra/posthog_alerts.tf
@@ -41,7 +41,10 @@ locals {
 resource "restapi_object" "posthog_log_alert" {
   for_each = local.posthog_log_alerts
 
-  path         = "/api/projects/${var.posthog_project_id}/logs/alerts"
+  path         = "/api/projects/${var.posthog_project_id}/logs/alerts/"
+  read_path    = "/api/projects/${var.posthog_project_id}/logs/alerts/{id}/"
+  update_path  = "/api/projects/${var.posthog_project_id}/logs/alerts/{id}/"
+  destroy_path = "/api/projects/${var.posthog_project_id}/logs/alerts/{id}/"
   id_attribute = "id"
   data = jsonencode({
     name    = each.value.name

--- a/infra/posthog_alerts.tf
+++ b/infra/posthog_alerts.tf
@@ -1,0 +1,69 @@
+# PostHog log alerts.
+#
+# Error responses and thrown failures are recorded on spans and emitted as
+# correlated ERROR logs by packages/observability. Alerting on those logs
+# therefore covers the operational failures visible in both Logs and Traces.
+#
+# Thresholds were simulated against the seven days ending 2026-07-29:
+# - recipe-api: one fire for sustained errors
+# - recipe-ingest: one fire for an ingestion failure
+# - recipe-pages: no fires
+
+locals {
+  posthog_log_alerts = {
+    recipe_api_sustained_errors = {
+      name                = "Recipe API sustained errors"
+      service_names       = ["recipe-api"]
+      threshold_count     = 5
+      evaluation_periods  = 3
+      datapoints_to_alarm = 2
+      cooldown_minutes    = 30
+    }
+    recipe_ingest_errors = {
+      name                = "Recipe ingestion errors"
+      service_names       = ["recipe-ingest"]
+      threshold_count     = 0
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      cooldown_minutes    = 30
+    }
+    recipe_pages_errors = {
+      name                = "Recipe Pages errors"
+      service_names       = ["recipe-pages"]
+      threshold_count     = 0
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      cooldown_minutes    = 30
+    }
+  }
+}
+
+resource "restapi_object" "posthog_log_alert" {
+  for_each = local.posthog_log_alerts
+
+  path         = "/api/projects/${var.posthog_project_id}/logs/alerts"
+  id_attribute = "id"
+  data = jsonencode({
+    name    = each.value.name
+    enabled = true
+    filters = {
+      severityLevels = ["error", "fatal"]
+      serviceNames   = each.value.service_names
+    }
+    threshold_count     = each.value.threshold_count
+    threshold_operator  = "above"
+    window_minutes      = 5
+    evaluation_periods  = each.value.evaluation_periods
+    datapoints_to_alarm = each.value.datapoints_to_alarm
+    cooldown_minutes    = each.value.cooldown_minutes
+  })
+
+  # PostHog returns scheduling, state, history, and creator metadata alongside
+  # the managed definition. Ignore only those server-added fields while still
+  # detecting drift in every configured alert field.
+  ignore_server_additions = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/posthog_alerts.tf
+++ b/infra/posthog_alerts.tf
@@ -10,6 +10,9 @@
 # - recipe-pages: no fires
 
 locals {
+  posthog_log_alert_collection_path = "/api/projects/${var.posthog_project_id}/logs/alerts/"
+  posthog_log_alert_item_path       = "${local.posthog_log_alert_collection_path}{id}/"
+
   posthog_log_alerts = {
     recipe_api_sustained_errors = {
       name                = "Recipe API sustained errors"
@@ -41,10 +44,10 @@ locals {
 resource "restapi_object" "posthog_log_alert" {
   for_each = local.posthog_log_alerts
 
-  path         = "/api/projects/${var.posthog_project_id}/logs/alerts/"
-  read_path    = "/api/projects/${var.posthog_project_id}/logs/alerts/{id}/"
-  update_path  = "/api/projects/${var.posthog_project_id}/logs/alerts/{id}/"
-  destroy_path = "/api/projects/${var.posthog_project_id}/logs/alerts/{id}/"
+  path         = local.posthog_log_alert_collection_path
+  read_path    = local.posthog_log_alert_item_path
+  update_path  = local.posthog_log_alert_item_path
+  destroy_path = local.posthog_log_alert_item_path
   id_attribute = "id"
   data = jsonencode({
     name    = each.value.name

--- a/infra/posthog_alerts.tf
+++ b/infra/posthog_alerts.tf
@@ -39,30 +39,34 @@ locals {
       cooldown_minutes    = 30
     }
   }
+
+  posthog_log_alert_payloads = {
+    for key, alert in local.posthog_log_alerts : key => {
+      name    = alert.name
+      enabled = true
+      filters = {
+        severityLevels = ["error", "fatal"]
+        serviceNames   = alert.service_names
+      }
+      threshold_count     = alert.threshold_count
+      threshold_operator  = "above"
+      window_minutes      = 5
+      evaluation_periods  = alert.evaluation_periods
+      datapoints_to_alarm = alert.datapoints_to_alarm
+      cooldown_minutes    = alert.cooldown_minutes
+    }
+  }
 }
 
 resource "restapi_object" "posthog_log_alert" {
-  for_each = local.posthog_log_alerts
+  for_each = local.posthog_log_alert_payloads
 
   path         = local.posthog_log_alert_collection_path
   read_path    = local.posthog_log_alert_item_path
   update_path  = local.posthog_log_alert_item_path
   destroy_path = local.posthog_log_alert_item_path
   id_attribute = "id"
-  data = jsonencode({
-    name    = each.value.name
-    enabled = true
-    filters = {
-      severityLevels = ["error", "fatal"]
-      serviceNames   = each.value.service_names
-    }
-    threshold_count     = each.value.threshold_count
-    threshold_operator  = "above"
-    window_minutes      = 5
-    evaluation_periods  = each.value.evaluation_periods
-    datapoints_to_alarm = each.value.datapoints_to_alarm
-    cooldown_minutes    = each.value.cooldown_minutes
-  })
+  data         = jsonencode(each.value)
 
   # PostHog returns scheduling, state, history, and creator metadata alongside
   # the managed definition. Ignore only those server-added fields while still
@@ -71,5 +75,25 @@ resource "restapi_object" "posthog_log_alert" {
 
   lifecycle {
     prevent_destroy = true
+
+    precondition {
+      condition = (
+        length(trimspace(each.value.name)) > 0 &&
+        length(each.value.filters.serviceNames) > 0 &&
+        alltrue([
+          for service_name in each.value.filters.serviceNames :
+          length(trimspace(service_name)) > 0
+        ]) &&
+        each.value.threshold_count >= 0 &&
+        contains(["above", "below"], each.value.threshold_operator) &&
+        contains([5, 10, 15, 30, 60], each.value.window_minutes) &&
+        each.value.evaluation_periods >= 1 &&
+        each.value.datapoints_to_alarm >= 1 &&
+        each.value.datapoints_to_alarm <= each.value.evaluation_periods &&
+        each.value.cooldown_minutes >= 0
+      )
+
+      error_message = "PostHog log alerts must have valid names, services, thresholds, operators, windows, evaluation periods, datapoints, and cooldowns."
+    }
   }
 }

--- a/infra/scripts/doppler-terraform-env
+++ b/infra/scripts/doppler-terraform-env
@@ -40,6 +40,7 @@ set_if_unset TF_VAR_posthog_project_id "${POSTHOG_PROJECT_ID:-}"
 # POSTHOG_API_KEY is canonical; this fallback can be removed once all Doppler
 # configs have migrated away from POSTHOG_PERSONAL_API_KEY.
 set_if_unset POSTHOG_API_KEY "${POSTHOG_PERSONAL_API_KEY:-}"
+set_if_unset TF_VAR_posthog_api_key "${POSTHOG_API_KEY:-}"
 set_if_unset TF_VAR_recipe_api_preview_origin_template "${RECIPE_API_PREVIEW_ORIGIN_TEMPLATE:-}"
 set_if_unset TF_VAR_recipe_api_url "${RECIPE_API_URL:-}"
 set_if_unset TF_VAR_cf_pages_host "${CF_PAGES_HOST:-}"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -54,6 +54,12 @@ variable "posthog_key" {
   sensitive   = true
 }
 
+variable "posthog_api_key" {
+  description = "PostHog personal API key used to manage resources through Terraform"
+  type        = string
+  sensitive   = true
+}
+
 variable "github_token" {
   description = "GitHub personal access token for mise tool downloads in Cloudflare Pages builds"
   type        = string

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -21,6 +21,10 @@ terraform {
       source  = "PostHog/posthog"
       version = "~> 1.0"
     }
+    restapi = {
+      source  = "Mastercard/restapi"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -36,4 +40,14 @@ provider "posthog" {
   host       = var.posthog_host
   project_id = var.posthog_project_id
   # API key should be provided via POSTHOG_API_KEY.
+}
+
+# The official PostHog provider does not yet expose the newer Logs Alert API.
+# Keep alert definitions in Terraform through a narrowly scoped REST provider
+# until posthog_alert supports log-backed alerts.
+provider "restapi" {
+  uri                  = var.posthog_host
+  bearer_token         = var.posthog_api_key
+  write_returns_object = true
+  update_method        = "PATCH"
 }


### PR DESCRIPTION
## Summary

- manage PostHog Logs Alert definitions for the production recipe Pages Function, API Worker, and ingestion Workflow
- alert on correlated error/fatal logs emitted alongside failed traces
- use a narrowly scoped REST provider because the official PostHog Terraform provider only exposes insight-backed alerts
- document the required personal API key scopes and the one-time notification-destination setup

## Why

Logs and distributed traces are now exported to PostHog, but operational failures did not have alert definitions. These thresholds were back-tested against the seven days ending 2026-07-29:

- `recipe-api`: sustained errors above 5 per five-minute window, firing on two of three evaluations; one simulated fire
- `recipe-ingest`: any error in five minutes; one simulated fire
- `recipe-pages`: any error in five minutes; zero simulated fires

## Impact

The Terraform apply will create three enabled alert definitions with deletion protection. PostHog will track their state immediately. A Slack, Teams, or webhook destination must be attached to each alert once in the PostHog UI because the Logs Alert destination API exposes internal Hog-function groups rather than a stable CRUD resource.

## Validation

- `mise //infra:format`
- `mise //infra:lint`
- `mise //infra:lint:tflint`
- `mise //infra:plan` — 3 to add, 0 to change, 0 to destroy
- `mise //:lint:markdown:check -- infra/README.md`
- `bash -n infra/scripts/doppler-terraform-env`
- pre-commit hooks, including Terraform validation and gitleaks

## QA

No application preview or backend preview is required; this change only affects Terraform-managed PostHog resources. Review the Terraform plan and documentation. Do not apply production infrastructure from the PR preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production log alerts for the recipe API, ingestion workflow and Pages Function.
  * Alerts monitor error and fatal logs, with configurable thresholds and cooldowns.
  * Correlated trace errors are included in relevant log alert coverage.

* **Documentation**
  * Updated infrastructure documentation with PostHog API access requirements and log alert coverage.
  * Documented how alert notification destinations are managed through PostHog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->