### PR TITLE
Persist stateful AI review identities and analytics

### DIFF
--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -39,9 +39,11 @@ export interface Settings {
 export interface PullRequest {
   state: string;
   draft: boolean;
+  title?: string;
   author_association?: string;
+  labels?: Array<{ name?: string }>;
   user: { login: string };
-  head: { sha: string; repo?: { full_name?: string } };
+  head: { sha: string; ref?: string; repo?: { full_name?: string } };
 }
 
 interface ChangedFile {

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -10,8 +10,8 @@ The service is a visible, stateful publisher:
 - a Worker verifies GitHub App webhook signatures and rejects other
   repositories;
 - one SQLite Durable Object per pull request deduplicates deliveries, review
-  configurations, and already-reviewed heads while enforcing per-PR run and
-  cost ceilings;
+  configurations, and already-reviewed heads, assigns durable hunk and finding
+  identities, and enforces per-PR run and cost ceilings;
 - Durable Object alarms provide a trailing-edge debounce boundary, coalescing
   rapid events to one review of the latest pull request state after a quiet
   period;
@@ -21,7 +21,9 @@ The service is a visible, stateful publisher:
   separate rolling comment; OpenRouter and OpenCode scouts use separate
   Workflow steps so a stalled free provider cannot replay completed paid calls,
   while deterministic publication and storage steps remain retryable;
-- the private `ai-review-data` R2 bucket stores versioned findings plus provider
+- the private `ai-review-data` R2 bucket stores versioned terminal records for
+  published, skipped, denied, and failed runs, including raw candidates,
+  published findings, change characteristics, stable identities, and provider
   cost, latency, token, cache, availability, and failure metrics; and
 - the former stateless GitHub Actions orchestrator is retired; its prompts,
   model clients, validation, and rendering code remain as the shared review
@@ -121,6 +123,24 @@ Cloudflare Workflow and waits for that operation to succeed. Paid OpenRouter
 completion requests also make exactly one HTTP attempt because the provider
 does not expose an idempotency key; GitHub and free-provider requests retain
 their bounded transient retries.
+
+### Review data schema
+
+New analytical records use schema version 2 under
+`v2/<owner>/<repository>/pr-<number>/<head>/<workflow>/<status>.json`. The
+status is `published`, `skipped`, `denied`, or `failed`; using a distinct object
+per terminal status preserves a published record if a later deterministic
+completion step fails. Existing schema-version-1 objects remain readable and
+are not rewritten.
+
+PR-scoped hunk IDs hash the repository path and normalized unified-diff body while
+excluding hunk coordinates, so an unchanged hunk keeps its identity when lines
+move. PR-scoped finding IDs hash the path and normalized finding title, excluding line,
+severity, status, and model provenance. The Durable Object upserts these
+identities into `review_hunks`, `review_findings`, and
+`review_finding_hunks`; first-seen values remain immutable while last-seen
+values advance with later completed runs. R2 retains raw per-model candidates
+separately from the merged findings that were actually published.
 
 ## Deploy
 

--- a/ai-review/scripts/staging-e2e.sh
+++ b/ai-review/scripts/staging-e2e.sh
@@ -95,7 +95,7 @@ fi
 printf 'Accepted staging delivery %s for head %s\n' \
   "$delivery_id" "${head_sha:0:12}"
 
-record_key="v1/${repository}/pr-${pull_request}/${head_sha}/${instance_id}.json"
+record_key="v2/${repository}/pr-${pull_request}/${head_sha}/${instance_id}/published.json"
 deadline=$((SECONDS + 600))
 while ((SECONDS < deadline)); do
   if pnpm exec wrangler r2 object get \
@@ -119,7 +119,9 @@ fi
 jq -e \
   --arg head_sha "$head_sha" \
   '
-    .status == "published"
+    .schemaVersion == 2
+    and .recordType == "review-run-terminal"
+    and .status == "published"
     and .headSha == $head_sha
     and any(.models[]; .role == "scout" and .ok == true)
   ' \
@@ -144,7 +146,9 @@ jq '{
   status,
   headSha,
   runCostUsd,
-  findingCount: (.findings.findings | length),
+  findingCount: (.findings.published | length),
+  candidateCount: ([.candidates[] | length] | add // 0),
+  hunkCount: (.hunks | length),
   models: [.models[] | {model, provider, role, ok, costUsd}]
 }' "$record_file"
 printf 'Visible comment: %s\n' "$(jq -r '.html_url' <<<"$comment")"

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -196,9 +196,28 @@ function isIdentifiedFinding(value: unknown): value is IdentifiedMergedFinding {
     /^f_[a-f0-9]{24}$/.test(finding.findingId) &&
     typeof finding.file === "string" &&
     finding.file.length > 0 &&
+    (finding.line === null ||
+      (typeof finding.line === "number" &&
+        Number.isSafeInteger(finding.line) &&
+        finding.line >= 0)) &&
     typeof finding.title === "string" &&
     finding.title.length > 0 &&
+    typeof finding.evidence === "string" &&
+    typeof finding.recommendation === "string" &&
+    typeof finding.confidence === "number" &&
+    Number.isFinite(finding.confidence) &&
+    finding.confidence >= 0 &&
+    finding.confidence <= 1 &&
+    (finding.severity === "critical" ||
+      finding.severity === "high" ||
+      finding.severity === "medium" ||
+      finding.severity === "low") &&
+    Array.isArray(finding.source_models) &&
+    finding.source_models.every(
+      (model) => typeof model === "string" && model.length > 0,
+    ) &&
     (finding.status === "open" || finding.status === "resolved") &&
+    typeof finding.resolution_note === "string" &&
     Array.isArray(finding.hunkIds) &&
     finding.hunkIds.every(
       (hunkId) => typeof hunkId === "string" && /^h_[a-f0-9]{24}$/.test(hunkId),

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -11,12 +11,18 @@ import {
   combineScoutRuns,
   completeReview,
   failReview,
+  identifyReviewArtifacts,
   mergeFindings,
   prepareReview,
   publishReview,
   recordReview,
+  recordReviewTerminal,
   runScouts,
+  type IdentifiedMergedFinding,
+  type IdentifiedReviewArtifacts,
   type MergedRun,
+  type PreparedReview,
+  type ReviewHunk,
   type ScoutRun,
 } from "./review-engine";
 import { parseReviewEvent, verifyGitHubSignature } from "./webhook";
@@ -48,6 +54,32 @@ const CREATE_REVIEW_RUNS_TABLE =
   "comment_id INTEGER, " +
   "findings_json TEXT, " +
   "error TEXT)";
+const CREATE_REVIEW_HUNKS_TABLE =
+  "CREATE TABLE IF NOT EXISTS review_hunks (" +
+  "hunk_id TEXT PRIMARY KEY, " +
+  "fingerprint TEXT NOT NULL, " +
+  "file_path TEXT NOT NULL, " +
+  "first_seen_head_sha TEXT NOT NULL, " +
+  "last_seen_head_sha TEXT NOT NULL, " +
+  "first_seen_at TEXT NOT NULL, " +
+  "last_seen_at TEXT NOT NULL)";
+const CREATE_REVIEW_FINDINGS_TABLE =
+  "CREATE TABLE IF NOT EXISTS review_findings (" +
+  "finding_id TEXT PRIMARY KEY, " +
+  "file_path TEXT NOT NULL, " +
+  "title TEXT NOT NULL, " +
+  "status TEXT NOT NULL, " +
+  "first_seen_head_sha TEXT NOT NULL, " +
+  "last_seen_head_sha TEXT NOT NULL, " +
+  "first_seen_run_id TEXT NOT NULL, " +
+  "last_seen_run_id TEXT NOT NULL, " +
+  "first_seen_at TEXT NOT NULL, " +
+  "last_seen_at TEXT NOT NULL)";
+const CREATE_REVIEW_FINDING_HUNKS_TABLE =
+  "CREATE TABLE IF NOT EXISTS review_finding_hunks (" +
+  "finding_id TEXT NOT NULL, " +
+  "hunk_id TEXT NOT NULL, " +
+  "PRIMARY KEY (finding_id, hunk_id))";
 const DEFAULT_DEBOUNCE_DELAY_MS = 120_000;
 const MINIMUM_DEBOUNCE_DELAY_MS = 1_000;
 const MAXIMUM_DEBOUNCE_DELAY_MS = 3_600_000;
@@ -123,6 +155,49 @@ function bindingHealth(env: Env) {
   };
 }
 
+function isReviewHunk(value: unknown): value is ReviewHunk {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const hunk = value as Partial<ReviewHunk>;
+  return (
+    typeof hunk.hunkId === "string" &&
+    /^h_[a-f0-9]{24}$/.test(hunk.hunkId) &&
+    typeof hunk.fingerprint === "string" &&
+    /^[a-f0-9]{64}$/.test(hunk.fingerprint) &&
+    typeof hunk.file === "string" &&
+    hunk.file.length > 0 &&
+    typeof hunk.oldStart === "number" &&
+    Number.isSafeInteger(hunk.oldStart) &&
+    hunk.oldStart >= 0 &&
+    typeof hunk.oldLines === "number" &&
+    Number.isSafeInteger(hunk.oldLines) &&
+    hunk.oldLines >= 0 &&
+    typeof hunk.newStart === "number" &&
+    Number.isSafeInteger(hunk.newStart) &&
+    hunk.newStart >= 0 &&
+    typeof hunk.newLines === "number" &&
+    Number.isSafeInteger(hunk.newLines) &&
+    hunk.newLines >= 0
+  );
+}
+
+function isIdentifiedFinding(value: unknown): value is IdentifiedMergedFinding {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const finding = value as Partial<IdentifiedMergedFinding>;
+  return (
+    typeof finding.findingId === "string" &&
+    /^f_[a-f0-9]{24}$/.test(finding.findingId) &&
+    typeof finding.file === "string" &&
+    finding.file.length > 0 &&
+    typeof finding.title === "string" &&
+    finding.title.length > 0 &&
+    (finding.status === "open" || finding.status === "resolved") &&
+    Array.isArray(finding.hunkIds) &&
+    finding.hunkIds.every(
+      (hunkId) => typeof hunkId === "string" && /^h_[a-f0-9]{24}$/.test(hunkId),
+    )
+  );
+}
+
 function healthResponse(env: Env): Response {
   const bindings = bindingHealth(env);
   const ok = Object.values(bindings).every(Boolean);
@@ -195,6 +270,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     super(ctx, env);
     this.ctx.storage.sql.exec(CREATE_WEBHOOK_DELIVERIES_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_RUNS_TABLE);
+    this.ctx.storage.sql.exec(CREATE_REVIEW_HUNKS_TABLE);
+    this.ctx.storage.sql.exec(CREATE_REVIEW_FINDINGS_TABLE);
+    this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_HUNKS_TABLE);
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -473,6 +551,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       headSha?: unknown;
       costUsd?: unknown;
       commentId?: unknown;
+      hunks?: unknown;
       findings?: unknown;
     } | null;
     if (
@@ -483,26 +562,101 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       !Number.isFinite(body.costUsd) ||
       body.costUsd < 0 ||
       (body.commentId !== undefined && typeof body.commentId !== "number") ||
-      !Array.isArray(body.findings)
+      !Array.isArray(body.hunks) ||
+      !body.hunks.every(isReviewHunk) ||
+      !Array.isArray(body.findings) ||
+      !body.findings.every(isIdentifiedFinding)
     ) {
       return json({ error: "Invalid review completion" }, 400);
     }
-    const update = this.ctx.storage.sql.exec(
-      `UPDATE review_runs
-       SET status = 'completed', completed_at = ?, cost_usd = ?,
-           comment_id = ?, findings_json = ?, error = NULL
-       WHERE run_id = ? AND head_sha = ? AND status = 'running'`,
-      new Date().toISOString(),
-      body.costUsd,
-      body.commentId ?? null,
-      JSON.stringify(body.findings),
-      body.runId,
-      body.headSha,
-    );
-    if (update.rowsWritten === 0) {
+    const completedAt = new Date().toISOString();
+    const completion = this.ctx.storage.transactionSync(() => {
+      const update = this.ctx.storage.sql.exec(
+        `UPDATE review_runs
+         SET status = 'completed', completed_at = ?, cost_usd = ?,
+             comment_id = ?, findings_json = ?, error = NULL
+         WHERE run_id = ? AND head_sha = ? AND status = 'running'`,
+        completedAt,
+        body.costUsd,
+        body.commentId ?? null,
+        JSON.stringify(body.findings),
+        body.runId,
+        body.headSha,
+      );
+      if (update.rowsWritten === 0) {
+        const existing = this.ctx.storage.sql
+          .exec<{ head_sha: string; status: string }>(
+            "SELECT head_sha, status FROM review_runs WHERE run_id = ?",
+            body.runId,
+          )
+          .toArray()[0];
+        return existing?.head_sha === body.headSha &&
+          existing?.status === "completed"
+          ? "duplicate"
+          : "missing";
+      }
+      for (const hunk of body.hunks as ReviewHunk[]) {
+        this.ctx.storage.sql.exec(
+          `INSERT INTO review_hunks
+           (hunk_id, fingerprint, file_path, first_seen_head_sha,
+            last_seen_head_sha, first_seen_at, last_seen_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(hunk_id) DO UPDATE SET
+             last_seen_head_sha = excluded.last_seen_head_sha,
+             last_seen_at = excluded.last_seen_at`,
+          hunk.hunkId,
+          hunk.fingerprint,
+          hunk.file,
+          body.headSha,
+          body.headSha,
+          completedAt,
+          completedAt,
+        );
+      }
+      for (const finding of body.findings as IdentifiedMergedFinding[]) {
+        this.ctx.storage.sql.exec(
+          `INSERT INTO review_findings
+           (finding_id, file_path, title, status, first_seen_head_sha,
+            last_seen_head_sha, first_seen_run_id, last_seen_run_id,
+            first_seen_at, last_seen_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(finding_id) DO UPDATE SET
+             file_path = excluded.file_path,
+             title = excluded.title,
+             status = excluded.status,
+             last_seen_head_sha = excluded.last_seen_head_sha,
+             last_seen_run_id = excluded.last_seen_run_id,
+             last_seen_at = excluded.last_seen_at`,
+          finding.findingId,
+          finding.file,
+          finding.title,
+          finding.status,
+          body.headSha,
+          body.headSha,
+          body.runId,
+          body.runId,
+          completedAt,
+          completedAt,
+        );
+        for (const hunkId of finding.hunkIds) {
+          this.ctx.storage.sql.exec(
+            `INSERT OR IGNORE INTO review_finding_hunks (finding_id, hunk_id)
+             VALUES (?, ?)`,
+            finding.findingId,
+            hunkId,
+          );
+        }
+      }
+      return "completed";
+    });
+    if (completion === "missing") {
       return json({ error: "No matching review run to complete" }, 409);
     }
-    return json({ completed: true });
+    return json(
+      completion === "duplicate"
+        ? { completed: true, duplicate: true }
+        : { completed: true },
+    );
   }
 
   private async failReview(request: Request): Promise<Response> {
@@ -570,8 +724,13 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
       ): Promise<T>;
     };
     let incurredCostUsd = 0;
+    let failedPhase = "prepare-review";
+    let prepared: PreparedReview | undefined;
+    let scouts: ScoutRun | undefined;
+    let merged: MergedRun | undefined;
+    let artifacts: IdentifiedReviewArtifacts | undefined;
     try {
-      const prepared = await workflowStep.do("prepare-review", () =>
+      prepared = await workflowStep.do("prepare-review", () =>
         prepareReview(this.env, event.payload),
       );
       if (prepared.skipReason) {
@@ -580,10 +739,22 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           pullRequestNumber: event.payload.pullRequestNumber,
           reason: prepared.skipReason,
         });
+        await workflowStep.do("record-skipped-review", () =>
+          recordReviewTerminal({
+            env: this.env,
+            params: event.payload,
+            instanceId: event.instanceId,
+            status: "skipped",
+            reason: prepared?.skipReason,
+            prepared,
+            timestamp: event.timestamp,
+          }),
+        );
         return;
       }
+      failedPhase = "claim-review";
       const claim = await workflowStep.do("claim-review", () =>
-        claimReview(this.env, event.payload, event.instanceId, prepared),
+        claimReview(this.env, event.payload, event.instanceId, prepared!),
       );
       if (!claim.claimed) {
         console.log("Skipping duplicate or over-budget AI review", {
@@ -591,17 +762,27 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           pullRequestNumber: event.payload.pullRequestNumber,
           reason: claim.reason,
         });
+        await workflowStep.do("record-denied-review", () =>
+          recordReviewTerminal({
+            env: this.env,
+            params: event.payload,
+            instanceId: event.instanceId,
+            status: "denied",
+            reason: claim.reason,
+            prepared,
+            timestamp: event.timestamp,
+          }),
+        );
         return;
       }
 
-      let scouts: ScoutRun;
-      let merged: MergedRun;
       if (prepared.diff?.trim()) {
+        failedPhase = "run-openrouter-scouts";
         const openRouterScouts = await workflowStep.do(
           "run-openrouter-scouts",
           MODEL_STEP_CONFIG,
           () =>
-            runScouts(this.env, event.payload, prepared, {
+            runScouts(this.env, event.payload, prepared!, {
               providers: ["openrouter"],
             }),
         );
@@ -609,19 +790,21 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           (total, cost) => total + cost,
           0,
         );
+        failedPhase = "run-opencode-scouts";
         const openCodeScouts = await workflowStep.do(
           "run-opencode-scouts",
           MODEL_STEP_CONFIG,
           () =>
-            runScouts(this.env, event.payload, prepared, {
+            runScouts(this.env, event.payload, prepared!, {
               providers: ["opencode"],
             }),
         );
         scouts = combineScoutRuns(openRouterScouts, openCodeScouts);
+        failedPhase = "merge-current-scout-findings";
         merged = await workflowStep.do(
           "merge-current-scout-findings",
           MODEL_STEP_CONFIG,
-          () => mergeFindings(this.env, event.payload, prepared, scouts),
+          () => mergeFindings(this.env, event.payload, prepared!, scouts!),
         );
         incurredCostUsd += merged.cost;
       } else {
@@ -643,35 +826,43 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           cost: 0,
         };
       }
+      failedPhase = "identify-review-artifacts";
+      artifacts = await workflowStep.do("identify-review-artifacts", () =>
+        identifyReviewArtifacts(prepared!, scouts!, merged!),
+      );
+      failedPhase = "publish-rolling-comment";
       const publication = await workflowStep.do("publish-rolling-comment", () =>
         publishReview(
           this.env,
           event.payload,
-          prepared,
-          scouts,
-          merged,
+          prepared!,
+          scouts!,
+          merged!,
           claim.previousState,
         ),
       );
+      failedPhase = "record-versioned-review";
       await workflowStep.do("record-versioned-review", () =>
         recordReview({
           env: this.env,
           params: event.payload,
           instanceId: event.instanceId,
-          prepared,
-          scouts,
-          merged,
+          prepared: prepared!,
+          scouts: scouts!,
+          merged: merged!,
+          artifacts: artifacts!,
           publication,
           timestamp: event.timestamp,
         }),
       );
+      failedPhase = "complete-review-state";
       await workflowStep.do("complete-review-state", () =>
         completeReview(
           this.env,
           event.payload,
           event.instanceId,
-          prepared,
-          merged,
+          prepared!,
+          artifacts!,
           publication,
         ),
       );
@@ -689,6 +880,31 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           type:
             stateError instanceof Error ? stateError.name : typeof stateError,
         });
+      }
+      try {
+        await workflowStep.do("record-failed-review", () =>
+          recordReviewTerminal({
+            env: this.env,
+            params: event.payload,
+            instanceId: event.instanceId,
+            status: "failed",
+            error: error instanceof Error ? error.message : String(error),
+            failedPhase,
+            incurredCostUsd,
+            prepared,
+            scouts,
+            merged,
+            artifacts,
+            timestamp: event.timestamp,
+          }),
+        );
+      } catch (recordError) {
+        console.error(
+          "Could not record failed review analytics",
+          recordError instanceof Error
+            ? { type: recordError.name }
+            : { type: typeof recordError },
+        );
       }
       throw error;
     }

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -604,6 +604,16 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     ) {
       return json({ error: "Invalid review completion" }, 400);
     }
