### PR TITLE
Fix preview seed ingredients and add household/pantry fixtures

### DIFF
--- a/docs/preview-environments.md
+++ b/docs/preview-environments.md
@@ -214,7 +214,8 @@ open or update an internal PR — the workflow runs from `main`. Confirm:
    of `preview-base`, with no production rows.
 3. Cloudflare contains `recipe-api-pr-<number>` with no Hyperdrive binding.
 4. The canonical `https://pr-<number>.<pages-host>` URL requires Access.
-5. The sign-in menu offers the empty, populated, and administrator scenarios.
+5. The sign-in menu offers the empty, populated, administrator, and paired
+   household (owner and member) scenarios.
 6. The onboarding sign-up button creates a new empty QA account on every use.
 7. Closing the PR removes both the Neon branch and Worker.
 

--- a/workers/recipe-api/scripts/seed-preview.ts
+++ b/workers/recipe-api/scripts/seed-preview.ts
@@ -207,9 +207,12 @@ try {
 
   // A ready-made household so household features (shared pantry, member list,
   // household-only recipes, invitations) have data on first sign-in. Both
-  // members belong to one household from the start. Deterministic IDs keep the
-  // seed idempotent across retries within a workflow run.
-  const HOUSEHOLD_ID = "preview-household-shared";
+  // members belong to one household from the start. The IDs are deterministic
+  // (so the seed is idempotent across retries within a workflow run) but must
+  // be valid UUIDs: the household routes validate `householdId`/`memberId` with
+  // `z.string().uuid()`, matching the `crypto.randomUUID()` IDs real
+  // households get at runtime. Plain-string IDs 400 with "Invalid household ID".
+  const HOUSEHOLD_ID = "11111111-1111-4111-8111-111111111111";
   const HOUSEHOLD_SLUG = "preview-shared-household";
 
   await db
@@ -226,13 +229,13 @@ try {
 
   const householdMembers: Array<typeof schema.member.$inferInsert> = [
     {
-      id: "preview-member-household-owner",
+      id: "22222222-2222-4222-8222-222222222222",
       organizationId: HOUSEHOLD_ID,
       userId: householdOwnerUserId,
       role: "owner",
     },
     {
-      id: "preview-member-household-member",
+      id: "33333333-3333-4333-8333-333333333333",
       organizationId: HOUSEHOLD_ID,
       userId: householdMemberUserId,
       role: "member",

--- a/workers/recipe-api/scripts/seed-preview.ts
+++ b/workers/recipe-api/scripts/seed-preview.ts
@@ -5,6 +5,8 @@ import { RecipeContentSchema } from "recipe-domain";
 import { previewScenarios } from "../src/preview-scenarios";
 import { syncCanonicalUserEmail } from "../src/user-emails";
 
+type PantryLocation = (typeof schema.pantryLocationEnum.enumValues)[number];
+
 function previewRecipeBody(
   slug: string,
   title: string,
@@ -103,7 +105,18 @@ try {
   );
   const recipesUserId = userIdByEmail.get("recipes-user@preview.invalid");
   const adminUserId = userIdByEmail.get("admin-user@preview.invalid");
-  if (!recipesUserId || !adminUserId) {
+  const householdOwnerUserId = userIdByEmail.get(
+    "household-owner@preview.invalid",
+  );
+  const householdMemberUserId = userIdByEmail.get(
+    "household-member@preview.invalid",
+  );
+  if (
+    !recipesUserId ||
+    !adminUserId ||
+    !householdOwnerUserId ||
+    !householdMemberUserId
+  ) {
     throw new Error("Preview users were not created correctly");
   }
 
@@ -116,12 +129,12 @@ try {
           "preview-private-weeknight-pasta",
           "Preview Weeknight Pasta",
           "Private fixture for authenticated recipe QA.",
-          "Cook the @pasta{200%g}, then combine with @tomato sauce{150%g}.",
+          "Cook the @pasta{200%g}, then combine with @tomato passata{150%g}.",
           [
             { ingredient: "pasta", amount: 200, unit: "g" },
-            { ingredient: "tomato-sauce", amount: 150, unit: "g" },
+            { ingredient: "tomato-passata", amount: 150, unit: "g" },
           ],
-          ["Cook the pasta, then combine with tomato sauce."],
+          ["Cook the pasta, then combine with tomato passata."],
         ),
         userId: recipesUserId,
         visibility: "private",
@@ -134,12 +147,12 @@ try {
           "preview-public-tomato-toast",
           "Preview Tomato Toast",
           "Public fixture for visibility and listing QA.",
-          "Toast the @bread{2%slices} and top with @tomato{1}.",
+          "Toast the @bread{2%slices} and top with @vine tomato{1}.",
           [
             { ingredient: "bread", amount: 2 },
-            { ingredient: "tomato", amount: 1 },
+            { ingredient: "vine-tomato", amount: 1 },
           ],
-          ["Toast the bread and top with tomato."],
+          ["Toast the bread and top with vine tomato."],
         ),
         userId: recipesUserId,
         visibility: "public",
@@ -152,15 +165,38 @@ try {
           "preview-admin-soup",
           "Preview Admin Soup",
           "Administrator-owned fixture.",
-          "Simmer @stock{500%ml} with @vegetables{300%g}.",
+          "Simmer @chicken stock{500%ml} with @frozen vegetables{300%g}.",
           [
-            { ingredient: "stock", amount: 500, unit: "ml" },
-            { ingredient: "vegetables", amount: 300, unit: "g" },
+            { ingredient: "chicken-stock", amount: 500, unit: "ml" },
+            { ingredient: "frozen-vegetables", amount: 300, unit: "g" },
           ],
-          ["Simmer the stock with the vegetables."],
+          ["Simmer the chicken stock with the frozen vegetables."],
         ),
         userId: adminUserId,
         visibility: "private",
+    },
+    {
+        slug: "preview-household-veggie-curry",
+        title: "Preview Household Veggie Curry",
+        description: "Household-only fixture for shared feed and pantry QA.",
+        body: previewRecipeBody(
+          "preview-household-veggie-curry",
+          "Preview Household Veggie Curry",
+          "Household-only fixture for shared feed and pantry QA.",
+          "Fry the @garlic{2%cloves} and @carrot{1}, add @frozen vegetables{300%g}, then simmer in @coconut milk{200%ml} and @chicken stock{200%ml}.",
+          [
+            { ingredient: "garlic", amount: 2 },
+            { ingredient: "carrot", amount: 1 },
+            { ingredient: "frozen-vegetables", amount: 300, unit: "g" },
+            { ingredient: "coconut-milk", amount: 200, unit: "ml" },
+            { ingredient: "chicken-stock", amount: 200, unit: "ml" },
+          ],
+          [
+            "Fry the garlic and carrot, add the frozen vegetables, then simmer in coconut milk and chicken stock.",
+          ],
+        ),
+        userId: householdOwnerUserId,
+        visibility: "household",
     },
   ];
 
@@ -173,6 +209,136 @@ try {
         set: previewRecipe,
       });
   }
+
+  // A ready-made household so household features (shared pantry, member list,
+  // household-only recipes, invitations) have data on first sign-in. Both
+  // members belong to one household from the start. Deterministic IDs keep the
+  // seed idempotent across retries within a workflow run.
+  const HOUSEHOLD_ID = "preview-household-shared";
+  const HOUSEHOLD_SLUG = "preview-shared-household";
+
+  await db
+    .insert(schema.organization)
+    .values({
+      id: HOUSEHOLD_ID,
+      name: "Preview Shared Household",
+      slug: HOUSEHOLD_SLUG,
+    })
+    .onConflictDoUpdate({
+      target: schema.organization.id,
+      set: { name: "Preview Shared Household", slug: HOUSEHOLD_SLUG },
+    });
+
+  const householdMembers: Array<typeof schema.member.$inferInsert> = [
+    {
+      id: "preview-member-household-owner",
+      organizationId: HOUSEHOLD_ID,
+      userId: householdOwnerUserId,
+      role: "owner",
+    },
+    {
+      id: "preview-member-household-member",
+      organizationId: HOUSEHOLD_ID,
+      userId: householdMemberUserId,
+      role: "member",
+    },
+  ];
+  for (const householdMember of householdMembers) {
+    await db
+      .insert(schema.member)
+      .values(householdMember)
+      .onConflictDoUpdate({
+        target: schema.member.userId,
+        set: {
+          organizationId: householdMember.organizationId,
+          role: householdMember.role,
+        },
+      });
+  }
+
+  // Shared household pantry: owned by the organization, so every member sees the
+  // same stock. Ingredients are canonical slugs that also appear in the seeded
+  // recipes, so "what can I cook" style matching lights up.
+  const sharedPantry: Array<{ slug: string; location: PantryLocation }> = [
+    { slug: "butter", location: "fridge" },
+    { slug: "milk", location: "fridge" },
+    { slug: "cheddar-cheese", location: "fridge" },
+    { slug: "chicken-breast", location: "fridge" },
+    { slug: "pasta", location: "cupboards" },
+    { slug: "rice", location: "cupboards" },
+    { slug: "chicken-stock", location: "cupboards" },
+    { slug: "tomato-passata", location: "cupboards" },
+    { slug: "olive-oil", location: "cupboards" },
+    { slug: "coconut-milk", location: "cupboards" },
+    { slug: "garlic", location: "fresh" },
+    { slug: "carrot", location: "fresh" },
+    { slug: "spinach", location: "fresh" },
+  ];
+  for (const item of sharedPantry) {
+    await db
+      .insert(schema.pantryItem)
+      .values({
+        organizationId: HOUSEHOLD_ID,
+        ingredientSlug: item.slug,
+        location: item.location,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.pantryItem.organizationId,
+          schema.pantryItem.ingredientSlug,
+        ],
+        set: { location: item.location },
+      });
+  }
+
+  // Solo pantry for the recipes user, who is not in a household. This exercises
+  // the personal (user-owned) pantry path alongside the shared one.
+  const soloPantry: Array<{ slug: string; location: PantryLocation }> = [
+    { slug: "double-cream", location: "fridge" },
+    { slug: "mozzarella", location: "fridge" },
+    { slug: "penne-pasta", location: "cupboards" },
+    { slug: "tomato-passata", location: "cupboards" },
+    { slug: "olive-oil", location: "cupboards" },
+    { slug: "vine-tomato", location: "fresh" },
+    { slug: "garlic", location: "fresh" },
+  ];
+  for (const item of soloPantry) {
+    await db
+      .insert(schema.pantryItem)
+      .values({
+        userId: recipesUserId,
+        ingredientSlug: item.slug,
+        location: item.location,
+      })
+      .onConflictDoUpdate({
+        target: [schema.pantryItem.userId, schema.pantryItem.ingredientSlug],
+        set: { location: item.location },
+      });
+  }
+
+  // A dietary profile for the household owner so diet features (presets,
+  // excluded groups/ingredients, warn vs hide) have representative data. "warn"
+  // plus an excluded ingredient present in the household curry surfaces a diet
+  // clash rather than hiding the recipe outright.
+  await db
+    .insert(schema.userDietProfile)
+    .values({ userId: householdOwnerUserId, recipeMatchMode: "warn" })
+    .onConflictDoUpdate({
+      target: schema.userDietProfile.userId,
+      set: { recipeMatchMode: "warn" },
+    });
+  await db
+    .insert(schema.userDietPreset)
+    .values({ userId: householdOwnerUserId, presetKey: "pescatarian" })
+    .onConflictDoNothing();
+  await db
+    .insert(schema.userDietExcludedGroup)
+    .values({ userId: householdOwnerUserId, groupKey: "nuts" })
+    .onConflictDoNothing();
+  await db
+    .insert(schema.userDietExcludedIngredient)
+    .values({ userId: householdOwnerUserId, ingredientSlug: "coconut-milk" })
+    .onConflictDoNothing();
 
   console.log(`Seeded ${previewScenarios.length} preview scenarios.`);
 } finally {

--- a/workers/recipe-api/scripts/seed-preview.ts
+++ b/workers/recipe-api/scripts/seed-preview.ts
@@ -261,7 +261,7 @@ try {
     { slug: "chicken-breast", location: "fridge" },
     { slug: "pasta", location: "cupboards" },
     { slug: "rice", location: "cupboards" },
-    { slug: "chicken-stock", location: "cupboards" },
+    { slug: "vegetable-stock", location: "cupboards" },
     { slug: "tomato-passata", location: "cupboards" },
     { slug: "olive-oil", location: "cupboards" },
     { slug: "coconut-milk", location: "cupboards" },

--- a/workers/recipe-api/scripts/seed-preview.ts
+++ b/workers/recipe-api/scripts/seed-preview.ts
@@ -103,22 +103,17 @@ try {
   const userIdByEmail = new Map(
     seededUsers.map((seededUser) => [seededUser.email, seededUser.id]),
   );
-  const recipesUserId = userIdByEmail.get("recipes-user@preview.invalid");
-  const adminUserId = userIdByEmail.get("admin-user@preview.invalid");
-  const householdOwnerUserId = userIdByEmail.get(
-    "household-owner@preview.invalid",
-  );
-  const householdMemberUserId = userIdByEmail.get(
+  const requireUserId = (email: string): string => {
+    const id = userIdByEmail.get(email);
+    if (!id) throw new Error(`Preview user was not created correctly: ${email}`);
+    return id;
+  };
+  const recipesUserId = requireUserId("recipes-user@preview.invalid");
+  const adminUserId = requireUserId("admin-user@preview.invalid");
+  const householdOwnerUserId = requireUserId("household-owner@preview.invalid");
+  const householdMemberUserId = requireUserId(
     "household-member@preview.invalid",
   );
-  if (
-    !recipesUserId ||
-    !adminUserId ||
-    !householdOwnerUserId ||
-    !householdMemberUserId
-  ) {
-    throw new Error("Preview users were not created correctly");
-  }
 
   const previewRecipes: Array<typeof schema.recipe.$inferInsert> = [
     {
@@ -183,16 +178,16 @@ try {
           "preview-household-veggie-curry",
           "Preview Household Veggie Curry",
           "Household-only fixture for shared feed and pantry QA.",
-          "Fry the @garlic{2%cloves} and @carrot{1}, add @frozen vegetables{300%g}, then simmer in @coconut milk{200%ml} and @chicken stock{200%ml}.",
+          "Fry the @garlic{2%cloves} and @carrot{1}, add @frozen vegetables{300%g}, then simmer in @coconut milk{200%ml} and @vegetable stock{200%ml}.",
           [
             { ingredient: "garlic", amount: 2 },
             { ingredient: "carrot", amount: 1 },
             { ingredient: "frozen-vegetables", amount: 300, unit: "g" },
             { ingredient: "coconut-milk", amount: 200, unit: "ml" },
-            { ingredient: "chicken-stock", amount: 200, unit: "ml" },
+            { ingredient: "vegetable-stock", amount: 200, unit: "ml" },
           ],
           [
-            "Fry the garlic and carrot, add the frozen vegetables, then simmer in coconut milk and chicken stock.",
+            "Fry the garlic and carrot, add the frozen vegetables, then simmer in coconut milk and vegetable stock.",
           ],
         ),
         userId: householdOwnerUserId,
@@ -340,7 +335,9 @@ try {
     .values({ userId: householdOwnerUserId, ingredientSlug: "coconut-milk" })
     .onConflictDoNothing();
 
-  console.log(`Seeded ${previewScenarios.length} preview scenarios.`);
+  console.log(
+    `Seeded ${previewScenarios.length} preview scenarios with household, pantry, and diet fixtures.`,
+  );
 } finally {
   await client.end({ timeout: 5 });
 }

--- a/workers/recipe-api/scripts/seed-preview.ts
+++ b/workers/recipe-api/scripts/seed-preview.ts
@@ -208,10 +208,10 @@ try {
   // A ready-made household so household features (shared pantry, member list,
   // household-only recipes, invitations) have data on first sign-in. Both
   // members belong to one household from the start. The IDs are deterministic
-  // (so the seed is idempotent across retries within a workflow run) but must
-  // be valid UUIDs: the household routes validate `householdId`/`memberId` with
-  // `z.string().uuid()`, matching the `crypto.randomUUID()` IDs real
-  // households get at runtime. Plain-string IDs 400 with "Invalid household ID".
+  // (keeping the seed idempotent across retries within a run) and must be valid
+  // UUIDs: the household routes accept `householdId`/`memberId` only as
+  // `z.string().uuid()`, the same shape `crypto.randomUUID()` produces for
+  // households created at runtime.
   const HOUSEHOLD_ID = "11111111-1111-4111-8111-111111111111";
   const HOUSEHOLD_SLUG = "preview-shared-household";
 

--- a/workers/recipe-api/scripts/seed-preview.ts
+++ b/workers/recipe-api/scripts/seed-preview.ts
@@ -268,6 +268,7 @@ try {
     { slug: "tomato-passata", location: "cupboards" },
     { slug: "olive-oil", location: "cupboards" },
     { slug: "coconut-milk", location: "cupboards" },
+    { slug: "frozen-vegetables", location: "fridge" },
     { slug: "garlic", location: "fresh" },
     { slug: "carrot", location: "fresh" },
     { slug: "spinach", location: "fresh" },

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -201,11 +201,22 @@ if (!household.id || household.membership.role !== "owner") {
   throw new Error("Household owner fixture did not match");
 }
 
+// The ID must be a UUID — that is exactly what the household routes require —
+// and validating it before building the request path keeps untrusted response
+// data out of the URL.
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+if (!uuidPattern.test(household.id)) {
+  throw new Error(`Household ID is not a UUID: ${household.id}`);
+}
+
 const members = await expectJson<HouseholdMember[]>(
-  `/households/${household.id}/members`,
+  `/households/${encodeURIComponent(household.id)}/members`,
   ownerCookie,
 );
-const memberRoles = members.map((member) => member.role).sort();
+const memberRoles = members
+  .map((member) => member.role)
+  .sort((a, b) => a.localeCompare(b));
 if (
   members.length !== 2 ||
   memberRoles[0] !== "member" ||

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -25,6 +25,18 @@ type DietProfile = {
   recipeMatchMode: "hide" | "warn";
 };
 
+type HouseholdSummary = {
+  id: string;
+  name: string;
+  membership: { id: string; role: string };
+};
+
+type HouseholdMember = {
+  id: string;
+  userId: string;
+  role: string;
+};
+
 const databaseURL = requiredEnv("DATABASE_URL");
 const siteURL = requiredEnv("BETTER_AUTH_URL");
 const apiURL = requiredEnv("PREVIEW_API_URL").replace(/\/$/, "");
@@ -83,7 +95,9 @@ async function expectAuthenticationRequired(path: string): Promise<void> {
   }
 }
 
-async function createSessionCookie(): Promise<string> {
+async function createSessionCookie(
+  email: string = previewScenarios[0].email,
+): Promise<string> {
   const { db, client } = createDb(databaseURL);
   try {
     const auth = createAuth(db, {
@@ -93,7 +107,7 @@ async function createSessionCookie(): Promise<string> {
     });
     const signIn = await auth.api.signInEmail({
       body: {
-        email: previewScenarios[0].email,
+        email,
         password: requiredEnv("PREVIEW_AUTH_PASSWORD"),
       },
       asResponse: true,
@@ -166,6 +180,40 @@ if (
   dietProfile.recipeMatchMode !== "hide"
 ) {
   throw new Error("Empty-account diet fixture did not match");
+}
+
+// Household owner scenario. This exercises the household routes, which validate
+// `householdId` (and `memberId`) as UUIDs. A non-UUID seeded organization/member
+// ID passes the seed insert (the columns are `text`) but 400s here, so this is
+// the coverage that catches an "Invalid household ID" regression.
+const ownerCookie = await createSessionCookie("household-owner@preview.invalid");
+const households = await expectJson<HouseholdSummary[]>(
+  "/households",
+  ownerCookie,
+);
+const household = households[0];
+if (households.length !== 1 || !household) {
+  throw new Error(
+    `Household owner should belong to exactly one household, saw ${households.length}`,
+  );
+}
+if (!household.id || household.membership.role !== "owner") {
+  throw new Error("Household owner fixture did not match");
+}
+
+const members = await expectJson<HouseholdMember[]>(
+  `/households/${household.id}/members`,
+  ownerCookie,
+);
+const memberRoles = members.map((member) => member.role).sort();
+if (
+  members.length !== 2 ||
+  memberRoles[0] !== "member" ||
+  memberRoles[1] !== "owner"
+) {
+  throw new Error(
+    `Household should have one owner and one member, saw roles: ${memberRoles.join(", ")}`,
+  );
 }
 
 console.log("Authenticated preview profile smoke test passed.");

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -182,10 +182,10 @@ if (
   throw new Error("Empty-account diet fixture did not match");
 }
 
-// Household owner scenario. This exercises the household routes, which validate
-// `householdId` (and `memberId`) as UUIDs. A non-UUID seeded organization/member
-// ID passes the seed insert (the columns are `text`) but 400s here, so this is
-// the coverage that catches an "Invalid household ID" regression.
+// Household owner scenario. The household routes accept only UUID-form
+// `householdId`/`memberId`, so drive them end to end — resolve the household,
+// then read its members — to confirm the seeded household is reachable through
+// the API rather than merely present in the database.
 const ownerCookie = await createSessionCookie("household-owner@preview.invalid");
 const households = await expectJson<HouseholdSummary[]>(
   "/households",

--- a/workers/recipe-api/src/preview-scenarios.ts
+++ b/workers/recipe-api/src/preview-scenarios.ts
@@ -20,6 +20,22 @@ export const previewScenarios = [
     email: "admin-user@preview.invalid",
     role: "admin",
   },
+  {
+    id: "household-owner",
+    name: "Household owner",
+    description:
+      "Owns a shared household with a stocked pantry and a dietary profile.",
+    email: "household-owner@preview.invalid",
+    role: "user",
+  },
+  {
+    id: "household-member",
+    name: "Household member",
+    description:
+      "Shares the household pantry and household-only recipes with the owner.",
+    email: "household-member@preview.invalid",
+    role: "user",
+  },
 ] as const;
 
 export type PreviewScenario = (typeof previewScenarios)[number];


### PR DESCRIPTION
## Summary

The recipe-site preview environment's seeded QA data had drifted from the canonical ingredient catalog, and several features had no data to exercise. This makes the preview coherent again and adds fixtures for household + pantry features.

### Ingredient mismatch (the "behaves weird" bug)

The seed recipes in `seed-preview.ts` referenced ingredient slugs that don't exist in the seeded `ingredient` table (populated by the `0001_diet_catalog` migration) nor in `packages/recipe-parsing/.../canonical-ingredients.json`. Recipe bodies aren't FK-validated, so these passed at write time but broke runtime ingredient/pantry matching. Repointed to real canonical slugs present in **both** sources:

| Was | Now |
| --- | --- |
| `tomato-sauce` | `tomato-passata` |
| `tomato` | `vine-tomato` |
| `stock` | `chicken-stock` |
| `vegetables` | `frozen-vegetables` |

### Missing feature data

The three existing scenarios were all solo cooks, so households, shared pantries, household-visibility feeds, and diet profiles had nothing behind them. Added:

- **Two new scenarios** — `household-owner` and `household-member` — that belong to one shared household from first sign-in. Appended after the existing three, so `previewScenarios[0]` stays `empty-user` (the smoke tests depend on that).
- **A shared, household-owned pantry** stocked across all three locations (fridge/cupboards/fresh), using ingredients that overlap the seeded recipes so pantry/"what can I cook" matching lights up.
- **A solo, user-owned pantry** for `recipes-user` to cover the non-household pantry path.
- **A household-only recipe** (`preview-household-veggie-curry`) for shared-feed QA.
- **A dietary profile** on the household owner (pescatarian preset, excluded `nuts` group, excluded `coconut-milk`, `warn` mode) — the excluded ingredient appears in the household curry, so it surfaces a diet clash rather than hiding the recipe.

All new writes use deterministic IDs and upserts, so the seed stays idempotent across retries within a workflow run, matching the existing convention.

## Validation

- `pnpm typecheck` (incl. `tsconfig.scripts.json`) — pass
- `pnpm test` — 197 pass
- `pnpm db:check` (migration/snapshot parity) — pass
- `markdownlint` on the changed doc — pass

The pre-commit hook couldn't run locally (`mise` unavailable in the session); its equivalent checks were run by hand.

## QA requirements

Needs a backend preview (sign-in + seeded data + API Worker). Commenting `/preview-backend` to provision it. Once up:

1. Sign-in menu lists five scenarios including **Household owner** and **Household member**.
2. Sign in as each household user → both see the same shared pantry and the household-only curry.
3. Sign in as **User with recipes** → sees a personal pantry and no household.
4. Recipe pages for the seeded recipes resolve ingredients cleanly (no unmatched slugs).
5. Household owner's diet profile flags the curry's `coconut-milk` under `warn` mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEifd6ada77ECNPcfbWTiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added household owner and household member preview scenarios.
  * Preview data now includes shared and personal pantries, household-only recipes, and household membership.
  * Added household owner dietary preferences, presets, and exclusions to preview data.
* **Documentation**
  * Updated the preview smoke-test checklist to include the paired household sign-in scenario alongside existing scenarios.
* **Tests**
  * Added checks for household membership, member roles, and valid household identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->