### PR TITLE
Sink and strike completed sections in shopping aisle view

### DIFF
--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -218,10 +218,18 @@ function ItemRow({
 function SectionHeading({
   title,
   hint,
-}: Readonly<{ title: string; hint?: string }>) {
+  done = false,
+}: Readonly<{ title: string; hint?: string; done?: boolean }>) {
   return (
     <div className="flex items-baseline justify-between border-b border-[var(--line)] pb-1 mt-5 first:mt-0">
-      <h3 className="rt-display text-2xl text-[var(--terracotta)]">
+      <h3
+        className={[
+          "rt-display text-2xl transition-colors",
+          done
+            ? "text-[var(--ink-3)] line-through"
+            : "text-[var(--terracotta)]",
+        ].join(" ")}
+      >
         · {title}
       </h3>
       {hint && <span className="rt-mono text-[var(--ink-3)]">{hint}</span>}
@@ -441,6 +449,24 @@ export function ShoppingList({
     .join(" · ");
   const hasTicked = tickedCount > 0;
 
+  // In aisle view, once every (still-to-buy) item in a section is ticked off,
+  // the whole section is done: its header gets struck through and the section
+  // sinks below the aisles that still have shopping left, keeping attention on
+  // what remains. Ordering is stable within each partition.
+  const aisleSections = aisleGroups
+    .map((group) => {
+      const lines = groupLines(group.lines);
+      const done =
+        lines.length > 0 &&
+        lines.every((line) => checkedSet.has(line.ingredient));
+      return { group, lines, done };
+    })
+    .filter((section) => section.lines.length > 0);
+  const orderedAisleSections = [
+    ...aisleSections.filter((section) => !section.done),
+    ...aisleSections.filter((section) => section.done),
+  ];
+
   if (selected.length === 0 && state.extras.length === 0) {
     return (
       <div className="rounded-xl border-[1.25px] border-dashed border-[var(--line-strong)] bg-[var(--card)] p-10 text-center">
@@ -527,29 +553,25 @@ export function ShoppingList({
         )}
 
         {view === "aisle" &&
-          aisleGroups.map((group) => {
-            const lines = groupLines(group.lines);
-            if (lines.length === 0) return null;
-            return (
-              <div key={group.id}>
-                <SectionHeading title={group.name} />
-                <div className="mt-1">
-                  {lines.map((line) => (
-                    <ItemRow
-                      key={line.ingredient}
-                      line={line}
-                      system={system}
-                      checked={checkedSet.has(line.ingredient)}
-                      kitchenLocation={locationOf(line)}
-                      onToggle={handleIngredientToggle}
-                      showRecipes
-                      onRemoveFromStock={stockActions.removeFromStock}
-                    />
-                  ))}
-                </div>
+          orderedAisleSections.map(({ group, lines, done }) => (
+            <div key={group.id}>
+              <SectionHeading title={group.name} done={done} />
+              <div className="mt-1">
+                {lines.map((line) => (
+                  <ItemRow
+                    key={line.ingredient}
+                    line={line}
+                    system={system}
+                    checked={checkedSet.has(line.ingredient)}
+                    kitchenLocation={locationOf(line)}
+                    onToggle={handleIngredientToggle}
+                    showRecipes
+                    onRemoveFromStock={stockActions.removeFromStock}
+                  />
+                ))}
               </div>
-            );
-          })}
+            </div>
+          ))}
 
         {view === "recipe" &&
           recipeGroups.map((group) => {

--- a/ui/tests/components/recipes/shopping/shopping-list.test.tsx
+++ b/ui/tests/components/recipes/shopping/shopping-list.test.tsx
@@ -119,6 +119,73 @@ describe("ShoppingList value analytics", () => {
   });
 });
 
+type Slug = ShoppingRecipe["ingredients"][number]["ingredient"];
+
+const twoAisleRecipes: ShoppingRecipe[] = [
+  {
+    slug: "veg-and-chicken",
+    title: "Veg and chicken",
+    servings: 2,
+    cuisine: [],
+    ingredients: [
+      {
+        ingredient: "garlic" as Slug,
+        name: "garlic",
+        amount: 1,
+        unit: "clove",
+        category: "vegetable",
+      },
+      {
+        ingredient: "chicken-breast" as Slug,
+        name: "chicken breast",
+        amount: 200,
+        unit: "g",
+        category: "protein",
+      },
+    ],
+  },
+];
+
+const aisleHeadings = () =>
+  screen
+    .getAllByRole("heading", { level: 3 })
+    .filter((h) => /fruit & veg|meat & fish/i.test(h.textContent ?? ""));
+
+describe("ShoppingList aisle view section completion", () => {
+  beforeEach(() => {
+    pantryState.error = null;
+    pantryState.isPending = false;
+    localStorage.clear();
+    __resetShoppingListForTests();
+    addRecipe("veg-and-chicken");
+  });
+
+  afterEach(() => {
+    __resetShoppingListForTests();
+  });
+
+  it("sinks a fully-checked aisle below aisles still to buy and strikes its header", async () => {
+    const user = userEvent.setup();
+    render(<ShoppingList recipes={twoAisleRecipes} />);
+
+    const [first, second] = aisleHeadings();
+    expect(first).toHaveTextContent("Fruit & veg");
+    expect(second).toHaveTextContent("Meat & fish");
+    expect(first).not.toHaveClass("line-through");
+
+    // Tick off the only produce item, completing the Fruit & veg aisle.
+    await user.click(screen.getByRole("button", { name: /garlic/i }));
+
+    const [newFirst, newSecond] = aisleHeadings();
+    // Meat & fish (still to buy) rises above the completed Fruit & veg aisle.
+    expect(newFirst).toHaveTextContent("Meat & fish");
+    expect(newSecond).toHaveTextContent("Fruit & veg");
+    // The completed aisle's header is scored off.
+    expect(newSecond).toHaveClass("line-through");
+    expect(newFirst).not.toHaveClass("line-through");
+  });
+});
+
 describe("ShoppingList pantry state", () => {
   beforeEach(() => {
     pantryState.error = null;


### PR DESCRIPTION
## Summary

In the shopping list's **aisle view**, once every still-to-buy item in a section is ticked off, the whole section is now treated as done:

- **The section header is scored off** — muted ink with a `line-through` in place of the terracotta accent.
- **The completed section sinks** below the aisles that still have shopping left, keeping attention on what remains. Ordering is stable within each partition (aisles still to buy keep their store-walk order; completed ones stack at the bottom).

Only the aisle view is affected; by-recipe and just-ingredients views are unchanged. "All checked" is measured against still-to-buy items only — ingredients already in your kitchen are filtered out of the section by the existing `groupLines` helper, so a section counts as done when the remaining to-buy items are all ticked.

## Changes

- `ui/components/recipes/shopping/shopping-list.tsx`
  - `SectionHeading` gains a `done` prop that swaps the accent colour for a struck-through muted style.
  - Aisle sections are computed at render time (matching the existing inline `groupLines` usage), with fully-checked sections partitioned to the bottom.
- `ui/tests/components/recipes/shopping/shopping-list.test.tsx`
  - New regression test: ticking off the only item in one aisle sinks it below an aisle still to buy and strikes its header.

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` (Biome) — no errors
- `pnpm test` — 803 tests pass; new test included (6 in the shopping-list suite)
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder pnpm build` — succeeds

## QA notes

No backend/sign-in needed. To check in preview: open the recipes shopping list, add a couple of recipes spanning more than one aisle, switch to **by aisle**, and tick off every item in one aisle — that aisle's header should strike through and drop below the aisles that still have items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2Qs32tLs6a7bfUDe9y9Dk)_