+    const completionHunkIds = new Set(
+      (body.hunks as ReviewHunk[]).map(({ hunkId }) => hunkId),
+    );
+    if (
+      (body.findings as IdentifiedMergedFinding[]).some((finding) =>
+        finding.hunkIds.some((hunkId) => !completionHunkIds.has(hunkId)),
+      )
+    ) {
+      return json({ error: "Invalid review completion" }, 400);
+    }
     const completionHash = await sha256(
       JSON.stringify({
         headSha: body.headSha,

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -53,6 +53,7 @@ const CREATE_REVIEW_RUNS_TABLE =
   "cost_usd REAL NOT NULL DEFAULT 0, " +
   "comment_id INTEGER, " +
   "findings_json TEXT, " +
+  "completion_hash TEXT, " +
   "error TEXT)";
 const CREATE_REVIEW_HUNKS_TABLE =
   "CREATE TABLE IF NOT EXISTS review_hunks (" +
@@ -104,6 +105,13 @@ const MODEL_STEP_CONFIG = {
   timeout: "10 minutes",
 } satisfies WorkflowStepConfig;
 const textEncoder = new TextEncoder();
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", textEncoder.encode(value));
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
 
 function json(data: unknown, status = 200): Response {
   return Response.json(data, { status, headers: JSON_HEADERS });
@@ -270,6 +278,14 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     super(ctx, env);
     this.ctx.storage.sql.exec(CREATE_WEBHOOK_DELIVERIES_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_RUNS_TABLE);
+    const reviewRunColumns = this.ctx.storage.sql
+      .exec<{ name: string }>("PRAGMA table_info(review_runs)")
+      .toArray();
+    if (!reviewRunColumns.some(({ name }) => name === "completion_hash")) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE review_runs ADD COLUMN completion_hash TEXT",
+      );
+    }
     this.ctx.storage.sql.exec(CREATE_REVIEW_HUNKS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDINGS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_HUNKS_TABLE);
@@ -569,31 +585,49 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     ) {
       return json({ error: "Invalid review completion" }, 400);
     }
+    const completionHash = await sha256(
+      JSON.stringify({
+        headSha: body.headSha,
+        costUsd: body.costUsd,
+        commentId: body.commentId ?? null,
+        hunks: body.hunks,
+        findings: body.findings,
+      }),
+    );
     const completedAt = new Date().toISOString();
     const completion = this.ctx.storage.transactionSync(() => {
       const update = this.ctx.storage.sql.exec(
         `UPDATE review_runs
          SET status = 'completed', completed_at = ?, cost_usd = ?,
-             comment_id = ?, findings_json = ?, error = NULL
+             comment_id = ?, findings_json = ?, completion_hash = ?, error = NULL
          WHERE run_id = ? AND head_sha = ? AND status = 'running'`,
         completedAt,
         body.costUsd,
         body.commentId ?? null,
         JSON.stringify(body.findings),
+        completionHash,
         body.runId,
         body.headSha,
       );
       if (update.rowsWritten === 0) {
         const existing = this.ctx.storage.sql
-          .exec<{ head_sha: string; status: string }>(
-            "SELECT head_sha, status FROM review_runs WHERE run_id = ?",
+          .exec<{ head_sha: string; status: string; completion_hash: string | null }>(
+            `SELECT head_sha, status, completion_hash
+             FROM review_runs WHERE run_id = ?`,
             body.runId,
           )
           .toArray()[0];
-        return existing?.head_sha === body.headSha &&
-          existing?.status === "completed"
-          ? "duplicate"
-          : "missing";
+        if (
+          existing &&
+          existing.head_sha === body.headSha &&
+          existing.status === "completed"
+        ) {
+          return existing.completion_hash === null ||
+            existing.completion_hash === completionHash
+            ? "duplicate"
+            : "conflict";
+        }
+        return "missing";
       }
       for (const hunk of body.hunks as ReviewHunk[]) {
         this.ctx.storage.sql.exec(
@@ -651,6 +685,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     });
     if (completion === "missing") {
       return json({ error: "No matching review run to complete" }, 409);
+    }
+    if (completion === "conflict") {
+      return json({ error: "Review completion payload does not match" }, 409);
     }
     return json(
       completion === "duplicate"

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -284,7 +284,7 @@ function summarizeChange(
         .map((extension) => (extension ? EXTENSION_LANGUAGE[extension] : undefined))
         .filter((language): language is string => language !== undefined),
     ),
-  ].sort();
+  ].sort((left, right) => left.localeCompare(right));
   const repositoryAreas = [
     ...new Set(
       allPaths.map((path) => {
@@ -292,7 +292,7 @@ function summarizeChange(
         return path.includes("/") && first ? first : "root";
       }),
     ),
-  ].sort();
+  ].sort((left, right) => left.localeCompare(right));
   const riskSignals = [
     allPaths.some((path) => /(^|\/)(auth|security|secrets?)(\/|\.|$)/i.test(path))
       ? "authentication-or-secrets"
@@ -361,7 +361,7 @@ export async function identifyDiffHunks(diff: string): Promise<ReviewHunk[]> {
       pending.push(current);
       continue;
     }
-    if (current && line !== "\\ No newline at end of file") {
+    if (current && line !== String.raw`\ No newline at end of file`) {
       current.body.push(line);
     }
   }

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -37,6 +37,39 @@ type JsonObject = Record<string, unknown>;
 
 export const STATEFUL_REVIEW_MARKER = "<!-- stateful-ai-code-review -->";
 
+export interface ReviewHunk {
+  hunkId: string;
+  fingerprint: string;
+  file: string;
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+}
+
+export interface ChangeProfile {
+  diffCharacters: number;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  reviewableFiles: number;
+  omittedFiles: number;
+  hunks: number;
+  languages: string[];
+  repositoryAreas: string[];
+  riskSignals: string[];
+}
+
+export interface PullRequestMetadata {
+  author: string;
+  authorAssociation?: string;
+  title?: string;
+  labels: string[];
+  headRef?: string;
+  taskType?: "bug" | "dependency" | "documentation" | "feature";
+  originatingAgent?: "claude" | "codex" | "opencode";
+}
+
 export interface PreparedReview {
   skipReason?: string;
   headSha?: string;
@@ -45,6 +78,9 @@ export interface PreparedReview {
   diff?: string;
   paths: string[];
   omitted: string[];
+  hunks?: ReviewHunk[];
+  changeProfile?: ChangeProfile;
+  pullRequest?: PullRequestMetadata;
   context?: string;
   guidelines?: string;
   threads?: string;
@@ -81,6 +117,24 @@ export interface MergedRun {
   cost: number;
   metric?: ModelMetric;
 }
+
+export interface IdentifiedFinding extends Finding {
+  findingId: string;
+  hunkIds: string[];
+}
+
+export interface IdentifiedMergedFinding extends MergedFinding {
+  findingId: string;
+  hunkIds: string[];
+}
+
+export interface IdentifiedReviewArtifacts {
+  hunks: ReviewHunk[];
+  candidates: Record<string, IdentifiedFinding[]>;
+  publishedFindings: IdentifiedMergedFinding[];
+}
+
+export type ReviewRecordStatus = "denied" | "failed" | "published" | "skipped";
 
 interface ClaimResponse {
   claimed: boolean;
@@ -158,6 +212,269 @@ async function sha256(value: string): Promise<string> {
     .join("");
 }
 
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  css: "CSS",
+  go: "Go",
+  html: "HTML",
+  java: "Java",
+  js: "JavaScript",
+  json: "JSON",
+  jsx: "JavaScript",
+  md: "Markdown",
+  mdx: "MDX",
+  py: "Python",
+  rs: "Rust",
+  sh: "Shell",
+  sql: "SQL",
+  tf: "Terraform",
+  toml: "TOML",
+  ts: "TypeScript",
+  tsx: "TypeScript",
+  yaml: "YAML",
+  yml: "YAML",
+};
+
+function countPatchLines(diff: string, prefix: "+" | "-"): number {
+  return diff
+    .split("\n")
+    .filter(
+      (line) =>
+        line.startsWith(prefix) &&
+        !line.startsWith(prefix === "+" ? "+++" : "---"),
+    ).length;
+}
+
+function taskType(labels: string[]): PullRequestMetadata["taskType"] {
+  const normalized = new Set(labels.map((label) => label.toLowerCase()));
+  if (["bug", "fix"].some((label) => normalized.has(label))) return "bug";
+  if (["dependencies", "dependency"].some((label) => normalized.has(label))) {
+    return "dependency";
+  }
+  if (["documentation", "docs"].some((label) => normalized.has(label))) {
+    return "documentation";
+  }
+  if (["enhancement", "feature"].some((label) => normalized.has(label))) {
+    return "feature";
+  }
+  return undefined;
+}
+
+function originatingAgent(
+  title: string | undefined,
+  headRef: string | undefined,
+): PullRequestMetadata["originatingAgent"] {
+  const source = `${title ?? ""} ${headRef ?? ""}`.toLowerCase();
+  if (/(^|[^a-z])claude([^a-z]|$)/.test(source)) return "claude";
+  if (/(^|[^a-z])codex([^a-z]|$)/.test(source)) return "codex";
+  if (/(^|[^a-z])opencode([^a-z]|$)/.test(source)) return "opencode";
+  return undefined;
+}
+
+function summarizeChange(
+  diff: string,
+  paths: string[],
+  omitted: string[],
+  hunks: ReviewHunk[],
+): ChangeProfile {
+  const allPaths = [...new Set([...paths, ...omitted])];
+  const languages = [
+    ...new Set(
+      allPaths
+        .map((path) => path.split(".").at(-1)?.toLowerCase())
+        .map((extension) => (extension ? EXTENSION_LANGUAGE[extension] : undefined))
+        .filter((language): language is string => language !== undefined),
+    ),
+  ].sort();
+  const repositoryAreas = [
+    ...new Set(
+      allPaths.map((path) => {
+        const [first] = path.split("/");
+        return path.includes("/") && first ? first : "root";
+      }),
+    ),
+  ].sort();
+  const riskSignals = [
+    allPaths.some((path) => /(^|\/)(auth|security|secrets?)(\/|\.|$)/i.test(path))
+      ? "authentication-or-secrets"
+      : undefined,
+    allPaths.some((path) => /(^|\/)(drizzle|migrations?|schema)(\/|\.|$)/i.test(path))
+      ? "database-schema"
+      : undefined,
+    allPaths.some((path) => /(^|\/)(infra|infra-bootstrap)(\/|$)/i.test(path))
+      ? "infrastructure"
+      : undefined,
+    allPaths.some((path) => path.startsWith(".github/workflows/"))
+      ? "ci-or-deployment"
+      : undefined,
+  ].filter((signal): signal is string => signal !== undefined);
+  return {
+    diffCharacters: diff.length,
+    additions: countPatchLines(diff, "+"),
+    deletions: countPatchLines(diff, "-"),
+    changedFiles: allPaths.length,
+    reviewableFiles: paths.length,
+    omittedFiles: omitted.length,
+    hunks: hunks.length,
+    languages,
+    repositoryAreas,
+    riskSignals,
+  };
+}
+
+function parseHunkHeader(line: string): {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+} | null {
+  const match = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(line);
+  if (!match) return null;
+  return {
+    oldStart: Number(match[1]),
+    oldLines: Number(match[2] ?? 1),
+    newStart: Number(match[3]),
+    newLines: Number(match[4] ?? 1),
+  };
+}
+
+export async function identifyDiffHunks(diff: string): Promise<ReviewHunk[]> {
+  const pending: Array<{
+    file: string;
+    body: string[];
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+  }> = [];
+  let file: string | undefined;
+  let current: (typeof pending)[number] | undefined;
+  for (const line of diff.split("\n")) {
+    const fileMatch = /^diff --git a\/.* b\/(.+)$/.exec(line);
+    if (fileMatch) {
+      file = fileMatch[1];
+      current = undefined;
+      continue;
+    }
+    const header = parseHunkHeader(line);
+    if (header && file) {
+      current = { file, body: [], ...header };
+      pending.push(current);
+      continue;
+    }
+    if (current && line !== "\\ No newline at end of file") {
+      current.body.push(line);
+    }
+  }
+
+  const occurrences = new Map<string, number>();
+  return Promise.all(
+    pending.map(async ({ file: path, body, ...coordinates }) => {
+      const canonical = `${path}\n${body.join("\n")}`;
+      const occurrence = (occurrences.get(canonical) ?? 0) + 1;
+      occurrences.set(canonical, occurrence);
+      const fingerprint = await sha256(canonical);
+      const identity = await sha256(`${canonical}\noccurrence:${occurrence}`);
+      return {
+        hunkId: `h_${identity.slice(0, 24)}`,
+        fingerprint,
+        file: path,
+        ...coordinates,
+      };
+    }),
+  );
+}
+
+function normalizedFindingTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function hunkIdsForFinding(
+  finding: Pick<Finding, "file" | "line">,
+  hunks: ReviewHunk[],
+): string[] {
+  const sameFile = hunks.filter((hunk) => hunk.file === finding.file);
+  if (finding.line === null) return sameFile.map(({ hunkId }) => hunkId);
+  const containing = sameFile.filter(
+    (hunk) =>
+      finding.line !== null &&
+      finding.line >= hunk.newStart &&
+      finding.line < hunk.newStart + Math.max(hunk.newLines, 1),
+  );
+  if (containing.length > 0) return containing.map(({ hunkId }) => hunkId);
+  const nearest = [...sameFile].sort(
+    (left, right) =>
+      Math.abs(left.newStart - (finding.line ?? 0)) -
+      Math.abs(right.newStart - (finding.line ?? 0)),
+  )[0];
+  return nearest ? [nearest.hunkId] : [];
+}
+
+async function findingIdentity(finding: Pick<Finding, "file" | "title">) {
+  const digest = await sha256(
+    `${finding.file.toLowerCase()}\n${normalizedFindingTitle(finding.title)}`,
+  );
+  return `f_${digest.slice(0, 24)}`;
+}
+
+function findingSimilarity(left: Finding, right: Finding): number {
+  if (left.file !== right.file) return Number.NEGATIVE_INFINITY;
+  const leftTokens = new Set(normalizedFindingTitle(left.title).split(" "));
+  const rightTokens = new Set(normalizedFindingTitle(right.title).split(" "));
+  const overlap = [...leftTokens].filter((token) => rightTokens.has(token)).length;
+  const union = new Set([...leftTokens, ...rightTokens]).size || 1;
+  const lineDistance =
+    left.line === null || right.line === null ? 0 : Math.abs(left.line - right.line);
+  return overlap / union - Math.min(lineDistance, 100) / 1_000;
+}
+
+export async function identifyReviewArtifacts(
+  prepared: PreparedReview,
+  scouts: ScoutRun,
+  merged: MergedRun,
+): Promise<IdentifiedReviewArtifacts> {
+  const hunks = prepared.hunks ?? [];
+  const candidates: Record<string, IdentifiedFinding[]> = {};
+  for (const [model, findings] of Object.entries(scouts.candidates)) {
+    candidates[model] = await Promise.all(
+      findings.map(async (finding) => ({
+        ...finding,
+        findingId: await findingIdentity(finding),
+        hunkIds: hunkIdsForFinding(finding, hunks),
+      })),
+    );
+  }
+  const mergedFindings = Array.isArray(merged.result.findings)
+    ? (merged.result.findings as MergedFinding[])
+    : [];
+  const publishedFindings = await Promise.all(
+    mergedFindings.map(async (finding): Promise<IdentifiedMergedFinding> => {
+      const sourceCandidates = finding.source_models.flatMap(
+        (model) => candidates[model] ?? [],
+      );
+      const closest = [...sourceCandidates].sort(
+        (left, right) =>
+          findingSimilarity(finding, right) - findingSimilarity(finding, left),
+      )[0];
+      const sufficientlySimilar =
+        closest && findingSimilarity(finding, closest) >= 0.25;
+      return {
+        ...finding,
+        findingId: sufficientlySimilar
+          ? closest.findingId
+          : await findingIdentity(finding),
+        hunkIds: sufficientlySimilar
+          ? closest.hunkIds
+          : hunkIdsForFinding(finding, hunks),
+      };
+    }),
+  );
+  return { hunks, candidates, publishedFindings };
+}
+
 function coordinatorStub(env: Env, params: ReviewWorkflowParams) {
   const name = `${params.repository}#${params.pullRequestNumber}`;
   return env.PR_STATE.get(env.PR_STATE.idFromName(name));
@@ -218,6 +535,10 @@ export async function prepareReview(
 
   const headSha = pr.head.sha;
   const { diff, paths, omitted } = await reviewer.changedFiles();
+  const hunks = await identifyDiffHunks(diff);
+  const labels = (pr.labels ?? [])
+    .map(({ name }) => name?.trim())
+    .filter((name): name is string => Boolean(name));
   const config = JSON.stringify({
     promptVersion: env.AI_REVIEW_PROMPT_VERSION,
     openRouterScouts: settings.openRouterScouts,
@@ -237,6 +558,17 @@ export async function prepareReview(
     diff,
     paths,
     omitted,
+    hunks,
+    changeProfile: summarizeChange(diff, paths, omitted, hunks),
+    pullRequest: {
+      author: pr.user.login,
+      authorAssociation: pr.author_association,
+      title: pr.title,
+      labels,
+      headRef: pr.head.ref,
+      taskType: taskType(labels),
+      originatingAgent: originatingAgent(pr.title, pr.head.ref),
+    },
     context: diff.trim() ? await reviewer.fileContext(paths, headSha) : "",
     guidelines: diff.trim() ? await reviewer.headGuidelines(headSha) : "",
     threads: diff.trim() ? await reviewer.reviewThreadContext() : "",
@@ -583,54 +915,115 @@ export async function recordReview(options: {
   prepared: PreparedReview;
   scouts: ScoutRun;
   merged: MergedRun;
+  artifacts: IdentifiedReviewArtifacts;
   publication: { commentId?: number; runCostUsd: number };
   timestamp: Date;
+}): Promise<void> {
+  if (!options.prepared.headSha) {
+    throw new Error("Cannot record an unprepared review");
+  }
+  await recordReviewTerminal({ ...options, status: "published" });
+}
+
+export async function recordReviewTerminal(options: {
+  env: Env;
+  params: ReviewWorkflowParams;
+  instanceId: string;
+  status: ReviewRecordStatus;
+  timestamp: Date;
+  prepared?: PreparedReview;
+  scouts?: ScoutRun;
+  merged?: MergedRun;
+  artifacts?: IdentifiedReviewArtifacts;
+  publication?: { commentId?: number; runCostUsd: number };
+  reason?: string;
+  error?: string;
+  failedPhase?: string;
+  incurredCostUsd?: number;
 }): Promise<void> {
   const {
     env,
     params,
     instanceId,
+    status,
+    timestamp,
     prepared,
     scouts,
     merged,
+    artifacts,
     publication,
-    timestamp,
   } = options;
-  if (!prepared.headSha) throw new Error("Cannot record an unprepared review");
+  const headSha = prepared?.headSha ?? params.headSha ?? "unknown-head";
   const key = [
-    "v1",
+    "v2",
     params.repository,
     `pr-${params.pullRequestNumber}`,
-    prepared.headSha,
-    `${instanceId}.json`,
+    headSha,
+    instanceId,
+    `${status}.json`,
   ].join("/");
+  const summary =
+    merged && typeof merged.result.summary === "string"
+      ? merged.result.summary
+      : undefined;
   await env.REVIEW_DATA.put(
     key,
     JSON.stringify({
-      schemaVersion: 1,
-      status: "published",
+      schemaVersion: 2,
+      recordType: "review-run-terminal",
+      status,
       repository: params.repository,
       pullRequestNumber: params.pullRequestNumber,
-      headSha: prepared.headSha,
-      diffFingerprint: prepared.diffFingerprint,
-      configFingerprint: prepared.configFingerprint,
+      headSha,
+      diffFingerprint: prepared?.diffFingerprint,
+      configFingerprint: prepared?.configFingerprint,
       promptVersion: env.AI_REVIEW_PROMPT_VERSION,
+      reviewerConfiguration: {
+        openRouterScouts: csv(env.AI_REVIEW_MODELS, DEFAULT_OPENROUTER_SCOUTS),
+        openCodeScouts: csv(env.AI_REVIEW_OPENCODE_MODELS, []),
+        merger: env.AI_REVIEW_MERGER_MODEL?.trim() || DEFAULT_MERGER,
+        requireZeroDataRetention: ["1", "true", "yes", "on"].includes(
+          env.AI_REVIEW_ZDR?.trim().toLowerCase() ?? "",
+        ),
+      },
       trigger: {
+        deliveryId: params.deliveryId,
         eventName: params.eventName,
         action: params.action,
         force: params.force,
+        webhookHeadSha: params.headSha,
       },
-      coverage: {
-        paths: prepared.paths,
-        omitted: prepared.omitted,
+      pullRequest: prepared?.pullRequest,
+      change: prepared?.changeProfile,
+      coverage: prepared
+        ? {
+            paths: prepared.paths,
+            omitted: prepared.omitted,
+          }
+        : undefined,
+      hunks: artifacts?.hunks ?? prepared?.hunks ?? [],
+      candidates: artifacts?.candidates ?? {},
+      findings:
+        summary !== undefined || artifacts
+          ? {
+              summary,
+              published: artifacts?.publishedFindings ?? [],
+            }
+          : undefined,
+      models: scouts
+        ? [...scouts.metrics, ...(merged?.metric ? [merged.metric] : [])]
+        : [],
+      runCostUsd: publication?.runCostUsd ?? options.incurredCostUsd ?? 0,
+      commentId: publication?.commentId,
+      terminal: {
+        reason: options.reason,
+        error: options.error,
+        failedPhase: options.failedPhase,
       },
-      findings: merged.result,
-      models: [...scouts.metrics, ...(merged.metric ? [merged.metric] : [])],
-      runCostUsd: publication.runCostUsd,
-      commentId: publication.commentId,
       workflow: {
         instanceId,
-        timestamp: timestamp.toISOString(),
+        triggeredAt: timestamp.toISOString(),
+        recordedAt: new Date().toISOString(),
       },
     }),
     { httpMetadata: { contentType: "application/json" } },
@@ -642,7 +1035,7 @@ export async function completeReview(
   params: ReviewWorkflowParams,
   instanceId: string,
   prepared: PreparedReview,
-  merged: MergedRun,
+  artifacts: IdentifiedReviewArtifacts,
   publication: { commentId?: number; runCostUsd: number },
 ): Promise<void> {
   await coordinatorRequest(env, params, "/reviews/complete", {
@@ -650,7 +1043,8 @@ export async function completeReview(
     headSha: prepared.headSha,
     costUsd: publication.runCostUsd,
     commentId: publication.commentId,
-    findings: merged.result.findings ?? [],
+    hunks: artifacts.hunks,
+    findings: artifacts.publishedFindings,
   });
 }
 

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -466,9 +466,7 @@ export async function identifyReviewArtifacts(
         findingId: sufficientlySimilar
           ? closest.findingId
           : await findingIdentity(finding),
-        hunkIds: sufficientlySimilar
-          ? closest.hunkIds
-          : hunkIdsForFinding(finding, hunks),
+        hunkIds: hunkIdsForFinding(finding, hunks),
       };
     }),
   );

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -85,7 +85,33 @@ describe("PullRequestCoordinator in workerd", () => {
           headSha: event.headSha,
           costUsd: 0.25,
           commentId: 123,
-          findings: [{ title: "Finding" }],
+          hunks: [
+            {
+              hunkId: `h_${"c".repeat(24)}`,
+              fingerprint: "d".repeat(64),
+              file: "app.ts",
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+            },
+          ],
+          findings: [
+            {
+              findingId: `f_${"b".repeat(24)}`,
+              hunkIds: [`h_${"c".repeat(24)}`],
+              severity: "high",
+              file: "app.ts",
+              line: 1,
+              title: "Finding",
+              evidence: "Evidence",
+              recommendation: "Fix it",
+              confidence: 0.9,
+              source_models: ["model/scout"],
+              status: "open",
+              resolution_note: "",
+            },
+          ],
         }),
       },
     );
@@ -102,6 +128,70 @@ describe("PullRequestCoordinator in workerd", () => {
       claimed: false,
       reason: "this content and reviewer configuration were already reviewed",
     });
+
+    const laterHead = "e".repeat(40);
+    const laterRunId = "workerd-review-3";
+    const laterClaim = await stub.fetch(
+      "https://coordinator.test/reviews/claim",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ...claimBody,
+          runId: laterRunId,
+          headSha: laterHead,
+          diffFingerprint: "later-diff-hash",
+        }),
+      },
+    );
+    await expect(laterClaim.json()).resolves.toMatchObject({ claimed: true });
+    const laterCompletionBody = JSON.stringify({
+      runId: laterRunId,
+      headSha: laterHead,
+      costUsd: 0.1,
+      hunks: [
+        {
+          hunkId: `h_${"c".repeat(24)}`,
+          fingerprint: "d".repeat(64),
+          file: "app.ts",
+          oldStart: 50,
+          oldLines: 1,
+          newStart: 60,
+          newLines: 1,
+        },
+      ],
+      findings: [
+        {
+          findingId: `f_${"b".repeat(24)}`,
+          hunkIds: [`h_${"c".repeat(24)}`],
+          severity: "high",
+          file: "app.ts",
+          line: 60,
+          title: "Finding",
+          evidence: "Evidence",
+          recommendation: "Fix it",
+          confidence: 0.9,
+          source_models: ["model/scout"],
+          status: "resolved",
+          resolution_note: "Fixed in the later head",
+        },
+      ],
+    });
+    const laterCompletion = await stub.fetch(
+      "https://coordinator.test/reviews/complete",
+      {
+        method: "POST",
+        body: laterCompletionBody,
+      },
+    );
+    await expect(laterCompletion.json()).resolves.toEqual({ completed: true });
+    const retriedCompletion = await stub.fetch(
+      "https://coordinator.test/reviews/complete",
+      { method: "POST", body: laterCompletionBody },
+    );
+    await expect(retriedCompletion.json()).resolves.toEqual({
+      completed: true,
+      duplicate: true,
+    });
     await runInDurableObject(stub, async (_instance, state) => {
       expect(
         state.storage.sql
@@ -111,6 +201,31 @@ describe("PullRequestCoordinator in workerd", () => {
           )
           .toArray(),
       ).toEqual([{ status: "completed", cost_usd: 0.25 }]);
+      expect(
+        state.storage.sql
+          .exec<{
+            finding_id: string;
+            status: string;
+            first_seen_head_sha: string;
+            last_seen_head_sha: string;
+            first_seen_run_id: string;
+            last_seen_run_id: string;
+          }>(
+            `SELECT finding_id, status, first_seen_head_sha,
+                    last_seen_head_sha, first_seen_run_id, last_seen_run_id
+             FROM review_findings`,
+          )
+          .toArray(),
+      ).toEqual([
+        {
+          finding_id: `f_${"b".repeat(24)}`,
+          status: "resolved",
+          first_seen_head_sha: event.headSha,
+          last_seen_head_sha: laterHead,
+          first_seen_run_id: claimBody.runId,
+          last_seen_run_id: laterRunId,
+        },
+      ]);
     });
   });
 });

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -14,6 +14,31 @@ const event: ReviewWorkflowParams = {
   force: false,
 };
 
+const identifiedFinding = {
+  findingId: `f_${"b".repeat(24)}`,
+  hunkIds: [`h_${"c".repeat(24)}`],
+  severity: "high",
+  file: "app.ts",
+  line: 1,
+  title: "Finding",
+  evidence: "Evidence",
+  recommendation: "Fix it",
+  confidence: 0.9,
+  source_models: ["model/scout"],
+  status: "open",
+  resolution_note: "",
+};
+
+const identifiedHunk = {
+  hunkId: `h_${"c".repeat(24)}`,
+  fingerprint: "d".repeat(64),
+  file: "app.ts",
+  oldStart: 1,
+  oldLines: 1,
+  newStart: 1,
+  newLines: 1,
+};
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -344,7 +369,8 @@ describe("PullRequestCoordinator", () => {
           headSha: event.headSha,
           costUsd: 0.42,
           commentId: 987,
-          findings: [{ title: "Finding" }],
+          hunks: [identifiedHunk],
+          findings: [identifiedFinding],
         }),
       }),
     );
@@ -370,6 +396,7 @@ describe("PullRequestCoordinator", () => {
           runId: "missing-review",
           headSha: event.headSha,
           costUsd: 0.42,
+          hunks: [],
           findings: [],
         }),
       }),
