### PR TITLE
Add home lab project with ADRs and technology entries

### DIFF
--- a/ui/app/(site)/projects/[slug]/page.tsx
+++ b/ui/app/(site)/projects/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { Markdown } from "@/components/markdown";
+import { Mermaid } from "@/components/mermaid";
 import { ADRList } from "@/components/projects/adr-list";
 import { DesignEmbed } from "@/components/projects/design-embed";
 import { ProjectRoleBadge } from "@/components/projects/project-role-badge";
@@ -18,7 +19,7 @@ import {
   type ProjectWithADRs,
 } from "@/lib/api/projects";
 
-const projectComponents = { DesignEmbed };
+const projectComponents = { DesignEmbed, Mermaid };
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/ui/content/projects/homelab/adrs/000-tailscale.mdx
+++ b/ui/content/projects/homelab/adrs/000-tailscale.mdx
@@ -33,9 +33,11 @@ personal devices on a single private tailnet.
 Each node runs the Tailscale client and joins the tailnet; the control plane
 (coordinated through Tailscale's service) handles NAT traversal and hands out
 stable `100.x.y.z` addresses and DNS names. My router stays closed: no inbound
-ports, no dynamic DNS, no port forwarding. Wake-on-LAN on the Asus desktop is
-sent *over* the tailnet from the Mac mini, and the NixOS box trusts the
-`tailscale0` interface in its firewall so SSH and agent traffic just work.
+ports, no dynamic DNS, no port forwarding. Waking the Asus desktop is a
+two-hop affair: the tailnet carries the wake *request* to the Mac mini, which
+then sends the Wake-on-LAN magic packet on the home LAN, because that packet
+is a Layer 2 broadcast and can't route over the tailnet. The NixOS box trusts
+the `tailscale0` interface in its firewall so SSH and agent traffic just work.
 
 # Alternatives
 
@@ -49,12 +51,12 @@ sent *over* the tailnet from the Mac mini, and the NixOS box trusts the
 * **Decision**: Rejected. The lab's goal is boring reliability, not running
   a VPN control plane.
 
-## Tailscale vs. other mesh providers (ZeroTier, Netbird)
+## Other mesh providers (ZeroTier, Netbird)
 
 * **Pros**: ZeroTier and Netbird are viable open-source meshes.
 * **Cons**: Tailscale has the simplest join flow, is built on WireGuard
   (auditable, fast), and has first-class support in NixOS (`services.tailscale.enable`).
-* **Decision**: Accepted. Tailscale wins on ecosystem fit with NixOS and
+* **Decision**: Rejected. Tailscale wins on ecosystem fit with NixOS and
   simplicity.
 
 ## Cloudflare Tunnel / other reverse proxies

--- a/ui/content/projects/homelab/adrs/000-tailscale.mdx
+++ b/ui/content/projects/homelab/adrs/000-tailscale.mdx
@@ -7,23 +7,28 @@ tech_stack: ["Tailscale"]
 
 # Context
 
-The home lab spans several machines in different roles — a Mac mini hub, a
-Raspberry Pi, and an Asus desktop — and I want to reach all of them from any
-of my personal devices (laptops, phones) with no port forwarding, no
-public exposure, and no per-machine VPN configuration. The machines are
-behind a home router doing NAT; some of them are only ever on the tailnet.
+The home lab spans several machines in different roles — an always-on hub, a
+small always-on sidekick, and desktop-class hardware I expect to bring in
+later — and I want to reach all of them from any of my personal devices
+(laptops, phones) with no port forwarding, no public exposure, and no
+per-machine VPN configuration. The machines are behind a home router doing
+NAT; some of them are only ever on the tailnet.
 
 Requirements:
 
 * **No public exposure.** None of the lab services should be reachable from
   the internet. No ports forwarded, no public DNS, no dashboards exposed.
-* **Zero-config joining.** A new node (the NixOS box, a laptop, a phone)
-  should join the network in one command and be reachable by name, not by
+* **Zero-config joining.** A new node (a desktop, a laptop, a phone) should
+  join the network in one command and be reachable by name, not by
   remembering IP addresses.
 * **Survives heterogeneous networks.** The lab has to work from home Wi-Fi,
   mobile data, and other people's networks without reconfiguration.
-* **Name-based addressing.** I want to `ssh robbie@asus-desktop` and open the
-  hub's GUIs by hostname, from anywhere.
+* **Name-based addressing.** I want to `ssh` to any node and open the hub's
+  GUIs by hostname, from anywhere.
+* **Reaching machines that sleep.** I plan to add higher-powered machines
+  that are only used occasionally. Those should sleep when idle rather than
+  burn electricity and make noise around the clock, so the network has to
+  give me a way to wake them on demand from anywhere.
 
 # Decision
 
@@ -33,15 +38,18 @@ personal devices on a single private tailnet.
 Each node runs the Tailscale client and joins the tailnet; the control plane
 (coordinated through Tailscale's service) handles NAT traversal and hands out
 stable `100.x.y.z` addresses and DNS names. My router stays closed: no inbound
-ports, no dynamic DNS, no port forwarding. Waking the
-[planned Asus desktop](/projects/homelab/adrs/010-nixos-gpu-worker) will take
-two hops: the tailnet carries the wake *request* to the Mac mini, which then
-sends the Wake-on-LAN magic packet on the home LAN, because that packet is a
-Layer 2 broadcast and can't route over the tailnet. That box will also put
-`tailscale0` in `networking.firewall.trustedInterfaces`, which accepts *all*
-traffic arriving on that interface — a deliberate choice that makes the
-tailnet itself the security boundary, rather than maintaining per-service
-firewall rules behind it.
+ports, no dynamic DNS, no port forwarding.
+
+Waking a sleeping machine takes two hops, because a Wake-on-LAN magic packet
+is a Layer 2 broadcast and can't route over the tailnet: the tailnet carries
+the wake *request* to an always-on node on the same physical LAN, and that
+node broadcasts the magic packet locally. The always-on hub is what makes
+this work from anywhere.
+
+The tailnet is the lab's trust boundary. Nodes treat traffic arriving over it
+as trusted rather than filtering service by service — the mesh is what keeps
+things private, so anything joining the tailnet is inside the boundary by
+definition.
 
 # Alternatives
 
@@ -59,9 +67,9 @@ firewall rules behind it.
 
 * **Pros**: ZeroTier and Netbird are viable open-source meshes.
 * **Cons**: Tailscale has the simplest join flow, is built on WireGuard
-  (auditable, fast), and has first-class support in NixOS (`services.tailscale.enable`).
-* **Decision**: Rejected. Tailscale wins on ecosystem fit with NixOS and
-  simplicity.
+  (auditable, fast), and is first-class packaged on every operating system
+  the lab runs.
+* **Decision**: Rejected. Tailscale wins on ecosystem fit and simplicity.
 
 ## Cloudflare Tunnel / other reverse proxies
 
@@ -75,13 +83,14 @@ firewall rules behind it.
 
 ### Pros
 
-* **One network for everything**: Mac mini, Pi, Asus desktop, laptop, and
-  phone all reachable by hostname with no port forwarding.
+* **One network for everything**: every lab machine, laptop, and phone
+  reachable by hostname with no port forwarding.
 * **Inspectable from any device**: The entire lab is reachable from any
   machine on the tailnet, which is the point of the project.
-* **NixOS-native**: `services.tailscale.enable = true` in the GPU worker
-  config, with `tailscale0` as a trusted firewall interface.
-* **No public attack surface**: Every dashboard, printer port, and agent
+* **Wake-on-demand stays possible**: machines that sleep to save power and
+  noise can still be woken from anywhere, via a request over the tailnet
+  relayed as a broadcast on the local network.
+* **No public attack surface**: Every dashboard, service port, and agent
   endpoint is tailnet-only.
 
 ### Cons

--- a/ui/content/projects/homelab/adrs/000-tailscale.mdx
+++ b/ui/content/projects/homelab/adrs/000-tailscale.mdx
@@ -33,11 +33,15 @@ personal devices on a single private tailnet.
 Each node runs the Tailscale client and joins the tailnet; the control plane
 (coordinated through Tailscale's service) handles NAT traversal and hands out
 stable `100.x.y.z` addresses and DNS names. My router stays closed: no inbound
-ports, no dynamic DNS, no port forwarding. Waking the Asus desktop is a
-two-hop affair: the tailnet carries the wake *request* to the Mac mini, which
-then sends the Wake-on-LAN magic packet on the home LAN, because that packet
-is a Layer 2 broadcast and can't route over the tailnet. The NixOS box trusts
-the `tailscale0` interface in its firewall so SSH and agent traffic just work.
+ports, no dynamic DNS, no port forwarding. Waking the
+[planned Asus desktop](/projects/homelab/adrs/010-nixos-gpu-worker) will take
+two hops: the tailnet carries the wake *request* to the Mac mini, which then
+sends the Wake-on-LAN magic packet on the home LAN, because that packet is a
+Layer 2 broadcast and can't route over the tailnet. That box will also put
+`tailscale0` in `networking.firewall.trustedInterfaces`, which accepts *all*
+traffic arriving on that interface — a deliberate choice that makes the
+tailnet itself the security boundary, rather than maintaining per-service
+firewall rules behind it.
 
 # Alternatives
 

--- a/ui/content/projects/homelab/adrs/000-tailscale.mdx
+++ b/ui/content/projects/homelab/adrs/000-tailscale.mdx
@@ -1,0 +1,89 @@
+---
+title: "ADR 000: Tailscale"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["Tailscale"]
+---
+
+# Context
+
+The home lab spans several machines in different roles — a Mac mini hub, a
+Raspberry Pi, and an Asus desktop — and I want to reach all of them from any
+of my personal devices (laptops, phones) with no port forwarding, no
+public exposure, and no per-machine VPN configuration. The machines are
+behind a home router doing NAT; some of them are only ever on the tailnet.
+
+Requirements:
+
+* **No public exposure.** None of the lab services should be reachable from
+  the internet. No ports forwarded, no public DNS, no dashboards exposed.
+* **Zero-config joining.** A new node (the NixOS box, a laptop, a phone)
+  should join the network in one command and be reachable by name, not by
+  remembering IP addresses.
+* **Survives heterogeneous networks.** The lab has to work from home Wi-Fi,
+  mobile data, and other people's networks without reconfiguration.
+* **Name-based addressing.** I want to `ssh robbie@asus-desktop` and open the
+  hub's GUIs by hostname, from anywhere.
+
+# Decision
+
+Use **Tailscale**, a WireGuard-based mesh VPN, to overlay all lab nodes and
+personal devices on a single private tailnet.
+
+Each node runs the Tailscale client and joins the tailnet; the control plane
+(coordinated through Tailscale's service) handles NAT traversal and hands out
+stable `100.x.y.z` addresses and DNS names. My router stays closed: no inbound
+ports, no dynamic DNS, no port forwarding. Wake-on-LAN on the Asus desktop is
+sent *over* the tailnet from the Mac mini, and the NixOS box trusts the
+`tailscale0` interface in its firewall so SSH and agent traffic just work.
+
+# Alternatives
+
+## Self-hosted WireGuard + static config
+
+* **Pros**: No third-party coordination service; full control.
+* **Cons**: Manual key exchange and endpoint management on every node, no
+  NAT traversal, painful on changing networks, and it doesn't give me
+  name-based discovery. For a handful of devices it's all maintenance and no
+  benefit.
+* **Decision**: Rejected. The lab's goal is boring reliability, not running
+  a VPN control plane.
+
+## Tailscale vs. other mesh providers (ZeroTier, Netbird)
+
+* **Pros**: ZeroTier and Netbird are viable open-source meshes.
+* **Cons**: Tailscale has the simplest join flow, is built on WireGuard
+  (auditable, fast), and has first-class support in NixOS (`services.tailscale.enable`).
+* **Decision**: Accepted. Tailscale wins on ecosystem fit with NixOS and
+  simplicity.
+
+## Cloudflare Tunnel / other reverse proxies
+
+* **Pros**: Exposes specific HTTP services via the edge.
+* **Cons**: Still creates public surface and requires a domain + access
+  policy per service. The lab services don't need to be public at all.
+* **Decision**: Rejected. A mesh VPN covers every service uniformly without
+  per-service edge configuration.
+
+# Consequences
+
+### Pros
+
+* **One network for everything**: Mac mini, Pi, Asus desktop, laptop, and
+  phone all reachable by hostname with no port forwarding.
+* **Inspectable from any device**: The entire lab is reachable from any
+  machine on the tailnet, which is the point of the project.
+* **NixOS-native**: `services.tailscale.enable = true` in the GPU worker
+  config, with `tailscale0` as a trusted firewall interface.
+* **No public attack surface**: Every dashboard, printer port, and agent
+  endpoint is tailnet-only.
+
+### Cons
+
+* **Third-party control plane**: Node-to-node traffic is end-to-end
+  encrypted, but the coordination service is a dependency. If it's
+  unavailable, existing connections may still work, but new ones can't join.
+* **Dependency on a free-tier account**: The personal tailnet relies on
+  Tailscale's free tier for coordination.
+* **Another credential**: Nodes authenticate to the tailnet, adding one more
+  trust boundary to keep secure.

--- a/ui/content/projects/homelab/adrs/000-tailscale.mdx
+++ b/ui/content/projects/homelab/adrs/000-tailscale.mdx
@@ -37,8 +37,10 @@ personal devices on a single private tailnet.
 
 Each node runs the Tailscale client and joins the tailnet; the control plane
 (coordinated through Tailscale's service) handles NAT traversal and hands out
-stable `100.x.y.z` addresses and DNS names. My router stays closed: no inbound
-ports, no dynamic DNS, no port forwarding.
+stable `100.x.y.z` addresses. MagicDNS resolves those to short device names,
+which is what makes the name-based access above work — I reach nodes as
+`hostname`, never as an IP. My router stays closed: no inbound ports, no
+dynamic DNS, no port forwarding.
 
 Waking a sleeping machine takes two hops, because a Wake-on-LAN magic packet
 is a Layer 2 broadcast and can't route over the tailnet: the tailnet carries

--- a/ui/content/projects/homelab/adrs/001-adguard-home.mdx
+++ b/ui/content/projects/homelab/adrs/001-adguard-home.mdx
@@ -1,0 +1,112 @@
+---
+title: "ADR 001: AdGuard Home for DNS"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["AdGuard Home"]
+---
+
+# Context
+
+Every device on my home network — phones, laptops, TVs, and streaming boxes —
+was sending DNS lookups through the router's upstream, with embedded trackers
+phoning home to advertisers and analytics vendors on every device. There was
+no network-wide way to stop that. I want network-wide ad and tracker blocking
+applied at the DNS layer.
+
+Running a local resolver adds a dependency: if the resolver is down, every
+device on the network loses DNS. So resilience is a requirement from the
+start, not an afterthought.
+
+Requirements:
+
+* **Network-wide filtering.** Blocking must apply to every device on the
+  LAN regardless of what it's running. Per-device ad blockers don't cover the
+  IoT and streaming boxes.
+* **Resilient resolution.** DNS is a single point of failure for the whole
+  house — if the resolver is down, the internet "is down". There must be no
+  single box whose failure takes the network with it.
+* **Self-hosted.** No external DNS proxy or commercial filtering service
+  sitting between me and my lookups.
+* **Configurable from a web UI**, with block stats I can actually read.
+
+# Decision
+
+Run **AdGuard Home** as the local, network-wide DNS filter, deployed in a
+redundant pair: the Mac mini is the primary resolver my home router points
+at, and the Raspberry Pi is the secondary resolver the router also points at.
+If one box is down — e.g. during a reboot — the other keeps the home network
+functioning.
+
+The two instances stay in sync with **AdGuardHome-Sync**
+([bakito/adguardhome-sync](https://github.com/bakito/adguardhome-sync)),
+which runs on a schedule and replicates filters, rewrites, and settings from
+the primary to the replica. Config is maintained in one place; the Pi mirrors
+it automatically.
+
+Because the nodes are on the [Tailscale tailnet](/projects/homelab/adrs/000-tailscale),
+AdGuard Home's DNS is reachable off the home network too: the phone can point
+at the tailnet resolver while on cellular or any other network, so tracking
+and ad blocking follow the device wherever it goes — coverage a
+router-level setup can't provide.
+
+The result has been remarkable: AdGuard Home blocks roughly **33% of all
+requests** over my home network. That's a third of the queries my devices
+were making to trackers and ad servers.
+
+# Alternatives
+
+## Pi-hole
+
+* **Pros**: The best-known self-hosted DNS blocker, huge community, battle-tested.
+* **Cons**: Slightly more assembly required (the famous DHCP+adblocking
+  combo needs a web server and extra packages). On a Pi it does the same job
+  with the same result.
+* **Decision**: Rejected. AdGuard Home was picked for its easier install, a
+  friendlier admin UI, and built-in DoH/DoT upstream support — the practical
+  difference on my network is marginal.
+
+## Router-integrated filtering (e.g. OpenWrt adblock)
+
+* **Pros**: No extra hardware; filtering lives in the router.
+* **Cons**: Ties blocking to the router's lifecycle and firmware, and my
+  router doesn't run OpenWrt. Locks filtering into whatever the router does.
+* **Decision**: Rejected. Keeping DNS filtering on dedicated boxes decouples
+  it from router upgrades and lets me move it between hardware freely.
+
+## Commercial DNS filtering (e.g. NextDNS, Cloudflare 1.1.1.1)
+
+* **Pros**: Zero maintenance, managed dashboards.
+* **Cons**: DNS lookups (and their filtering) become a privacy dependency on
+  a third party; I want the data about my own network's DNS to stay mine.
+* **Decision**: Rejected. Self-hosting was the point — this ADR exists
+  partly because of the privacy motivation.
+
+# Consequences
+
+### Pros
+
+* **Privacy win**: A third of network DNS traffic was tracking — now blocked
+  at the source, including on devices I can't install anything on.
+* **Resilience**: Two independent DNS nodes on separate hardware; router
+  fails over automatically.
+* **Self-hosted and transparent**: Full logs and block stats in the AdGuard
+  Home UI, on hardware I own.
+* **Portable filtering**: the tailnet resolver means blocking follows the
+  phone off the home network, onto cellular or any other Wi-Fi.
+* **Single config to maintain**: AdGuardHome-Sync keeps both instances in
+  sync, so filters and settings are managed once rather than twice.
+
+### Cons
+
+* **Another service to maintain**: Two AdGuard Home instances to keep
+  updated. AdGuardHome-Sync keeps their configs in sync automatically, but
+  it's still one more tool that has to run.
+* **Blocklist churn to manage**: Legit domains can get caught by blocklists
+  and need occasional allowlisting, and new tracker domains keep appearing
+  and need adding to the block list as things change.
+* **DNS is critical infrastructure now**: If both boxes are down, the whole
+  network loses resolution. The redundant pair covers any single-box
+  failure — but a total outage also takes out Netdata's path to Slack, since
+  Netdata runs on the same boxes and DNS is needed to reach it. In that
+  scenario nothing alerts; the failure is noticed when the network doesn't
+  work.

--- a/ui/content/projects/homelab/adrs/001-adguard-home.mdx
+++ b/ui/content/projects/homelab/adrs/001-adguard-home.mdx
@@ -106,7 +106,6 @@ were making to trackers and ad servers.
   and need adding to the block list as things change.
 * **DNS is critical infrastructure now**: If both boxes are down, the whole
   network loses resolution. The redundant pair covers any single-box
-  failure — but a total outage also takes out Netdata's path to Slack, since
-  Netdata runs on the same boxes and DNS is needed to reach it. In that
-  scenario nothing alerts; the failure is noticed when the network doesn't
-  work.
+  failure, but a total outage is self-concealing — anything that would tell
+  me about it needs DNS to reach the outside world too. In that scenario the
+  failure is noticed when the network stops working.

--- a/ui/content/projects/homelab/adrs/002-claude-code.mdx
+++ b/ui/content/projects/homelab/adrs/002-claude-code.mdx
@@ -1,0 +1,9 @@
+---
+inherits_from: "personal-site:012-claude-code"
+---
+
+The Mac mini is the always-on host for Claude Code, so sessions can run
+continuously and be driven remotely over the tailnet. All the context from
+the source decision — deep reasoning, repository-wide changes, autonomous
+iteration — carries over; the home lab just provides the persistent execution
+environment that makes those properties useful from a phone.

--- a/ui/content/projects/homelab/adrs/003-codex.mdx
+++ b/ui/content/projects/homelab/adrs/003-codex.mdx
@@ -1,0 +1,10 @@
+---
+inherits_from: "personal-site:043-codex"
+---
+
+The home hub holds two distinct Codex subscriptions, each with its own
+allowance. The hub provides the connected host that Codex mobile remote work
+needs, and — as the source ADR notes — a persistent local environment beats
+re-bootstrapping a fresh cloud one. The same least-privilege and sandboxing
+discipline from the source decision applies doubly here, because the hub also
+holds personal photos and the backup drive.

--- a/ui/content/projects/homelab/adrs/004-grok-build.mdx
+++ b/ui/content/projects/homelab/adrs/004-grok-build.mdx
@@ -31,8 +31,9 @@ For the hub, what matters is:
 Install **Grok Build** on the Mac mini alongside Claude Code, Codex, and
 opencode.
 
-Grok Build runs as the `grok` CLI (`curl -fsSL https://x.ai/cli/install.sh |
-bash`), authenticates with an xAI/SuperGrok account, and is available both as
+Grok Build runs as the `grok` CLI, installed per
+[xAI's official instructions](https://x.ai/cli), authenticates with an
+xAI/SuperGrok account, and is available both as
 an interactive agent and headless (`grok -p`) for scripted jobs. Managed from
 the same orchestration surface as the other agents, its sessions, diffs, and
 PR workflow live in the same mobile-friendly place, and its allowance stays

--- a/ui/content/projects/homelab/adrs/004-grok-build.mdx
+++ b/ui/content/projects/homelab/adrs/004-grok-build.mdx
@@ -28,8 +28,7 @@ For the hub, what matters is:
 
 # Decision
 
-Install **Grok Build** on the Mac mini alongside Claude Code, Codex, and
-opencode.
+Install **Grok Build** on the Mac mini alongside Claude Code and Codex.
 
 Grok Build runs as the `grok` CLI, installed per
 [xAI's official instructions](https://x.ai/cli), authenticates with an

--- a/ui/content/projects/homelab/adrs/004-grok-build.mdx
+++ b/ui/content/projects/homelab/adrs/004-grok-build.mdx
@@ -1,0 +1,84 @@
+---
+title: "ADR 004: Grok Build"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["Grok Build"]
+---
+
+# Context
+
+The hub hosts multiple coding agents so I have independent usage allowances
+and model diversity ([Claude Code](/projects/homelab/adrs/002-claude-code)
+and [Codex](/projects/homelab/adrs/003-codex) are already accepted). Grok's
+models are a meaningful third model family, and Grok Build is xAI's terminal
+coding agent: a full-screen TUI with a plan mode, parallel subagents, skills,
+plugins, hooks, MCP servers, and a headless `-p` mode for scripts.
+
+For the hub, what matters is:
+
+* **A different model family with its own subscription.** Using Claude,
+  OpenAI, *and* Grok spreads the availability and pricing risk across three
+  providers rather than two.
+* **Extensibility.** AGENTS.md, plugins, hooks, and MCP servers work out of
+  the box, so it slots into the same agent conventions as the rest of the
+  stack.
+* **Fits the orchestration layer.** Like the other agents, it should be
+  runnable from the single orchestration surface rather than only as a
+  standalone TUI.
+
+# Decision
+
+Install **Grok Build** on the Mac mini alongside Claude Code, Codex, and
+opencode.
+
+Grok Build runs as the `grok` CLI (`curl -fsSL https://x.ai/cli/install.sh |
+bash`), authenticates with an xAI/SuperGrok account, and is available both as
+an interactive agent and headless (`grok -p`) for scripted jobs. Managed from
+the same orchestration surface as the other agents, its sessions, diffs, and
+PR workflow live in the same mobile-friendly place, and its allowance stays
+independent of Claude and OpenAI.
+
+# Alternatives
+
+## Skip Grok; stay on two providers
+
+* **Pros**: Two agents already give redundancy; less to install and maintain.
+* **Cons**: Leaves the third major model family unused. If both Claude and
+  OpenAI are constrained at once, there's no third fallback.
+* **Decision**: Rejected. Provider diversity is the stated resilience
+  strategy; Grok Build adds it cheaply since the hub already exists.
+
+## Use Grok only via the API from another tool
+
+* **Pros**: No separate agent to manage.
+* **Cons**: Loses Grok Build's agent harness (skills, plugins, subagents,
+  worktrees) and adds per-token cost instead of using a subscription.
+* **Decision**: Rejected. The standalone agent is free to run against my
+  existing subscription.
+
+## Grok Build as the primary agent
+
+* **Pros**: One agent to learn deeply.
+* **Cons**: Concentrates workflow on a beta product and one provider;
+  contradicts the multi-agent resilience goal.
+* **Decision**: Rejected. Grok Build is a complement, not a replacement.
+
+# Consequences
+
+### Pros
+
+* **Third independent provider** for agent work, with its own allowance and
+  reset cadence.
+* **Different reasoning model** — route work to whichever agent handles it
+  best.
+* **Fits the existing conventions** (AGENTS.md, MCP, plugins) and is driven
+  from the same surface as the rest.
+* **Open source** since July 2026, with the freedom to point it at any
+  model provider rather than being locked to xAI's.
+
+### Cons
+
+* **Another agent to authenticate and update.**
+* **Early-beta risk**: Grok Build's harness is younger than Claude Code's.
+* **xAI dependency**: availability and pricing of Grok models are outside my
+  control.

--- a/ui/content/projects/homelab/adrs/005-opencode.mdx
+++ b/ui/content/projects/homelab/adrs/005-opencode.mdx
@@ -49,7 +49,7 @@ through whichever provider serves them.
 * **Pros**: Aider and Continue are mature, well-known open-source options.
 * **Cons**: opencode's model-agnostic design and clean `AGENTS.md`-style
   conventions fit the hub best.
-* **Decision**: Accepted. opencode is the orchestrator-friendly choice.
+* **Decision**: Rejected. opencode is the orchestrator-friendly choice.
 
 ## No open-source agent; rely on the three commercial ones
 

--- a/ui/content/projects/homelab/adrs/005-opencode.mdx
+++ b/ui/content/projects/homelab/adrs/005-opencode.mdx
@@ -1,0 +1,79 @@
+---
+title: "ADR 005: opencode"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["opencode"]
+---
+
+# Context
+
+The hub's agent lineup is Claude Code, Codex, and Grok Build — three
+proprietary agents, each tied to a commercial model family and subscription.
+I want at least one open-source agent in the mix for the same reasons the
+rest of the lab is built on open tooling: no account dependency, no per-token
+surprise, and the freedom to point it at any model.
+
+opencode is an open-source, terminal-based agent that is intentionally
+model-agnostic — it can run against API providers or any OpenAI-compatible
+endpoint. That's what matters here, because open weight is how you get to the
+interesting models:
+
+* **Free model access.** Providers such as DeepSeek (and Big Pickle) offer
+  genuinely capable models at no cost, which a subscription-only lineup can't
+  touch.
+* **Open-weight frontier models as they land.** New frontier open-weight
+  releases (e.g. Kimi K3) become usable through third-party providers without
+  waiting for a commercial agent vendor to wire them in.
+
+To be clear: I'm **not** planning to self-host models. Open weight is a good
+direction, but local inference isn't — self-hostable models are too small and
+weak, and the frontier open-weight models (Kimi K3 reportedly needs on the
+order of $2M of GPUs to serve a single instance) are only runnable by
+third-party providers anyway. Open weight means provider competition, not a
+box in my house.
+
+# Decision
+
+Install **opencode** on the Mac mini alongside the proprietary agents.
+
+opencode provides the model-agnostic fallback: if a provider's allowance is
+exhausted or its pricing changes, opencode can be pointed at a different
+model without changing the tool. It's also the way to use free and
+open-weight models — DeepSeek, Big Pickle, Kimi K3, whatever comes next —
+through whichever provider serves them.
+
+# Alternatives
+
+## Open source agents other than opencode (Aider, Continue)
+
+* **Pros**: Aider and Continue are mature, well-known open-source options.
+* **Cons**: opencode's model-agnostic design and clean `AGENTS.md`-style
+  conventions fit the hub best.
+* **Decision**: Accepted. opencode is the orchestrator-friendly choice.
+
+## No open-source agent; rely on the three commercial ones
+
+* **Pros**: Fewer tools to maintain.
+* **Cons**: Leaves no model-agnostic fallback; all agent capacity depends on
+  commercial accounts.
+* **Decision**: Rejected. The open-source slot is deliberate — it's the
+  resilience fallback for the whole agent stack.
+
+# Consequences
+
+### Pros
+
+* **Model-agnostic fallback**: works against any OpenAI-compatible endpoint.
+* **Free and open-weight models**: DeepSeek, Big Pickle, and frontier
+  open-weight releases like Kimi K3 are a few lines of config away, through
+  third-party providers.
+* **Open source**: no account dependency, inspectable, and free.
+* **Complements the commercial agents** as the fourth in the lineup, all
+  driven from the same orchestration surface.
+
+### Cons
+
+* **Younger ecosystem**: fewer battle-tested integrations than Claude Code.
+* **Another tool to configure and keep updated.**
+* **Not the primary agent**: by design it's the fallback, so it gets less
+  real-world exercise than the commercial agents.

--- a/ui/content/projects/homelab/adrs/006-t3-code.mdx
+++ b/ui/content/projects/homelab/adrs/006-t3-code.mdx
@@ -106,7 +106,8 @@ best-fitting one per task.
 
 * **New orchestration dependency**: t3-code is young; the provider landscape
   it wraps changes quickly.
-* **Host availability**: remote sessions depend on the Mac mini staying up
-  (which it's designed to do, and which Netdata monitors).
+* **Host availability**: remote sessions depend on the Mac mini staying up,
+  which is exactly what an always-on hub is for — but it does make the hub a
+  single point of failure for all agent work.
 * **Configuration surface**: agent auth, t3-code pairing, and the tailnet
   binding all need to be kept working together.

--- a/ui/content/projects/homelab/adrs/006-t3-code.mdx
+++ b/ui/content/projects/homelab/adrs/006-t3-code.mdx
@@ -1,0 +1,112 @@
+---
+title: "ADR 006: t3-code as the agent orchestrator"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["t3-code"]
+---
+
+# Context
+
+The Mac mini's primary use case is remote, mobile-friendly, agentic
+development. It hosts four coding agents — [Claude Code](/projects/homelab/adrs/002-claude-code),
+[Codex](/projects/homelab/adrs/003-codex) (two subscriptions),
+[Grok Build](/projects/homelab/adrs/004-grok-build), and
+[opencode](/projects/homelab/adrs/005-opencode) — and I want to drive them
+from a phone over the tailnet without juggling four different CLIs or web
+UIs.
+
+The agents themselves are already covered by earlier decisions — Claude Code
+[inherited](/projects/homelab/adrs/002-claude-code) from `personal-site:012-claude-code`,
+Codex [inherited](/projects/homelab/adrs/003-codex) from `personal-site:043-codex`,
+plus [Grok Build](/projects/homelab/adrs/004-grok-build) and
+[opencode](/projects/homelab/adrs/005-opencode). This ADR is about the
+*orchestration layer* that runs them all from one surface, and specifically
+about hosting it on the always-on hub.
+
+Requirements:
+
+* **One surface, many agents.** A single GUI that can start a session on any
+  of the four agents with a model/tool choice, preserving thread and project
+  context across them.
+* **Bring your own subscription.** It must not resell tokens or require its
+  own API keys — it wires in the credentials and plans I already pay for
+  (including both distinct Codex subscriptions, each keeping its own
+  allowance).
+* **Mobile-friendly and remote.** It has to be usable from a phone over the
+  tailnet, which means a web surface backed by a headless server on the hub,
+  not a terminal on my laptop.
+* **Git-native workflow.** Agents write to their own branches; committing,
+  pushing, and opening PRs should be one button.
+
+# Decision
+
+Use **t3-code** as the open-source GUI/orchestrator for my coding agents,
+hosted on the Mac mini.
+
+t3-code runs as a Node.js server wrapping the agent backends (it starts
+`codex app-server` per session and can connect to the other agents), serves a
+web UI, and exposes a headless `t3 serve` mode bound to the tailnet IP. That
+headless mode is what makes the phone workflow work: `t3 serve --host
+"$(tailscale ip -4)"` lets me pair a phone or the desktop app to the hub's
+server, scan a QR code, and drive real agent sessions with the repos,
+credentials, and tools already prepared on the Mac mini.
+
+Each of the two Codex subscriptions is its own account; t3-code manages them
+as separate providers so I can draw down each plan's allowance and pick the
+best-fitting one per task.
+
+# Alternatives
+
+## Use each agent's own CLI/web UI, no orchestrator
+
+* **Pros**: No extra layer to maintain.
+* **Cons**: t3-code doesn't interfere with the agent harnesses — it drives
+  the same CLIs directly, so the agents are just as capable either way; the
+  difference is the surface. Without an orchestrator there are four different
+  UIs, four sets of shortcuts and mental models, and no shared thread or
+  project context. I used the Claude and Codex apps from mobile for a while,
+  and t3-code is a far better UX for juggling multiple sessions and
+  coordinating work on GitHub — and Codex required a user-provided machine
+  to run on anyway before remote development environments existed.
+* **Decision**: Rejected. The orchestrator is a coordinator, not a
+  replacement for the agents.
+
+## Write my own orchestrator / web shell
+
+* **Pros**: Full control, exactly my workflow.
+* **Cons**: Rebuilds what t3-code already does (session management, provider
+  switching, diff viewing, PR workflow, remote pairing) for zero marginal
+  benefit.
+* **Decision**: Rejected. t3-code is open source (MIT) and forkable — if it
+  doesn't do something, I extend it rather than reimplement it.
+
+## Only run hosted cloud agent environments
+
+* **Pros**: No host to keep alive.
+* **Cons**: Fresh environments re-bootstrap dependencies and context each
+  time; I'd lose the prepped repos and credentials on the hub. Also doesn't
+  help with the two Codex subscriptions I already pay for.
+* **Decision**: Rejected. The hub's existing environment is the value.
+
+# Consequences
+
+### Pros
+
+* **One mobile surface for all agent work**, over the tailnet, from the
+  sofa.
+* **Both Codex subscriptions managed as separate providers**, each keeping
+  its own allowance.
+* **BYOK economics**: no extra token reseller; my existing subscriptions
+  power everything.
+* **Git-native**: one-click commit, push, and PR per agent thread.
+* **Open source and forkable**: it's infrastructure I can own, like the rest
+  of the lab.
+
+### Cons
+
+* **New orchestration dependency**: t3-code is young; the provider landscape
+  it wraps changes quickly.
+* **Host availability**: remote sessions depend on the Mac mini staying up
+  (which it's designed to do, and which Netdata monitors).
+* **Configuration surface**: agent auth, t3-code pairing, and the tailnet
+  binding all need to be kept working together.

--- a/ui/content/projects/homelab/adrs/007-ente-photo-backup.mdx
+++ b/ui/content/projects/homelab/adrs/007-ente-photo-backup.mdx
@@ -29,9 +29,9 @@ which stays in Ente's cloud — down on a schedule into the backup drive. The
 drive is
 formatted as a straightforward filesystem layout (not a proprietary archive)
 so the photos remain readable by normal tools even if every Ente tool
-disappears. Netdata monitors the sync job and alerts Slack if it fails or the
-drive fills up, so a silent failure is caught instead of discovered months
-later.
+disappears. A backup that fails quietly is barely better than no backup, so
+the sync has to be watched and has to raise an alarm on failure or a full
+drive — a pipeline to monitor, not a script to forget.
 
 The Mac mini is the right owner for this: it's always on, and it already
 hosts the backup drive. That does mean sharing a box with the
@@ -71,8 +71,8 @@ least-privilege rules tight around the photo library and backup drive.
 ### Pros
 
 * **An offline copy I own**: photos are no longer hostage to one vendor.
-* **Automated and monitored**: the sync runs on a schedule; failures page
-  Slack.
+* **Automated and observable**: the sync runs on a schedule and is built to
+  surface its failures rather than swallow them.
 * **Plain files on disk**: readable with normal tools, no proprietary lock-in.
 
 ### Cons

--- a/ui/content/projects/homelab/adrs/007-ente-photo-backup.mdx
+++ b/ui/content/projects/homelab/adrs/007-ente-photo-backup.mdx
@@ -24,8 +24,9 @@ script I have to remember to run.
 Connect the Mac mini to **Ente** and run regular syncs from it down to the
 connected 10TB HDD.
 
-Ente's server can be self-hosted and the CLI supports export/backup flows, so
-the hub can pull the library on a schedule into the backup drive. The drive is
+Ente's CLI supports export/backup flows, so the hub can pull the library —
+which stays in Ente's cloud — down on a schedule into the backup drive. The
+drive is
 formatted as a straightforward filesystem layout (not a proprietary archive)
 so the photos remain readable by normal tools even if every Ente tool
 disappears. Netdata monitors the sync job and alerts Slack if it fails or the

--- a/ui/content/projects/homelab/adrs/007-ente-photo-backup.mdx
+++ b/ui/content/projects/homelab/adrs/007-ente-photo-backup.mdx
@@ -1,0 +1,83 @@
+---
+title: "ADR 007: Ente for photo backup"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["Ente"]
+---
+
+# Context
+
+My photo library lives in the cloud with Ente, an end-to-end encrypted photo
+provider. Ente already replicates the library across three cloud providers
+and it doubles as the sync mechanism between my devices. What it doesn't
+provide is a copy I own: if the service ever goes down or stops being a
+workable option, years of family photos live only behind someone else's
+decisions.
+
+I want a regular, automated sync from Ente down to a local 10TB HDD connected
+to the Mac mini — an offline backup I own. Manual syncing has already proven
+itself painful, so this must be a monitored, repeatable pipeline, not a
+script I have to remember to run.
+
+# Decision
+
+Connect the Mac mini to **Ente** and run regular syncs from it down to the
+connected 10TB HDD.
+
+Ente's server can be self-hosted and the CLI supports export/backup flows, so
+the hub can pull the library on a schedule into the backup drive. The drive is
+formatted as a straightforward filesystem layout (not a proprietary archive)
+so the photos remain readable by normal tools even if every Ente tool
+disappears. Netdata monitors the sync job and alerts Slack if it fails or the
+drive fills up, so a silent failure is caught instead of discovered months
+later.
+
+The Mac mini is the right owner for this: it's always on, and it already
+hosts the backup drive. That does mean sharing a box with the
+[agent stack](/projects/homelab/adrs/006-t3-code), which is a risk rather
+than a benefit — the Codex decision flags it as the reason to keep
+least-privilege rules tight around the photo library and backup drive.
+
+# Alternatives
+
+## Rely on Ente's cloud redundancy alone
+
+* **Pros**: Zero effort; the provider already replicates data across three
+  clouds.
+* **Cons**: Still a single vendor. Ente's redundancy protects against its
+  own infrastructure failures but not against the service being unavailable
+  or unusable from my side. "The cloud is the backup" is not a backup I own.
+* **Decision**: Rejected. The whole point of this ADR is owning a copy I
+  control.
+
+## Full manual export on a schedule
+
+* **Pros**: No tooling.
+* **Cons**: Exactly the painful, forgettable workflow this lab exists to
+  eliminate.
+* **Decision**: Rejected. Automate or it won't happen.
+
+## Different local backup target (e.g. NAS, cold storage)
+
+* **Pros**: NAS gives redundancy and network access.
+* **Cons**: More hardware and more complexity than the existing 10TB drive;
+  cold storage adds retrieval friction.
+* **Decision**: Deferred. The 10TB HDD covers the need today. A NAS or
+  offsite copy is on the [future direction](/projects/homelab#future-direction) list.
+
+# Consequences
+
+### Pros
+
+* **An offline copy I own**: photos are no longer hostage to one vendor.
+* **Automated and monitored**: the sync runs on a schedule; failures page
+  Slack.
+* **Plain files on disk**: readable with normal tools, no proprietary lock-in.
+
+### Cons
+
+* **Local storage dependency**: the 10TB drive is a single physical disk —
+  a NAS or offsite copy would close that gap.
+* **Sync pipeline to maintain**: Ente's CLI/export paths can change.
+* **Privacy boundary to respect**: the photo library and backup drive must
+  stay out of agent permission profiles on the same host.

--- a/ui/content/projects/homelab/adrs/008-dvc.mdx
+++ b/ui/content/projects/homelab/adrs/008-dvc.mdx
@@ -2,9 +2,9 @@
 inherits_from: "recipe-site:029-dvc"
 ---
 
-Applied to the GPU worker: the 1TB HDD on the Asus desktop holds local copies
-of datasets as a DVC remote, so batch CV jobs run against a local cache
-instead of re-pulling over the network each time. The same principles —
+Applied to the lab: whichever machine runs batch jobs keeps local copies of
+datasets on its own disk as a DVC remote, so those jobs read from a local
+cache instead of re-pulling over the network each time. The same principles —
 dataset hashes pinned to git commits, stage caching via `dvc repro`, and
 metrics surfaced in PRs — govern how datasets are managed across the ML
 pipelines (`ml-pipelines/recipe-parsing/`).

--- a/ui/content/projects/homelab/adrs/008-dvc.mdx
+++ b/ui/content/projects/homelab/adrs/008-dvc.mdx
@@ -1,0 +1,10 @@
+---
+inherits_from: "recipe-site:029-dvc"
+---
+
+Applied to the GPU worker: the 1TB HDD on the Asus desktop holds local copies
+of datasets as a DVC remote, so batch CV jobs run against a local cache
+instead of re-pulling over the network each time. The same principles —
+dataset hashes pinned to git commits, stage caching via `dvc repro`, and
+metrics surfaced in PRs — govern how datasets are managed across the ML
+pipelines (`ml-pipelines/recipe-parsing/`).

--- a/ui/content/projects/homelab/adrs/009-netdata.mdx
+++ b/ui/content/projects/homelab/adrs/009-netdata.mdx
@@ -1,0 +1,80 @@
+---
+title: "ADR 009: Netdata for monitoring"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["Netdata"]
+---
+
+# Context
+
+The lab's two core workloads — photo backup and agent hosting — both depend
+on the Mac mini being up and healthy, and DNS (AdGuard Home) depends on both
+the Mac mini and the Raspberry Pi. I want to know about problems *before*
+they matter: a dead hub, a full backup drive, or a Pi overheating. Waiting to
+notice manually is how failures slip through — and a backup that fails
+quietly just means the library quietly isn't being backed up.
+
+I already use Slack for ops notifications (the recipe site's
+[PostHog alerting](/projects/recipe-site/adrs/063-posthog-alerting-and-slack)
+was the first link), so alerts should land in my personal Slack workspace.
+
+Requirements:
+
+* **Low-friction install** on both the Mac mini and the Pi.
+* **Hub-and-spoke collection**: the Pi exports its metrics to the Mac mini
+  as the central point, so there's one place to look.
+* **Slack delivery**: alert on anything going wrong — host down, disk full,
+  temperature too high — via a Slack app.
+* **Real-time**, not batch polling.
+
+# Decision
+
+Install **Netdata** on the Mac mini and the Raspberry Pi, with the Pi
+exporting to the Mac mini as the main hub. A Slack app in my personal
+workspace receives alerts: anything going wrong on the Mac mini, and on the
+Pi, notably if its temperature climbs too high.
+
+# Alternatives
+
+## Prometheus + Grafana
+
+* **Pros**: The industry-standard stack; extremely flexible.
+* **Cons**: Heavier to operate (scrapers, TSDB, dashboards, alert rules)
+  than a two-node home lab needs. I'd rather spend effort on the lab itself
+  than on maintaining an observability platform.
+* **Decision**: Rejected. Netdata gives real-time metrics and alerts with a
+  fraction of the operations burden.
+
+## Uptime checks / pinging only
+
+* **Pros**: Simple.
+* **Cons**: Tells me a host is down but nothing about *why* — disk full,
+  overheating, or memory pressure happen before a host dies.
+* **Decision**: Rejected. I need the metrics, not just the outage.
+
+## Vendor monitoring (e.g. a cloud SaaS agent)
+
+* **Pros**: Zero maintenance.
+* **Cons**: Sends my home infrastructure telemetry to a third party and
+  costs money at the scale of a whole home network.
+* **Decision**: Rejected. Monitoring the privacy box should itself stay
+  private.
+
+# Consequences
+
+### Pros
+
+* **Early warning on the critical path**: DNS, backup, and agent-hosting
+  health all monitored.
+* **One place to look**: the Pi's metrics flow to the hub.
+* **Slack as the single alert surface**, consistent with how I already
+  operate.
+* **Self-hosted and private** telemetry.
+
+### Cons
+
+* **Another always-on service** to keep updated on both boxes.
+* **Alert noise**: thresholds need tuning (temperature alerts especially) to
+  avoid paging Slack for nothing.
+* **Hub dependency**: if the Mac mini is down, the Pi's central export
+  destination is down too — the Pi must still alarm independently.

--- a/ui/content/projects/homelab/adrs/009-netdata.mdx
+++ b/ui/content/projects/homelab/adrs/009-netdata.mdx
@@ -31,8 +31,30 @@ Requirements:
 
 Install **Netdata** on the Mac mini and the Raspberry Pi, with the Pi
 exporting to the Mac mini as the main hub. A Slack app in my personal
-workspace receives alerts: anything going wrong on the Mac mini, and on the
-Pi, notably if its temperature climbs too high.
+workspace receives the alerts.
+
+What it watches, and why each earns its place:
+
+* **Host health on both boxes.** A dead Mac mini takes the agent stack and
+  the photo backup down with it; a dead Pi takes the fallback resolver and
+  the print server.
+* **The photo backup sync.** The
+  [Ente pipeline](/projects/homelab/adrs/007-ente-photo-backup) is the job
+  that most needs watching, because a sync failing quietly looks exactly
+  like one that works. Alert on the job failing or the 10TB drive filling
+  up, so it's caught instead of discovered months later.
+* **Pi temperature.** The Pi is fanless and does real work; heat is its
+  most likely way to fail.
+* **The DNS pair.** [AdGuard Home](/projects/homelab/adrs/001-adguard-home)
+  runs on both boxes, so host-level alerting covers resolver availability
+  and catches any single-box outage.
+
+One gap is worth stating plainly, because it's structural rather than
+fixable by tuning: this monitoring shares fate with the network it watches.
+Netdata runs on the same two boxes as the resolvers and needs DNS to reach
+Slack, so a *total* DNS outage is precisely the case where nothing alerts —
+it gets noticed when the network stops working. Single-box failure, which is
+what the redundant pair exists for, does alert normally.
 
 # Alternatives
 

--- a/ui/content/projects/homelab/adrs/010-nixos-gpu-worker.mdx
+++ b/ui/content/projects/homelab/adrs/010-nixos-gpu-worker.mdx
@@ -1,0 +1,95 @@
+---
+title: "ADR 010: NixOS GPU worker"
+date: "2026-08-02"
+status: "Proposed"
+tech_stack: ["NixOS", "Docker"]
+---
+
+# Context
+
+I have an Asus desktop with a GTX 1060 — Pascal-era (`sm_61`), released 2016,
+and now "unsupported" by the modern toolchain: CUDA 13 and the 585+ driver
+branches dropped Pascal entirely. Rather than e-waste it, I'm turning it into
+a headless, wake-on-demand GPU worker for batch computer vision jobs — the
+kind of workload that needs many GPU-hours, not a modern GPU.
+
+Managing dependencies on end-of-life hardware is fiddly: the driver, kernel,
+and CUDA versions all have to be pinned just so, and there's no vendor telling
+you what still works. That's exactly the kind of detail I want declared in a
+config file, not remembered. It's also the kind of system my coding agents
+can maintain well: the whole config is a git repo, so every change is
+reviewable and rollbackable — the same config in produces the same system
+out. An agent can edit a flake and I can review the diff, instead of someone
+SSH-ing in and hand-editing driver settings on a box that then forgets them.
+
+The details live in the `homelab/` directory of this repo (host config for
+`asus-desktop`).
+
+# Decision (proposed)
+
+Set up the desktop as a **NixOS** configuration managed with flakes,
+declared in this repository, with the GPU stack deliberately pinned:
+
+* An **LTS kernel** (6.12) plus the **580 driver branch** — the last with
+  Pascal support — on `nixos-25.11`, locked there on purpose.
+* **NVIDIA container toolkit + Docker**, so models run via
+  `nvidia/cuda:12.x` images only (`--gpus all`). CUDA 13 dropped Pascal, so
+  the CUDA 12 image family is the ceiling.
+* **Tailscale** enabled, with the `tailscale0` interface trusted in the
+  firewall and SSH for access from the Mac mini / laptop.
+* **Wake-on-LAN** on the real interface plus BIOS power-on-by-PCI-E, so the
+  box sleeps when idle and is woken on demand. The WoL magic packet is a
+  Layer 2 broadcast that can't route over the tailnet — it's sent by the Mac
+  mini on the home LAN, while the tailnet carries the wake request to it.
+* A `robbie` user in the `docker` and `wheel` groups; no passwords committed
+  to the repo.
+* The **1TB HDD** reused as the data disk for models and datasets — Docker
+  stays on the 111G SSD. It inherits the
+  [DVC](/projects/homelab/adrs/008-dvc) approach as the local dataset remote.
+
+# Alternatives
+
+## Keep the old OS and install the driver by hand
+
+* **Pros**: No migration effort.
+* **Cons**: Non-reproducible; a kernel/driver update can silently break the
+  GPU with no clean rollback — exactly the failure this project exists to
+  prevent.
+* **Decision**: Rejected. Declarative config is the point.
+
+## Modern GPU / newer box instead
+
+* **Pros**: No driver pins needed.
+* **Cons**: Buys new hardware to do a job the existing box handles. The
+  1060's batch-CV workload doesn't need modern hardware.
+* **Decision**: Rejected. This is an ewaste-avoidance project.
+
+## CUDA 13 / current drivers anyway
+
+* **Pros**: Future-proof tooling.
+* **Cons**: CUDA 13 and 585+ drivers dropped Pascal — the GPU simply won't
+  work. Not a viable option, hence the pin.
+* **Decision**: Rejected. The pin *is* the compatibility strategy.
+
+# Consequences
+
+### Pros
+
+* **The 1060 keeps earning its place** doing batch CV work instead of going
+  to landfill.
+* **Reproducible and rollbackable**: a broken upgrade is a `git revert` and
+  `nixos-rebuild switch` away, not a Saturday.
+* **Upskilling in NixOS and heterogeneous orchestration** while fixing a
+  real problem.
+* **DVC integration**: the 1TB HDD becomes a local dataset remote shared
+  with the ML pipelines.
+
+### Cons
+
+* **Frozen in time**: the box is pinned to nixos-25.11 and CUDA 12 — no new
+  GPU features ever, and staying on the pinned channel is a deliberate,
+  ongoing choice.
+* **Docker-container-only GPU**: bare-metal CUDA 13 code won't run; must
+  always run inside CUDA 12 images.
+* **Wake-on-LAN discipline**: WOL only works if the BIOS, interface, and
+  sleep config all cooperate; it's the most fragile part of the setup.

--- a/ui/content/projects/homelab/adrs/010-nixos-gpu-worker.mdx
+++ b/ui/content/projects/homelab/adrs/010-nixos-gpu-worker.mdx
@@ -22,8 +22,8 @@ reviewable and rollbackable — the same config in produces the same system
 out. An agent can edit a flake and I can review the diff, instead of someone
 SSH-ing in and hand-editing driver settings on a box that then forgets them.
 
-The details live in the `homelab/` directory of this repo (host config for
-`asus-desktop`).
+Nothing is built yet. If this is accepted, the host config for `asus-desktop`
+will live in a `homelab/` directory in this repo.
 
 # Decision (proposed)
 

--- a/ui/content/projects/homelab/adrs/011-jellyfin.mdx
+++ b/ui/content/projects/homelab/adrs/011-jellyfin.mdx
@@ -54,11 +54,11 @@ exposed publicly.
 ## Emby
 
 * **Pros**: Mature, close to Jellyfin.
-* **Cons**: Closed source core; Jellyfin is the actively-forked, open-source
+* **Cons**: Closed source core; Jellyfin is the actively forked, open-source
   evolution of the same codebase.
 * **Decision**: Rejected. Jellyfin is the open, no-account choice.
 
-# Consequences (if accepted)
+# Consequences
 
 ### Pros
 

--- a/ui/content/projects/homelab/adrs/011-jellyfin.mdx
+++ b/ui/content/projects/homelab/adrs/011-jellyfin.mdx
@@ -1,0 +1,78 @@
+---
+title: "ADR 011: Jellyfin media server"
+date: "2026-08-02"
+status: "Proposed"
+tech_stack: ["Jellyfin"]
+---
+
+# Context
+
+I want to serve TV shows and movies to my Fire TV Stick from the home hub,
+so the media I actually own has a proper home instead of sitting as a pile of
+files. I already pay for Netflix, Disney Plus, Amazon Prime, and Apple TV,
+and still end up rewatching things — the library I've bought deserves a
+better player than the streaming apps I pay for repeatedly.
+
+This is **Proposed**, not Accepted, for reasons that aren't about scope:
+
+* It's strictly for local use in my own home — it will never be a public
+  service, so there's no exposure or multi-user internet angle to design for.
+* The UX has to be good enough to switch to from the streaming apps, and
+  playback latency has to be low enough to not be noticed.
+* Adoption is the real test: it only gets built out if it's tested with my
+  family and they actually use it.
+
+# Decision (proposed)
+
+Run **Jellyfin** on the Mac mini to serve my media library to the Fire TV
+Stick.
+
+Jellyfin is free, open source, self-hosted, and has a first-class Fire TV
+client. The library lives on the hub's storage (the same machine that already
+holds the photo backup), served only over the home network/tailnet — not
+exposed publicly.
+
+# Alternatives
+
+## Plex
+
+* **Pros**: Polished clients, easy setup.
+* **Cons**: Closed source, account required, and its newer features keep
+  pushing toward the paid tier.
+* **Decision**: Rejected. For a home-lab library, open source with no
+  account wins.
+
+## Keep using streaming subscriptions only
+
+* **Pros**: Zero maintenance, content discovery built in.
+* **Cons**: I already pay for Netflix, Disney Plus, Amazon Prime, and Apple
+  TV, and still end up rewatching things; my own library stays a pile of
+  files.
+* **Decision**: Rejected as the only mechanism. Jellyfin serves content I
+  already own; it doesn't replace the subscriptions.
+
+## Emby
+
+* **Pros**: Mature, close to Jellyfin.
+* **Cons**: Closed source core; Jellyfin is the actively-forked, open-source
+  evolution of the same codebase.
+* **Decision**: Rejected. Jellyfin is the open, no-account choice.
+
+# Consequences (if accepted)
+
+### Pros
+
+* **Own library, self-hosted**: free, open source, and account-free on the
+  Fire TV Stick.
+* **Strictly local**: served over the home network/tailnet only, never
+  public.
+* **Better use of the library I already own**, instead of rewatching the
+  same titles on the streaming apps I pay for.
+
+### Cons
+
+* **Media library management** (curation, metadata, storage growth) becomes
+  an ongoing task.
+* **Storage pressure** on the hub alongside the photo backup.
+* **Adoption risk**: if the UX or latency isn't good enough for the family,
+  it won't get used — the reason it stays Proposed until tested.

--- a/ui/content/projects/homelab/adrs/012-cups.mdx
+++ b/ui/content/projects/homelab/adrs/012-cups.mdx
@@ -1,0 +1,79 @@
+---
+title: "ADR 012: CUPS for the unsupported printer"
+date: "2026-08-02"
+status: "Accepted"
+tech_stack: ["CUPS"]
+---
+
+# Context
+
+I own a 2011 Canon MX3100 printer. Canon no longer supports it — the vendor
+would have me buy a new printer — but the hardware still works, so the plan
+is to avoid ewaste by keeping it in service with free software.
+
+My own experience with the open-source route: it printed fine from an old
+Ubuntu 18 setup, but not from Ubuntu 22+ or from macOS, and I couldn't test
+Windows because I don't have a Windows machine. I wasn't willing to keep a
+box running Ubuntu 18 just to hold drivers — it's end-of-life.
+
+That points at the Raspberry Pi as the host. Linux is where these open-source
+drivers are actively maintained: Gutenprint formally deprecated macOS support
+in 2024 and no longer produces binaries for modern macOS, while on Linux it's
+the standard driver set. The Pi is always on, already part of the lab, and
+can run a print server that every device on the network reaches. I also want
+to print remotely from my phone — the classic case where a print server
+shines.
+
+# Decision
+
+Install **CUPS** on the Raspberry Pi and connect it to the Canon MX3100 via
+its (USB) connection, using **Gutenprint** — the open-source driver suite for
+Canon, Epson, and others — to bridge the gap left by Canon's dropped
+support.
+
+CUPS exposes the printer over IPP to the whole network, so the Mac, phones,
+and other devices print to it as a network printer. Remote printing works over
+the tailnet, and the Pi keeps the printer alive independently of any one
+device.
+
+# Alternatives
+
+## Buy a new printer
+
+* **Pros**: Modern drivers, no tinkering.
+* **Cons**: Unnecessary spend; discards working hardware. Exactly the ewaste
+  this lab exists to avoid.
+* **Decision**: Rejected. The MX3100 still prints.
+
+## Run the printer off the Mac mini instead of the Pi
+
+* **Pros**: The hub is already always-on.
+* **Cons**: Puts the printer (a hardware peripheral) on the same box as the
+  photo backup and agent stack; a hub reboot takes printing with it.
+* **Decision**: Rejected. The Pi keeps the lab's responsibilities separated
+  and redundant.
+
+## Keep the printer on an old machine with vendor drivers
+
+* **Pros**: Vendor-native drivers.
+* **Cons**: Keeps a dedicated old machine alive just to hold drivers; CUPS
+  with a generic driver does the job on hardware already in the lab.
+* **Decision**: Rejected. More ewaste, more power draw, more maintenance.
+
+# Consequences
+
+### Pros
+
+* **Working hardware stays working**: the MX3100 prints again, no new
+  hardware purchased.
+* **Network + remote printing**: any device prints via IPP; remote printing
+  works over the tailnet from the phone.
+* **Redundancy preserved**: printing is decoupled from the Mac mini hub.
+
+### Cons
+
+* **Generic-driver tradeoffs**: some printer-specific features (scanning
+  niceties, vendor utilities) may not work through the generic path.
+* **A service to maintain on the Pi** alongside AdGuard Home and Netdata.
+* **Physical dependency**: the printer still needs USB to the Pi, so it must
+  live near the Pi.

--- a/ui/content/projects/homelab/adrs/013-amazon-echo.mdx
+++ b/ui/content/projects/homelab/adrs/013-amazon-echo.mdx
@@ -1,0 +1,90 @@
+---
+title: "ADR 013: Resurrecting the first-gen Amazon Echo"
+date: "2026-08-02"
+status: "Rejected"
+---
+
+# Context
+
+I have a first-generation Amazon Echo. It's long past Amazon's support
+window, and I tried to connect it to the home lab to give it a useful job —
+the same second-life treatment that worked for the 2011 printer and the 2016
+GPU.
+
+The first-gen Echo is notoriously closed. It will no longer join modern Wi-Fi
+networks: Amazon rejects the device on newer routers (the 2014-era radio and
+its provisioning flow are simply not accepted), so it can't get online at
+all. There's no firmware or "factory reset" route around that — the failure
+is at network join time, before anything else can be attempted.
+
+The only open path is replacing Alexa outright, which means opening the
+hardware: the EchoRoot project by André Hentschel
+([GitHub](https://github.com/AndreRH/EchoRoot) /
+[project site](https://andrerh.gitlab.io/echoroot/)) boots a tiny Linux from
+a microSD card
+and needs soldering to the bottom board (pogo pins, a device-tree change for
+the kernel). That is well beyond the reasonable effort for this device.
+
+# Decision
+
+**Rejected.** The first-gen Echo cannot be meaningfully connected to the
+home lab. It is unsupported hardware that is now, unfortunately, ewaste.
+
+The attempt is recorded here deliberately: the lab's whole reason for being
+includes keeping working hardware out of landfill, and this is the honest
+case where that goal is not achievable — not for want of trying, but because
+the device is architecturally closed.
+
+# Alternatives
+
+## Use it as a plain speaker (Bluetooth/aux)
+
+* **Pros**: Keeps it out of landfill as a dumb speaker.
+* **Cons**: Not possible. The first-gen Echo has no aux jack at all — no
+  line-in, no line-out; its connectivity is Wi-Fi and Bluetooth only, and its
+  sole external connector is power. Bluetooth pairing is managed through the
+  Alexa app, which needs the device online — which it no longer can be.
+* **Decision**: Rejected, not for lack of interest but because there is no
+  offline audio path into the device.
+
+## Replace Alexa via the EchoRoot hardware hack
+
+* **Pros**: A genuine open-source second life; the community has done the
+  hard reverse-engineering.
+* **Cons**: Requires soldering/pogo pins into the bottom board, a microSD
+  adapter, and a custom rootfs and device tree; brick risk is high and
+  hardware access is destructive on a sealed speaker.
+* **Decision**: Rejected. It's a hardware-tinkering project, not a lab
+  integration, and the effort is better spent on devices that can be
+  salvaged without opening them up.
+
+## Keep trying community firmware routes
+
+* **Pros**: There's always a newer exploit.
+* **Cons**: High brick risk, zero upstream support, and time spent on a
+  device whose salvage value is minimal.
+* **Decision**: Rejected. The effort is better spent on supported devices.
+
+## Donate / recycle the device properly
+
+* **Pros**: Responsible disposal; aligns with the no-ewaste intent.
+* **Cons**: No functional reuse.
+* **Decision**: Accepted as the outcome. Proper recycling is the honest end
+  for this device.
+
+# Consequences
+
+### Pros
+
+* **An explicit record** that not every old device gets a second life, and
+  why.
+* **Lesson for future salvage**: closed firmware is the hard blocker, and a
+  device that can't even join the network is unrecoverable without hardware
+  surgery; check openness before buying or rescuing "unsupported" devices.
+
+### Cons
+
+* **The Echo joins the e-waste stream**, despite the lab's goal of avoiding
+  it — the boundary case this ADR documents.
+* **A slot in the home for a voice assistant** remains unfilled, if I ever
+  want one (would need to be an open/friendly device).

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -103,41 +103,38 @@ constraint is software, not silicon.
 
 <Mermaid
   chart={`flowchart LR
-  Internet["Internet"] -->|"router DNS"| Router["Home router"]
-  subgraph hub["Mac mini — home hub"]
-      ADG1["AdGuard Home — primary DNS"]
-      ENT["Ente sync"]
-      NET1["Netdata"]
-      T3["t3-code + agents"]
-      CUP["CUPS"]
-      JEL["Jellyfin — planned"]
-  end
-  subgraph pi["Raspberry Pi"]
-      ADG2["AdGuard Home — fallback DNS"]
-      NET2["Netdata → hub"]
-  end
-  subgraph asus["Asus desktop (NixOS)"]
-      GPU["GTX 1060 — CV jobs"]
-      DVC["DVC dataset cache"]
-  end
-  Router --> ADG1
-  Router --> ADG2
-  ADG2 --> ADG1
-  ENT <-->|"photo sync"| Ente["Ente cloud"]
-  ENT --> HDD[("10TB HDD")]
-  NET1 --> Slack["Slack"]
-  NET2 --> Slack
-  CUP --> Printer["Canon MX3100 (2011)"]
-  JEL --> FireStick["Fire TV Stick"]
-  subgraph tailnet["Tailnet overlay"]
-      Phone["Phone"]
-      Lap["Laptop (4080 — future)"]
-  end
-  Phone -->|"agents"| T3
-  Lap -->|"agents"| T3
-  Lap -->|"wake request"| hub
-  hub -->|"WoL (L2 broadcast)"| asus
-  Lap -->|"SSH / tailnet"| asus
+Internet["Internet"] -->|"router DNS"| Router["Home router"]
+subgraph hub["Mac mini — home hub"]
+    ADG1["AdGuard Home — primary DNS"]
+    ENT["Ente sync"]
+    NET1["Netdata"]
+    T3["t3-code + agents"]
+    JEL["Jellyfin — planned"]
+end
+subgraph pi["Raspberry Pi"]
+    ADG2["AdGuard Home — fallback DNS"]
+    NET2["Netdata → hub"]
+    CUP["CUPS"]
+end
+subgraph asus["Asus desktop (NixOS)"]
+    GPU["GTX 1060 — CV jobs"]
+    DVC["DVC dataset cache"]
+end
+Router --> ADG1
+Router --> ADG2
+ADG2 --> ADG1
+Phone -->|"photo upload"| Ente["Ente cloud"]
+Ente -->|"download backup"| ENT
+ENT --> HDD[("10TB HDD")]
+NET1 --> Slack["Slack"]
+NET2 --> Slack
+CUP --> Printer["Canon MX3100 (2011)"]
+JEL --> FireStick["Fire TV Stick"]
+GitHub["GitHub"]
+Phone["Phone"]
+Phone -->|"agents"| T3
+T3 -->|"repos / PRs"| GitHub
+hub -->|"WoL (L2 broadcast)"| asus
 `}
 />
 

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -116,7 +116,7 @@ subgraph pi["Raspberry Pi"]
     NET2["Netdata → hub"]
     CUP["CUPS"]
 end
-subgraph asus["Asus desktop (NixOS)"]
+subgraph asus["Asus desktop (NixOS) — proposed"]
     GPU["GTX 1060 — CV jobs"]
     DVC["DVC dataset cache"]
 end
@@ -181,22 +181,23 @@ the whole house depends on: DNS and monitoring.
   open-source driver suite, I can still print to it (and even print remotely
   from my phone), keeping working hardware out of landfill.
 
-## Asus desktop — the NixOS GPU worker (in progress)
+## Asus desktop — the NixOS GPU worker (proposed)
 
-A headless wake-on-demand box, configured declaratively with
+A headless wake-on-demand box, to be configured declaratively with
 [NixOS](/projects/homelab/adrs/010-nixos-gpu-worker).
 
 * **Old, unsupported 1060 GPU.** The GTX 1060 is Pascal-era (`sm_61`) — CUDA
   13 and the newer driver branches dropped support for it, so the config
-  pins an LTS kernel and the 580 driver branch, the last with Pascal support.
+  will pin an LTS kernel and the 580 driver branch, the last with Pascal
+  support.
 * **Batch GPU CV jobs.** The ambition is to use it for running batch computer
   vision jobs — the exact workload that doesn't need a modern GPU, just many
   GPU-hours.
 * **DVC data cache.** It inherits the
-  [DVC ADR](/projects/homelab/adrs/008-dvc) and its 1TB connected HDD holds
-  local copies of datasets for the ML pipelines (`ml-pipelines/recipe-parsing/`)
-  and any CV work.
-* **Wake-on-LAN.** It sleeps when idle and is woken on demand. The WoL magic
+  [DVC ADR](/projects/homelab/adrs/008-dvc) and its 1TB connected HDD will
+  hold local copies of datasets for the ML pipelines
+  (`ml-pipelines/recipe-parsing/`) and any CV work.
+* **Wake-on-LAN.** It will sleep when idle and be woken on demand. The WoL magic
   packet is a Layer 2 broadcast, so it can't travel over the tailnet — the
   Mac mini, on the home LAN, sends it when a wake request arrives from a
   remote device.
@@ -227,7 +228,7 @@ workloads and layering on the rest:
 | 2     | Agentic development hub (t3-code + agents)                    | Live        |
 | 3     | DNS privacy (AdGuard Home, primary + failover)                | Live        |
 | 4     | CUPS printing on the Pi (avoiding printer ewaste)             | Live        |
-| 5     | NixOS GPU worker for batch CV jobs, with DVC-managed datasets | In progress |
+| 5     | NixOS GPU worker for batch CV jobs, with DVC-managed datasets | Proposed    |
 | 6     | Jellyfin media server for the Fire TV Stick                   | Proposed    |
 | 7     | Second compute node (idle 4080 laptop)                        | Idea        |
 

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -1,0 +1,318 @@
+---
+title: "Home Lab"
+description: "A small always-on fleet for data backup and coordination, agentic development, network privacy, and keeping old hardware out of the bin"
+date: "2026-08-02"
+status: "in_progress"
+tech_stack:
+  - "Tailscale"
+  - "AdGuard Home"
+  - "t3-code"
+  - "Claude Code"
+  - "Codex"
+  - "Grok Build"
+  - "opencode"
+  - "Ente"
+  - "DVC"
+  - "Netdata"
+  - "NixOS"
+  - "CUPS"
+  - "Docker"
+---
+
+# Vision
+
+A small, always-on fleet of machines in my home that handles the recurring
+infrastructure of my digital life — backups, remote development, network
+privacy — so I don't have to remember to do it by hand.
+
+The home lab exists to serve four goals, in priority order:
+
+1. **Data backup and coordination.** Cloud photo libraries, datasets, and
+   project files get reliably synced and backed up without manual effort.
+   Manual drive synchronisation has failed repeatedly; the point of this
+   project is to make it someone else's job.
+2. **Agentic development environments.** An always-on machine hosts my coding
+   agents (Claude Code, Codex, opencode, Grok Build) behind a mobile-friendly
+   GUI, so I can drive real development work from my phone over the tailnet.
+3. **Privacy.** Network-wide ad and tracker blocking keeps my devices from
+   phoning home to trackers, applied to every device on the LAN regardless of
+   what it runs.
+4. **Avoiding ewaste.** Old, "unsupported" hardware — a 2011 printer, a
+   Pascal-era GPU, and two older phones — gets a second life doing useful work
+   instead of filling a landfill.
+
+A secondary goal that runs through the whole project is upskilling on
+networking, DNS, and heterogeneous orchestration. The lab is a real system to
+learn on, not a toy.
+
+Everything is reachable over my [Tailscale](/projects/homelab/adrs/000-tailscale)
+tailnet, so I can inspect and drive the whole lab from any of my devices.
+
+# Problem Statement
+
+The problems the lab solves are the recurring ones that manual effort handles
+badly:
+
+**Manual data sync is painful and lossy.** Copying photos and files between
+drives by hand is easy to forget, easy to get wrong, and leaves no audit
+trail. The cloud photo library has grown into the single source of truth for
+family photos, and a single point of failure.
+
+**Agentic development needs a persistent host.** Coding agents are most useful
+when they run somewhere always-on with the right repos, credentials, and tools
+already prepared. A laptop that sleeps when closed can't drive a session from
+a phone. Mobile "cloud" agent environments exist, but they re-bootstrap
+context each time, and they're slower, less reliable, and burn more tokens
+than a prepared local environment.
+
+**Home devices make a lot of tracking DNS traffic.** Without network-wide
+filtering, apps and embedded trackers on phones, TVs, and streaming boxes
+resolve ad and analytics domains on every device on the LAN. Fixing this at
+the DNS layer covers devices nothing else can be installed on. This adds a
+dependency (the resolver), so it has to be built with redundancy from the
+start.
+
+**Unsupported hardware is actually still fine.** The Canon MX3100 printer
+(2011), the GTX 1060 (2016), and two older phones are past their vendor
+support windows, but each still works for a real job if the right software
+bridges the gap. Buying new kit to replace them is wasteful when the
+constraint is software, not silicon.
+
+# User Stories
+
+* As the owner of thousands of family photos, I want them automatically
+  synced from the cloud down to a local 10TB drive, so I have an offline
+  backup that doesn't depend on a subscription or the internet.
+* As a developer working away from my desk, I want to open the home hub's
+  agent GUI on my phone and have working repos, credentials, and a choice of
+  agents, so I can keep shipping from the sofa.
+* As someone with two Codex subscriptions, I want both managed in one place,
+  so I can use each plan's allowance and pick the best-fitting one per task.
+* As a household with a home router, I want ad and tracker blocking applied
+  network-wide with automatic failover, so every device is protected even if
+  one DNS box reboots.
+* As someone who owns a 2011 printer, I want to print from my phone remotely
+  over CUPS, so I keep using hardware that still works and avoid ewaste.
+* As someone running a NixOS box, I want the whole config declared in git, so
+  an upgrade can never silently break the GPU and every change is reviewable
+  and rollbackable.
+* As the lab owner, I want Netdata to tell Slack when something is
+  overheating or down, so I find out about problems before they matter.
+
+# Topology
+
+<Mermaid
+  chart={`flowchart LR
+  Internet["Internet"] -->|"router DNS"| Router["Home router"]
+  subgraph hub["Mac mini — home hub"]
+      ADG1["AdGuard Home — primary DNS"]
+      ENT["Ente sync"]
+      NET1["Netdata"]
+      T3["t3-code + agents"]
+      CUP["CUPS"]
+      JEL["Jellyfin — planned"]
+  end
+  subgraph pi["Raspberry Pi"]
+      ADG2["AdGuard Home — fallback DNS"]
+      NET2["Netdata → hub"]
+  end
+  subgraph asus["Asus desktop (NixOS)"]
+      GPU["GTX 1060 — CV jobs"]
+      DVC["DVC dataset cache"]
+  end
+  Router --> ADG1
+  Router --> ADG2
+  ADG2 --> ADG1
+  ENT <-->|"photo sync"| Ente["Ente cloud"]
+  ENT --> HDD[("10TB HDD")]
+  NET1 --> Slack["Slack"]
+  NET2 --> Slack
+  CUP --> Printer["Canon MX3100 (2011)"]
+  JEL --> FireStick["Fire TV Stick"]
+  subgraph tailnet["Tailnet overlay"]
+      Phone["Phone"]
+      Lap["Laptop (4080 — future)"]
+  end
+  Phone -->|"agents"| T3
+  Lap -->|"agents"| T3
+  Lap -->|"wake request"| hub
+  hub -->|"WoL (L2 broadcast)"| asus
+  Lap -->|"SSH / tailnet"| asus
+`}
+/>
+
+# Nodes
+
+## Mac mini — the home hub
+
+The primary always-on machine and the heart of the lab. It runs the two most
+important jobs: hosting my agentic development environment and owning the
+photo backup pipeline.
+
+* **Agentic development hub.** Installs [Claude Code](/projects/homelab/adrs/002-claude-code),
+  [Codex](/projects/homelab/adrs/003-codex) (both subscriptions),
+  [opencode](/projects/homelab/adrs/005-opencode) and
+  [Grok Build](/projects/homelab/adrs/004-grok-build), all orchestrated from
+  [t3-code](/projects/homelab/adrs/006-t3-code) so I can drive remote,
+  mobile-friendly, agentic development.
+* **Photo backup.** Connects to [Ente](/projects/homelab/adrs/007-ente-photo-backup),
+  the end-to-end encrypted cloud photo provider, and regularly syncs my
+  library down to a connected 10TB HDD as an offline backup.
+* **DNS privacy.** Runs [AdGuard Home](/projects/homelab/adrs/001-adguard-home)
+  as the primary DNS server that my router points at. It blocks \~33% of all
+  requests over my home network. AdGuard is also reachable over the tailnet,
+  so the phone keeps blocking trackers and ads on cellular or any other
+  network — coverage a router-level setup can't provide.
+* **Monitoring.** Runs [Netdata](/projects/homelab/adrs/009-netdata),
+  connected to my Slack workspace via a Slack app, to alarm on anything
+  going wrong.
+* **Media (planned).** Will run [Jellyfin](/projects/homelab/adrs/011-jellyfin)
+  to serve TV shows and movies to my Fire TV Stick.
+
+## Raspberry Pi — the resilient sidekick
+
+A secondary node that removes single points of failure from the two things
+the whole house depends on: DNS and monitoring.
+
+* **Secondary AdGuard Home.** The home router also points at the Pi, so if
+  either DNS box is down (e.g. during reboots) the other keeps the network
+  functioning.
+* **Netdata child.** Exports metrics to the Mac mini as the main hub, and
+  alerts my Slack workspace if its temperature climbs too high.
+* **CUPS print server.** Runs CUPS connected to my 2011 Canon MX3100
+  printer, which is no longer supported by Canon — but with Gutenprint, the
+  open-source driver suite, I can still print to it (and even print remotely
+  from my phone), keeping working hardware out of landfill.
+
+## Asus desktop — the NixOS GPU worker (in progress)
+
+A headless wake-on-demand box, configured declaratively with
+[NixOS](/projects/homelab/adrs/010-nixos-gpu-worker).
+
+* **Old, unsupported 1060 GPU.** The GTX 1060 is Pascal-era (`sm_61`) — CUDA
+  13 and the newer driver branches dropped support for it, so the config
+  pins an LTS kernel and the 580 driver branch, the last with Pascal support.
+* **Batch GPU CV jobs.** The ambition is to use it for running batch computer
+  vision jobs — the exact workload that doesn't need a modern GPU, just many
+  GPU-hours.
+* **DVC data cache.** It inherits the
+  [DVC ADR](/projects/homelab/adrs/008-dvc) and its 1TB connected HDD holds
+  local copies of datasets for the ML pipelines (`ml-pipelines/recipe-parsing/`)
+  and any CV work.
+* **Wake-on-LAN.** It sleeps when idle and is woken on demand. The WoL magic
+  packet is a Layer 2 broadcast, so it can't travel over the tailnet — the
+  Mac mini, on the home LAN, sends it when a wake request arrives from a
+  remote device.
+
+## Future: the idle 4080 laptop
+
+I have an idle laptop with a 4080 GPU in it. Once the NixOS box proves out
+the wake-on-demand pattern, the laptop is a natural candidate for a second,
+much faster compute node — particularly for heavier inference or training
+that the 1060 can't handle.
+
+## Future: old phones and the iPhone 6s
+
+Two older Android phones (Android 10 and Android 14) and an old iPhone 6s are
+still functional. They're candidates for lightweight roles: a spare secondary
+DNS node, a status display, a camera, or spare test targets for agentic work.
+The Android devices are the more capable candidates; the iPhone 6s is limited
+by a locked-down OS. No commitment yet — this is an open question.
+
+# Plan
+
+The lab is being built incrementally, starting from the highest-value
+workloads and layering on the rest:
+
+| Phase | Workload                                                      | Status      |
+| ----- | ------------------------------------------------------------- | ----------- |
+| 1     | Photo backup (Ente → 10TB HDD)                                | Live        |
+| 2     | Agentic development hub (t3-code + agents)                    | Live        |
+| 3     | DNS privacy (AdGuard Home, primary + failover)                | Live        |
+| 4     | CUPS printing on the Pi (avoiding printer ewaste)             | Live        |
+| 5     | NixOS GPU worker for batch CV jobs, with DVC-managed datasets | In progress |
+| 6     | Jellyfin media server for the Fire TV Stick                   | Proposed    |
+| 7     | Second compute node (idle 4080 laptop)                        | Idea        |
+
+# What This Is Not
+
+* **Not a public service.** Everything is behind the tailnet. No ports
+  forwarded to the internet, no exposed dashboards.
+* **Not a data hoard.** Bulk data has a purpose and an owner: the photo
+  backup, local dataset copies, and (planned) media library. Backup scope may
+  grow to documents, games, movies, TV, and music, but each addition has to
+  earn its place.
+* **Not a fixed shape.** The lab started as a handful of machines doing
+  boring jobs. If it grows past that — a proper NAS, or Kubernetes for the
+  compute nodes — that's on the table rather than ruled out.
+
+# Future Direction
+
+Beyond the phases above, there are ideas on the horizon that would lean into
+the same four goals:
+
+* **Offsite backup.** The 10TB drive is a second copy, but it's in the same
+  house. A cheap offsite target (a friend's tailnet node, or cold storage)
+  for the photo library would close the last gap in the backup story.
+* **Expanded backup scope.** Documents, game saves, movies, TV, and music
+  are candidates for the same sync-and-verify pipeline as the photos.
+* **Dashboards on this site.** Netdata graphs and lab status could be
+  surfaced as a page on this site, so the lab is visible to anyone looking.
+* **Heterogeneous orchestration.** As the lab grows past one or two compute
+  nodes, scheduling GPU work across the 1060 box and the 4080 laptop becomes
+  a genuine upskilling exercise in heterogeneous clusters — possibly growing
+  into Kubernetes.
+* **Old phones in the cluster.** The Android phones and iPhone 6s as
+  lightweight nodes (see above).
+
+# Risks
+
+## DNS is a single point of failure for the whole house
+
+Running a local resolver adds a dependency that didn't exist before: if both
+AdGuard Home instances go down, every device in the house loses DNS and the
+internet "stops working."
+
+**Mitigation:** Two independent DNS nodes on separate hardware with the
+router configured to fail over. The Pi keeps working during Mac mini reboots
+and vice versa.
+
+## Photo backup silently failing
+
+A sync pipeline that fails quietly means the library quietly isn't backed up.
+Catching that late is only slightly better than not having a backup at all —
+but the risk is real, so it's monitored.
+
+**Mitigation:** Netdata monitors the sync process and alerts Slack on
+failure or when the HDD fills up. The backup is treated as a system to be
+monitored, not a script to be forgotten.
+
+## Agent blast radius
+
+The Mac mini holds credentials, plugins, and browser state for remote agent
+sessions, and it also holds personal photos and the backup drive. A broad
+permission profile on any one agent could expose unrelated personal data, and
+an agent acting wrongly could delete things as easily as read them.
+
+**Mitigation:** The [Codex ADR](/projects/homelab/adrs/003-codex) already
+documents the need for least-privilege filesystem rules and sandboxing on
+the connected host. This stays a first-class concern as more agents land on
+the hub, with backups covering the "wrong deletion" case.
+
+## Pascal never comes back
+
+The 1060's driver support is a moving target that NixOS upgrades could
+silently break.
+
+**Mitigation:** The whole point of the declarative NixOS config is that the
+driver, kernel, and CUDA container versions are pinned in git. No surprise
+upgrade can break the GPU without a reviewable, rollbackable diff.
+
+## Media server scope creep
+
+Jellyfin is the most consumer-facing thing on the roadmap and the easiest to
+over-invest in.
+
+**Mitigation:** It's explicitly a Phase 6 "nice to have." It only gets built
+after the higher-priority workloads are solid, and it stays behind the
+tailnet with a simple client story.

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -997,7 +997,7 @@ export const technologies: TechnologyContent[] = [
     description:
       "Reproducible Linux distribution built on the Nix package manager with declarative system configuration",
     website: "https://nixos.org",
-    type: "tool",
+    type: "platform",
   },
   {
     name: "Ente",
@@ -1013,6 +1013,6 @@ export const technologies: TechnologyContent[] = [
     description:
       "Free, self-hosted media server for streaming movies and TV shows to any client",
     website: "https://jellyfin.org",
-    type: "platform",
+    type: "tool",
   },
 ];

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -935,4 +935,84 @@ export const technologies: TechnologyContent[] = [
     website: "https://www.oasdiff.com",
     type: "tool",
   },
+  {
+    name: "Tailscale",
+    added: "2026-08-02",
+    description:
+      "WireGuard-based mesh VPN overlaying the internet with private device networking across all machines",
+    website: "https://tailscale.com",
+    type: "tool",
+  },
+  {
+    name: "AdGuard Home",
+    added: "2026-08-02",
+    description:
+      "Self-hosted network-wide DNS filtering with ad and tracker blocking, acting as a local DNS resolver",
+    website: "https://adguard.com/en/adguard-home.html",
+    type: "tool",
+  },
+  {
+    name: "t3-code",
+    added: "2026-08-02",
+    description:
+      "Open-source web GUI for managing coding agents (Claude Code, Codex, opencode, Grok Build) from one surface",
+    website: "https://t3.codes",
+    type: "tool",
+  },
+  {
+    name: "opencode",
+    added: "2026-08-02",
+    description:
+      "Open-source terminal-based AI coding agent built for custom models and agentic workflows",
+    website: "https://opencode.ai",
+    type: "tool",
+  },
+  {
+    name: "Grok Build",
+    added: "2026-08-02",
+    description:
+      "xAI's terminal coding agent and CLI powered by Grok models, with skills, plugins, and headless mode",
+    website: "https://x.ai/cli",
+    type: "tool",
+  },
+  {
+    name: "Netdata",
+    added: "2026-08-02",
+    description:
+      "Real-time infrastructure monitoring with alerts delivered to Slack and distributed metric collection",
+    website: "https://www.netdata.cloud",
+    type: "tool",
+  },
+  {
+    name: "CUPS",
+    added: "2026-08-02",
+    description:
+      "Unix printing system that keeps unsupported printers working via generic drivers and IPP",
+    website: "https://www.cups.org",
+    type: "tool",
+  },
+  {
+    name: "NixOS",
+    added: "2026-08-02",
+    description:
+      "Reproducible Linux distribution built on the Nix package manager with declarative system configuration",
+    website: "https://nixos.org",
+    type: "tool",
+  },
+  {
+    name: "Ente",
+    added: "2026-08-02",
+    description:
+      "Open-source, end-to-end encrypted cloud photo storage with a self-hostable server",
+    website: "https://ente.io",
+    type: "tool",
+  },
+  {
+    name: "Jellyfin",
+    added: "2026-08-02",
+    description:
+      "Free, self-hosted media server for streaming movies and TV shows to any client",
+    website: "https://jellyfin.org",
+    type: "platform",
+  },
 ];

--- a/ui/tests/app/(site)/projects/[slug]/page.test.tsx
+++ b/ui/tests/app/(site)/projects/[slug]/page.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import type { Mock } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import ProjectPage from "@/app/(site)/projects/[slug]/page";
+import type { ProjectWithADRs } from "@/lib/api/projects";
+import { getProject } from "@/lib/api/projects";
+
+vi.mock("@/lib/api/projects", () => ({
+  getAllProjectSlugs: () => ["homelab"],
+  getProject: vi.fn(),
+}));
+
+vi.mock("@/components/projects/project-tabs", () => ({
+  ProjectTabs: ({
+    overview,
+    adrs,
+  }: {
+    overview: React.ReactNode;
+    adrs: React.ReactNode;
+  }) => (
+    <div>
+      <div data-testid="overview">{overview}</div>
+      <div data-testid="adrs">{adrs}</div>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/markdown", () => ({
+  Markdown: ({ source }: { source: string }) => <div>{source}</div>,
+}));
+
+vi.mock("@/components/mermaid", () => ({
+  Mermaid: () => <div>mermaid</div>,
+}));
+
+vi.mock("@/components/projects/adr-list", () => ({
+  ADRList: () => <div>adr-list</div>,
+}));
+
+const fixture = {
+  slug: "homelab",
+  title: "Home Lab",
+  description: "Test description",
+  date: "2026-08-02",
+  status: "live",
+  content: "# Home Lab\n\nHello",
+  technologies: [
+    {
+      name: "Tailscale",
+      slug: "tailscale",
+      iconSlug: "tailscale",
+      hasIcon: true,
+      website: "https://tailscale.com",
+    },
+  ],
+  adrSlugs: ["000-tailscale"],
+  adrs: [
+    {
+      adrRef: "ADR-000",
+      slug: "000-tailscale",
+      title: "Tailscale",
+      date: "2026-08-02",
+      status: "Accepted",
+      readingTime: "1 min",
+      projectSlug: "homelab",
+      originProjectSlug: "homelab",
+      originAdrSlug: "000-tailscale",
+      isInherited: false,
+      technologies: [],
+    },
+  ],
+  tags: [],
+} as ProjectWithADRs;
+
+describe("project page", () => {
+  it("renders the project with the content component registry", async () => {
+    (getProject as Mock).mockReturnValue(fixture);
+
+    render(await ProjectPage({ params: Promise.resolve({ slug: "homelab" }) }));
+
+    expect(
+      screen.getByRole("heading", { name: "Home Lab" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Test description")).toBeInTheDocument();
+    expect(screen.getByText("adr-list")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/app/(site)/projects/[slug]/page.test.tsx
+++ b/ui/tests/app/(site)/projects/[slug]/page.test.tsx
@@ -26,7 +26,22 @@ vi.mock("@/components/projects/project-tabs", () => ({
 }));
 
 vi.mock("@/components/markdown", () => ({
-  Markdown: ({ source }: { source: string }) => <div>{source}</div>,
+  Markdown: ({
+    source,
+    components,
+  }: {
+    source: string;
+    components?: Record<string, unknown>;
+  }) => (
+    <div>
+      <div>{source}</div>
+      <div data-testid="registered-components">
+        {Object.keys(components ?? {})
+          .sort()
+          .join(",")}
+      </div>
+    </div>
+  ),
 }));
 
 vi.mock("@/components/mermaid", () => ({
@@ -83,5 +98,15 @@ describe("project page", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Test description")).toBeInTheDocument();
     expect(screen.getByText("adr-list")).toBeInTheDocument();
+  });
+
+  it("passes Mermaid and DesignEmbed to the project markdown renderer", async () => {
+    (getProject as Mock).mockReturnValue(fixture);
+
+    render(await ProjectPage({ params: Promise.resolve({ slug: "homelab" }) }));
+
+    expect(screen.getByTestId("registered-components")).toHaveTextContent(
+      "DesignEmbed,Mermaid",
+    );
   });
 });

--- a/ui/tests/lib/content/mermaid-charts.test.ts
+++ b/ui/tests/lib/content/mermaid-charts.test.ts
@@ -3,16 +3,32 @@ import { join, relative } from "node:path";
 import mermaid from "mermaid";
 import { describe, expect, it } from "vitest";
 
-const CONTENT_ROOT = join(process.cwd(), "content");
+// Resolved from this file, not process.cwd(): under coverage the vitest root is
+// the repo root, so cwd depends on where the run was launched from.
+const CONTENT_ROOT = join(import.meta.dirname, "../../../content");
 
 // Mermaid renders client-side, so a malformed chart only surfaces as an error
 // box in the browser — nothing in the build or the type checker catches it.
-const CHART_PATTERN = /<Mermaid[\s\S]*?chart=\{`([\s\S]*?)`\}/g;
+// [^>]* keeps the match inside a single tag, so props may precede `chart` but a
+// propless <Mermaid /> can't pair with a later element's chart.
+const CHART_PATTERN = /<Mermaid\b[^>]*?chart=\{`([\s\S]*?)`\}/g;
+const TAG_PATTERN = /<Mermaid\b/g;
 
 function extractCharts(source: string): string[] {
   return Array.from(source.matchAll(CHART_PATTERN))
     .map((match) => match[1])
     .filter((chart) => chart !== undefined);
+}
+
+// Prose that documents the component (`<Mermaid chart={...} />` in a code span)
+// isn't rendered, so it must not count as a chart the test failed to read.
+// Fences first — they are backtick runs the inline-span pattern would misread.
+function stripCode(source: string): string {
+  return source.replace(/```[\s\S]*?```/g, "").replace(/`[^`]*`/g, "");
+}
+
+function countTags(source: string): number {
+  return Array.from(stripCode(source).matchAll(TAG_PATTERN)).length;
 }
 
 function contentFiles(): string[] {
@@ -25,20 +41,36 @@ describe("Mermaid charts in MDX content", () => {
   it("parse without error", async () => {
     mermaid.initialize({ startOnLoad: false });
 
+    const files = contentFiles();
+    expect(files.length).toBeGreaterThan(0);
+
     const failures: string[] = [];
+    const skipped: string[] = [];
     let charts = 0;
 
-    for (const file of contentFiles()) {
-      for (const chart of extractCharts(readFileSync(file, "utf8"))) {
+    for (const file of files) {
+      const source = readFileSync(file, "utf8");
+      const extracted = extractCharts(source);
+      const name = relative(CONTENT_ROOT, file);
+
+      // A chart the pattern can't read would otherwise go unchecked silently.
+      if (extracted.length !== countTags(source)) {
+        skipped.push(
+          `${name}: ${countTags(source)} <Mermaid> tags, ${extracted.length} charts extracted`,
+        );
+      }
+
+      for (const chart of extracted) {
         charts += 1;
         try {
           await mermaid.parse(chart);
         } catch (error) {
-          failures.push(`${relative(CONTENT_ROOT, file)}: ${error}`);
+          failures.push(`${name}: ${error}`);
         }
       }
     }
 
+    expect(skipped).toEqual([]);
     expect(failures).toEqual([]);
     expect(charts).toBeGreaterThan(0);
   });

--- a/ui/tests/lib/content/mermaid-charts.test.ts
+++ b/ui/tests/lib/content/mermaid-charts.test.ts
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import mermaid from "mermaid";
+import { describe, expect, it } from "vitest";
+
+const CONTENT_ROOT = join(process.cwd(), "content");
+
+// Mermaid renders client-side, so a malformed chart only surfaces as an error
+// box in the browser — nothing in the build or the type checker catches it.
+const CHART_PATTERN = /<Mermaid[\s\S]*?chart=\{`([\s\S]*?)`\}/g;
+
+function extractCharts(source: string): string[] {
+  return Array.from(source.matchAll(CHART_PATTERN))
+    .map((match) => match[1])
+    .filter((chart) => chart !== undefined);
+}
+
+function contentFiles(): string[] {
+  return readdirSync(CONTENT_ROOT, { recursive: true, encoding: "utf8" })
+    .filter((entry) => entry.endsWith(".mdx"))
+    .map((entry) => join(CONTENT_ROOT, entry));
+}
+
+describe("Mermaid charts in MDX content", () => {
+  it("parse without error", async () => {
+    mermaid.initialize({ startOnLoad: false });
+
+    const failures: string[] = [];
+    let charts = 0;
+
+    for (const file of contentFiles()) {
+      for (const chart of extractCharts(readFileSync(file, "utf8"))) {
+        charts += 1;
+        try {
+          await mermaid.parse(chart);
+        } catch (error) {
+          failures.push(`${relative(CONTENT_ROOT, file)}: ${error}`);
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+    expect(charts).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **Home Lab** project to the site with a full ADR suite, plus supporting technology entries and a Mermaid diagram renderer for project pages.

### Content
- `ui/content/projects/homelab/index.mdx` — project overview with phased roadmap (P1–P7), topology Mermaid diagram (Mac mini hub, Raspberry Pi, NixOS box; CUPS on the Pi, Ente photo flow to the 10TB HDD, t3-code/agents wiring to GitHub), and risks
- 14 ADRs under `ui/content/projects/homelab/adrs/`:
  - Tailscale (VPN mesh), AdGuard Home (DNS filtering, 2× instance sync), coding agent tooling (Claude Code, Codex, Grok Build, opencode), t3-code orchestration, Ente (photo backup), DVC, Netdata (monitoring), NixOS GPU worker, Jellyfin (media), CUPS (printer), Amazon Echo (rejected)

### Code
- `ui/app/(site)/projects/[slug]/page.tsx` — register `Mermaid` in project markdown components
- `ui/content/technologies.ts` — 10 new technology entries for the new ADRs
- `ui/tests/app/(site)/projects/[slug]/page.test.tsx` — project page render test, asserting the content component registry
- `ui/tests/lib/content/mermaid-charts.test.ts` — parses every `<Mermaid>` chart in MDX content

## Review loop

Settled across `6a614f4` and `f9ee6cd`. Full dispositions, including rejected findings and why, are in [this comment](https://github.com/Robbie-Palmer/personal-site/pull/896#issuecomment-5160568151).

**Correctness fixes**
- ADR 000 and ADR 005 each marked an alternative `Accepted` inside `# Alternatives`, inverting the ADR's actual outcome — both now `Rejected`, matching repo convention
- ADR 000 said the Wake-on-LAN packet is sent *over* the tailnet, contradicting ADR 010 and the project page. Reworded to the two-hop reality: the tailnet carries the wake request to the Mac mini, which broadcasts the magic packet on the LAN
- ADR 010 is `Proposed` and nothing is built, so the claim that its config already lives in a `homelab/` directory is gone. Phase 5 moved `In progress` → `Proposed`, with the node heading, topology label and tense aligned
- ADR 000 now states plainly that `trustedInterfaces` accepts *all* traffic on `tailscale0` — the deliberate posture, with the tailnet as the security boundary
- ADR 007 pulls via Ente's CLI; the library stays in Ente's cloud, so the self-hosting aside is dropped
- ADR 004 links to xAI's official install guidance instead of publishing a `curl | bash` one-liner
- ADR 011 hyphenation and heading normalised; NixOS retyped `platform`, Jellyfin `tool`

**Test coverage**
- The project page test mocked `Markdown` without inspecting its `components` prop, so deleting `Mermaid` from the registry left the suite green. It now asserts the registry contents — verified by mutation
- Mermaid charts render client-side, so a malformed diagram was invisible to typecheck, lint, build and CI, surfacing only as an error box in the browser. Now covered (21 charts across 165 content files)

## Validation

- `pnpm typecheck` ✓
- `biome check` — clean on changed files
- MDX lint (`remark --frail`) ✓
- Tests (`pnpm test`) — **803 passing** ✓
- Production build (`NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder pnpm build`) ✓ — regenerates `out/projects/homelab/**` and the agent-markdown twins
- SonarQube quality gate ✓ — 0 new issues, 0 hotspots, 100% coverage on new code, 0% duplication
- All 17 CI checks green (`backend` skipped — frontend-only preview)

`mise` was unavailable in the review environment, so per `AGENTS.md` the equivalents were run directly and the pre-commit hook was bypassed; `gitleaks` and the git-history secret scan both pass in CI.

## QA requirements
- Verify /projects/homelab renders with the Mermaid topology diagram
- Verify an ADR page (e.g. /projects/homelab/adrs/013-amazon-echo) renders
- Verify /projects/homelab.md and /llms.txt include the new project

## Summary by CodeRabbit

* **New Features**
  * Added Mermaid diagram support to project descriptions.
  * Added a comprehensive Home Lab project overview covering architecture, services, implementation plans and future improvements.
  * Added ten Home Lab technologies to the technology catalogue.
* **Documentation**
  * Added architecture decision records covering networking, DNS, monitoring, backups, development tools, media, printing and hardware.
* **Tests**
  * Added coverage for Home Lab project rendering, ADR output and Mermaid chart validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Home Lab project, including architecture, services, implementation plans and future direction.
  * Added documentation for Home Lab technology decisions and operational practices.
  * Added ten technologies to the technology catalogue.
  * Project descriptions now support Mermaid diagrams.

* **Documentation**
  * Documented networking, monitoring, backups, media, printing, development tools and compute infrastructure.

* **Tests**
  * Added coverage for project rendering, Mermaid integration and Mermaid diagram validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->