### PR TITLE
Group split toolchains and auto-merge dev-only dependencies in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,9 +46,57 @@
       "automerge": true
     },
     {
+      "description": "Auto-merge mise-managed dev tooling - linters, scanners and toolchains that CI exercises on every PR",
+      "matchManagers": ["mise"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true
+    },
+    {
+      "description": "Review mise tools that touch real infrastructure or backup data by hand - no CI job proves these before they run for real",
+      "matchManagers": ["mise"],
+      "matchDepNames": ["terraform", "awscli", "age", "jq"],
+      "minimumReleaseAge": "7 days",
+      "automerge": false
+    },
+    {
+      "description": "Auto-merge pip tooling pinned in workflow run steps (e.g. dvc)",
+      "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true
+    },
+    {
+      "description": "ai-review and ml-pipelines never ship to production, so treat their runtime dependencies like devDependencies",
+      "matchFileNames": ["ai-review/**", "ml-pipelines/**"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true
+    },
+    {
       "description": "Keep the pnpm version pinned in package.json (packageManager) and .mise.toml in one PR so they land together",
       "matchPackageNames": ["pnpm", "pnpm/pnpm"],
       "groupName": "pnpm"
+    },
+    {
+      "description": "pnpm is dev tooling in practice, so auto-merge it on the devDependencies terms",
+      "matchPackageNames": ["pnpm", "pnpm/pnpm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "3 days",
+      "automerge": true
+    },
+    {
+      "description": "drizzle-orm (dependencies) and drizzle-kit (devDependencies) generate and apply the same migrations, so land them together and review by hand",
+      "matchPackageNames": ["drizzle-orm", "drizzle-kit"],
+      "groupName": "drizzle",
+      "minimumReleaseAge": "7 days",
+      "automerge": false
+    },
+    {
+      "description": "Group the Cloudflare Workers toolchain so wrangler and its types/test-pool packages stay aligned",
+      "matchPackageNames": ["wrangler", "@cloudflare/**"],
+      "groupName": "cloudflare workers toolchain"
     },
     {
       "description": "Disable release age for lockfile maintenance",

--- a/renovate.json
+++ b/renovate.json
@@ -67,8 +67,8 @@
       "automerge": true
     },
     {
-      "description": "ai-review and ml-pipelines never ship to production, so treat their runtime dependencies like devDependencies",
-      "matchFileNames": ["ai-review/**", "ml-pipelines/**"],
+      "description": "ml-pipelines is offline tooling with no deploy of its own, so treat its runtime dependencies like devDependencies",
+      "matchFileNames": ["ml-pipelines/**"],
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "minimumReleaseAge": "3 days",

--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,11 @@
       "automerge": true
     },
     {
+      "description": "Keep the pnpm version pinned in package.json (packageManager) and .mise.toml in one PR so they land together",
+      "matchPackageNames": ["pnpm", "pnpm/pnpm"],
+      "groupName": "pnpm"
+    },
+    {
       "description": "Disable release age for lockfile maintenance",
       "matchUpdateTypes": ["lockFileMaintenance"],
       "minimumReleaseAge": null

--- a/renovate.json
+++ b/renovate.json
@@ -53,9 +53,9 @@
       "automerge": true
     },
     {
-      "description": "Review mise tools that touch real infrastructure or backup data by hand - no CI job proves these before they run for real",
+      "description": "Review the Neon backup toolchain by hand - the backup job runs against real data and no CI job proves these beforehand",
       "matchManagers": ["mise"],
-      "matchDepNames": ["terraform", "awscli", "age", "jq"],
+      "matchDepNames": ["awscli", "age", "jq"],
       "minimumReleaseAge": "7 days",
       "automerge": false
     },


### PR DESCRIPTION
## Why

Renovate tracks the pnpm version twice — as `packageManager` in the root `package.json` (npm manager) and as the `github:pnpm/pnpm` tool in `.mise.toml` (mise manager). Different managers mean different branch topics, so it kept opening two PRs (#916, #917) that had to be merged in lockstep to keep the pins consistent. Those two are now merged; this change stops the split recurring.

Auditing for the same shape turned up a second, broader problem: the existing automerge rules key off the npm `dependencies` / `devDependencies` depTypes, so **anything Renovate tracks with neither depType falls through every rule and lands on manual review**. That was silently catching every mise-managed tool.

## What changed

Only `renovate.json`. Nine new `packageRules`.

### Now auto-merged (non-major, 3-day release age)

| Category | Examples |
|---|---|
| mise-managed tooling | `terraform`, `tflint`, `actionlint`, `zizmor`, `gitleaks`, `typos`, `uv`, `node`, `pnpm` |
| pip pins in workflow run steps (custom manager) | `dvc[s3]` in `ml-pipelines-ci.yml` |
| runtime deps of `ml-pipelines/**` | incl. `tools/viz` |

Every mise tool is a linter, scanner or toolchain that CI already exercises on each PR, so a bad release fails a check rather than reaching anything real. `terraform` is included because `infra-ci` runs a plan on every PR, proving a CLI bump before it can reach an apply.

`awscli`, `age` and `jq` are **excluded** and keep the 7-day age plus manual review: they drive the Neon backup job against real data, and no CI job proves them beforehand.

`ml-pipelines` qualifies as dev-only because it has a CI workflow but no CD workflow — nothing it depends on is deployed. Everything else stays on production terms, including `ai-review`: an earlier revision of this PR wrongly classified it as dev-only, but `ai-review-cd.yml` deploys a Worker, Durable Object and Workflow to a `production-ai-review` environment, and its runtime dependency `@octokit/auth-app` handles the GitHub App private key. Caught in review; fixed in 2017ccb. `packages/*` likewise stays on production terms — observability, recipe-db, recipe-domain and recipe-parsing all get bundled into the UI and Workers.

### Now grouped

- **pnpm** — `packageManager` + `.mise.toml` in one PR. Two names are needed because the deps normalize differently and `matchPackageNames` matches on `packageName` only: `pnpm` (the `packageManager` dep sets no explicit `packageName`, so Renovate defaults it from `depName`) and `pnpm/pnpm` (the mise `github:` backend strips the prefix for the `github-tags` datasource).
- **drizzle** — `drizzle-orm` (dependencies) and `drizzle-kit` (devDependencies) aren't in Renovate's monorepo preset, so they arrived separately *with different policies*: kit minors auto-merged while orm minors waited for review. Two halves of one migration toolchain drifting apart. Now one manually-reviewed PR. Tradeoff: drizzle patches no longer auto-merge.
- **cloudflare workers toolchain** — `wrangler` + `@cloudflare/*` (types, vitest-pool-workers). One toolchain, also absent from the monorepo preset. Noise reduction rather than a correctness fix.

Each group carries an explicit `minimumReleaseAge`. Without it the drizzle group inherited 7 days for orm and 3 for kit, so kit would have become eligible four days early and shipped alone — recreating the exact split the grouping removes.

## Validation

- `renovate-config-validator` passes (same check `renovate-config-validator.yml` runs on this path).
- Ran the config through Renovate's own `applyPackageRules` against 20 representative deps × patch/minor/major, confirming each resolves to the intended automerge, group and release age. Negative cases included: `next`, `hono` and `postgres` minors still require review; `ai-review`'s `@octokit/auth-app` minor requires review at 7 days; majors stay behind `dependencyDashboardApproval` everywhere; and the `cloudflare` API SDK in `ui/` devDependencies is not pulled into the `@cloudflare/**` group.

Checked and deliberately left alone: `terraform required_version = ">= 1.14"` is a floor constraint Renovate won't bump; the vitest, opentelemetry, radix-ui, react, tanstack and remark families are already grouped by `group:monorepos` via `config:recommended`.

## Known follow-up, out of scope here

CodeRabbit flagged that the `main` ruleset reportedly has no required status checks, which combined with Renovate's default `platformAutomerge: true` would let GitHub auto-merge fire before CI. The mechanism is real, but it is pre-existing — devDependencies, production patches, all GitHub Actions updates and lockfile maintenance already auto-merge — and in practice auto-merged PRs are merging hours after creation rather than instantly (#930: 3h37m, #931: 3h15m), which is the signature of Renovate merging after verifying branch status. Fixing it means changing repository settings or setting `platformAutomerge: false` globally, both of which affect every existing automerge rule. Flagged for a separate decision. Full disposition in the review thread.

## QA

No preview backend needed — config-only change, no runtime or infrastructure surface. The real proof is behavioural and arrives after merge: the next pnpm bump should appear as a single `renovate/pnpm` PR touching both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated maintenance for project tooling and development packages.
  * Added safer grouping and review controls for updates, helping reduce unnecessary disruption.
  * No changes to the product’s user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->