@@ -626,8 +653,13 @@ describe("ReviewWorkflow", () => {
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(put).not.toHaveBeenCalled();
-    expect(step.do).toHaveBeenCalledTimes(1);
+    expect(put).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(put.mock.calls[0]?.[1]))).toMatchObject({
+      schemaVersion: 2,
+      status: "skipped",
+      terminal: { reason: "pull request is closed" },
+    });
+    expect(step.do).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -408,6 +408,39 @@ describe("PullRequestCoordinator", () => {
     });
   });
 
+  it("rejects a mismatched retry of an already completed run", async () => {
+    const { coordinator, sqlExec } = coordinatorFixture();
+    sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: query.includes("UPDATE review_runs") ? 0 : 1,
+      toArray: () =>
+        query.includes("SELECT head_sha, status, completion_hash")
+          ? [{
+              head_sha: event.headSha,
+              status: "completed",
+              completion_hash: "0".repeat(64),
+            }]
+          : [],
+    }));
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/reviews/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          runId: "review-delivery-123",
+          headSha: event.headSha,
+          costUsd: 0.43,
+          hunks: [identifiedHunk],
+          findings: [identifiedFinding],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Review completion payload does not match",
+    });
+  });
+
   it("rejects malformed internal review-state updates", async () => {
     const { coordinator } = coordinatorFixture();
     for (const path of [

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -480,6 +480,27 @@ describe("PullRequestCoordinator", () => {
     });
   });
 
+  it("rejects a finding linked to a hunk absent from its completion", async () => {
+    const { coordinator } = coordinatorFixture();
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/reviews/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          runId: "review-delivery-123",
+          headSha: event.headSha,
+          costUsd: 0.42,
+          hunks: [],
+          findings: [identifiedFinding],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid review completion",
+    });
+  });
+
   it.each([
     [{ attempts: 20, runs: 18, total_cost: 1 }, "review-run budget"],
     [{ attempts: 2, runs: 2, total_cost: 5 }, "cost budget"],

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -458,6 +458,28 @@ describe("PullRequestCoordinator", () => {
     }
   });
 
+  it("rejects an incomplete identified finding at the completion boundary", async () => {
+    const { coordinator } = coordinatorFixture();
+    const { evidence: _evidence, ...incompleteFinding } = identifiedFinding;
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/reviews/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          runId: "review-delivery-123",
+          headSha: event.headSha,
+          costUsd: 0.42,
+          hunks: [identifiedHunk],
+          findings: [incompleteFinding],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid review completion",
+    });
+  });
+
   it.each([
     [{ attempts: 20, runs: 18, total_cost: 1 }, "review-run budget"],
     [{ attempts: 2, runs: 2, total_cost: 5 }, "cost budget"],

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -792,4 +792,50 @@ describe("stateful review engine", () => {
     expect(moved[0]?.hunkId).toBe(first[0]?.hunkId);
     expect(moved[0]?.fingerprint).toBe(first[0]?.fingerprint);
   });
+
+  it("links a merged finding to its published line while retaining its source identity", async () => {
+    const hunks = await identifyDiffHunks(
+      "diff --git a/app.ts b/app.ts\n@@ -1 +1 @@\n-old\n+first\n@@ -20 +20 @@\n-old\n+second",
+    );
+    const candidate = {
+      severity: "high" as const,
+      file: "app.ts",
+      line: 1,
+      title: "Incorrect return value",
+      evidence: "Candidate evidence",
+      recommendation: "Fix it",
+      confidence: 0.9,
+    };
+    const artifacts = await identifyReviewArtifacts(
+      { paths: ["app.ts"], omitted: [], hunks },
+      {
+        models: ["model/scout"],
+        candidates: { "model/scout": [candidate] },
+        failed: [],
+        candidateCounts: { "model/scout": 1 },
+        invalidCounts: { "model/scout": 0 },
+        outOfScopeCounts: { "model/scout": 0 },
+        costs: { "model/scout": 0 },
+        metrics: [],
+      },
+      {
+        result: {
+          summary: "One issue.",
+          findings: [{
+            ...candidate,
+            line: 20,
+            source_models: ["model/scout"],
+            status: "open" as const,
+            resolution_note: "",
+          }],
+        },
+        cost: 0,
+      },
+    );
+
+    expect(artifacts.publishedFindings[0]?.findingId).toBe(
+      artifacts.candidates["model/scout"]?.[0]?.findingId,
+    );
+    expect(artifacts.publishedFindings[0]?.hunkIds).toEqual([hunks[1]?.hunkId]);
+  });
 });

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -11,6 +11,8 @@ import {
   combineScoutRuns,
   completeReview,
   failReview,
+  identifyReviewArtifacts,
+  identifyDiffHunks,
   mergeFindings,
   prepareReview,
   publishReview,
@@ -479,7 +481,7 @@ describe("stateful review engine", () => {
       params,
       "review-1",
       prepared,
-      { result: { findings: [] }, cost: 0 },
+      { hunks: [], candidates: {}, publishedFindings: [] },
       { commentId: 42, runCostUsd: 0.25 },
     );
     await failReview(env, params, "review-1", "failed");
@@ -557,6 +559,7 @@ describe("stateful review engine", () => {
         prepared: { paths: [], omitted: [] },
         scouts: emptyScouts,
         merged: emptyMerged,
+        artifacts: { hunks: [], candidates: {}, publishedFindings: [] },
         publication: { runCostUsd: 0 },
         timestamp: new Date(),
       }),
@@ -723,6 +726,7 @@ describe("stateful review engine", () => {
     const prepared = await prepareReview(env, params);
     const scouts = await runScouts(env, params, prepared);
     const merged = await mergeFindings(env, params, prepared, scouts);
+    const artifacts = await identifyReviewArtifacts(prepared, scouts, merged);
     const publication = await publishReview(
       env,
       params,
@@ -738,6 +742,7 @@ describe("stateful review engine", () => {
       prepared,
       scouts,
       merged,
+      artifacts,
       publication,
       timestamp: new Date("2026-07-28T12:00:00Z"),
     });
@@ -757,14 +762,34 @@ describe("stateful review engine", () => {
     expect(publishedBodies[0]).toContain("Reported by: `moonshotai/kimi-k2.6`");
     expect(put).toHaveBeenCalledOnce();
     const record = JSON.parse(String(put.mock.calls[0]?.[1])) as {
+      schemaVersion: number;
       status: string;
+      findings: { published: Array<{ findingId: string }> };
+      hunks: Array<{ hunkId: string }>;
       models: Array<{
         provider: string;
         usage?: { cachedInputTokens: number };
       }>;
     };
     expect(record.status).toBe("published");
+    expect(record.schemaVersion).toBe(2);
+    expect(record.findings.published[0]?.findingId).toMatch(/^f_[a-f0-9]{24}$/);
+    expect(record.hunks[0]?.hunkId).toMatch(/^h_[a-f0-9]{24}$/);
     expect(record.models.map(({ provider }) => provider)).toContain("opencode");
     expect(record.models.at(-1)?.usage?.cachedInputTokens).toBe(10);
+  });
+
+  it("keeps hunk identities stable when only unified-diff coordinates move", async () => {
+    const first = await identifyDiffHunks(
+      "diff --git a/app.ts b/app.ts\nstatus modified\n@@ -1,2 +1,2 @@\n-old\n+new\n context\n",
+    );
+    const moved = await identifyDiffHunks(
+      "diff --git a/app.ts b/app.ts\nstatus modified\n@@ -40,2 +55,2 @@\n-old\n+new\n context\n",
+    );
+
+    expect(first).toHaveLength(1);
+    expect(moved).toHaveLength(1);
+    expect(moved[0]?.hunkId).toBe(first[0]?.hunkId);
+    expect(moved[0]?.fingerprint).toBe(first[0]?.fingerprint);
   });
 });

--- a/ai-review/tests/workflow.test.ts
+++ b/ai-review/tests/workflow.test.ts
@@ -7,10 +7,12 @@ const engine = vi.hoisted(() => ({
   combineScoutRuns: vi.fn(),
   completeReview: vi.fn(),
   failReview: vi.fn(),
+  identifyReviewArtifacts: vi.fn(),
   mergeFindings: vi.fn(),
   prepareReview: vi.fn(),
   publishReview: vi.fn(),
   recordReview: vi.fn(),
+  recordReviewTerminal: vi.fn(),
   runScouts: vi.fn(),
 }));
 
@@ -57,6 +59,12 @@ const scouts = {
 const merged = {
   result: { summary: "Clean.", findings: [] },
   cost: 0.2,
+};
+
+const artifacts = {
+  hunks: [],
+  candidates: {},
+  publishedFindings: [],
 };
 
 const emptyScouts = {
@@ -106,11 +114,13 @@ beforeEach(() => {
     .mockResolvedValueOnce(emptyScouts);
   engine.combineScoutRuns.mockReturnValue(scouts);
   engine.mergeFindings.mockResolvedValue(merged);
+  engine.identifyReviewArtifacts.mockResolvedValue(artifacts);
   engine.publishReview.mockResolvedValue({
     commentId: 123,
     runCostUsd: 0.6,
   });
   engine.recordReview.mockResolvedValue(undefined);
+  engine.recordReviewTerminal.mockResolvedValue(undefined);
   engine.completeReview.mockResolvedValue(undefined);
   engine.failReview.mockResolvedValue(undefined);
 });
@@ -148,12 +158,18 @@ describe("ReviewWorkflow orchestration", () => {
       retries: { limit: 1 },
     });
     expect(engine.publishReview).toHaveBeenCalledOnce();
+    expect(engine.identifyReviewArtifacts).toHaveBeenCalledWith(
+      prepared,
+      scouts,
+      merged,
+    );
     expect(engine.recordReview).toHaveBeenCalledWith(
       expect.objectContaining({
         instanceId: event.instanceId,
         prepared,
         scouts,
         merged,
+        artifacts,
         timestamp: event.timestamp,
       }),
     );
@@ -166,6 +182,7 @@ describe("ReviewWorkflow orchestration", () => {
       "run-openrouter-scouts",
       "run-opencode-scouts",
       "merge-current-scout-findings",
+      "identify-review-artifacts",
       "publish-rolling-comment",
       "record-versioned-review",
       "complete-review-state",
@@ -205,6 +222,9 @@ describe("ReviewWorkflow orchestration", () => {
     });
     await skipped.workflow.run(event, skipped.step);
     expect(engine.claimReview).not.toHaveBeenCalled();
+    expect(engine.recordReviewTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "skipped" }),
+    );
 
     engine.prepareReview.mockResolvedValueOnce(prepared);
     engine.claimReview.mockResolvedValueOnce({
@@ -215,6 +235,9 @@ describe("ReviewWorkflow orchestration", () => {
     const duplicate = fixture();
     await duplicate.workflow.run(event, duplicate.step);
     expect(engine.runScouts).not.toHaveBeenCalled();
+    expect(engine.recordReviewTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "denied" }),
+    );
   });
 
   it("records known model spend before propagating a failure", async () => {
@@ -231,6 +254,13 @@ describe("ReviewWorkflow orchestration", () => {
       event.instanceId,
       expect.any(Error),
       0.4,
+    );
+    expect(engine.recordReviewTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failedPhase: "merge-current-scout-findings",
+        incurredCostUsd: 0.4,
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary

- introduce schema-v2 terminal R2 records for published, skipped, denied, and failed review runs
- assign stable PR-scoped hunk and finding identities and persist first/last-seen state in Durable Object SQLite
- retain raw per-model candidates separately from published findings, with change and reviewer metadata
- make completion retries idempotent and update staging E2E coverage for the new record layout

## Validation

- mise run //ai-review:check
- mise run //ai-review:deploy:dry-run
- git diff --check

## QA

No browser preview is required. The change is isolated to the AI review Worker, Durable Object, R2 analytics contract, and staging E2E tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reviews now provide stable identities for code changes and findings, linking findings to relevant diff sections.
  * Review records include richer metadata, model usage, change characteristics, and terminal statuses.
  * Review outcomes now distinguish published, skipped, denied, and failed runs.
  * Closed pull requests are recorded as skipped reviews.

* **Reliability**
  * Duplicate completion attempts are detected and handled safely.
  * Review data remains consistent across retries and subsequent runs.

* **Documentation**
  * Added guidance on versioned review records, compatibility, identity tracking, and stored review details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->