### PR TITLE
Cycle active filter chips through their tri-state on tap

### DIFF
--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -60,7 +60,6 @@ interface FilterBarProps {
   stackControls?: boolean;
   activeFilters?: ActiveFilter[];
   onRemoveFilter?: (paramName: string, value: string) => void;
-  /** Advance an active chip's tri-state on tap (include → exclude → off). */
   onCycleFilter?: (paramName: string, value: string) => void;
   onClearAll?: () => void;
   hasActiveFilters?: boolean;

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -257,6 +257,7 @@ export function FilterBar({
             <FilterChip
               key={`${filter.paramName}-${filter.excluded ? "!" : ""}${filter.value}`}
               icon={filter.icon}
+              name={filter.displayValue}
               excluded={filter.excluded}
               onRemove={() => onRemoveFilter?.(filter.paramName, filter.value)}
               onCycle={

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -60,6 +60,8 @@ interface FilterBarProps {
   stackControls?: boolean;
   activeFilters?: ActiveFilter[];
   onRemoveFilter?: (paramName: string, value: string) => void;
+  /** Advance an active chip's tri-state on tap (include → exclude → off). */
+  onCycleFilter?: (paramName: string, value: string) => void;
   onClearAll?: () => void;
   hasActiveFilters?: boolean;
   activeFilterCount?: number;
@@ -79,6 +81,7 @@ export function FilterBar({
   stackControls = false,
   activeFilters = [],
   onRemoveFilter,
+  onCycleFilter,
   onClearAll,
   hasActiveFilters = false,
   activeFilterCount = 0,
@@ -256,6 +259,11 @@ export function FilterBar({
               icon={filter.icon}
               excluded={filter.excluded}
               onRemove={() => onRemoveFilter?.(filter.paramName, filter.value)}
+              onCycle={
+                onCycleFilter
+                  ? () => onCycleFilter(filter.paramName, filter.value)
+                  : undefined
+              }
             >
               {filter.displayValue}
             </FilterChip>

--- a/ui/components/ui/filter-chip.tsx
+++ b/ui/components/ui/filter-chip.tsx
@@ -84,7 +84,7 @@ export function FilterChip({
           disabled={disabled}
           className={cn(
             "flex min-w-0 items-center gap-1.5 rounded-sm transition-colors",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
             disabled ? "cursor-not-allowed" : "cursor-pointer",
           )}
           aria-label={
@@ -105,7 +105,7 @@ export function FilterChip({
         className={cn(
           "rounded-full p-0.5 transition-colors",
           "hover:bg-background/50 focus-visible:bg-background/50",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
           disabled && "cursor-not-allowed",
         )}
         aria-label={`Remove ${name} filter`}

--- a/ui/components/ui/filter-chip.tsx
+++ b/ui/components/ui/filter-chip.tsx
@@ -10,15 +10,10 @@ interface FilterChipProps
   extends Omit<React.ComponentProps<"span">, "onClick">,
     VariantProps<typeof badgeVariants> {
   onRemove: () => void;
-  /**
-   * Advance the value's tri-state when the chip body is activated: an included
-   * chip becomes excluded, an excluded chip turns off. Omit to render a static
-   * chip whose only action is the remove button.
-   */
   onCycle?: () => void;
   icon?: React.ReactNode;
   children: React.ReactNode;
-  /** Plain-text value name for the buttons' accessible labels. */
+  /** Plain-text name for the buttons' accessible labels. */
   name: string;
   disabled?: boolean;
   /** Render as an exclude filter (destructive, struck through, minus glyph). */

--- a/ui/components/ui/filter-chip.tsx
+++ b/ui/components/ui/filter-chip.tsx
@@ -18,6 +18,8 @@ interface FilterChipProps
   onCycle?: () => void;
   icon?: React.ReactNode;
   children: React.ReactNode;
+  /** Plain-text value name for the buttons' accessible labels. */
+  name: string;
   disabled?: boolean;
   /** Render as an exclude filter (destructive, struck through, minus glyph). */
   excluded?: boolean;
@@ -28,6 +30,7 @@ export function FilterChip({
   onCycle,
   icon,
   children,
+  name,
   disabled = false,
   excluded = false,
   variant = "secondary",
@@ -50,7 +53,7 @@ export function FilterChip({
     }
   };
 
-  const label = (
+  const body = (
     <>
       {excluded ? (
         <Minus className="size-3 shrink-0" aria-hidden />
@@ -86,14 +89,14 @@ export function FilterChip({
           )}
           aria-label={
             excluded
-              ? `${children} excluded. Activate to clear this filter.`
-              : `${children} included. Activate to exclude it.`
+              ? `${name} excluded. Activate to clear this filter.`
+              : `${name} included. Activate to exclude it.`
           }
         >
-          {label}
+          {body}
         </button>
       ) : (
-        label
+        body
       )}
       <button
         type="button"
@@ -105,7 +108,7 @@ export function FilterChip({
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
           disabled && "cursor-not-allowed",
         )}
-        aria-label={`Remove ${children} filter`}
+        aria-label={`Remove ${name} filter`}
       >
         <X className="size-3" />
       </button>

--- a/ui/components/ui/filter-chip.tsx
+++ b/ui/components/ui/filter-chip.tsx
@@ -10,6 +10,12 @@ interface FilterChipProps
   extends Omit<React.ComponentProps<"span">, "onClick">,
     VariantProps<typeof badgeVariants> {
   onRemove: () => void;
+  /**
+   * Advance the value's tri-state when the chip body is activated: an included
+   * chip becomes excluded, an excluded chip turns off. Omit to render a static
+   * chip whose only action is the remove button.
+   */
+  onCycle?: () => void;
   icon?: React.ReactNode;
   children: React.ReactNode;
   disabled?: boolean;
@@ -19,6 +25,7 @@ interface FilterChipProps
 
 export function FilterChip({
   onRemove,
+  onCycle,
   icon,
   children,
   disabled = false,
@@ -35,6 +42,28 @@ export function FilterChip({
     }
   };
 
+  const handleCycle = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!disabled) {
+      onCycle?.();
+    }
+  };
+
+  const label = (
+    <>
+      {excluded ? (
+        <Minus className="size-3 shrink-0" aria-hidden />
+      ) : (
+        icon && <span className="shrink-0 [&>svg]:size-3">{icon}</span>
+      )}
+      <span className={cn("truncate", excluded && "line-through")}>
+        {children}
+        {excluded && <span className="sr-only"> (excluded)</span>}
+      </span>
+    </>
+  );
+
   return (
     <Badge
       variant={excluded ? "destructive" : variant}
@@ -45,15 +74,27 @@ export function FilterChip({
       )}
       {...props}
     >
-      {excluded ? (
-        <Minus className="size-3 shrink-0" aria-hidden />
+      {onCycle ? (
+        <button
+          type="button"
+          onClick={handleCycle}
+          disabled={disabled}
+          className={cn(
+            "flex min-w-0 items-center gap-1.5 rounded-sm transition-colors",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            disabled ? "cursor-not-allowed" : "cursor-pointer",
+          )}
+          aria-label={
+            excluded
+              ? `${children} excluded. Activate to clear this filter.`
+              : `${children} included. Activate to exclude it.`
+          }
+        >
+          {label}
+        </button>
       ) : (
-        icon && <span className="shrink-0 [&>svg]:size-3">{icon}</span>
+        label
       )}
-      <span className={cn("truncate", excluded && "line-through")}>
-        {children}
-        {excluded && <span className="sr-only"> (excluded)</span>}
-      </span>
       <button
         type="button"
         onClick={handleRemove}

--- a/ui/components/ui/filterable-card-grid.tsx
+++ b/ui/components/ui/filterable-card-grid.tsx
@@ -128,7 +128,6 @@ export function FilterableCardGrid<T>({
     getSelection,
     getState,
     peekState,
-    cycleValue,
     setValues,
     setState,
     clearFilter,
@@ -314,6 +313,17 @@ export function FilterableCardGrid<T>({
     [pathname],
   );
 
+  const cycleFilter = useCallback(
+    (paramName: string, value: string) => {
+      // peekState, not getState: the reactive read can lag the URL, which would
+      // record an action that doesn't match the state written here.
+      const next = nextFilterState(peekState(paramName, value));
+      captureFilterChange(paramName, value, next);
+      setState(paramName, value, next);
+    },
+    [captureFilterChange, peekState, setState],
+  );
+
   const filterOptions = useMemo(() => {
     if (!filterConfigs) return [];
     return filterConfigs.map((config) => {
@@ -346,24 +356,10 @@ export function FilterableCardGrid<T>({
           icon: option.icon ?? config.icon,
         })),
         getOptionState: (value: string) => getState(config.paramName, value),
-        onCycleOption: (value: string) => {
-          // Derive the analytics action from the same latest read cycleValue
-          // writes from, so the recorded action can't drift from the URL.
-          const next = nextFilterState(peekState(config.paramName, value));
-          captureFilterChange(config.paramName, value, next);
-          cycleValue(config.paramName, value);
-        },
+        onCycleOption: (value: string) => cycleFilter(config.paramName, value),
       };
     });
-  }, [filterOptions, getState, peekState, cycleValue, captureFilterChange]);
-
-  const handleCycleFilter = (paramName: string, value: string) => {
-    // Derive the action from the same latest read the write uses, so analytics
-    // can't drift from the URL (mirrors the mobile drawer's cycle handler).
-    const next = nextFilterState(peekState(paramName, value));
-    captureFilterChange(paramName, value, next);
-    setState(paramName, value, next);
-  };
+  }, [filterOptions, getState, cycleFilter]);
 
   const handleRemoveFilter = (paramName: string, value: string) => {
     captureFilterChange(paramName, value, "off");
@@ -398,7 +394,7 @@ export function FilterableCardGrid<T>({
         stackControls={stackControls}
         activeFilters={activeFilters}
         onRemoveFilter={handleRemoveFilter}
-        onCycleFilter={filterConfigs ? handleCycleFilter : undefined}
+        onCycleFilter={filterConfigs ? cycleFilter : undefined}
         onClearAll={clearAllFilters}
         hasActiveFilters={hasActiveFilters}
         activeFilterCount={activeFilterCount}

--- a/ui/components/ui/filterable-card-grid.tsx
+++ b/ui/components/ui/filterable-card-grid.tsx
@@ -357,6 +357,14 @@ export function FilterableCardGrid<T>({
     });
   }, [filterOptions, getState, peekState, cycleValue, captureFilterChange]);
 
+  const handleCycleFilter = (paramName: string, value: string) => {
+    // Derive the action from the same latest read the write uses, so analytics
+    // can't drift from the URL (mirrors the mobile drawer's cycle handler).
+    const next = nextFilterState(peekState(paramName, value));
+    captureFilterChange(paramName, value, next);
+    setState(paramName, value, next);
+  };
+
   const handleRemoveFilter = (paramName: string, value: string) => {
     captureFilterChange(paramName, value, "off");
     if (filterConfigs) {
@@ -390,6 +398,7 @@ export function FilterableCardGrid<T>({
         stackControls={stackControls}
         activeFilters={activeFilters}
         onRemoveFilter={handleRemoveFilter}
+        onCycleFilter={filterConfigs ? handleCycleFilter : undefined}
         onClearAll={clearAllFilters}
         hasActiveFilters={hasActiveFilters}
         activeFilterCount={activeFilterCount}

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -188,6 +188,30 @@ describe("RecipeList", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("cycles an included active filter chip to excluded", async () => {
+    currentSearchParams = new URLSearchParams("cuisine=Mexican");
+    const user = userEvent.setup();
+
+    render(<RecipeList recipes={recipes} />);
+
+    await user.click(screen.getByRole("button", { name: /Mexican included/i }));
+
+    expect(replaceMock).toHaveBeenCalledWith("/recipes?cuisine=%21Mexican", {
+      scroll: false,
+    });
+  });
+
+  it("clears an excluded active filter chip on the next tap", async () => {
+    currentSearchParams = new URLSearchParams("cuisine=!Mexican");
+    const user = userEvent.setup();
+
+    render(<RecipeList recipes={recipes} />);
+
+    await user.click(screen.getByRole("button", { name: /Mexican excluded/i }));
+
+    expect(replaceMock).toHaveBeenCalledWith("/recipes", { scroll: false });
+  });
+
   it("filters recipes from the inline search field", async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## What

Tapping an active filter chip in the filter bar now advances its tri-state (include → exclude → off) instead of only offering removal, matching the behaviour recipe card badges already have.

- `FilterChip` takes an optional `onCycle`. When provided, the chip's icon + label become a button (the remove `X` stays a separate sibling button, so no nested buttons), and its aria-label names both the current state and the next action: *"Mexican included. Activate to exclude it."* → *"Mexican excluded. Activate to clear this filter."*
- `FilterBar` threads a new optional `onCycleFilter(paramName, value)` through to each chip; chips stay static for consumers that don't pass it.
- `FilterableCardGrid` wires it to `nextFilterState(peekState(...))` + `setState`, capturing the same PostHog `filter_applied` event as the mobile drawer, with the action derived from the same latest read the write uses so analytics can't drift from the URL.

Tapping an included chip makes it excluded (destructive styling, strike-through, minus glyph — all pre-existing); tapping again turns it off and the chip disappears. The `X` still clears in one tap. No exclude toast here, unlike card badges, since the chip stays on screen and acts as its own undo.

This covers the recipe list plus the blog and projects grids, which share `FilterableCardGrid`. The ADR list and experience technology grid render `FilterBar` directly and keep remove-only chips for now; both already hold a cycle function if we want them wired the same way.

## Testing

- `mise //ui:test` — 752 tests pass, including two new `recipe-list` cases asserting `cuisine=Mexican` → `cuisine=!Mexican` → cleared.
- `mise //ui:typecheck` and Biome clean.
- Not confirmed in a real browser locally: the dev server renders the chip and its cycle button in the DOM, but the page never hydrates in my preview tab (the pre-existing remove `X` is equally inert there, and the Cooklang wasm module warns about an unsupported async/await target), so this wants a click-through on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter chips can now cycle through included, excluded and inactive states.
  * Filter bars support cycling active filters across supported filter configurations.
  * Filter interactions keep the filter state and URL in sync during cycling.

* **Bug Fixes**
  * Improved filter-chip accessibility, including focus styling and clearer removal labels.
  * Fixed active filter cycling so analytics and state transitions stay aligned.

* **Tests**
  * Added coverage for cycling cuisine filters and verifying the resulting URL navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->