### PR TITLE
Fix recipe-site status drift in project and ADRs

### DIFF
--- a/ui/content/projects/recipe-site/adrs/031-openrouter.mdx
+++ b/ui/content/projects/recipe-site/adrs/031-openrouter.mdx
@@ -54,7 +54,7 @@ The recipe site is governed by a small set of strong constraints:
 
 # Decision
 
-I **propose** using **[OpenRouter](https://openrouter.ai)** as the single LLM/VLM access point
+I **accept** using **[OpenRouter](https://openrouter.ai)** as the single LLM/VLM access point
 for all AI-powered features in the recipe site — the ML ingestion pipeline today, and any future
 user-facing AI features (recipe URL import, smooth-onboarding photo capture, meal planning,
 nutrition) as they ship.

--- a/ui/content/projects/recipe-site/adrs/031-openrouter.mdx
+++ b/ui/content/projects/recipe-site/adrs/031-openrouter.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ADR 031: OpenRouter"
 date: "2026-05-23"
-status: "Proposed"
+status: "Accepted"
 tech_stack: ["OpenRouter"]
 ---
 

--- a/ui/content/projects/recipe-site/adrs/049-cloudflare-workflows-recipe-ingestion.mdx
+++ b/ui/content/projects/recipe-site/adrs/049-cloudflare-workflows-recipe-ingestion.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ADR 049: Cloudflare Workflows for Recipe Ingestion"
 date: "2026-07-08"
-status: "Proposed"
+status: "Accepted"
 tech_stack: ["Cloudflare Workflows", "Cloudflare Workers", "Neon", "Cloudflare R2", "OpenRouter"]
 ---
 
@@ -36,16 +36,16 @@ handle provider failures, and eventually return an editable draft recipe.
 
 The pipeline has several properties that make a normal request/response endpoint a poor fit:
 
-- It is multi-step: upload, preprocess, extract, normalize, derive, canonicalize, validate, and
+* It is multi-step: upload, preprocess, extract, normalize, derive, canonicalize, validate, and
   publish or await review.
-- It calls external providers several times, with different retry and timeout behavior per stage.
-- It needs durable progress: a browser tab closing should not cancel the job.
-- It needs per-user quotas and active-job limits before expensive work starts.
-- It needs intermediate artifacts for debugging, user review, and future evaluation against
+* It calls external providers several times, with different retry and timeout behavior per stage.
+* It needs durable progress: a browser tab closing should not cancel the job.
+* It needs per-user quotas and active-job limits before expensive work starts.
+* It needs intermediate artifacts for debugging, user review, and future evaluation against
   corrected recipes.
-- It needs to capture user corrections as ground truth so production quality can be measured and
+* It needs to capture user corrections as ground truth so production quality can be measured and
   improved over time.
-- It should not couple the availability or deploy risk of `recipe-api` to a long-running LLM
+* It should not couple the availability or deploy risk of `recipe-api` to a long-running LLM
   pipeline.
 
 Cloudflare Workflows now provides durable multi-step execution, step retries, sleeps,
@@ -105,14 +105,14 @@ API->>R2: write user-corrected final artifact
 
 ## Responsibilities
 
-| Component                 | Responsibility                                                                 |
-| ------------------------- | ------------------------------------------------------------------------------ |
-| `recipe-api` Worker       | Auth, authorization, CSRF, quota checks, job creation, job reads, publish flow |
-| `recipe-ingest` Workflow  | Durable step orchestration, retries, provider calls, stage transitions         |
-| Neon Postgres             | Jobs, ownership, quotas, usage, status, manifests, corrections, idempotency     |
-| R2                        | Uploaded source images and immutable raw artifact snapshots                     |
-| OpenRouter                | VLM/LLM provider routing, structured outputs, model/provider fallback           |
-| Evaluation pipeline       | Prompt/model experiments, quality reports, regression tracking                  |
+| Component                | Responsibility                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `recipe-api` Worker      | Auth, authorization, CSRF, quota checks, job creation, job reads, publish flow |
+| `recipe-ingest` Workflow | Durable step orchestration, retries, provider calls, stage transitions         |
+| Neon Postgres            | Jobs, ownership, quotas, usage, status, manifests, corrections, idempotency    |
+| R2                       | Uploaded source images and immutable raw artifact snapshots                    |
+| OpenRouter               | VLM/LLM provider routing, structured outputs, model/provider fallback          |
+| Evaluation pipeline      | Prompt/model experiments, quality reports, regression tracking                 |
 
 ## Job and quota model
 
@@ -137,9 +137,9 @@ recipes.
 
 Initial status delivery is intentionally simple:
 
-- `GET /recipe-imports/:jobId` returns the current stage, progress label, failure diagnostics, and
+* `GET /recipe-imports/:jobId` returns the current stage, progress label, failure diagnostics, and
   draft output when available.
-- The frontend polls while a job is active and stops when the job reaches `succeeded`, `failed`,
+* The frontend polls while a job is active and stops when the job reaches `succeeded`, `failed`,
   `canceled`, or `awaiting_review`.
 
 Push updates are out of scope for this ADR. Polling is enough to prove the ingestion architecture;
@@ -149,20 +149,20 @@ SSE or another live update mechanism can be added later without changing the job
 
 Use both Postgres and R2, with different jobs:
 
-- Postgres stores queryable metadata, status, indexes, usage, review state, and user corrections.
-- R2 stores immutable raw snapshots of every source and stage artifact.
+* Postgres stores queryable metadata, status, indexes, usage, review state, and user corrections.
+* R2 stores immutable raw snapshots of every source and stage artifact.
 
 The R2 artifact corpus should include:
 
-- extracted raw recipe text/JSON
-- model input envelope and provider routing metadata
-- provider output payload or normalized response body
-- Cooklang draft
-- derived normalized recipe
-- canonicalization decisions
-- retry/failure diagnostics
-- final draft recipe payload
-- user-corrected final recipe and correction metadata
+* extracted raw recipe text/JSON
+* model input envelope and provider routing metadata
+* provider output payload or normalized response body
+* Cooklang draft
+* derived normalized recipe
+* canonicalization decisions
+* retry/failure diagnostics
+* final draft recipe payload
+* user-corrected final recipe and correction metadata
 
 Postgres keeps an artifact manifest row for each snapshot: job id, stage, kind, R2 key, checksum,
 schema version, model/provider, created timestamp, and any small fields needed for filtering or UI
@@ -180,11 +180,11 @@ gets stable object snapshots to consume later.
 
 Every generated draft needs a way to produce a correction record:
 
-- original source image keys
-- generated extraction, Cooklang, canonicalization, and final draft artifact keys
-- user-edited accepted recipe
-- field-level or whole-document diff when practical
-- timestamp, user id, model/provider versions, prompt/schema versions, and usage metrics
+* original source image keys
+* generated extraction, Cooklang, canonicalization, and final draft artifact keys
+* user-edited accepted recipe
+* field-level or whole-document diff when practical
+* timestamp, user id, model/provider versions, prompt/schema versions, and usage metrics
 
 This correction record is the bridge from production ingestion to evaluation. It lets the project
 measure parse success, identify recurring failure modes, and build future training/evaluation
@@ -259,44 +259,44 @@ schemas, artifact layout, and parsing code without making DVC the orchestrator.
 
 ## Positive
 
-- **Durable user jobs.** Browser disconnects and transient provider failures do not lose work.
-- **Platform continuity.** Stays inside Cloudflare Workers, the backend platform already chosen in
+* **Durable user jobs.** Browser disconnects and transient provider failures do not lose work.
+* **Platform continuity.** Stays inside Cloudflare Workers, the backend platform already chosen in
   [ADR 033](/projects/recipe-site/adrs/033-backend-platform-for-authenticated-features).
-- **Clear service boundary.** The product API stays thin; ingestion owns provider calls and retries.
-- **Transactional quotas.** Usage limits are enforced in Postgres before expensive work starts.
-- **Ground-truth capture from day one.** Raw artifacts and user corrections become a usable
+* **Clear service boundary.** The product API stays thin; ingestion owns provider calls and retries.
+* **Transactional quotas.** Usage limits are enforced in Postgres before expensive work starts.
+* **Ground-truth capture from day one.** Raw artifacts and user corrections become a usable
   evaluation corpus, not a one-off debugging trace.
-- **Simple application reads.** Status, manifests, review state, and frequently displayed outputs
+* **Simple application reads.** Status, manifests, review state, and frequently displayed outputs
   remain queryable and authorizable through Postgres.
-- **OpenRouter remains strategic.** Workflow steps call the same OpenRouter-backed parsing helpers
+* **OpenRouter remains strategic.** Workflow steps call the same OpenRouter-backed parsing helpers
   used by the offline pipeline.
-- **Temporal escape hatch.** Job state and artifact contracts are not Cloudflare-specific.
+* **Temporal escape hatch.** Job state and artifact contracts are not Cloudflare-specific.
 
 ## Negative
 
-- **New Cloudflare primitive.** Workflows is another product to learn, test locally, monitor, and
+* **New Cloudflare primitive.** Workflows is another product to learn, test locally, monitor, and
   configure.
-- **Platform maturity risk.** Temporal is more proven for complex durable workflows.
-- **State split.** Workflow instance state and Postgres job state must be kept consistent enough for
+* **Platform maturity risk.** Temporal is more proven for complex durable workflows.
+* **State split.** Workflow instance state and Postgres job state must be kept consistent enough for
   user-facing status.
-- **Manual idempotency still matters.** Provider calls and final recipe writes must use stage/job
+* **Manual idempotency still matters.** Provider calls and final recipe writes must use stage/job
   idempotency keys so retries cannot double-publish or double-charge.
-- **More storage plumbing.** The first implementation must write both Postgres manifest rows and R2
+* **More storage plumbing.** The first implementation must write both Postgres manifest rows and R2
   artifact snapshots.
-- **Retention policy required.** Capturing prompts, outputs, images, and corrections creates a real
+* **Retention policy required.** Capturing prompts, outputs, images, and corrections creates a real
   data-governance surface that needs explicit retention and deletion behavior.
 
 # Implementation Notes
 
 Start with a small schema:
 
-- `recipe_import_job`: owner, source type, status, current stage, progress label, quota reservation,
+* `recipe_import_job`: owner, source type, status, current stage, progress label, quota reservation,
   actual usage, error summary, timestamps, workflow instance id.
-- `recipe_import_artifact`: job id, stage, artifact kind, R2 key, checksum, schema version,
+* `recipe_import_artifact`: job id, stage, artifact kind, R2 key, checksum, schema version,
   model/provider metadata, created timestamp, optional JSONB preview.
-- `recipe_import_attempt`: job id, stage, attempt number, retryable flag, provider request id,
+* `recipe_import_attempt`: job id, stage, attempt number, retryable flag, provider request id,
   status/error fields, duration, token/image usage.
-- `recipe_import_correction`: job id, accepted recipe id or draft id, corrected artifact key,
+* `recipe_import_correction`: job id, accepted recipe id or draft id, corrected artifact key,
   correction summary/diff, reviewer user id, created timestamp.
 
 The source images and raw stage artifacts live in R2 under keys derived from the job id, stage, and
@@ -308,12 +308,12 @@ later UX proves auto-publish is safe.
 
 # When To Revisit
 
-- Job volume grows enough that Cloudflare Workflows limits, retention, or debugging become painful.
-- The ingestion chain gains complex cancellation, compensation, or long human-review lifecycles that
+* Job volume grows enough that Cloudflare Workflows limits, retention, or debugging become painful.
+* The ingestion chain gains complex cancellation, compensation, or long human-review lifecycles that
   make Temporal's workflow model materially better.
-- Batch processing volume grows enough to justify a separate batch runner alongside user-facing
+* Batch processing volume grows enough to justify a separate batch runner alongside user-facing
   Workflows.
-- The production artifact corpus needs a more formal lake layout, catalog, or warehouse export.
-- Live progress becomes important enough to replace polling with SSE or another push mechanism.
-- The pipeline needs persistent CPU/GPU-heavy processing, including custom deep-learning models,
+* The production artifact corpus needs a more formal lake layout, catalog, or warehouse export.
+* Live progress becomes important enough to replace polling with SSE or another push mechanism.
+* The pipeline needs persistent CPU/GPU-heavy processing, including custom deep-learning models,
   prompting Temporal workers, Cloudflare Containers, GPU infrastructure, or another compute runtime.

--- a/ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx
+++ b/ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ADR 063: PostHog Alerting and Lightweight Incident Management"
 date: "2026-07-29"
-status: "Proposed"
+status: "Accepted"
 tech_stack: ["PostHog", "Slack"]
 ---
 
@@ -20,9 +20,10 @@ workflow for a solo founder:
 * Slack provides an isolated, high-visibility notification inbox;
 * each notification links back to PostHog for investigation.
 
-This ADR remains proposed until the workspace, integration, notification settings, and end-to-end
-firing and resolution paths have been configured and tested. It is not a claim that PostHog and
-Slack form a complete incident-management platform. The proposed system has no on-call schedule,
+The PostHog and Slack path is accepted: the workspace, integration, notification settings, and
+end-to-end firing and resolution paths have been configured and tested. The Cloudflare-to-Slack
+complementary path is not yet operational. This ADR is not a claim that PostHog and Slack form a
+complete incident-management platform. The proposed system has no on-call schedule,
 acknowledgement deadline, escalation, SMS or voice paging, status page, or independently hosted
 uptime check. Those capabilities are unnecessary at the current team size and incident volume, but
 this decision defines when a dedicated error-tracking, observability, uptime, or
@@ -62,12 +63,12 @@ This provides several parts of an incident-management loop, but not all of them:
 | Signal capture                                   | PostHog Logs and Traces, with Cloudflare logs as fallback | Implemented                  |
 | Detection and thresholds                         | Terraform-managed PostHog log alerts                      | Implemented                  |
 | Alert state and history                          | PostHog                                                   | Implemented                  |
-| Notification transport                           | Native PostHog Slack integration                          | Proposed; not yet verified   |
-| Notification inbox                               | Private Slack channel in a dedicated workspace            | Proposed; not yet configured |
+| Notification transport                           | Native PostHog Slack integration                          | Implemented and verified     |
+| Notification inbox                               | Private Slack channel in a dedicated workspace            | Implemented                  |
 | Investigation                                    | PostHog filtered logs, traces, users, and session replays | Implemented                  |
 | Cloudflare platform incidents                    | Terraform-managed Cloudflare notifications → Slack        | Proposed complementary path  |
 | Independent availability monitoring              | None                                                      | Deferred                     |
-| Acknowledgement and ownership                    | One owner reading Slack                                   | Proposed informal process    |
+| Acknowledgement and ownership                    | One owner reading Slack                                   | Implemented informal process |
 | Escalation, schedules, SMS, and voice            | None                                                      | Deferred                     |
 | Incident coordination, timeline, and status page | None                                                      | Deferred                     |
 
@@ -339,7 +340,8 @@ for this decision.
 
 ## Adoption Criteria
 
-Keep this ADR in `Proposed` status until all of the following have been completed:
+The PostHog alerting and Slack delivery criteria below were completed before this ADR was marked
+`Accepted`:
 
 * create the dedicated Slack workspace using a domain-controlled project identity with a tested
   account-recovery path;
@@ -355,18 +357,21 @@ Keep this ADR in `Proposed` status until all of the following have been complete
 * verify that notification links open the correct PostHog alert and filtered investigation views;
 * confirm that no raw secrets, request headers, full payloads, or unnecessary personal data are
   copied into Slack;
+
+The Cloudflare-to-Slack complementary path is not yet implemented or verified. Before it becomes
+operational, the following remain:
+
 * grant the Terraform Cloudflare token least-privilege Notifications permissions and create the
   Slack webhook destination and selected policies through Terraform;
 * verify Terraform Cloud treats the Slack webhook URL as sensitive, restrict state access, and
   document its rotation procedure;
-* trigger at least one Cloudflare test notification and verify that it reaches Slack; if webhook
-  entitlement fails on the current plan, record the fallback and leave the ADR proposed;
+* confirm Cloudflare webhook entitlement on the current plan, trigger at least one Cloudflare test
+  notification and verify that it reaches Slack, and record the fallback if entitlement fails;
 * verify the initial Pages, incident, certificate or token, and billing or usage policies against
   the account's live available-alert list rather than assuming every provider enum is entitled;
 
-Record the verification outcome and change the ADR status to `Accepted` in a follow-up commit only
-after every criterion passes. Until then, the existing PostHog alert definitions remain implemented,
-but Slack delivery and the incident workflow described here are not operational.
+Every criterion that gates the PostHog alerting and Slack delivery decision passed before the ADR
+was marked `Accepted`. Slack delivery and the incident workflow are operational.
 
 ## Guardrails and Verification
 

--- a/ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx
+++ b/ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx
@@ -7,7 +7,7 @@ tech_stack: ["PostHog", "Slack"]
 
 ## Summary
 
-Propose using PostHog log alerts as the recipe system's operational detection, alert-state, and
+Use PostHog log alerts as the recipe system's operational detection, alert-state, and
 investigation layer, with delivery through PostHog's native Slack integration to a private channel
 in a dedicated workspace.
 
@@ -23,7 +23,7 @@ workflow for a solo founder:
 The PostHog and Slack path is accepted: the workspace, integration, notification settings, and
 end-to-end firing and resolution paths have been configured and tested. The Cloudflare-to-Slack
 complementary path is not yet operational. This ADR is not a claim that PostHog and Slack form a
-complete incident-management platform. The proposed system has no on-call schedule,
+complete incident-management platform. The system has no on-call schedule,
 acknowledgement deadline, escalation, SMS or voice paging, status page, or independently hosted
 uptime check. Those capabilities are unnecessary at the current team size and incident volume, but
 this decision defines when a dedicated error-tracking, observability, uptime, or
@@ -144,7 +144,8 @@ for operational alert state.
 ### Slack Delivery
 
 Create a Slack workspace dedicated to project operations and connect it using PostHog's native
-Slack integration. This is the proposed delivery design until the adoption criteria below pass.
+Slack integration. This is the accepted delivery design; the adoption criteria below were
+completed before acceptance.
 
 * Register the workspace with a domain-controlled project email address rather than a personal
   address.
@@ -212,7 +213,7 @@ provider migration.
 
 ### Incident Workflow
 
-When a Slack alert arrives, the proposed response process is:
+When a Slack alert arrives, the response process is:
 
 1. open the PostHog alert or filtered-log link;
 2. identify the affected service, route, trace, and user impact;
@@ -278,7 +279,7 @@ loop that the current PostHog-centred system only partially covers.
 
 | Option                                                                                  | What it would improve                                                                                                                              | Costs and gaps at the current scale                                                                                                                                                                                                         | Decision                                                                          |
 | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| **PostHog alerts with native Slack delivery**                                           | Keeps detection beside logs, traces, users, replays, and product impact; avoids a public receiver; visible and isolated mobile/desktop alert inbox | Requires workspace, identity recovery, MFA, clients, permission review, and notification administration; free-plan retention is limited; Slack is not durable incident management                                                           | **Propose; accept after setup and end-to-end verification**                       |
+| **PostHog alerts with native Slack delivery**                                           | Keeps detection beside logs, traces, users, replays, and product impact; avoids a public receiver; visible and isolated mobile/desktop alert inbox | Requires workspace, identity recovery, MFA, clients, permission review, and notification administration; free-plan retention is limited; Slack is not durable incident management                                                           | **Accepted**                                                                      |
 | **Dedicated Cloudflare email relay**                                                    | Fixed email recipient; infrastructure could remain in the existing Cloudflare account                                                              | Requires a secret URL, Worker, route, email binding, rotation, schema and failure-path tests, deployment and security monitoring, plus a high-visibility mailbox; a single-purpose patch that compounds poorly as people and use cases grow | Reject while native Slack meets the need                                          |
 | **Microsoft Teams**                                                                     | Similar chat-based notification surface; strong fit if the project later adopts Microsoft 365 and Entra                                            | PostHog's Teams destination requires a webhook URL; adds Microsoft account and workflow complexity; weaker Linux experience; no current Microsoft ecosystem benefit                                                                         | Reject for the current stack                                                      |
 | **Discord**                                                                             | Free private channels, capable desktop and mobile clients, roles, webhooks, and a strong bot ecosystem                                             | PostHog uses a bearer webhook URL rather than an installed workspace integration; less aligned with future operational SaaS integrations and professional responder onboarding than Slack                                                   | Viable fallback, but Slack better fits the expected direction                     |

--- a/ui/content/projects/recipe-site/index.mdx
+++ b/ui/content/projects/recipe-site/index.mdx
@@ -4,7 +4,7 @@ description: "A digital recipe book that replaces handwritten collections with p
 date: "2026-02-14"
 repo_url: "https://github.com/Robbie-Palmer/personal-site"
 demo_url: "https://robbiepalmer.me/recipes"
-status: "live"
+status: "in_progress"
 ---
 
 # Vision


### PR DESCRIPTION
Update the recipe-site project and three ADRs whose statuses had drifted:

- Project status `live` → `in_progress` (not ready for public signups yet)
- ADR 031 OpenRouter: `Proposed` → `Accepted`
- ADR 049 Cloudflare Workflows for Recipe Ingestion: `Proposed` → `Accepted`
- ADR 063 PostHog Alerting and Slack: `Proposed` → `Accepted`, with body updated to record the PostHog/Slack path as verified while keeping the Cloudflare-to-Slack complementary path as pending/not-yet-implemented