### PR TITLE
Improve mobile filter search

### DIFF
--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -221,153 +221,152 @@ export function FilterBar({
 
         {/* Mobile filters use a category-first drill-down so large option sets
             never turn the drawer into one long, difficult-to-scan page. */}
-        {mobileFilterSections?.length ? (
-          mobileSection ? (
-            <div className="flex min-h-0 flex-1 flex-col">
-              <div className="shrink-0 border-b p-4">
-                <div className="relative">
-                  <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    type="search"
-                    placeholder={`Search ${mobileSection.label.toLocaleLowerCase()}…`}
-                    value={mobileFilterQuery}
-                    onChange={(event) =>
-                      setMobileFilterQuery(event.target.value)
-                    }
-                    className="h-11 pl-9 pr-9 [&::-webkit-search-cancel-button]:appearance-none"
-                    aria-label={`Search ${mobileSection.label} filter values`}
-                  />
-                  {mobileFilterQuery && (
-                    <button
-                      type="button"
-                      onClick={() => setMobileFilterQuery("")}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:text-foreground"
-                      aria-label={`Clear ${mobileSection.label} search`}
-                    >
-                      <X className="size-4" />
-                    </button>
-                  )}
-                </div>
-                <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
-                  <span>Tap once to include · again to exclude</span>
-                  <span aria-live="polite">
-                    {visibleMobileOptions.length} of{" "}
-                    {mobileSection.options.length}
-                  </span>
-                </div>
-              </div>
-              <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
-                {visibleMobileOptions.length > 0 ? (
-                  <div className="space-y-1">
-                    {visibleMobileOptions.map((option) => {
-                      const state = mobileSection.getOptionState(option.value);
-                      const isIncluded = state === "include";
-                      const isExcluded = state === "exclude";
-                      return (
-                        <button
-                          key={option.value}
-                          type="button"
-                          aria-label={filterStateAriaLabel(option.label, state)}
-                          className={cn(
-                            "flex min-h-11 w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                            (isIncluded || isExcluded) && "bg-accent/60",
-                          )}
-                          onClick={() =>
-                            mobileSection.onCycleOption(option.value)
-                          }
-                        >
-                          {option.icon && (
-                            <span className="shrink-0 text-muted-foreground">
-                              {option.icon}
-                            </span>
-                          )}
-                          <span
-                            className={cn(
-                              "min-w-0 flex-1 truncate",
-                              isExcluded && "line-through",
-                            )}
-                          >
-                            {option.label}
-                          </span>
-                          {isIncluded && (
-                            <span className="flex items-center gap-1 text-xs font-medium text-primary">
-                              Included <Check className="size-4" />
-                            </span>
-                          )}
-                          {isExcluded && (
-                            <span className="flex items-center gap-1 text-xs font-medium text-destructive">
-                              Excluded <Minus className="size-4" />
-                            </span>
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <div className="px-4 py-12 text-center">
-                    <Search className="mx-auto mb-3 size-6 text-muted-foreground" />
-                    <p className="font-medium">No matching values</p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      Try a different search for{" "}
-                      {mobileSection.label.toLowerCase()}.
-                    </p>
-                  </div>
+        {mobileFilterSections?.length && mobileSection && (
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 border-b p-4">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  type="search"
+                  placeholder={`Search ${mobileSection.label.toLocaleLowerCase()}…`}
+                  value={mobileFilterQuery}
+                  onChange={(event) => setMobileFilterQuery(event.target.value)}
+                  className="h-11 pl-9 pr-9 [&::-webkit-search-cancel-button]:appearance-none"
+                  aria-label={`Search ${mobileSection.label} filter values`}
+                />
+                {mobileFilterQuery && (
+                  <button
+                    type="button"
+                    onClick={() => setMobileFilterQuery("")}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:text-foreground"
+                    aria-label={`Clear ${mobileSection.label} search`}
+                  >
+                    <X className="size-4" />
+                  </button>
                 )}
               </div>
-            </div>
-          ) : (
-            <div className="min-h-0 flex-1 overflow-y-auto p-4">
-              <p className="mb-3 text-sm text-muted-foreground">
-                Choose a category, then search or browse its values.
-              </p>
-              {mobileExtraContent && (
-                <div className="mb-4 rounded-lg border p-3">
-                  <h4 className="mb-2 text-sm font-medium">Date Range</h4>
-                  {mobileExtraContent}
-                </div>
-              )}
-              <div className="space-y-2">
-                {mobileFilterSections.map((section) => {
-                  const activeCount = section.options.reduce(
-                    (count, option) =>
-                      count +
-                      (section.getOptionState(option.value) === "off" ? 0 : 1),
-                    0,
-                  );
-                  return (
-                    <button
-                      key={section.paramName}
-                      type="button"
-                      onClick={() => openMobileSection(section.paramName)}
-                      aria-label={`${section.label}, ${section.options.length} values${activeCount ? `, ${activeCount} active` : ""}`}
-                      className="flex min-h-14 w-full items-center gap-3 rounded-lg border bg-card px-3 py-2 text-left shadow-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      {section.icon && (
-                        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-                          {section.icon}
-                        </span>
-                      )}
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-medium">
-                          {section.label}
-                        </span>
-                        <span className="block text-xs text-muted-foreground">
-                          {section.options.length} values
-                        </span>
-                      </span>
-                      {activeCount > 0 && (
-                        <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
-                          {activeCount}
-                        </span>
-                      )}
-                      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
-                    </button>
-                  );
-                })}
+              <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                <span>Tap once to include · again to exclude</span>
+                <span aria-live="polite">
+                  {visibleMobileOptions.length} of{" "}
+                  {mobileSection.options.length}
+                </span>
               </div>
             </div>
-          )
-        ) : (
+            <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+              {visibleMobileOptions.length > 0 ? (
+                <div className="space-y-1">
+                  {visibleMobileOptions.map((option) => {
+                    const state = mobileSection.getOptionState(option.value);
+                    const isIncluded = state === "include";
+                    const isExcluded = state === "exclude";
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        aria-label={filterStateAriaLabel(option.label, state)}
+                        className={cn(
+                          "flex min-h-11 w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                          (isIncluded || isExcluded) && "bg-accent/60",
+                        )}
+                        onClick={() =>
+                          mobileSection.onCycleOption(option.value)
+                        }
+                      >
+                        {option.icon && (
+                          <span className="shrink-0 text-muted-foreground">
+                            {option.icon}
+                          </span>
+                        )}
+                        <span
+                          className={cn(
+                            "min-w-0 flex-1 truncate",
+                            isExcluded && "line-through",
+                          )}
+                        >
+                          {option.label}
+                        </span>
+                        {isIncluded && (
+                          <span className="flex items-center gap-1 text-xs font-medium text-primary">
+                            Included <Check className="size-4" />
+                          </span>
+                        )}
+                        {isExcluded && (
+                          <span className="flex items-center gap-1 text-xs font-medium text-destructive">
+                            Excluded <Minus className="size-4" />
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="px-4 py-12 text-center">
+                  <Search className="mx-auto mb-3 size-6 text-muted-foreground" />
+                  <p className="font-medium">No matching values</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Try a different search for{" "}
+                    {mobileSection.label.toLowerCase()}.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+        {mobileFilterSections?.length && !mobileSection && (
+          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+            <p className="mb-3 text-sm text-muted-foreground">
+              Choose a category, then search or browse its values.
+            </p>
+            {mobileExtraContent && (
+              <div className="mb-4 rounded-lg border p-3">
+                <h4 className="mb-2 text-sm font-medium">Date Range</h4>
+                {mobileExtraContent}
+              </div>
+            )}
+            <div className="space-y-2">
+              {mobileFilterSections.map((section) => {
+                const activeCount = section.options.reduce(
+                  (count, option) =>
+                    count +
+                    (section.getOptionState(option.value) === "off" ? 0 : 1),
+                  0,
+                );
+                const activeDescription = activeCount
+                  ? `, ${activeCount} active`
+                  : "";
+                return (
+                  <button
+                    key={section.paramName}
+                    type="button"
+                    onClick={() => openMobileSection(section.paramName)}
+                    aria-label={`${section.label}, ${section.options.length} values${activeDescription}`}
+                    className="flex min-h-14 w-full items-center gap-3 rounded-lg border bg-card px-3 py-2 text-left shadow-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {section.icon && (
+                      <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                        {section.icon}
+                      </span>
+                    )}
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-medium">{section.label}</span>
+                      <span className="block text-xs text-muted-foreground">
+                        {section.options.length} values
+                      </span>
+                    </span>
+                    {activeCount > 0 && (
+                      <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+                        {activeCount}
+                      </span>
+                    )}
+                    <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+        {!mobileFilterSections?.length && (
           /* Fallback to children if no mobile sections provided */
           <div className="flex flex-col gap-3 py-4">{children}</div>
         )}

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -10,7 +10,7 @@ import {
   X,
 } from "lucide-react";
 import type * as React from "react";
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Drawer,
@@ -93,6 +93,8 @@ export function FilterBar({
   const [mobileOpen, setMobileOpen] = useState(false);
   const [mobileSectionName, setMobileSectionName] = useState<string>();
   const [mobileFilterQuery, setMobileFilterQuery] = useState("");
+  const mobileOptionsId = useId();
+  const mobileResultsStatusId = useId();
   const mobileSection = mobileFilterSections?.find(
     (section) => section.paramName === mobileSectionName,
   );
@@ -117,11 +119,13 @@ export function FilterBar({
   }, [mobileFilterQuery, mobileSection]);
 
   const handleMobileOpenChange = (open: boolean) => {
-    setMobileOpen(open);
-    if (!open) {
+    // Keep the current content mounted during Vaul's close animation, then
+    // reset the navigation state just before the next open.
+    if (open) {
       setMobileSectionName(undefined);
       setMobileFilterQuery("");
     }
+    setMobileOpen(open);
   };
 
   const openMobileSection = (paramName: string) => {
@@ -186,8 +190,8 @@ export function FilterBar({
       </DrawerTrigger>
       <DrawerContent className="h-[85dvh] max-h-[85dvh] pb-[env(safe-area-inset-bottom)]">
         <DrawerHeader className="border-b pb-3">
-          <DrawerTitle className="flex min-h-8 items-center justify-between gap-2">
-            <span className="flex min-w-0 items-center gap-2">
+          <div className="flex min-h-8 items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               {mobileSection && (
                 <Button
                   type="button"
@@ -200,11 +204,11 @@ export function FilterBar({
                   <ArrowLeft />
                 </Button>
               )}
-              <span className="truncate">
+              <DrawerTitle className="truncate">
                 {mobileSection?.label ?? "Filters"}
-              </span>
-            </span>
-            <span className="flex items-center gap-1">
+              </DrawerTitle>
+            </div>
+            <div className="flex items-center gap-1">
               {!mobileSection && hasActiveFilters && onClearAll && (
                 <Button
                   type="button"
@@ -223,8 +227,8 @@ export function FilterBar({
               >
                 Done
               </Button>
-            </span>
-          </DrawerTitle>
+            </div>
+          </div>
         </DrawerHeader>
 
         {/* Mobile filters use a category-first drill-down so large option sets
@@ -241,6 +245,8 @@ export function FilterBar({
                   onChange={(event) => setMobileFilterQuery(event.target.value)}
                   className="h-11 pl-9 pr-9 [&::-webkit-search-cancel-button]:appearance-none"
                   aria-label={`Search ${mobileSection.label} filter values`}
+                  aria-controls={mobileOptionsId}
+                  aria-describedby={mobileResultsStatusId}
                 />
                 {mobileFilterQuery && (
                   <button
@@ -255,13 +261,20 @@ export function FilterBar({
               </div>
               <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
                 <span>Tap once to include · again to exclude</span>
-                <span aria-live="polite" aria-atomic="true">
+                <span
+                  id={mobileResultsStatusId}
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
                   {visibleMobileOptions.length} of{" "}
                   {mobileSection.options.length}
                 </span>
               </div>
             </div>
-            <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+            <div
+              id={mobileOptionsId}
+              className="min-h-0 flex-1 overflow-y-auto px-2 py-2"
+            >
               {visibleMobileOptions.length > 0 ? (
                 <div className="space-y-1">
                   {visibleMobileOptions.map((option) => {

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -69,6 +69,7 @@ interface FilterBarProps {
   sortButton?: React.ReactNode;
   mobileFilterSections?: MobileFilterSection[];
   mobileExtraContent?: React.ReactNode;
+  mobileExtraContentLabel?: string;
 }
 
 export function FilterBar({
@@ -89,34 +90,43 @@ export function FilterBar({
   sortButton,
   mobileFilterSections,
   mobileExtraContent,
+  mobileExtraContentLabel,
 }: Readonly<FilterBarProps>) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [mobileSectionName, setMobileSectionName] = useState<string>();
   const [mobileFilterQuery, setMobileFilterQuery] = useState("");
+  const [mobileOptionOrder, setMobileOptionOrder] = useState<string[]>([]);
   const mobileOptionsId = useId();
   const mobileResultsStatusId = useId();
-  const mobileSection = mobileFilterSections?.find(
+  const availableMobileFilterSections = mobileFilterSections ?? [];
+  const mobileSection = availableMobileFilterSections.find(
     (section) => section.paramName === mobileSectionName,
   );
+  const hasMobileFilterSections = availableMobileFilterSections.length > 0;
+  const orderedMobileOptions = useMemo(() => {
+    if (!mobileSection) return [];
+
+    const orderByValue = new Map(
+      mobileOptionOrder.map((value, index) => [value, index]),
+    );
+    return [...mobileSection.options].sort((a, b) => {
+      const aIndex = orderByValue.get(a.value);
+      const bIndex = orderByValue.get(b.value);
+      if (aIndex === undefined && bIndex === undefined) return 0;
+      if (aIndex === undefined) return 1;
+      if (bIndex === undefined) return -1;
+      return aIndex - bIndex;
+    });
+  }, [mobileOptionOrder, mobileSection]);
   const visibleMobileOptions = useMemo(() => {
     if (!mobileSection) return [];
 
     const query = mobileFilterQuery.trim().toLocaleLowerCase();
-    const matchingOptions = query
-      ? mobileSection.options.filter((option) =>
-          option.label.toLocaleLowerCase().includes(query),
-        )
-      : mobileSection.options;
-
-    // Keep active values within easy reach when returning to a category.
-    if (query) return matchingOptions;
-    return [...matchingOptions].sort((a, b) => {
-      const aIsActive = mobileSection.getOptionState(a.value) !== "off";
-      const bIsActive = mobileSection.getOptionState(b.value) !== "off";
-      if (aIsActive === bIsActive) return 0;
-      return aIsActive ? -1 : 1;
-    });
-  }, [mobileFilterQuery, mobileSection]);
+    if (!query) return orderedMobileOptions;
+    return orderedMobileOptions.filter((option) =>
+      option.label.toLocaleLowerCase().includes(query),
+    );
+  }, [mobileFilterQuery, mobileSection, orderedMobileOptions]);
 
   const handleMobileOpenChange = (open: boolean) => {
     // Keep the current content mounted during Vaul's close animation, then
@@ -124,18 +134,34 @@ export function FilterBar({
     if (open) {
       setMobileSectionName(undefined);
       setMobileFilterQuery("");
+      setMobileOptionOrder([]);
     }
     setMobileOpen(open);
   };
 
   const openMobileSection = (paramName: string) => {
+    const section = availableMobileFilterSections.find(
+      (candidate) => candidate.paramName === paramName,
+    );
+    const orderedOptions = section
+      ? [...section.options].sort((a, b) => {
+          const aIsActive = section.getOptionState(a.value) !== "off";
+          const bIsActive = section.getOptionState(b.value) !== "off";
+          if (aIsActive === bIsActive) return 0;
+          return aIsActive ? -1 : 1;
+        })
+      : [];
     setMobileSectionName(paramName);
     setMobileFilterQuery("");
+    // Capture the active-first order when entering the category. Keeping it
+    // stable prevents a tapped row from moving underneath the user's finger.
+    setMobileOptionOrder(orderedOptions.map((option) => option.value));
   };
 
   const closeMobileSection = () => {
     setMobileSectionName(undefined);
     setMobileFilterQuery("");
+    setMobileOptionOrder([]);
   };
   const searchControl = showSearch && onSearchChange && (
     <div
@@ -233,7 +259,7 @@ export function FilterBar({
 
         {/* Mobile filters use a category-first drill-down so large option sets
             never turn the drawer into one long, difficult-to-scan page. */}
-        {mobileFilterSections?.length && mobileSection && (
+        {hasMobileFilterSections && mobileSection && (
           <div className="flex min-h-0 flex-1 flex-col">
             <div className="shrink-0 border-b p-4">
               <div className="relative">
@@ -334,19 +360,23 @@ export function FilterBar({
             </div>
           </div>
         )}
-        {mobileFilterSections?.length && !mobileSection && (
+        {hasMobileFilterSections && !mobileSection && (
           <div className="min-h-0 flex-1 overflow-y-auto p-4">
             <p className="mb-3 text-sm text-muted-foreground">
               Choose a category, then search or browse its values.
             </p>
             {mobileExtraContent && (
               <div className="mb-4 rounded-lg border p-3">
-                <h4 className="mb-2 text-sm font-medium">Date Range</h4>
+                {mobileExtraContentLabel && (
+                  <h4 className="mb-2 text-sm font-medium">
+                    {mobileExtraContentLabel}
+                  </h4>
+                )}
                 {mobileExtraContent}
               </div>
             )}
             <div className="space-y-2">
-              {mobileFilterSections.map((section) => {
+              {availableMobileFilterSections.map((section) => {
                 const activeCount = section.options.reduce(
                   (count, option) =>
                     count +
@@ -387,7 +417,7 @@ export function FilterBar({
             </div>
           </div>
         )}
-        {!mobileFilterSections?.length && (
+        {!hasMobileFilterSections && (
           /* Fallback to children if no mobile sections provided */
           <div className="flex flex-col gap-3 py-4">{children}</div>
         )}

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -170,6 +170,7 @@ export function FilterBar({
     <Drawer open={mobileOpen} onOpenChange={handleMobileOpenChange}>
       <DrawerTrigger asChild>
         <Button
+          type="button"
           variant="outline"
           size="sm"
           className="md:hidden flex items-center gap-2"
@@ -189,6 +190,7 @@ export function FilterBar({
             <span className="flex min-w-0 items-center gap-2">
               {mobileSection && (
                 <Button
+                  type="button"
                   variant="ghost"
                   size="icon-sm"
                   onClick={closeMobileSection}
@@ -204,11 +206,17 @@ export function FilterBar({
             </span>
             <span className="flex items-center gap-1">
               {!mobileSection && hasActiveFilters && onClearAll && (
-                <Button variant="ghost" size="sm" onClick={onClearAll}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={onClearAll}
+                >
                   Clear all
                 </Button>
               )}
               <Button
+                type="button"
                 variant="ghost"
                 size="sm"
                 onClick={() => handleMobileOpenChange(false)}
@@ -247,7 +255,7 @@ export function FilterBar({
               </div>
               <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
                 <span>Tap once to include · again to exclude</span>
-                <span aria-live="polite">
+                <span aria-live="polite" aria-atomic="true">
                   {visibleMobileOptions.length} of{" "}
                   {mobileSection.options.length}
                 </span>
@@ -306,7 +314,7 @@ export function FilterBar({
                   <p className="font-medium">No matching values</p>
                   <p className="mt-1 text-sm text-muted-foreground">
                     Try a different search for{" "}
-                    {mobileSection.label.toLowerCase()}.
+                    {mobileSection.label.toLocaleLowerCase()}.
                   </p>
                 </div>
               )}
@@ -381,6 +389,7 @@ export function FilterBar({
 
       {hasActiveFilters && onClearAll && (
         <Button
+          type="button"
           variant="ghost"
           size="sm"
           onClick={onClearAll}

--- a/ui/components/ui/filter-bar.tsx
+++ b/ui/components/ui/filter-bar.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { Check, Filter, Minus, Search, X } from "lucide-react";
+import {
+  ArrowLeft,
+  Check,
+  ChevronRight,
+  Filter,
+  Minus,
+  Search,
+  X,
+} from "lucide-react";
 import type * as React from "react";
-import { useState } from "react";
-import { Badge } from "@/components/ui/badge";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Drawer,
@@ -19,14 +26,6 @@ import {
   filterStateAriaLabel,
 } from "@/hooks/use-filter-params";
 import { cn } from "@/lib/generic/styles";
-
-function chipVariantForState(
-  state: FilterState,
-): "destructive" | "default" | "outline" {
-  if (state === "exclude") return "destructive";
-  if (state === "include") return "default";
-  return "outline";
-}
 
 interface ActiveFilter {
   paramName: string;
@@ -46,6 +45,7 @@ export interface MobileFilterOption {
 export interface MobileFilterSection {
   paramName: string;
   label: string;
+  icon?: React.ReactNode;
   options: MobileFilterOption[];
   getOptionState: (value: string) => FilterState;
   onCycleOption: (value: string) => void;
@@ -91,6 +91,48 @@ export function FilterBar({
   mobileExtraContent,
 }: Readonly<FilterBarProps>) {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [mobileSectionName, setMobileSectionName] = useState<string>();
+  const [mobileFilterQuery, setMobileFilterQuery] = useState("");
+  const mobileSection = mobileFilterSections?.find(
+    (section) => section.paramName === mobileSectionName,
+  );
+  const visibleMobileOptions = useMemo(() => {
+    if (!mobileSection) return [];
+
+    const query = mobileFilterQuery.trim().toLocaleLowerCase();
+    const matchingOptions = query
+      ? mobileSection.options.filter((option) =>
+          option.label.toLocaleLowerCase().includes(query),
+        )
+      : mobileSection.options;
+
+    // Keep active values within easy reach when returning to a category.
+    if (query) return matchingOptions;
+    return [...matchingOptions].sort((a, b) => {
+      const aIsActive = mobileSection.getOptionState(a.value) !== "off";
+      const bIsActive = mobileSection.getOptionState(b.value) !== "off";
+      if (aIsActive === bIsActive) return 0;
+      return aIsActive ? -1 : 1;
+    });
+  }, [mobileFilterQuery, mobileSection]);
+
+  const handleMobileOpenChange = (open: boolean) => {
+    setMobileOpen(open);
+    if (!open) {
+      setMobileSectionName(undefined);
+      setMobileFilterQuery("");
+    }
+  };
+
+  const openMobileSection = (paramName: string) => {
+    setMobileSectionName(paramName);
+    setMobileFilterQuery("");
+  };
+
+  const closeMobileSection = () => {
+    setMobileSectionName(undefined);
+    setMobileFilterQuery("");
+  };
   const searchControl = showSearch && onSearchChange && (
     <div
       className={cn(
@@ -125,7 +167,7 @@ export function FilterBar({
     </div>
   );
   const mobileFilterButton = (
-    <Drawer open={mobileOpen} onOpenChange={setMobileOpen}>
+    <Drawer open={mobileOpen} onOpenChange={handleMobileOpenChange}>
       <DrawerTrigger asChild>
         <Button
           variant="outline"
@@ -141,70 +183,190 @@ export function FilterBar({
           )}
         </Button>
       </DrawerTrigger>
-      <DrawerContent className="max-h-[70vh] pb-8">
-        <DrawerHeader className="pb-2">
-          <DrawerTitle className="flex items-center justify-between">
-            <span>Filters</span>
-            {hasActiveFilters && onClearAll && (
+      <DrawerContent className="h-[85dvh] max-h-[85dvh] pb-[env(safe-area-inset-bottom)]">
+        <DrawerHeader className="border-b pb-3">
+          <DrawerTitle className="flex min-h-8 items-center justify-between gap-2">
+            <span className="flex min-w-0 items-center gap-2">
+              {mobileSection && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={closeMobileSection}
+                  aria-label="Back to filter categories"
+                  className="-ml-2"
+                >
+                  <ArrowLeft />
+                </Button>
+              )}
+              <span className="truncate">
+                {mobileSection?.label ?? "Filters"}
+              </span>
+            </span>
+            <span className="flex items-center gap-1">
+              {!mobileSection && hasActiveFilters && onClearAll && (
+                <Button variant="ghost" size="sm" onClick={onClearAll}>
+                  Clear all
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => {
-                  onClearAll();
-                  setMobileOpen(false);
-                }}
+                onClick={() => handleMobileOpenChange(false)}
               >
-                Clear all
+                Done
               </Button>
-            )}
+            </span>
           </DrawerTitle>
         </DrawerHeader>
 
-        {/* Mobile filter sections - inline tappable chips */}
+        {/* Mobile filters use a category-first drill-down so large option sets
+            never turn the drawer into one long, difficult-to-scan page. */}
         {mobileFilterSections?.length ? (
-          <div className="overflow-y-auto max-h-[calc(70vh-100px)] px-1">
-            <div className="space-y-4">
-              {mobileExtraContent && (
-                <div className="mb-4 pb-4 border-b">
-                  <h4 className="text-sm font-medium mb-2 px-1">Date Range</h4>
-                  {mobileExtraContent}
+          mobileSection ? (
+            <div className="flex min-h-0 flex-1 flex-col">
+              <div className="shrink-0 border-b p-4">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    type="search"
+                    placeholder={`Search ${mobileSection.label.toLocaleLowerCase()}…`}
+                    value={mobileFilterQuery}
+                    onChange={(event) =>
+                      setMobileFilterQuery(event.target.value)
+                    }
+                    className="h-11 pl-9 pr-9 [&::-webkit-search-cancel-button]:appearance-none"
+                    aria-label={`Search ${mobileSection.label} filter values`}
+                  />
+                  {mobileFilterQuery && (
+                    <button
+                      type="button"
+                      onClick={() => setMobileFilterQuery("")}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full p-1 text-muted-foreground hover:text-foreground"
+                      aria-label={`Clear ${mobileSection.label} search`}
+                    >
+                      <X className="size-4" />
+                    </button>
+                  )}
                 </div>
-              )}
-              {mobileFilterSections.map((section) => (
-                <div key={section.paramName}>
-                  <h4 className="text-sm font-medium mb-2 px-1">
-                    {section.label}
-                  </h4>
-                  <div className="flex flex-wrap gap-2">
-                    {section.options.map((option) => {
-                      const state = section.getOptionState(option.value);
+                <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+                  <span>Tap once to include · again to exclude</span>
+                  <span aria-live="polite">
+                    {visibleMobileOptions.length} of{" "}
+                    {mobileSection.options.length}
+                  </span>
+                </div>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+                {visibleMobileOptions.length > 0 ? (
+                  <div className="space-y-1">
+                    {visibleMobileOptions.map((option) => {
+                      const state = mobileSection.getOptionState(option.value);
                       const isIncluded = state === "include";
                       const isExcluded = state === "exclude";
                       return (
-                        <Badge
+                        <button
                           key={option.value}
-                          variant={chipVariantForState(state)}
-                          interactive
-                          active={isIncluded || isExcluded}
+                          type="button"
                           aria-label={filterStateAriaLabel(option.label, state)}
                           className={cn(
-                            "cursor-pointer gap-1.5 py-1.5 px-3",
-                            isExcluded && "line-through",
+                            "flex min-h-11 w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                            (isIncluded || isExcluded) && "bg-accent/60",
                           )}
-                          onClick={() => section.onCycleOption(option.value)}
+                          onClick={() =>
+                            mobileSection.onCycleOption(option.value)
+                          }
                         >
-                          {option.icon}
-                          <span>{option.label}</span>
-                          {isIncluded && <Check className="size-3 ml-0.5" />}
-                          {isExcluded && <Minus className="size-3 ml-0.5" />}
-                        </Badge>
+                          {option.icon && (
+                            <span className="shrink-0 text-muted-foreground">
+                              {option.icon}
+                            </span>
+                          )}
+                          <span
+                            className={cn(
+                              "min-w-0 flex-1 truncate",
+                              isExcluded && "line-through",
+                            )}
+                          >
+                            {option.label}
+                          </span>
+                          {isIncluded && (
+                            <span className="flex items-center gap-1 text-xs font-medium text-primary">
+                              Included <Check className="size-4" />
+                            </span>
+                          )}
+                          {isExcluded && (
+                            <span className="flex items-center gap-1 text-xs font-medium text-destructive">
+                              Excluded <Minus className="size-4" />
+                            </span>
+                          )}
+                        </button>
                       );
                     })}
                   </div>
-                </div>
-              ))}
+                ) : (
+                  <div className="px-4 py-12 text-center">
+                    <Search className="mx-auto mb-3 size-6 text-muted-foreground" />
+                    <p className="font-medium">No matching values</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      Try a different search for{" "}
+                      {mobileSection.label.toLowerCase()}.
+                    </p>
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="min-h-0 flex-1 overflow-y-auto p-4">
+              <p className="mb-3 text-sm text-muted-foreground">
+                Choose a category, then search or browse its values.
+              </p>
+              {mobileExtraContent && (
+                <div className="mb-4 rounded-lg border p-3">
+                  <h4 className="mb-2 text-sm font-medium">Date Range</h4>
+                  {mobileExtraContent}
+                </div>
+              )}
+              <div className="space-y-2">
+                {mobileFilterSections.map((section) => {
+                  const activeCount = section.options.reduce(
+                    (count, option) =>
+                      count +
+                      (section.getOptionState(option.value) === "off" ? 0 : 1),
+                    0,
+                  );
+                  return (
+                    <button
+                      key={section.paramName}
+                      type="button"
+                      onClick={() => openMobileSection(section.paramName)}
+                      aria-label={`${section.label}, ${section.options.length} values${activeCount ? `, ${activeCount} active` : ""}`}
+                      className="flex min-h-14 w-full items-center gap-3 rounded-lg border bg-card px-3 py-2 text-left shadow-xs transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      {section.icon && (
+                        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                          {section.icon}
+                        </span>
+                      )}
+                      <span className="min-w-0 flex-1">
+                        <span className="block font-medium">
+                          {section.label}
+                        </span>
+                        <span className="block text-xs text-muted-foreground">
+                          {section.options.length} values
+                        </span>
+                      </span>
+                      {activeCount > 0 && (
+                        <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+                          {activeCount}
+                        </span>
+                      )}
+                      <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )
         ) : (
           /* Fallback to children if no mobile sections provided */
           <div className="flex flex-col gap-3 py-4">{children}</div>

--- a/ui/components/ui/filterable-card-grid.tsx
+++ b/ui/components/ui/filterable-card-grid.tsx
@@ -401,6 +401,7 @@ export function FilterableCardGrid<T>({
         activeFilterCount={activeFilterCount}
         sortButton={sortButton}
         mobileFilterSections={mobileFilterSections}
+        mobileExtraContentLabel={dateRangeConfig ? "Date Range" : undefined}
         mobileExtraContent={
           dateRangeConfig ? (
             <DateRangeFilter

--- a/ui/components/ui/filterable-card-grid.tsx
+++ b/ui/components/ui/filterable-card-grid.tsx
@@ -351,6 +351,7 @@ export function FilterableCardGrid<T>({
       return {
         paramName: config.paramName,
         label: config.label,
+        icon: config.icon,
         options: options.map((option) => ({
           ...option,
           icon: option.icon ?? config.icon,

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -171,6 +171,35 @@ describe("RecipeList", () => {
     ).toBeInTheDocument();
   });
 
+  it("lets mobile users search within a filter category", () => {
+    render(<RecipeList recipes={recipes} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Ingredients, 5 values" }),
+    );
+
+    const ingredientSearch = screen.getByRole("searchbox", {
+      name: "Search Ingredients filter values",
+    });
+    fireEvent.change(ingredientSearch, { target: { value: "cheddar" } });
+
+    expect(
+      screen.getByRole("button", { name: "cheddar cheese" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "white onion" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("1 of 5")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "cheddar cheese" }));
+
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/recipes?ingredient=cheddar+cheese",
+      { scroll: false },
+    );
+  });
+
   it("applies the equipment filter via the equipment query param", () => {
     currentSearchParams = new URLSearchParams("equipment=slow cooker");
 

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -184,6 +184,9 @@ describe("RecipeList", () => {
     const ingredientSearch = screen.getByRole("searchbox", {
       name: "Search Ingredients filter values",
     });
+    const optionListId = ingredientSearch.getAttribute("aria-controls");
+    expect(optionListId).not.toBeNull();
+    expect(document.getElementById(optionListId ?? "")).toBeInTheDocument();
     fireEvent.change(ingredientSearch, { target: { value: "cheddar" } });
 
     expect(
@@ -192,7 +195,12 @@ describe("RecipeList", () => {
     expect(
       screen.queryByRole("button", { name: "white onion" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("1 of 5")).toHaveAttribute("aria-atomic", "true");
+    const resultCount = screen.getByText("1 of 5");
+    expect(resultCount).toHaveAttribute("aria-atomic", "true");
+    expect(ingredientSearch).toHaveAttribute(
+      "aria-describedby",
+      resultCount.id,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "cheddar cheese" }));
 

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -174,6 +174,8 @@ describe("RecipeList", () => {
   it("lets mobile users search within a filter category", () => {
     render(<RecipeList recipes={recipes} />);
 
+    // Vaul's pointer-capture gesture handling is not implemented by jsdom, so
+    // use click events here while asserting the resulting user-visible flow.
     fireEvent.click(screen.getByRole("button", { name: "Filters" }));
     fireEvent.click(
       screen.getByRole("button", { name: "Ingredients, 5 values" }),
@@ -190,7 +192,7 @@ describe("RecipeList", () => {
     expect(
       screen.queryByRole("button", { name: "white onion" }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText("1 of 5")).toBeInTheDocument();
+    expect(screen.getByText("1 of 5")).toHaveAttribute("aria-atomic", "true");
 
     fireEvent.click(screen.getByRole("button", { name: "cheddar cheese" }));
 

--- a/ui/tests/components/ui/filter-bar.test.tsx
+++ b/ui/tests/components/ui/filter-bar.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  FilterBar,
+  type MobileFilterSection,
+} from "@/components/ui/filter-bar";
+import { type FilterState, nextFilterState } from "@/hooks/use-filter-params";
+
+function StatefulFilterBar() {
+  const [states, setStates] = useState<Record<string, FilterState>>({
+    alpha: "include",
+  });
+  const mobileFilterSections: MobileFilterSection[] = [
+    {
+      paramName: "ingredient",
+      label: "Ingredients",
+      options: [
+        { value: "alpha", label: "Alpha" },
+        { value: "beta", label: "Beta" },
+        { value: "gamma", label: "Gamma" },
+      ],
+      getOptionState: (value) => states[value] ?? "off",
+      onCycleOption: (value) =>
+        setStates((current) => ({
+          ...current,
+          [value]: nextFilterState(current[value] ?? "off"),
+        })),
+    },
+  ];
+
+  return (
+    <FilterBar mobileFilterSections={mobileFilterSections}>
+      <span>Desktop filters</span>
+    </FilterBar>
+  );
+}
+
+describe("FilterBar", () => {
+  it("keeps option positions stable while filter states change", () => {
+    render(<StatefulFilterBar />);
+
+    // Vaul's pointer-capture gesture handling is not implemented by jsdom.
+    fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Ingredients, 3 values, 1 active",
+      }),
+    );
+
+    const search = screen.getByRole("searchbox", {
+      name: "Search Ingredients filter values",
+    });
+    const options = within(
+      document.getElementById(search.getAttribute("aria-controls") ?? "") ??
+        document.body,
+    );
+    expect(
+      options
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Alpha (included)", "Beta", "Gamma"]);
+
+    fireEvent.click(options.getByRole("button", { name: "Gamma" }));
+
+    expect(
+      options
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Alpha (included)", "Beta", "Gamma (included)"]);
+  });
+
+  it("falls back to the supplied mobile controls without rendering zero", () => {
+    render(
+      <FilterBar mobileFilterSections={[]}>
+        <span>Fallback controls</span>
+      </FilterBar>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+
+    const drawer = screen.getByRole("dialog");
+    expect(within(drawer).getByText("Fallback controls")).toBeInTheDocument();
+    expect(
+      Array.from(drawer.childNodes).some((node) => node.textContent === "0"),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- replace the mobile filter chip wall with a category-first drawer
- add a dedicated searchable option list for every filter category
- surface active counts, keep selected values easy to reach, and preserve include/exclude behavior
- increase the usable drawer height and touch target sizes for mobile

## Why

The recipe catalog now contains hundreds of ingredients. Desktop filter popovers were searchable, but mobile rendered every value from every category in one long scrolling panel, making a target ingredient difficult to locate.

## Validation

- `mise //ui:typecheck`
- `mise //ui:lint -- components/ui/filter-bar.tsx components/ui/filterable-card-grid.tsx tests/components/recipes/recipe-list.test.tsx`
- `mise //ui:test` — 816 tests passed
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`

## Manual QA

Use the backend preview on a mobile viewport:

1. Open Recipes and tap **Filters**.
2. Confirm filter categories show value counts instead of one combined value list.
3. Open **Ingredients**, search for an ingredient, and verify the result count and filtered option list.
4. Tap an ingredient through include → exclude → off and confirm the recipe results and active counts update.
5. Return to the category list and confirm active selections are counted; close and reopen the drawer to confirm navigation/search state resets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added category-first navigation to mobile filters, with searchable values and prioritisation of active selections.
  * Added explicit include/exclude states, filter icons, and clear, back, and done controls.
  * Mobile filter selections now update the URL without replacing browser history.

* **Accessibility**
  * Added accessible result announcements and improved relationships between search fields and result lists.

* **Improvements**
  * Mobile filter content remains visible during closing animations and resets navigation when reopened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->