### PR TITLE
Fix timezone hydration mismatch for content dates

### DIFF
--- a/ui/lib/generic/date.ts
+++ b/ui/lib/generic/date.ts
@@ -3,5 +3,10 @@ export function formatDate(dateString: string): string {
     year: "numeric",
     month: "long",
     day: "numeric",
+    // Content dates are calendar dates rather than instants. Date parses an
+    // ISO date-only string at UTC midnight, so formatting in the visitor's
+    // timezone can move it to the previous day and make hydration differ from
+    // the server-rendered HTML.
+    timeZone: "UTC",
   });
 }

--- a/ui/tests/lib/generic/date.test.ts
+++ b/ui/tests/lib/generic/date.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatDate } from "@/lib/generic/date";
+
+describe("formatDate", () => {
+  it("preserves the calendar date in timezones west of UTC", () => {
+    expect(formatDate("2020-07-25")).toBe("July 25, 2020");
+  });
+
+  it("formats leap days without timezone rollover", () => {
+    expect(formatDate("2024-02-29")).toBe("February 29, 2024");
+  });
+});


### PR DESCRIPTION
## Summary
- render date-only content values in UTC so server and client produce identical calendar dates
- preserve the authored `YYYY-MM-DD` date instead of rolling it to the previous day for users west of UTC
- add regression coverage for ordinary and leap-day calendar dates

## Why UTC is the intended behavior
These fields are validated and authored as date-only values (`YYYY-MM-DD`) for publication dates, project dates, ADR dates, and recipe dates. They do not contain a time or offset, so they represent calendar dates rather than instants to convert into a viewer's timezone.

## PostHog evidence
- the full non-minified message linked from SC-406 has 5 events, all from `localhost:3000/technologies/leaflet`; it is not itself a production sample
- production reports the equivalent minified React #418 hydration errors: 100 occurrences across 80 sessions on `robbiepalmer.me` / `www.robbiepalmer.me` in the last year
- 98 of those 100 occurrences are the `text` mismatch variant; the remaining 2 are the `HTML` variant
- another 74 occurrences across 47 sessions occurred on the public Pages deployment
- sampled text-mismatch routes include the home page, project pages, a blog article, and `/recipes`, overlapping client-rendered components that call `formatDate`

PostHog's production errors are minified and the deployed sourcemaps were unavailable, so telemetry cannot identify the mismatched text node conclusively. The date formatter is nevertheless a reproducible hydration mismatch and the production route/type evidence is consistent with it; this PR should be monitored after deployment to confirm the #418 rate falls.

## Validation
- `TZ=America/Los_Angeles mise //ui:test -- tests/lib/generic/date.test.ts`
- `mise //ui:check:static`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`
- `git diff --check`

## Preview QA
- no backend required
- verify dates on the home page, `/blog`, `/projects`, and `/recipes` remain unchanged after hydration
- verify browser console has no hydration mismatch from content date rendering

SC-406
