### PR TITLE
Add revisioned pantry collaboration foundation

### DIFF
--- a/packages/recipe-db/src/schema.ts
+++ b/packages/recipe-db/src/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import {
+  bigint,
   boolean,
   check,
   index,
@@ -344,6 +345,52 @@ export const pantryLocationEnum = pgEnum("pantry_location", [
 ]);
 
 /**
+ * Revision state for one logical pantry. The owner mirrors pantry_item so a
+ * solo pantry can become the household pantry without losing revision
+ * continuity. Operation receipts are cleared when that resource identity
+ * changes.
+ */
+export const pantryAggregate = pgTable(
+  "pantry_aggregate",
+  {
+    id: uuid().primaryKey().defaultRandom(),
+    userId: text().references(() => user.id, { onDelete: "cascade" }),
+    organizationId: text().references(() => organization.id, {
+      onDelete: "cascade",
+    }),
+    revision: bigint({ mode: "bigint" }).notNull().default(sql`0`),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp({ withTimezone: true })
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    check(
+      "pantry_aggregate_owner_check",
+      sql`num_nonnulls(${table.userId}, ${table.organizationId}) = 1`,
+    ),
+    uniqueIndex("pantry_aggregate_user_uidx").on(table.userId),
+    uniqueIndex("pantry_aggregate_household_uidx").on(table.organizationId),
+  ],
+);
+
+/** A committed pantry command and its canonical response for retry safety. */
+export const pantryOperation = pgTable(
+  "pantry_operation",
+  {
+    aggregateId: uuid()
+      .notNull()
+      .references(() => pantryAggregate.id, { onDelete: "cascade" }),
+    operationId: uuid().notNull(),
+    commandFingerprint: text().notNull(),
+    result: jsonb().$type<Record<string, unknown>>().notNull(),
+    createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [primaryKey({ columns: [table.aggregateId, table.operationId] })],
+);
+
+/**
  * Pantry stock has exactly one owner. Solo cooks own their stock directly;
  * joining or creating a household switches them to the household-owned rows.
  */
@@ -359,6 +406,7 @@ export const pantryItem = pgTable(
       .notNull()
       .references(() => ingredient.slug, { onDelete: "cascade" }),
     location: pantryLocationEnum().notNull(),
+    version: bigint({ mode: "bigint" }).notNull().default(sql`1`),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp({ withTimezone: true })
       .notNull()

--- a/packages/recipe-db/src/schema.ts
+++ b/packages/recipe-db/src/schema.ts
@@ -387,7 +387,10 @@ export const pantryOperation = pgTable(
     result: jsonb().$type<Record<string, unknown>>().notNull(),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [primaryKey({ columns: [table.aggregateId, table.operationId] })],
+  (table) => [
+    primaryKey({ columns: [table.aggregateId, table.operationId] }),
+    index("pantry_operation_created_at_idx").on(table.createdAt),
+  ],
 );
 
 /**

--- a/ui/hooks/use-kitchen-stock.ts
+++ b/ui/hooks/use-kitchen-stock.ts
@@ -160,7 +160,9 @@ export function useKitchenStockActions() {
     },
     onSuccess: (pantry) => {
       queryClient.setQueryData<Pantry>(queryKey, (current) =>
-        installPantrySnapshot(current, pantry),
+        current && current.resourceId !== pantry.resourceId
+          ? current
+          : installPantrySnapshot(current, pantry),
       );
     },
   });

--- a/ui/hooks/use-kitchen-stock.ts
+++ b/ui/hooks/use-kitchen-stock.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { captureRecipeProductActivity } from "@/lib/analytics/recipe-product";
 import {
+  installPantrySnapshot,
   type Pantry,
   removePantryItem,
   replacePantry,
@@ -20,22 +21,34 @@ import { recipeQueryKeys } from "@/lib/query/recipe-query-keys";
 
 const EMPTY_STOCK: KitchenStock = {};
 
+function stocksEqual(first: KitchenStock, second: KitchenStock): boolean {
+  const firstEntries = Object.entries(first);
+  return (
+    firstEntries.length === Object.keys(second).length &&
+    firstEntries.every(([slug, location]) => second[slug] === location)
+  );
+}
+
 type PantryMutation =
   | {
       kind: "set";
+      operationId: string;
       ingredientSlug: IngredientSlug;
       location: KitchenLocation;
     }
   | {
       kind: "remove";
+      operationId: string;
       ingredientSlug: IngredientSlug;
     }
   | {
       kind: "replace";
+      operationId: string;
       stock: KitchenStock;
     }
   | {
       kind: "restore";
+      operationId: string;
       stock: KitchenStock;
     };
 
@@ -63,13 +76,20 @@ export function useKitchenStockActions() {
     mutationFn: (operation: PantryMutation) => {
       switch (operation.kind) {
         case "set":
-          return setPantryItem(operation.ingredientSlug, operation.location);
+          return setPantryItem(
+            operation.ingredientSlug,
+            operation.location,
+            operation.operationId,
+          );
         case "remove":
-          return removePantryItem(operation.ingredientSlug);
+          return removePantryItem(
+            operation.ingredientSlug,
+            operation.operationId,
+          );
         case "replace":
-          return replacePantry(operation.stock);
+          return replacePantry(operation.stock, operation.operationId);
         case "restore":
-          return restorePantry(operation.stock);
+          return restorePantry(operation.stock, operation.operationId);
       }
     },
     onMutate: async (operation) => {
@@ -88,8 +108,8 @@ export function useKitchenStockActions() {
           });
         }
       }
+      let optimisticStock: KitchenStock | undefined;
       if (previous) {
-        let optimisticStock: KitchenStock;
         switch (operation.kind) {
           case "set":
             optimisticStock = {
@@ -111,35 +131,68 @@ export function useKitchenStockActions() {
         queryClient.setQueryData<Pantry>(queryKey, {
           ...previous,
           stock: optimisticStock,
+          itemVersions:
+            operation.kind === "remove"
+              ? Object.fromEntries(
+                  Object.entries(previous.itemVersions).filter(
+                    ([ingredientSlug]) =>
+                      ingredientSlug !== operation.ingredientSlug,
+                  ),
+                )
+              : previous.itemVersions,
         });
       }
-      return { previous };
+      return { optimisticStock, previous };
     },
     onError: (_error, _operation, context) => {
-      if (context?.previous) {
-        queryClient.setQueryData(queryKey, context.previous);
+      const previous = context?.previous;
+      const optimisticStock = context?.optimisticStock;
+      if (previous) {
+        queryClient.setQueryData<Pantry>(queryKey, (current) =>
+          current &&
+          (current.resourceId !== previous.resourceId ||
+            current.revision !== previous.revision ||
+            (optimisticStock && !stocksEqual(current.stock, optimisticStock)))
+            ? current
+            : previous,
+        );
       }
     },
     onSuccess: (pantry) => {
-      queryClient.setQueryData(queryKey, pantry);
+      queryClient.setQueryData<Pantry>(queryKey, (current) =>
+        installPantrySnapshot(current, pantry),
+      );
     },
   });
 
   return {
     clearStock() {
-      mutation.mutate({ kind: "replace", stock: {} });
+      mutation.mutate({
+        kind: "replace",
+        operationId: crypto.randomUUID(),
+        stock: {},
+      });
     },
     error: mutation.error,
     isPending: mutation.isPending,
     removeFromStock(ingredientSlug: IngredientSlug) {
-      mutation.mutate({ kind: "remove", ingredientSlug });
+      mutation.mutate({
+        kind: "remove",
+        ingredientSlug,
+        operationId: crypto.randomUUID(),
+      });
     },
     replaceStock(stock: KitchenStock) {
-      mutation.mutate({ kind: "replace", stock: { ...stock } });
+      mutation.mutate({
+        kind: "replace",
+        operationId: crypto.randomUUID(),
+        stock: { ...stock },
+      });
     },
     restoreStock(stock: KitchenStock) {
       mutation.mutate({
         kind: "restore",
+        operationId: crypto.randomUUID(),
         stock: { ...stock },
       });
     },
@@ -151,6 +204,7 @@ export function useKitchenStockActions() {
         kind: "set",
         ingredientSlug,
         location,
+        operationId: crypto.randomUUID(),
       });
     },
   };

--- a/ui/lib/api/pantry.ts
+++ b/ui/lib/api/pantry.ts
@@ -98,7 +98,7 @@ export function installPantrySnapshot(
   current: Pantry | undefined,
   incoming: Pantry,
 ): Pantry {
-  if (!current || current.resourceId !== incoming.resourceId) return incoming;
+  if (current?.resourceId !== incoming.resourceId) return incoming;
   return BigInt(incoming.revision) >= BigInt(current.revision)
     ? incoming
     : current;

--- a/ui/lib/api/pantry.ts
+++ b/ui/lib/api/pantry.ts
@@ -13,8 +13,12 @@ export type PantryScope =
     };
 
 export type Pantry = {
+  resourceId: string;
+  revision: string;
+  operationId?: string;
   scope: PantryScope;
   stock: KitchenStock;
+  itemVersions: Record<string, string>;
 };
 
 const LEGACY_PANTRY_STORAGE_KEY = "recipe-kitchen-stock-v1";
@@ -33,10 +37,12 @@ function pantryRequest(
   path: string,
   method: "PUT" | "PATCH" | "DELETE",
   body?: unknown,
+  operationId = crypto.randomUUID(),
 ): Promise<Pantry> {
   return apiRequest(path, {
     method,
     json: body,
+    headers: { "Idempotency-Key": operationId },
     fallbackMessage: "Pantry request failed.",
   });
 }
@@ -49,30 +55,51 @@ export async function getPantry(signal?: AbortSignal): Promise<Pantry> {
   });
 }
 
-export async function replacePantry(stock: KitchenStock): Promise<Pantry> {
-  return pantryRequest("/api/pantry", "PUT", { stock });
+export async function replacePantry(
+  stock: KitchenStock,
+  operationId?: string,
+): Promise<Pantry> {
+  return pantryRequest("/api/pantry", "PUT", { stock }, operationId);
 }
 
-export async function restorePantry(stock: KitchenStock): Promise<Pantry> {
-  return pantryRequest("/api/pantry", "PATCH", { stock });
+export async function restorePantry(
+  stock: KitchenStock,
+  operationId?: string,
+): Promise<Pantry> {
+  return pantryRequest("/api/pantry", "PATCH", { stock }, operationId);
 }
 
 export async function setPantryItem(
   ingredientSlug: IngredientSlug,
   location: KitchenLocation,
+  operationId?: string,
 ): Promise<Pantry> {
   return pantryRequest(
     `/api/pantry/items/${encodeURIComponent(ingredientSlug)}`,
     "PUT",
     { location },
+    operationId,
   );
 }
 
 export async function removePantryItem(
   ingredientSlug: IngredientSlug,
+  operationId?: string,
 ): Promise<Pantry> {
   return pantryRequest(
     `/api/pantry/items/${encodeURIComponent(ingredientSlug)}`,
     "DELETE",
+    undefined,
+    operationId,
   );
+}
+
+export function installPantrySnapshot(
+  current: Pantry | undefined,
+  incoming: Pantry,
+): Pantry {
+  if (!current || current.resourceId !== incoming.resourceId) return incoming;
+  return BigInt(incoming.revision) >= BigInt(current.revision)
+    ? incoming
+    : current;
 }

--- a/ui/lib/query/pantry-queries.ts
+++ b/ui/lib/query/pantry-queries.ts
@@ -1,11 +1,17 @@
 import { queryOptions } from "@tanstack/react-query";
-import { getPantry } from "@/lib/api/pantry";
+import {
+  getPantry,
+  installPantrySnapshot,
+  type Pantry,
+} from "@/lib/api/pantry";
 import { recipeQueryKeys } from "@/lib/query/recipe-query-keys";
 
 export const pantryQuery = (userId: string) =>
   queryOptions({
     queryKey: recipeQueryKeys.pantry(userId),
     queryFn: ({ signal }) => getPantry(signal),
+    structuralSharing: (current, incoming) =>
+      installPantrySnapshot(current as Pantry | undefined, incoming as Pantry),
     staleTime: 15_000,
     refetchInterval: 30_000,
     refetchOnWindowFocus: true,

--- a/ui/tests/hooks/use-kitchen-stock.test.tsx
+++ b/ui/tests/hooks/use-kitchen-stock.test.tsx
@@ -36,6 +36,12 @@ vi.mock("@/lib/api/pantry", () => ({
   replacePantry: mocks.replacePantry,
   restorePantry: mocks.restorePantry,
   setPantryItem: mocks.setPantryItem,
+  installPantrySnapshot: (current: Pantry | undefined, incoming: Pantry) =>
+    !current ||
+    current.resourceId !== incoming.resourceId ||
+    BigInt(incoming.revision) >= BigInt(current.revision)
+      ? incoming
+      : current,
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -44,9 +50,14 @@ vi.mock("@/lib/auth-client", () => ({
   },
 }));
 
-const personalPantry = (stock: Pantry["stock"]): Pantry => ({
+const personalPantry = (stock: Pantry["stock"], revision = "1"): Pantry => ({
+  resourceId: "user-1",
+  revision,
   scope: { type: "personal" },
   stock,
+  itemVersions: Object.fromEntries(
+    Object.keys(stock).map((ingredientSlug) => [ingredientSlug, "1"]),
+  ),
 });
 
 function createQueryClient() {
@@ -136,7 +147,11 @@ describe("useKitchenStockActions", () => {
 
     act(() => result.current.setStockLocation("onion", "fresh"));
     await waitFor(() =>
-      expect(mocks.setPantryItem).toHaveBeenCalledWith("onion", "fresh"),
+      expect(mocks.setPantryItem).toHaveBeenCalledWith(
+        "onion",
+        "fresh",
+        expect.any(String),
+      ),
     );
     await waitFor(() =>
       expect(queryClient.getQueryData(queryKey)).toEqual(
@@ -154,7 +169,10 @@ describe("useKitchenStockActions", () => {
 
     act(() => result.current.removeFromStock("milk"));
     await waitFor(() =>
-      expect(mocks.removePantryItem).toHaveBeenCalledWith("milk"),
+      expect(mocks.removePantryItem).toHaveBeenCalledWith(
+        "milk",
+        expect.any(String),
+      ),
     );
     await waitFor(() =>
       expect(queryClient.getQueryData(queryKey)).toEqual(
@@ -164,9 +182,10 @@ describe("useKitchenStockActions", () => {
 
     act(() => result.current.replaceStock({ egg: "cupboards" }));
     await waitFor(() =>
-      expect(mocks.replacePantry).toHaveBeenCalledWith({
-        egg: "cupboards",
-      }),
+      expect(mocks.replacePantry).toHaveBeenCalledWith(
+        { egg: "cupboards" },
+        expect.any(String),
+      ),
     );
     await waitFor(() =>
       expect(queryClient.getQueryData(queryKey)).toEqual(
@@ -175,7 +194,9 @@ describe("useKitchenStockActions", () => {
     );
 
     act(() => result.current.clearStock());
-    await waitFor(() => expect(mocks.replacePantry).toHaveBeenCalledWith({}));
+    await waitFor(() =>
+      expect(mocks.replacePantry).toHaveBeenCalledWith({}, expect.any(String)),
+    );
     await waitFor(() =>
       expect(queryClient.getQueryData(queryKey)).toEqual(personalPantry({})),
     );
@@ -187,10 +208,10 @@ describe("useKitchenStockActions", () => {
       }),
     );
     await waitFor(() =>
-      expect(mocks.restorePantry).toHaveBeenCalledWith({
-        milk: "fridge",
-        onion: "fresh",
-      }),
+      expect(mocks.restorePantry).toHaveBeenCalledWith(
+        { milk: "fridge", onion: "fresh" },
+        expect.any(String),
+      ),
     );
     await waitFor(() =>
       expect(queryClient.getQueryData(queryKey)).toEqual(
@@ -220,6 +241,32 @@ describe("useKitchenStockActions", () => {
       expect(result.current.error).toEqual(new Error("network unavailable")),
     );
     expect(queryClient.getQueryData(queryKey)).toEqual(original);
+  });
+
+  it("does not roll back over another cache writer at the same revision", async () => {
+    const queryClient = createQueryClient();
+    const queryKey = recipeQueryKeys.pantry("user-1");
+    queryClient.setQueryData(queryKey, personalPantry({ milk: "fridge" }));
+    let rejectMutation: ((error: Error) => void) | undefined;
+    mocks.setPantryItem.mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+    const { result } = renderHook(() => useKitchenStockActions(), {
+      wrapper: wrapper(queryClient),
+    });
+
+    act(() => result.current.setStockLocation("onion", "fresh"));
+    await waitFor(() => expect(mocks.setPantryItem).toHaveBeenCalled());
+
+    const independentlyInstalled = personalPantry({ egg: "cupboards" });
+    act(() => queryClient.setQueryData(queryKey, independentlyInstalled));
+    act(() => rejectMutation?.(new Error("network unavailable")));
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(queryClient.getQueryData(queryKey)).toEqual(independentlyInstalled);
   });
 
   it("bases optimistic removal on the cache after pending queries are cancelled", async () => {
@@ -277,12 +324,42 @@ describe("useKitchenStockActions", () => {
     act(() => result.current.setStockLocation("onion", "fresh"));
 
     await waitFor(() =>
-      expect(mocks.setPantryItem).toHaveBeenCalledWith("onion", "fresh"),
+      expect(mocks.setPantryItem).toHaveBeenCalledWith(
+        "onion",
+        "fresh",
+        expect.any(String),
+      ),
     );
     await waitFor(() =>
       expect(queryClient.getQueryData(queryKey)).toEqual(
         personalPantry({ onion: "fresh" }),
       ),
     );
+  });
+
+  it("does not let a delayed mutation response replace a newer snapshot", async () => {
+    const queryClient = createQueryClient();
+    const queryKey = recipeQueryKeys.pantry("user-1");
+    queryClient.setQueryData(queryKey, personalPantry({ milk: "fridge" }, "1"));
+    let resolveMutation: ((pantry: Pantry) => void) | undefined;
+    mocks.setPantryItem.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useKitchenStockActions(), {
+      wrapper: wrapper(queryClient),
+    });
+
+    act(() => result.current.setStockLocation("onion", "fresh"));
+    await waitFor(() => expect(mocks.setPantryItem).toHaveBeenCalled());
+
+    const newer = personalPantry({ egg: "cupboards" }, "3");
+    act(() => queryClient.setQueryData(queryKey, newer));
+    act(() => resolveMutation?.(personalPantry({ onion: "fresh" }, "2")));
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(queryClient.getQueryData(queryKey)).toEqual(newer);
   });
 });

--- a/ui/tests/hooks/use-kitchen-stock.test.tsx
+++ b/ui/tests/hooks/use-kitchen-stock.test.tsx
@@ -362,4 +362,37 @@ describe("useKitchenStockActions", () => {
     await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(queryClient.getQueryData(queryKey)).toEqual(newer);
   });
+
+  it("does not install a mutation response from an obsolete pantry resource", async () => {
+    const queryClient = createQueryClient();
+    const queryKey = recipeQueryKeys.pantry("user-1");
+    queryClient.setQueryData(queryKey, personalPantry({ milk: "fridge" }, "1"));
+    let resolveMutation: ((pantry: Pantry) => void) | undefined;
+    mocks.setPantryItem.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useKitchenStockActions(), {
+      wrapper: wrapper(queryClient),
+    });
+
+    act(() => result.current.setStockLocation("onion", "fresh"));
+    await waitFor(() => expect(mocks.setPantryItem).toHaveBeenCalled());
+
+    const householdPantry: Pantry = {
+      ...personalPantry({ egg: "cupboards" }, "1"),
+      resourceId: "household-1",
+      scope: {
+        type: "household",
+        household: { id: "household-1", name: "Shared household" },
+      },
+    };
+    act(() => queryClient.setQueryData(queryKey, householdPantry));
+    act(() => resolveMutation?.(personalPantry({ onion: "fresh" }, "2")));
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(queryClient.getQueryData(queryKey)).toEqual(householdPantry);
+  });
 });

--- a/ui/tests/lib/api/pantry.test.ts
+++ b/ui/tests/lib/api/pantry.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/api/pantry";
 
 describe("pantry API client", () => {
+  const operationId = "0198f1f0-1111-7111-8111-111111111111";
   beforeEach(() => {
     vi.restoreAllMocks();
     localStorage.clear();
@@ -20,11 +21,14 @@ describe("pantry API client", () => {
     );
     localStorage.setItem("recipe-kitchen-stock-v1-owner", "old-user");
     const pantry = {
+      resourceId: "household-1",
+      revision: "4",
       scope: {
         type: "household" as const,
         household: { id: "household-1", name: "Park Road" },
       },
       stock: { onion: "fresh" as const },
+      itemVersions: { onion: "2" },
     };
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -46,9 +50,9 @@ describe("pantry API client", () => {
         Response.json({ scope: { type: "personal" }, stock: {} }),
       );
 
-    await setPantryItem("red-onion", "fridge");
-    await removePantryItem("red-onion");
-    await restorePantry({ red: "fresh" });
+    await setPantryItem("red-onion", "fridge", operationId);
+    await removePantryItem("red-onion", operationId);
+    await restorePantry({ red: "fresh" }, operationId);
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
@@ -76,6 +80,11 @@ describe("pantry API client", () => {
         body: JSON.stringify({ stock: { red: "fresh" } }),
       }),
     );
+    for (const [, request] of fetchMock.mock.calls) {
+      expect(new Headers(request?.headers).get("Idempotency-Key")).toBe(
+        operationId,
+      );
+    }
   });
 
   it("surfaces pantry API errors with their status and message", async () => {

--- a/workers/recipe-api/drizzle/0007_revisioned_pantry_commands.sql
+++ b/workers/recipe-api/drizzle/0007_revisioned_pantry_commands.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "pantry_aggregate" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text,
+	"organization_id" text,
+	"revision" bigint DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "pantry_aggregate_owner_check" CHECK (num_nonnulls("pantry_aggregate"."user_id", "pantry_aggregate"."organization_id") = 1)
+);
+--> statement-breakpoint
+CREATE TABLE "pantry_operation" (
+	"aggregate_id" uuid NOT NULL,
+	"operation_id" uuid NOT NULL,
+	"command_fingerprint" text NOT NULL,
+	"result" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "pantry_operation_aggregate_id_operation_id_pk" PRIMARY KEY("aggregate_id","operation_id")
+);
+--> statement-breakpoint
+ALTER TABLE "pantry_item" ADD COLUMN "version" bigint DEFAULT 1 NOT NULL;--> statement-breakpoint
+ALTER TABLE "pantry_aggregate" ADD CONSTRAINT "pantry_aggregate_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pantry_aggregate" ADD CONSTRAINT "pantry_aggregate_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pantry_operation" ADD CONSTRAINT "pantry_operation_aggregate_id_pantry_aggregate_id_fk" FOREIGN KEY ("aggregate_id") REFERENCES "public"."pantry_aggregate"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "pantry_aggregate_user_uidx" ON "pantry_aggregate" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "pantry_aggregate_household_uidx" ON "pantry_aggregate" USING btree ("organization_id");

--- a/workers/recipe-api/drizzle/0007_revisioned_pantry_commands.sql
+++ b/workers/recipe-api/drizzle/0007_revisioned_pantry_commands.sql
@@ -22,4 +22,5 @@ ALTER TABLE "pantry_aggregate" ADD CONSTRAINT "pantry_aggregate_user_id_user_id_
 ALTER TABLE "pantry_aggregate" ADD CONSTRAINT "pantry_aggregate_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "pantry_operation" ADD CONSTRAINT "pantry_operation_aggregate_id_pantry_aggregate_id_fk" FOREIGN KEY ("aggregate_id") REFERENCES "public"."pantry_aggregate"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE UNIQUE INDEX "pantry_aggregate_user_uidx" ON "pantry_aggregate" USING btree ("user_id");--> statement-breakpoint
-CREATE UNIQUE INDEX "pantry_aggregate_household_uidx" ON "pantry_aggregate" USING btree ("organization_id");
+CREATE UNIQUE INDEX "pantry_aggregate_household_uidx" ON "pantry_aggregate" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "pantry_operation_created_at_idx" ON "pantry_operation" USING btree ("created_at");

--- a/workers/recipe-api/drizzle/meta/0007_snapshot.json
+++ b/workers/recipe-api/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,3286 @@
+{
+  "id": "b6bf11e9-de49-4d88-b5cc-9025aad5cd6e",
+  "prevId": "cbd99f31-2304-4500-a347-643e29515575",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_rate_limit": {
+      "name": "app_rate_limit",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cooking_session": {
+      "name": "cooking_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_slug": {
+          "name": "recipe_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_title": {
+          "name": "recipe_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cooking_session_user_started_idx": {
+          "name": "cooking_session_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cooking_session_user_completed_idx": {
+          "name": "cooking_session_user_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cooking_session_user_recipe_completed_idx": {
+          "name": "cooking_session_user_recipe_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cooking_session_user_id_user_id_fk": {
+          "name": "cooking_session_user_id_user_id_fk",
+          "tableFrom": "cooking_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset": {
+      "name": "diet_preset",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset_excluded_group": {
+      "name": "diet_preset_excluded_group",
+      "schema": "",
+      "columns": {
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_preset_excluded_group_group_key_idx": {
+          "name": "diet_preset_excluded_group_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diet_preset_excluded_group_preset_key_diet_preset_key_fk": {
+          "name": "diet_preset_excluded_group_preset_key_diet_preset_key_fk",
+          "tableFrom": "diet_preset_excluded_group",
+          "tableTo": "diet_preset",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diet_preset_excluded_group_group_key_ingredient_group_key_fk": {
+          "name": "diet_preset_excluded_group_group_key_ingredient_group_key_fk",
+          "tableFrom": "diet_preset_excluded_group",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "diet_preset_excluded_group_pk": {
+          "name": "diet_preset_excluded_group_pk",
+          "columns": [
+            "preset_key",
+            "group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset_excluded_ingredient": {
+      "name": "diet_preset_excluded_ingredient",
+      "schema": "",
+      "columns": {
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_preset_excluded_ingredient_slug_idx": {
+          "name": "diet_preset_excluded_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diet_preset_excluded_ingredient_preset_key_diet_preset_key_fk": {
+          "name": "diet_preset_excluded_ingredient_preset_key_diet_preset_key_fk",
+          "tableFrom": "diet_preset_excluded_ingredient",
+          "tableTo": "diet_preset",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diet_preset_excluded_ingredient_ingredient_slug_ingredient_slug_fk": {
+          "name": "diet_preset_excluded_ingredient_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "diet_preset_excluded_ingredient",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "diet_preset_excluded_ingredient_pk": {
+          "name": "diet_preset_excluded_ingredient_pk",
+          "columns": [
+            "preset_key",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient": {
+      "name": "ingredient",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_group": {
+      "name": "ingredient_group",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_group_member": {
+      "name": "ingredient_group_member",
+      "schema": "",
+      "columns": {
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingredient_group_member_ingredient_slug_idx": {
+          "name": "ingredient_group_member_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredient_group_member_group_key_ingredient_group_key_fk": {
+          "name": "ingredient_group_member_group_key_ingredient_group_key_fk",
+          "tableFrom": "ingredient_group_member",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingredient_group_member_ingredient_slug_ingredient_slug_fk": {
+          "name": "ingredient_group_member_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "ingredient_group_member",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ingredient_group_member_pk": {
+          "name": "ingredient_group_member_pk",
+          "columns": [
+            "group_key",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_unique": {
+          "name": "member_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_delivery_event_recipient_uidx": {
+          "name": "notification_delivery_event_recipient_uidx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_delivery_recipient_read_at_idx": {
+          "name": "notification_delivery_recipient_read_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_event_id_notification_event_id_fk": {
+          "name": "notification_delivery_event_id_notification_event_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "notification_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_recipient_user_id_user_id_fk": {
+          "name": "notification_delivery_recipient_user_id_user_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_event": {
+      "name": "notification_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name_snapshot": {
+          "name": "actor_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_event_kind_idx": {
+          "name": "notification_event_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_event_actor_user_id_user_id_fk": {
+          "name": "notification_event_actor_user_id_user_id_fk",
+          "tableFrom": "notification_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_household_event": {
+      "name": "notification_household_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_name_snapshot": {
+          "name": "household_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_household_event_household_idx": {
+          "name": "notification_household_event_household_idx",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_household_event_event_id_notification_event_id_fk": {
+          "name": "notification_household_event_event_id_notification_event_id_fk",
+          "tableFrom": "notification_household_event",
+          "tableTo": "notification_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_household_event_household_id_organization_id_fk": {
+          "name": "notification_household_event_household_id_organization_id_fk",
+          "tableFrom": "notification_household_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_household_invitation_event": {
+      "name": "notification_household_invitation_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_household_invitation_event_invitation_idx": {
+          "name": "notification_household_invitation_event_invitation_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_household_invitation_event_event_id_notification_household_event_event_id_fk": {
+          "name": "notification_household_invitation_event_event_id_notification_household_event_event_id_fk",
+          "tableFrom": "notification_household_invitation_event",
+          "tableTo": "notification_household_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "event_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_household_invitation_event_invitation_id_invitation_id_fk": {
+          "name": "notification_household_invitation_event_invitation_id_invitation_id_fk",
+          "tableFrom": "notification_household_invitation_event",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipe_recommendation_event": {
+      "name": "notification_recipe_recommendation_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_slug_snapshot": {
+          "name": "recipe_slug_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_title_snapshot": {
+          "name": "recipe_title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_recipe_recommendation_recipe_idx": {
+          "name": "notification_recipe_recommendation_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipe_recommendation_event_event_id_notification_event_id_fk": {
+          "name": "notification_recipe_recommendation_event_event_id_notification_event_id_fk",
+          "tableFrom": "notification_recipe_recommendation_event",
+          "tableTo": "notification_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_recipe_recommendation_event_recipe_id_recipe_id_fk": {
+          "name": "notification_recipe_recommendation_event_recipe_id_recipe_id_fk",
+          "tableFrom": "notification_recipe_recommendation_event",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pantry_aggregate": {
+      "name": "pantry_aggregate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_aggregate_user_uidx": {
+          "name": "pantry_aggregate_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pantry_aggregate_household_uidx": {
+          "name": "pantry_aggregate_household_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pantry_aggregate_user_id_user_id_fk": {
+          "name": "pantry_aggregate_user_id_user_id_fk",
+          "tableFrom": "pantry_aggregate",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_aggregate_organization_id_organization_id_fk": {
+          "name": "pantry_aggregate_organization_id_organization_id_fk",
+          "tableFrom": "pantry_aggregate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pantry_aggregate_owner_check": {
+          "name": "pantry_aggregate_owner_check",
+          "value": "num_nonnulls(\"pantry_aggregate\".\"user_id\", \"pantry_aggregate\".\"organization_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pantry_item": {
+      "name": "pantry_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "pantry_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "1"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_item_user_ingredient_uidx": {
+          "name": "pantry_item_user_ingredient_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pantry_item_household_ingredient_uidx": {
+          "name": "pantry_item_household_ingredient_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pantry_item_ingredient_slug_idx": {
+          "name": "pantry_item_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pantry_item_user_id_user_id_fk": {
+          "name": "pantry_item_user_id_user_id_fk",
+          "tableFrom": "pantry_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_item_organization_id_organization_id_fk": {
+          "name": "pantry_item_organization_id_organization_id_fk",
+          "tableFrom": "pantry_item",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_item_ingredient_slug_ingredient_slug_fk": {
+          "name": "pantry_item_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "pantry_item",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pantry_item_owner_check": {
+          "name": "pantry_item_owner_check",
+          "value": "num_nonnulls(\"pantry_item\".\"user_id\", \"pantry_item\".\"organization_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pantry_operation": {
+      "name": "pantry_operation",
+      "schema": "",
+      "columns": {
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_fingerprint": {
+          "name": "command_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pantry_operation_aggregate_id_pantry_aggregate_id_fk": {
+          "name": "pantry_operation_aggregate_id_pantry_aggregate_id_fk",
+          "tableFrom": "pantry_operation",
+          "tableTo": "pantry_aggregate",
+          "columnsFrom": [
+            "aggregate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pantry_operation_aggregate_id_operation_id_pk": {
+          "name": "pantry_operation_aggregate_id_operation_id_pk",
+          "columns": [
+            "aggregate_id",
+            "operation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe": {
+      "name": "recipe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_user_id_idx": {
+          "name": "recipe_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_public_feed_idx": {
+          "name": "recipe_public_feed_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_household_feed_idx": {
+          "name": "recipe_household_feed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_user_id_user_id_fk": {
+          "name": "recipe_user_id_user_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_slug_unique": {
+          "name": "recipe_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_artifact": {
+      "name": "recipe_import_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_import_artifact_job_id_idx": {
+          "name": "recipe_import_artifact_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_artifact_job_stage_kind_unique": {
+          "name": "recipe_import_artifact_job_stage_kind_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_artifact_job_id_recipe_import_job_id_fk": {
+          "name": "recipe_import_artifact_job_id_recipe_import_job_id_fk",
+          "tableFrom": "recipe_import_artifact",
+          "tableTo": "recipe_import_job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_attempt": {
+      "name": "recipe_import_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retryable": {
+          "name": "retryable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_import_attempt_job_id_idx": {
+          "name": "recipe_import_attempt_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_attempt_job_stage_attempt_unique": {
+          "name": "recipe_import_attempt_job_stage_attempt_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_attempt_job_id_recipe_import_job_id_fk": {
+          "name": "recipe_import_attempt_job_id_recipe_import_job_id_fk",
+          "tableFrom": "recipe_import_attempt",
+          "tableTo": "recipe_import_job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_job": {
+      "name": "recipe_import_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_import_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_label": {
+          "name": "progress_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipe_import_job_user_id_idx": {
+          "name": "recipe_import_job_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_job_user_status_idx": {
+          "name": "recipe_import_job_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_job_user_created_idx": {
+          "name": "recipe_import_job_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_job_user_id_user_id_fk": {
+          "name": "recipe_import_job_user_id_user_id_fk",
+          "tableFrom": "recipe_import_job",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_excluded_group": {
+      "name": "user_diet_excluded_group",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_excluded_group_group_key_idx": {
+          "name": "user_diet_excluded_group_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_diet_excluded_group_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_excluded_group_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_excluded_group",
+          "tableTo": "user_diet_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_diet_excluded_group_group_key_ingredient_group_key_fk": {
+          "name": "user_diet_excluded_group_group_key_ingredient_group_key_fk",
+          "tableFrom": "user_diet_excluded_group",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_excluded_group_pk": {
+          "name": "user_diet_excluded_group_pk",
+          "columns": [
+            "user_id",
+            "group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_excluded_ingredient": {
+      "name": "user_diet_excluded_ingredient",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_excluded_ingredient_slug_idx": {
+          "name": "user_diet_excluded_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_diet_excluded_ingredient_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_excluded_ingredient_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_excluded_ingredient",
+          "tableTo": "user_diet_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_diet_excluded_ingredient_ingredient_slug_ingredient_slug_fk": {
+          "name": "user_diet_excluded_ingredient_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "user_diet_excluded_ingredient",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_excluded_ingredient_pk": {
+          "name": "user_diet_excluded_ingredient_pk",
+          "columns": [
+            "user_id",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_preset": {
+      "name": "user_diet_preset",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_preset_preset_key_idx": {
+          "name": "user_diet_preset_preset_key_idx",
+          "columns": [
+            {
+              "expression": "preset_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_diet_preset_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_preset_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_preset",
+          "tableTo": "user_diet_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_diet_preset_preset_key_diet_preset_key_fk": {
+          "name": "user_diet_preset_preset_key_diet_preset_key_fk",
+          "tableFrom": "user_diet_preset",
+          "tableTo": "diet_preset",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_preset_pk": {
+          "name": "user_diet_preset_pk",
+          "columns": [
+            "user_id",
+            "preset_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_profile": {
+      "name": "user_diet_profile",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_match_mode": {
+          "name": "recipe_match_mode",
+          "type": "diet_recipe_match_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hide'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_diet_profile_user_id_user_id_fk": {
+          "name": "user_diet_profile_user_id_user_id_fk",
+          "tableFrom": "user_diet_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email": {
+      "name": "user_email",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_user_id_idx": {
+          "name": "user_email_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_email_user_id_user_id_fk": {
+          "name": "user_email_user_id_user_id_fk",
+          "tableFrom": "user_email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follow": {
+      "name": "user_follow",
+      "schema": "",
+      "columns": {
+        "follower_user_id": {
+          "name": "follower_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followed_user_id": {
+          "name": "followed_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follow_followed_user_id_idx": {
+          "name": "user_follow_followed_user_id_idx",
+          "columns": [
+            {
+              "expression": "followed_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follow_follower_user_id_user_id_fk": {
+          "name": "user_follow_follower_user_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "follower_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follow_followed_user_id_user_id_fk": {
+          "name": "user_follow_followed_user_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "followed_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_follow_pk": {
+          "name": "user_follow_pk",
+          "columns": [
+            "follower_user_id",
+            "followed_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_follow_not_self": {
+          "name": "user_follow_not_self",
+          "value": "\"user_follow\".\"follower_user_id\" <> \"user_follow\".\"followed_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_box": {
+      "name": "user_recipe_box",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_recipe_box_user_id_user_id_fk": {
+          "name": "user_recipe_box_user_id_user_id_fk",
+          "tableFrom": "user_recipe_box",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_box_item": {
+      "name": "user_recipe_box_item",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_slug": {
+          "name": "recipe_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_recipe_box_item_user_id_user_id_fk": {
+          "name": "user_recipe_box_item_user_id_user_id_fk",
+          "tableFrom": "user_recipe_box_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_recipe_box_item_user_id_recipe_slug_pk": {
+          "name": "user_recipe_box_item_user_id_recipe_slug_pk",
+          "columns": [
+            "user_id",
+            "recipe_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.diet_recipe_match_mode": {
+      "name": "diet_recipe_match_mode",
+      "schema": "public",
+      "values": [
+        "hide",
+        "warn"
+      ]
+    },
+    "public.pantry_location": {
+      "name": "pantry_location",
+      "schema": "public",
+      "values": [
+        "fridge",
+        "cupboards",
+        "fresh"
+      ]
+    },
+    "public.recipe_import_stage": {
+      "name": "recipe_import_stage",
+      "schema": "public",
+      "values": [
+        "extract",
+        "normalize",
+        "canonicalize",
+        "finalize"
+      ]
+    },
+    "public.recipe_import_status": {
+      "name": "recipe_import_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "household"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/workers/recipe-api/drizzle/meta/0007_snapshot.json
+++ b/workers/recipe-api/drizzle/meta/0007_snapshot.json
@@ -1734,7 +1734,23 @@
           "default": "now()"
         }
       },
-      "indexes": {},
+      "indexes": {
+        "pantry_operation_created_at_idx": {
+          "name": "pantry_operation_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
       "foreignKeys": {
         "pantry_operation_aggregate_id_pantry_aggregate_id_fk": {
           "name": "pantry_operation_aggregate_id_pantry_aggregate_id_fk",

--- a/workers/recipe-api/drizzle/meta/_journal.json
+++ b/workers/recipe-api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1786216368940,
       "tag": "0006_cook_follows",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1786273611769,
+      "tag": "0007_revisioned_pantry_commands",
+      "breakpoints": true
     }
   ]
 }

--- a/workers/recipe-api/openapi.json
+++ b/workers/recipe-api/openapi.json
@@ -3390,6 +3390,20 @@
             "sessionCookie": []
           }
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 36,
+              "format": "uuid",
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+            },
+            "required": false,
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "name": "idempotency-key",
+            "in": "header"
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -3550,6 +3564,20 @@
         "security": [
           {
             "sessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 36,
+              "format": "uuid",
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+            },
+            "required": false,
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "name": "idempotency-key",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -3726,6 +3754,18 @@
             "required": true,
             "name": "ingredientSlug",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 36,
+              "format": "uuid",
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+            },
+            "required": false,
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "name": "idempotency-key",
+            "in": "header"
           }
         ],
         "requestBody": {
@@ -3897,6 +3937,18 @@
             "required": true,
             "name": "ingredientSlug",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 36,
+              "format": "uuid",
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+            },
+            "required": false,
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "name": "idempotency-key",
+            "in": "header"
           }
         ],
         "responses": {

--- a/workers/recipe-api/openapi.json
+++ b/workers/recipe-api/openapi.json
@@ -3396,10 +3396,10 @@
               "type": "string",
               "maxLength": 36,
               "format": "uuid",
-              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours."
             },
             "required": false,
-            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours.",
             "name": "idempotency-key",
             "in": "header"
           }
@@ -3572,10 +3572,10 @@
               "type": "string",
               "maxLength": 36,
               "format": "uuid",
-              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours."
             },
             "required": false,
-            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours.",
             "name": "idempotency-key",
             "in": "header"
           }
@@ -3760,10 +3760,10 @@
               "type": "string",
               "maxLength": 36,
               "format": "uuid",
-              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours."
             },
             "required": false,
-            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours.",
             "name": "idempotency-key",
             "in": "header"
           }
@@ -3943,10 +3943,10 @@
               "type": "string",
               "maxLength": 36,
               "format": "uuid",
-              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result."
+              "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours."
             },
             "required": false,
-            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+            "description": "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours.",
             "name": "idempotency-key",
             "in": "header"
           }

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -177,6 +177,29 @@ const creatableRecipeSlugSchema = recipeSlugSchema.refine(
 const dietRecipeMatchModeSchema = z.enum(["hide", "warn"]);
 const pantryLocationSchema = z.enum(schema.pantryLocationEnum.enumValues);
 const pantryIngredientSlugSchema = z.string().min(1).max(200);
+const pantryResponseSchema = z
+  .object({
+    resourceId: z.string().min(1),
+    revision: z.string().regex(/^\d+$/),
+    operationId: z.uuid().optional(),
+    scope: z.discriminatedUnion("type", [
+      z.object({ type: z.literal("personal") }).strict(),
+      z
+        .object({
+          type: z.literal("household"),
+          household: z
+            .object({ id: z.string().min(1), name: z.string() })
+            .strict(),
+        })
+        .strict(),
+    ]),
+    stock: z.record(z.string().min(1), pantryLocationSchema),
+    itemVersions: z.record(z.string().min(1), z.string().regex(/^\d+$/)),
+  })
+  .strict();
+const pantryOperationReceiptSchema = z
+  .object({ version: z.literal(1), pantry: pantryResponseSchema })
+  .strict();
 const feedScopeSchema = z.enum(["public", "following"]);
 const feedLimitSchema = z.coerce.number().int().min(1).max(30).default(12);
 const recipeListLimitSchema = z.coerce.number().int().min(1).max(100).default(100);
@@ -431,7 +454,7 @@ const openApiRequestBodySchemas = new Map<string, z.ZodType>([
 const pantryOperationHeadersSchema = z.object({
   "idempotency-key": z.uuid().max(36).optional().openapi({
     description:
-      "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+      "Client-generated operation ID. Reusing it for the same pantry command returns the committed result while its receipt is retained for at least 24 hours.",
   }),
 });
 
@@ -1398,7 +1421,16 @@ async function executePantryOperation(
       if (recorded.commandFingerprint !== commandFingerprint) {
         throw new PantryOperationConflictError();
       }
-      return recorded.result as PantryResponse;
+      const receipt = pantryOperationReceiptSchema.safeParse(recorded.result);
+      if (receipt.success) return receipt.data.pantry;
+      await tx
+        .delete(schema.pantryOperation)
+        .where(
+          and(
+            eq(schema.pantryOperation.aggregateId, aggregate.id),
+            eq(schema.pantryOperation.operationId, operationId),
+          ),
+        );
     }
 
     await mutate(tx, scope);
@@ -1420,7 +1452,7 @@ async function executePantryOperation(
       aggregateId: aggregate.id,
       operationId,
       commandFingerprint,
-      result,
+      result: { version: 1, pantry: result },
     });
     return result;
   });
@@ -4979,22 +5011,25 @@ registerRoute("get", "/recipe-imports/:jobId", async (c) => {
 
 export { app };
 
-// Rows reset in place on each request, so only keys that fall idle linger. A
-// daily sweep past the longest window keeps the table bounded.
-const RATE_LIMIT_RETENTION_MS = 24 * 60 * 60 * 1000;
+// Idle rate-limit keys and pantry idempotency receipts do not need permanent
+// storage. The daily sweep retains both for at least the longest retry window.
+const OPERATIONAL_ROW_RETENTION_MS = 24 * 60 * 60 * 1000;
 
-async function cleanupRateLimits(env: Bindings): Promise<void> {
+async function cleanupOperationalRows(env: Bindings): Promise<void> {
   const connectionString = databaseConnection(env);
   if (!connectionString) return;
 
   const { db, client } = createDb(connectionString);
   try {
-    const cutoff = new Date(Date.now() - RATE_LIMIT_RETENTION_MS);
+    const cutoff = new Date(Date.now() - OPERATIONAL_ROW_RETENTION_MS);
     await db
       .delete(schema.appRateLimit)
       .where(lt(schema.appRateLimit.windowStart, cutoff));
+    await db
+      .delete(schema.pantryOperation)
+      .where(lt(schema.pantryOperation.createdAt, cutoff));
   } catch (e) {
-    console.error("Rate limit cleanup failed", e);
+    console.error("Operational row cleanup failed", e);
   } finally {
     await closeDbClient(client);
   }
@@ -5019,6 +5054,6 @@ export default {
       },
     ),
   scheduled: (_event, env, ctx) => {
-    ctx.waitUntil(cleanupRateLimits(env));
+    ctx.waitUntil(cleanupOperationalRows(env));
   },
 } satisfies ExportedHandler<Bindings>;

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -25,6 +25,7 @@ import {
   isNotNull,
   isNull,
   lt,
+  notInArray,
   or,
   sql,
   type SQL,
@@ -115,6 +116,17 @@ type PantryScope =
       householdId: string;
       householdName: string;
     };
+type PantryResponse = {
+  resourceId: string;
+  revision: string;
+  operationId?: string;
+  scope:
+    | { type: "personal" }
+    | { type: "household"; household: { id: string; name: string } };
+  stock: Record<string, PantryLocation>;
+  itemVersions: Record<string, string>;
+};
+type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 type InvitationNotificationStatus =
   | "pending"
   | "accepted"
@@ -416,6 +428,20 @@ const openApiRequestBodySchemas = new Map<string, z.ZodType>([
   ["PATCH /recipes/:slug", updateRecipeBodySchema],
 ]);
 
+const pantryOperationHeadersSchema = z.object({
+  "idempotency-key": z.uuid().max(36).optional().openapi({
+    description:
+      "Client-generated operation ID. Reusing it for the same pantry command returns the committed result.",
+  }),
+});
+
+const PANTRY_MUTATION_OPERATIONS = new Set([
+  "PUT /pantry",
+  "PATCH /pantry",
+  "PUT /pantry/items/:ingredientSlug",
+  "DELETE /pantry/items/:ingredientSlug",
+]);
+
 const openApiQuerySchemas = new Map<string, z.ZodObject>([
   [
     "GET /notifications",
@@ -572,6 +598,9 @@ function registerRoute(
   const key = `${method.toUpperCase()} ${path}`;
   const requestBodySchema = openApiRequestBodySchemas.get(key);
   const querySchema = openApiQuerySchemas.get(key);
+  const headersSchema = PANTRY_MUTATION_OPERATIONS.has(key)
+    ? pantryOperationHeadersSchema
+    : undefined;
   const paramsSchema = pathParamsSchema(path);
   const errorResponses = Object.fromEntries(
     ERROR_STATUS_CODES.map((status) => [
@@ -616,6 +645,7 @@ function registerRoute(
     request: {
       ...(paramsSchema ? { params: paramsSchema } : {}),
       ...(querySchema ? { query: querySchema } : {}),
+      ...(headersSchema ? { headers: headersSchema } : {}),
       ...(requestBodySchema
         ? {
             body: {
@@ -1181,6 +1211,16 @@ function pantryScopeFilter(scope: PantryScope): SQL {
     : eq(schema.pantryItem.userId, scope.userId);
 }
 
+function pantryAggregateScopeFilter(scope: PantryScope): SQL {
+  return scope.type === "household"
+    ? eq(schema.pantryAggregate.organizationId, scope.householdId)
+    : eq(schema.pantryAggregate.userId, scope.userId);
+}
+
+function pantryResourceId(scope: PantryScope): string {
+  return scope.type === "household" ? scope.householdId : scope.userId;
+}
+
 async function lockPantryScope(
   db: Pick<Db, "select">,
   userId: string,
@@ -1196,16 +1236,80 @@ async function lockPantryScope(
   return scope;
 }
 
-async function pantryResponseForScope(db: Pick<Db, "select">, scope: PantryScope) {
+async function findPantryAggregate(
+  db: Pick<Db, "select">,
+  scope: PantryScope,
+) {
+  const [aggregate] = await db
+    .select({
+      id: schema.pantryAggregate.id,
+      revision: schema.pantryAggregate.revision,
+    })
+    .from(schema.pantryAggregate)
+    .where(pantryAggregateScopeFilter(scope))
+    .limit(1);
+  return aggregate;
+}
+
+async function ensurePantryAggregate(tx: DbTransaction, scope: PantryScope) {
+  const [created] = await tx
+    .insert(schema.pantryAggregate)
+    .values({
+      userId: scope.type === "personal" ? scope.userId : null,
+      organizationId: scope.type === "household" ? scope.householdId : null,
+    })
+    .onConflictDoNothing()
+    .returning({
+      id: schema.pantryAggregate.id,
+      revision: schema.pantryAggregate.revision,
+    });
+  if (created) return created;
+
+  const [aggregate] = await tx
+    .select({
+      id: schema.pantryAggregate.id,
+      revision: schema.pantryAggregate.revision,
+    })
+    .from(schema.pantryAggregate)
+    .where(pantryAggregateScopeFilter(scope))
+    .for("update")
+    .limit(1);
+  if (!aggregate) throw new Error("Pantry aggregate could not be created");
+  return aggregate;
+}
+
+async function clearPantryOperationsForScope(
+  tx: DbTransaction,
+  scope: PantryScope,
+): Promise<void> {
+  const aggregate = await findPantryAggregate(tx, scope);
+  if (!aggregate) return;
+  await tx
+    .delete(schema.pantryOperation)
+    .where(eq(schema.pantryOperation.aggregateId, aggregate.id));
+}
+
+async function pantryResponseForScope(
+  db: Pick<Db, "select">,
+  scope: PantryScope,
+  options: { operationId?: string; revision?: bigint } = {},
+): Promise<PantryResponse> {
   const items = await db
     .select({
       ingredientSlug: schema.pantryItem.ingredientSlug,
       location: schema.pantryItem.location,
+      version: schema.pantryItem.version,
     })
     .from(schema.pantryItem)
     .where(pantryScopeFilter(scope));
 
+  const revision =
+    options.revision ?? (await findPantryAggregate(db, scope))?.revision ?? 0n;
+
   return {
+    resourceId: pantryResourceId(scope),
+    revision: revision.toString(),
+    ...(options.operationId ? { operationId: options.operationId } : {}),
     scope:
       scope.type === "household"
         ? {
@@ -1219,11 +1323,117 @@ async function pantryResponseForScope(db: Pick<Db, "select">, scope: PantryScope
     stock: Object.fromEntries(
       items.map(({ ingredientSlug, location }) => [ingredientSlug, location]),
     ) as Record<string, PantryLocation>,
+    itemVersions: Object.fromEntries(
+      items.map(({ ingredientSlug, version }) => [
+        ingredientSlug,
+        version.toString(),
+      ]),
+    ),
   };
 }
 
-async function pantryResponse(db: Pick<Db, "select">, userId: string) {
-  return pantryResponseForScope(db, await resolvePantryScope(db, userId));
+async function pantryResponse(db: Db, userId: string) {
+  return db.transaction(
+    async (tx) =>
+      pantryResponseForScope(tx, await resolvePantryScope(tx, userId)),
+    { accessMode: "read only", isolationLevel: "repeatable read" },
+  );
+}
+
+class PantryOperationConflictError extends Error {
+  constructor() {
+    super("Operation ID was already used for a different pantry command");
+  }
+}
+
+class UnknownPantryIngredientError extends Error {
+  constructor(readonly ingredientSlug: string) {
+    super(`Unknown ingredient: ${ingredientSlug}`);
+  }
+}
+
+function pantryOperationId(c: Context<AppEnv>): string | Response {
+  const supplied = c.req.header("Idempotency-Key");
+  if (!supplied) return crypto.randomUUID();
+  const parsed = uuidIdSchema.safeParse(supplied);
+  return parsed.success
+    ? parsed.data
+    : c.json({ error: "Invalid Idempotency-Key header" }, 400);
+}
+
+function pantryStockFingerprint(
+  kind: "replace" | "restore",
+  stock: Record<string, PantryLocation>,
+): string {
+  return JSON.stringify([
+    kind,
+    Object.entries(stock).sort(([a], [b]) => a.localeCompare(b)),
+  ]);
+}
+
+async function executePantryOperation(
+  db: Db,
+  userId: string,
+  operationId: string,
+  commandFingerprint: string,
+  mutate: (tx: DbTransaction, scope: PantryScope) => Promise<void>,
+): Promise<PantryResponse> {
+  return db.transaction(async (tx) => {
+    const scope = await lockPantryScope(tx, userId);
+    const aggregate = await ensurePantryAggregate(tx, scope);
+    const [recorded] = await tx
+      .select({
+        commandFingerprint: schema.pantryOperation.commandFingerprint,
+        result: schema.pantryOperation.result,
+      })
+      .from(schema.pantryOperation)
+      .where(
+        and(
+          eq(schema.pantryOperation.aggregateId, aggregate.id),
+          eq(schema.pantryOperation.operationId, operationId),
+        ),
+      )
+      .limit(1);
+    if (recorded) {
+      if (recorded.commandFingerprint !== commandFingerprint) {
+        throw new PantryOperationConflictError();
+      }
+      return recorded.result as PantryResponse;
+    }
+
+    await mutate(tx, scope);
+    const [updatedAggregate] = await tx
+      .update(schema.pantryAggregate)
+      .set({
+        revision: sql`${schema.pantryAggregate.revision} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.pantryAggregate.id, aggregate.id))
+      .returning({ revision: schema.pantryAggregate.revision });
+    if (!updatedAggregate) throw new Error("Pantry revision update failed");
+
+    const result = await pantryResponseForScope(tx, scope, {
+      operationId,
+      revision: updatedAggregate.revision,
+    });
+    await tx.insert(schema.pantryOperation).values({
+      aggregateId: aggregate.id,
+      operationId,
+      commandFingerprint,
+      result,
+    });
+    return result;
+  });
+}
+
+function pantryMutationErrorResponse(c: Context<AppEnv>, error: unknown) {
+  if (error instanceof PantryOperationConflictError) {
+    return c.json({ error: error.message }, 409);
+  }
+  if (error instanceof UnknownPantryIngredientError) {
+    return c.json({ error: error.message }, 400);
+  }
+  return undefined;
 }
 
 async function findUnknownPantryIngredient(
@@ -1267,6 +1477,11 @@ async function acceptPendingInvitation(
         "Pantry must be empty before joining a household",
       );
     }
+    // An empty personal aggregate must not carry stale operation receipts into
+    // a future solo pantry if this member later leaves the household.
+    await tx
+      .delete(schema.pantryAggregate)
+      .where(eq(schema.pantryAggregate.userId, userId));
 
     const mutationTime = new Date();
     const [accepted] = await tx
@@ -2475,6 +2690,8 @@ registerRoute("get", "/pantry", async (c) => {
 registerRoute("put", "/pantry", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
+  const operationId = pantryOperationId(c);
+  if (operationId instanceof Response) return operationId;
 
   return withRecipeSession(
     c,
@@ -2485,39 +2702,79 @@ registerRoute("put", "/pantry", async (c) => {
       if (!body.success) return body.response;
 
       const stockEntries = Object.entries(body.data.stock);
-      const ingredientSlugs = stockEntries.map(([ingredientSlug]) => ingredientSlug);
-      const unknownSlug = await findUnknownPantryIngredient(db, ingredientSlugs);
-      if (unknownSlug) {
-        return c.json({ error: `Unknown ingredient: ${unknownSlug}` }, 400);
-      }
+      const ingredientSlugs = stockEntries.map(
+        ([ingredientSlug]) => ingredientSlug,
+      );
 
-      const pantry = await db.transaction(async (tx) => {
-        const scope = await lockPantryScope(tx, session.user.id);
-        await tx
-          .delete(schema.pantryItem)
-          .where(pantryScopeFilter(scope));
-        if (ingredientSlugs.length > 0) {
-          await tx.insert(schema.pantryItem).values(
-            stockEntries.map(([ingredientSlug, location]) => ({
-              userId: scope.type === "personal" ? scope.userId : null,
-              organizationId:
-                scope.type === "household" ? scope.householdId : null,
-              ingredientSlug,
-              location,
-            })),
+      const pantry = await executePantryOperation(
+        db,
+        session.user.id,
+        operationId,
+        pantryStockFingerprint("replace", body.data.stock),
+        async (tx, scope) => {
+          const unknownSlug = await findUnknownPantryIngredient(
+            tx,
+            ingredientSlugs,
           );
-        }
-        return pantryResponseForScope(tx, scope);
-      });
+          if (unknownSlug) throw new UnknownPantryIngredientError(unknownSlug);
+          const scopeFilter = pantryScopeFilter(scope);
+          await tx
+            .delete(schema.pantryItem)
+            .where(
+              ingredientSlugs.length > 0
+                ? and(
+                    scopeFilter,
+                    notInArray(
+                      schema.pantryItem.ingredientSlug,
+                      ingredientSlugs,
+                    ),
+                  )
+                : scopeFilter,
+            );
+          if (ingredientSlugs.length > 0) {
+            await tx
+              .insert(schema.pantryItem)
+              .values(
+                stockEntries.map(([ingredientSlug, location]) => ({
+                  userId: scope.type === "personal" ? scope.userId : null,
+                  organizationId:
+                    scope.type === "household" ? scope.householdId : null,
+                  ingredientSlug,
+                  location,
+                })),
+              )
+              .onConflictDoUpdate({
+                target:
+                  scope.type === "household"
+                    ? [
+                        schema.pantryItem.organizationId,
+                        schema.pantryItem.ingredientSlug,
+                      ]
+                    : [
+                        schema.pantryItem.userId,
+                        schema.pantryItem.ingredientSlug,
+                      ],
+                set: {
+                  location: sql`excluded.location`,
+                  version: sql`${schema.pantryItem.version} + 1`,
+                  updatedAt: new Date(),
+                },
+              });
+          }
+        },
+      );
 
       return c.json(pantry);
     },
+    { onError: (error) => pantryMutationErrorResponse(c, error) },
   );
 });
 
 registerRoute("patch", "/pantry", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
+  const operationId = pantryOperationId(c);
+  if (operationId instanceof Response) return operationId;
 
   return withRecipeSession(
     c,
@@ -2528,38 +2785,49 @@ registerRoute("patch", "/pantry", async (c) => {
       if (!body.success) return body.response;
 
       const stockEntries = Object.entries(body.data.stock);
-      const ingredientSlugs = stockEntries.map(([ingredientSlug]) => ingredientSlug);
-      const unknownSlug = await findUnknownPantryIngredient(db, ingredientSlugs);
-      if (unknownSlug) {
-        return c.json({ error: `Unknown ingredient: ${unknownSlug}` }, 400);
-      }
+      const ingredientSlugs = stockEntries.map(
+        ([ingredientSlug]) => ingredientSlug,
+      );
 
-      const pantry = await db.transaction(async (tx) => {
-        const scope = await lockPantryScope(tx, session.user.id);
-        if (stockEntries.length > 0) {
-          await tx
-            .insert(schema.pantryItem)
-            .values(
-              stockEntries.map(([ingredientSlug, location]) => ({
-                userId: scope.type === "personal" ? scope.userId : null,
-                organizationId: scope.type === "household" ? scope.householdId : null,
-                ingredientSlug,
-                location,
-              })),
-            )
-            .onConflictDoNothing();
-        }
-        return pantryResponseForScope(tx, scope);
-      });
+      const pantry = await executePantryOperation(
+        db,
+        session.user.id,
+        operationId,
+        pantryStockFingerprint("restore", body.data.stock),
+        async (tx, scope) => {
+          const unknownSlug = await findUnknownPantryIngredient(
+            tx,
+            ingredientSlugs,
+          );
+          if (unknownSlug) throw new UnknownPantryIngredientError(unknownSlug);
+          if (stockEntries.length > 0) {
+            await tx
+              .insert(schema.pantryItem)
+              .values(
+                stockEntries.map(([ingredientSlug, location]) => ({
+                  userId: scope.type === "personal" ? scope.userId : null,
+                  organizationId:
+                    scope.type === "household" ? scope.householdId : null,
+                  ingredientSlug,
+                  location,
+                })),
+              )
+              .onConflictDoNothing();
+          }
+        },
+      );
 
       return c.json(pantry);
     },
+    { onError: (error) => pantryMutationErrorResponse(c, error) },
   );
 });
 
 registerRoute("put", "/pantry/items/:ingredientSlug", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
+  const operationId = pantryOperationId(c);
+  if (operationId instanceof Response) return operationId;
 
   return withRecipeSession(
     c,
@@ -2576,43 +2844,56 @@ registerRoute("put", "/pantry/items/:ingredientSlug", async (c) => {
       if (!body.success) return body.response;
 
       const ingredientSlug = ingredientSlugResult.data;
-      const [ingredient] = await db
-        .select({ slug: schema.ingredient.slug })
-        .from(schema.ingredient)
-        .where(eq(schema.ingredient.slug, ingredientSlug))
-        .limit(1);
-      if (!ingredient) {
-        return c.json({ error: `Unknown ingredient: ${ingredientSlug}` }, 400);
-      }
-
-      const pantry = await db.transaction(async (tx) => {
-        const scope = await lockPantryScope(tx, session.user.id);
-        await tx
-          .delete(schema.pantryItem)
-          .where(
-            and(
-              pantryScopeFilter(scope),
-              eq(schema.pantryItem.ingredientSlug, ingredientSlug),
-            ),
-          );
-        await tx.insert(schema.pantryItem).values({
-          userId: scope.type === "personal" ? scope.userId : null,
-          organizationId:
-            scope.type === "household" ? scope.householdId : null,
-          ingredientSlug,
-          location: body.data.location,
-        });
-        return pantryResponseForScope(tx, scope);
-      });
+      const pantry = await executePantryOperation(
+        db,
+        session.user.id,
+        operationId,
+        `set:${ingredientSlug}:${body.data.location}`,
+        async (tx, scope) => {
+          const unknownSlug = await findUnknownPantryIngredient(tx, [
+            ingredientSlug,
+          ]);
+          if (unknownSlug) throw new UnknownPantryIngredientError(unknownSlug);
+          await tx
+            .insert(schema.pantryItem)
+            .values({
+              userId: scope.type === "personal" ? scope.userId : null,
+              organizationId:
+                scope.type === "household" ? scope.householdId : null,
+              ingredientSlug,
+              location: body.data.location,
+            })
+            .onConflictDoUpdate({
+              target:
+                scope.type === "household"
+                  ? [
+                      schema.pantryItem.organizationId,
+                      schema.pantryItem.ingredientSlug,
+                    ]
+                  : [
+                      schema.pantryItem.userId,
+                      schema.pantryItem.ingredientSlug,
+                    ],
+              set: {
+                location: body.data.location,
+                version: sql`${schema.pantryItem.version} + 1`,
+                updatedAt: new Date(),
+              },
+            });
+        },
+      );
 
       return c.json(pantry);
     },
+    { onError: (error) => pantryMutationErrorResponse(c, error) },
   );
 });
 
 registerRoute("delete", "/pantry/items/:ingredientSlug", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
+  const operationId = pantryOperationId(c);
+  if (operationId instanceof Response) return operationId;
 
   return withRecipeSession(
     c,
@@ -2626,24 +2907,29 @@ registerRoute("delete", "/pantry/items/:ingredientSlug", async (c) => {
         return c.json({ error: "Invalid ingredient slug" }, 400);
       }
 
-      const pantry = await db.transaction(async (tx) => {
-        const scope = await lockPantryScope(tx, session.user.id);
-        await tx
-          .delete(schema.pantryItem)
-          .where(
-            and(
-              pantryScopeFilter(scope),
-              eq(
-                schema.pantryItem.ingredientSlug,
-                ingredientSlugResult.data,
+      const pantry = await executePantryOperation(
+        db,
+        session.user.id,
+        operationId,
+        `remove:${ingredientSlugResult.data}`,
+        async (tx, scope) => {
+          await tx
+            .delete(schema.pantryItem)
+            .where(
+              and(
+                pantryScopeFilter(scope),
+                eq(
+                  schema.pantryItem.ingredientSlug,
+                  ingredientSlugResult.data,
+                ),
               ),
-            ),
-          );
-        return pantryResponseForScope(tx, scope);
-      });
+            );
+        },
+      );
 
       return c.json(pantry);
     },
+    { onError: (error) => pantryMutationErrorResponse(c, error) },
   );
 });
 
@@ -2772,6 +3058,14 @@ registerRoute("post", "/households", async (c) => {
             organizationId: householdId,
           })
           .where(eq(schema.pantryItem.userId, session.user.id));
+        await clearPantryOperationsForScope(tx, {
+          type: "personal",
+          userId: session.user.id,
+        });
+        await tx
+          .update(schema.pantryAggregate)
+          .set({ userId: null, organizationId: householdId })
+          .where(eq(schema.pantryAggregate.userId, session.user.id));
 
         return createdHousehold;
       });
@@ -3314,7 +3608,21 @@ registerRoute("delete", "/households/:householdId", async (c) => {
             organizationId: null,
           })
           .where(eq(schema.pantryItem.organizationId, householdId));
-        await tx.delete(schema.organization).where(eq(schema.organization.id, householdId));
+        await clearPantryOperationsForScope(tx, {
+          type: "household",
+          householdId,
+          householdName: household.name,
+        });
+        await tx
+          .delete(schema.pantryAggregate)
+          .where(eq(schema.pantryAggregate.userId, session.user.id));
+        await tx
+          .update(schema.pantryAggregate)
+          .set({ userId: session.user.id, organizationId: null })
+          .where(eq(schema.pantryAggregate.organizationId, householdId));
+        await tx
+          .delete(schema.organization)
+          .where(eq(schema.organization.id, householdId));
       });
       return c.body(null, 204);
     },

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -172,6 +172,7 @@ const dbMock = vi.hoisted(() => {
     pantryItems: [] as PantryItemRow[],
     pantryAggregates: [] as PantryAggregateRow[],
     pantryOperations: [] as PantryOperationRow[],
+    pantryOperationSweeps: 0,
     ingredientGroupMembers: [] as {
       groupKey: string;
       ingredientSlug: string;
@@ -299,6 +300,7 @@ const dbMock = vi.hoisted(() => {
     state.pantryItems = [];
     state.pantryAggregates = [];
     state.pantryOperations = [];
+    state.pantryOperationSweeps = 0;
     state.ingredientGroupMembers = [];
     state.dietPresetExcludedGroups = [];
     state.dietPresetExcludedIngredients = [];
@@ -484,11 +486,15 @@ const dbMock = vi.hoisted(() => {
     }
 
     if (query.startsWith('insert into "pantry_operation"')) {
+      const result = params[3];
       state.pantryOperations.push({
         aggregateId: params[0] as string,
         operationId: params[1] as string,
         commandFingerprint: params[2] as string,
-        result: params[3] as Record<string, unknown>,
+        result:
+          typeof result === "string"
+            ? (JSON.parse(result) as Record<string, unknown>)
+            : (result as Record<string, unknown>),
         createdAt: date,
       });
       return [];
@@ -828,9 +834,16 @@ const dbMock = vi.hoisted(() => {
     }
 
     if (query.startsWith('delete from "pantry_operation"')) {
+      if (query.includes('"created_at" <')) {
+        state.pantryOperationSweeps += 1;
+        return [];
+      }
       const aggregateId = params[0] as string;
+      const operationId = params[1] as string | undefined;
       state.pantryOperations = state.pantryOperations.filter(
-        (operation) => operation.aggregateId !== aggregateId,
+        (operation) =>
+          operation.aggregateId !== aggregateId ||
+          (operationId !== undefined && operation.operationId !== operationId),
       );
       return [];
     }
@@ -4154,6 +4167,34 @@ describe("pantry mutation flows", () => {
     });
   });
 
+  it("replaces an incompatible pantry operation receipt instead of replaying it", async () => {
+    seedHousehold();
+    const operationId = "0198f1f0-1111-7111-8111-111111111111";
+    const request = () =>
+      app.request(
+        "/pantry/items/onion",
+        {
+          method: "PUT",
+          headers: { ...mutationHeaders, "idempotency-key": operationId },
+          body: JSON.stringify({ location: "fresh" }),
+        },
+        env,
+      );
+
+    expect((await request()).status).toBe(200);
+    dbMock.state.pantryOperations[0]!.result = { version: 0 };
+
+    expect(await (await request()).json()).toMatchObject({
+      operationId,
+      revision: "2",
+      itemVersions: { onion: "2" },
+    });
+    expect(dbMock.state.pantryOperations).toHaveLength(1);
+    expect(dbMock.state.pantryOperations[0]?.result).toMatchObject({
+      version: 1,
+    });
+  });
+
   it("rejects invalid item mutations", async () => {
     const invalidOperationId = await app.request(
       "/pantry/items/onion",
@@ -6096,7 +6137,7 @@ describe("unknown routes", () => {
   });
 });
 
-describe("scheduled rate-limit cleanup", () => {
+describe("scheduled operational-row cleanup", () => {
   function runScheduled(bindings: typeof env) {
     const pending: Promise<unknown>[] = [];
     const ctx = {
@@ -6106,9 +6147,10 @@ describe("scheduled rate-limit cleanup", () => {
     return Promise.all(pending);
   }
 
-  it("sweeps stale counters", async () => {
+  it("sweeps stale counters and pantry operation receipts", async () => {
     await runScheduled(env);
     expect(dbMock.state.rateLimitSweeps).toBe(1);
+    expect(dbMock.state.pantryOperationSweeps).toBe(1);
   });
 
   it("no-ops without a database connection", async () => {

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -114,8 +114,24 @@ const dbMock = vi.hoisted(() => {
     organizationId: string | null;
     ingredientSlug: string;
     location: "fridge" | "cupboards" | "fresh";
+    version?: bigint;
     createdAt: Date;
     updatedAt: Date;
+  };
+  type PantryAggregateRow = {
+    id: string;
+    userId: string | null;
+    organizationId: string | null;
+    revision: bigint;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  type PantryOperationRow = {
+    aggregateId: string;
+    operationId: string;
+    commandFingerprint: string;
+    result: Record<string, unknown>;
+    createdAt: Date;
   };
 
   const state = {
@@ -154,6 +170,8 @@ const dbMock = vi.hoisted(() => {
     ingredientGroups: [] as IngredientGroupRow[],
     ingredients: [] as IngredientRow[],
     pantryItems: [] as PantryItemRow[],
+    pantryAggregates: [] as PantryAggregateRow[],
+    pantryOperations: [] as PantryOperationRow[],
     ingredientGroupMembers: [] as {
       groupKey: string;
       ingredientSlug: string;
@@ -279,6 +297,8 @@ const dbMock = vi.hoisted(() => {
     state.ingredientGroups = [];
     state.ingredients = [];
     state.pantryItems = [];
+    state.pantryAggregates = [];
+    state.pantryOperations = [];
     state.ingredientGroupMembers = [];
     state.dietPresetExcludedGroups = [];
     state.dietPresetExcludedIngredients = [];
@@ -441,14 +461,53 @@ const dbMock = vi.hoisted(() => {
       return [invitationRow(invitation)];
     }
 
+    if (query.startsWith('insert into "pantry_aggregate"')) {
+      const userId = (params[0] as string | null) ?? null;
+      const organizationId = (params[1] as string | null) ?? null;
+      const existing = state.pantryAggregates.find(
+        (candidate) =>
+          (userId !== null && candidate.userId === userId) ||
+          (organizationId !== null &&
+            candidate.organizationId === organizationId),
+      );
+      if (existing) return [];
+      const aggregate: PantryAggregateRow = {
+        id: crypto.randomUUID(),
+        userId,
+        organizationId,
+        revision: 0n,
+        createdAt: date,
+        updatedAt: date,
+      };
+      state.pantryAggregates.push(aggregate);
+      return [[aggregate.id, aggregate.revision.toString()]];
+    }
+
+    if (query.startsWith('insert into "pantry_operation"')) {
+      state.pantryOperations.push({
+        aggregateId: params[0] as string,
+        operationId: params[1] as string,
+        commandFingerprint: params[2] as string,
+        result: params[3] as Record<string, unknown>,
+        createdAt: date,
+      });
+      return [];
+    }
+
     if (query.startsWith('insert into "pantry_item"')) {
-      for (let index = 0; index < params.length; index += 4) {
+      const valuesClause = query.split(" values ")[1]?.split(" on conflict")[0] ?? "";
+      const valueParameterCount = Math.max(
+        0,
+        ...[...valuesClause.matchAll(/\$(\d+)/g)].map((match) => Number(match[1])),
+      );
+      for (let index = 0; index < valueParameterCount; index += 4) {
         const pantryItem: PantryItemRow = {
           id: crypto.randomUUID(),
           userId: (params[index] as string | null) ?? null,
           organizationId: (params[index + 1] as string | null) ?? null,
           ingredientSlug: params[index + 2] as string,
           location: params[index + 3] as PantryItemRow["location"],
+          version: 1n,
           createdAt: date,
           updatedAt: date,
         };
@@ -459,7 +518,21 @@ const dbMock = vi.hoisted(() => {
               (pantryItem.organizationId !== null &&
                 candidate.organizationId === pantryItem.organizationId)),
         );
-        if (!query.includes("on conflict do nothing") || !conflicts) {
+        if (query.includes("do update set") && conflicts) {
+          const existing = state.pantryItems.find(
+            (candidate) =>
+              candidate.ingredientSlug === pantryItem.ingredientSlug &&
+              ((pantryItem.userId !== null &&
+                candidate.userId === pantryItem.userId) ||
+                (pantryItem.organizationId !== null &&
+                  candidate.organizationId === pantryItem.organizationId)),
+          );
+          if (existing) {
+            existing.location = pantryItem.location;
+            existing.version = (existing.version ?? 1n) + 1n;
+            existing.updatedAt = date;
+          }
+        } else if (!query.includes("on conflict do nothing") || !conflicts) {
           state.pantryItems.push(pantryItem);
         }
       }
@@ -704,6 +777,34 @@ const dbMock = vi.hoisted(() => {
       return [];
     }
 
+    if (query.startsWith('update "pantry_aggregate"')) {
+      if (query.includes('"revision" = "pantry_aggregate"."revision" + 1')) {
+        const aggregateId = params.at(-1) as string;
+        const aggregate = state.pantryAggregates.find(
+          (candidate) => candidate.id === aggregateId,
+        );
+        if (!aggregate) return [];
+        aggregate.revision += 1n;
+        aggregate.updatedAt = date;
+        return [[aggregate.revision.toString()]];
+      }
+      const userId = (params[0] as string | null) ?? null;
+      const organizationId = (params[1] as string | null) ?? null;
+      const previousOwnerId = params.at(-1) as string;
+      const personal = query.includes('"pantry_aggregate"."user_id" =');
+      for (const aggregate of state.pantryAggregates) {
+        const matchesPreviousOwner = personal
+          ? aggregate.userId === previousOwnerId
+          : aggregate.organizationId === previousOwnerId;
+        if (matchesPreviousOwner) {
+          aggregate.userId = userId;
+          aggregate.organizationId = organizationId;
+          aggregate.updatedAt = date;
+        }
+      }
+      return [];
+    }
+
     if (query.startsWith('delete from "app_rate_limit"')) {
       state.rateLimitSweeps += 1;
       return [];
@@ -722,6 +823,35 @@ const dbMock = vi.hoisted(() => {
             (ingredientSlugs.size === 0 ||
               ingredientSlugs.has(item.ingredientSlug))
           ),
+      );
+      return [];
+    }
+
+    if (query.startsWith('delete from "pantry_operation"')) {
+      const aggregateId = params[0] as string;
+      state.pantryOperations = state.pantryOperations.filter(
+        (operation) => operation.aggregateId !== aggregateId,
+      );
+      return [];
+    }
+
+    if (query.startsWith('delete from "pantry_aggregate"')) {
+      const ownerId = params[0] as string;
+      const personal = query.includes('"pantry_aggregate"."user_id" =');
+      const removedIds = new Set(
+        state.pantryAggregates
+          .filter((aggregate) =>
+            personal
+              ? aggregate.userId === ownerId
+              : aggregate.organizationId === ownerId,
+          )
+          .map((aggregate) => aggregate.id),
+      );
+      state.pantryAggregates = state.pantryAggregates.filter(
+        (aggregate) => !removedIds.has(aggregate.id),
+      );
+      state.pantryOperations = state.pantryOperations.filter(
+        (operation) => !removedIds.has(operation.aggregateId),
       );
       return [];
     }
@@ -1105,13 +1235,41 @@ const dbMock = vi.hoisted(() => {
           : item.organizationId === ownerId,
       );
       return pantryItems.map((item) => {
-        if (query.includes('select "ingredient_slug", "location"')) {
-          return [item.ingredientSlug, item.location];
+        if (query.includes('select "ingredient_slug", "location", "version"')) {
+          return [
+            item.ingredientSlug,
+            item.location,
+            (item.version ?? 1n).toString(),
+          ];
         }
         return query.includes('select "ingredient_slug"')
           ? [item.ingredientSlug]
           : [item.id];
       });
+    }
+
+
+    if (query.includes('from "pantry_aggregate"')) {
+      const ownerId = params[0] as string;
+      const personal = query.includes('"pantry_aggregate"."user_id" =');
+      return state.pantryAggregates
+        .filter((aggregate) =>
+          personal
+            ? aggregate.userId === ownerId
+            : aggregate.organizationId === ownerId,
+        )
+        .map((aggregate) => [aggregate.id, aggregate.revision.toString()]);
+    }
+
+    if (query.includes('from "pantry_operation"')) {
+      const [aggregateId, operationId] = params as [string, string];
+      return state.pantryOperations
+        .filter(
+          (operation) =>
+            operation.aggregateId === aggregateId &&
+            operation.operationId === operationId,
+        )
+        .map((operation) => [operation.commandFingerprint, operation.result]);
     }
 
     if (
@@ -3793,8 +3951,12 @@ describe("pantry mutation flows", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
+      resourceId: "owner-user",
+      revision: "1",
+      operationId: expect.any(String),
       scope: { type: "personal" },
       stock: { onion: "fresh", milk: "fridge" },
+      itemVersions: { onion: "1", milk: "1" },
     });
     expect(dbMock.state.pantryItems).toEqual([
       expect.objectContaining({
@@ -3851,11 +4013,15 @@ describe("pantry mutation flows", () => {
     );
     expect(setResponse.status).toBe(200);
     expect(await setResponse.json()).toEqual({
+      resourceId: HOUSEHOLD_ID,
+      revision: "1",
+      operationId: expect.any(String),
       scope: {
         type: "household",
         household: { id: HOUSEHOLD_ID, name: "Owner household" },
       },
       stock: { onion: "cupboards" },
+      itemVersions: { onion: "1" },
     });
     expect(dbMock.state.pantryItems[0]).toEqual(
       expect.objectContaining({
@@ -3877,11 +4043,15 @@ describe("pantry mutation flows", () => {
     );
     expect(moveResponse.status).toBe(200);
     expect(await moveResponse.json()).toEqual({
+      resourceId: HOUSEHOLD_ID,
+      revision: "2",
+      operationId: expect.any(String),
       scope: {
         type: "household",
         household: { id: HOUSEHOLD_ID, name: "Owner household" },
       },
       stock: { onion: "fresh" },
+      itemVersions: { onion: "2" },
     });
     expect(dbMock.state.pantryItems).toHaveLength(1);
 
@@ -3895,11 +4065,15 @@ describe("pantry mutation flows", () => {
     );
     expect(removeResponse.status).toBe(200);
     expect(await removeResponse.json()).toEqual({
+      resourceId: HOUSEHOLD_ID,
+      revision: "3",
+      operationId: expect.any(String),
       scope: {
         type: "household",
         household: { id: HOUSEHOLD_ID, name: "Owner household" },
       },
       stock: {},
+      itemVersions: {},
     });
     expect(dbMock.state.pantryItems).toEqual([]);
   });
@@ -3929,15 +4103,75 @@ describe("pantry mutation flows", () => {
     );
     expect(restoreResponse.status).toBe(200);
     expect(await restoreResponse.json()).toEqual({
+      resourceId: HOUSEHOLD_ID,
+      revision: "1",
+      operationId: expect.any(String),
       scope: {
         type: "household",
         household: { id: HOUSEHOLD_ID, name: "Owner household" },
       },
       stock: { milk: "fresh", onion: "cupboards" },
+      itemVersions: { milk: "1", onion: "1" },
+    });
+  });
+
+  it("replays a duplicate pantry operation without incrementing its revision", async () => {
+    seedHousehold();
+    const operationId = "0198f1f0-1111-7111-8111-111111111111";
+    const request = () =>
+      app.request(
+        "/pantry/items/onion",
+        {
+          method: "PUT",
+          headers: { ...mutationHeaders, "idempotency-key": operationId },
+          body: JSON.stringify({ location: "fresh" }),
+        },
+        env,
+      );
+
+    const first = await request();
+    const duplicate = await request();
+
+    expect(first.status).toBe(200);
+    expect(await duplicate.json()).toEqual(await first.json());
+    expect(dbMock.state.pantryAggregates).toEqual([
+      expect.objectContaining({ revision: 1n }),
+    ]);
+    expect(dbMock.state.pantryOperations).toHaveLength(1);
+
+    const conflictingReuse = await app.request(
+      "/pantry/items/onion",
+      {
+        method: "PUT",
+        headers: { ...mutationHeaders, "idempotency-key": operationId },
+        body: JSON.stringify({ location: "cupboards" }),
+      },
+      env,
+    );
+    expect(conflictingReuse.status).toBe(409);
+    expect(await conflictingReuse.json()).toEqual({
+      error: "Operation ID was already used for a different pantry command",
     });
   });
 
   it("rejects invalid item mutations", async () => {
+    const invalidOperationId = await app.request(
+      "/pantry/items/onion",
+      {
+        method: "PUT",
+        headers: {
+          ...mutationHeaders,
+          "idempotency-key": "not-a-uuid",
+        },
+        body: JSON.stringify({ location: "fresh" }),
+      },
+      env,
+    );
+    expect(invalidOperationId.status).toBe(400);
+    expect(await invalidOperationId.json()).toEqual({
+      error: "Invalid Idempotency-Key header",
+    });
+
     const invalidSlug = await app.request(
       `/pantry/items/${"x".repeat(201)}`,
       {
@@ -4023,6 +4257,8 @@ describe("household membership flows", () => {
       expect(response.status).toBe(200);
       expect(response.headers.get("cache-control")).toBe("private, no-store");
       expect(await response.json()).toEqual({
+        resourceId: HOUSEHOLD_ID,
+        revision: "0",
         scope: {
           type: "household",
           household: {
@@ -4031,6 +4267,7 @@ describe("household membership flows", () => {
           },
         },
         stock: { onion: "fresh" },
+        itemVersions: { onion: "1" },
       });
     }
   });

--- a/workers/recipe-api/tests/integration/database.test.ts
+++ b/workers/recipe-api/tests/integration/database.test.ts
@@ -108,6 +108,7 @@ function authenticatedRequest(
     body?: unknown;
     env?: Bindings;
     method?: "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
+    operationId?: string;
   } = {},
 ) {
   const method = options.method ?? "GET";
@@ -116,6 +117,9 @@ function authenticatedRequest(
   if (options.body !== undefined) {
     headers.set("content-type", "application/json");
     body = JSON.stringify(options.body);
+  }
+  if (options.operationId) {
+    headers.set("idempotency-key", options.operationId);
   }
   if (method !== "GET") headers.set("origin", authOrigin);
 
@@ -148,8 +152,8 @@ beforeAll(async () => {
     where slug in ('almond-milk', 'cajun-powder', 'cajun-seasoning')
     order by slug
   `;
-  expect(migrationCount?.count).toBe(7);
-  expect(tableCount?.count).toBe(33);
+  expect(migrationCount?.count).toBe(8);
+  expect(tableCount?.count).toBe(35);
   expect(catalogRows).toEqual([
     { category: "dairy", slug: "almond-milk" },
     { category: "spice", slug: "cajun-seasoning" },
@@ -175,6 +179,42 @@ afterAll(async () => {
 });
 
 describe("recipe API PostgreSQL integration", () => {
+  it("allocates pantry revisions and item versions exactly once per operation", async () => {
+    const cook = await createUser("Revision Cook", "revision@example.test");
+    const firstOperationId = "0198f1f0-3333-7333-8333-333333333333";
+    const secondOperationId = "0198f1f0-4444-7444-8444-444444444444";
+
+    const first = await authenticatedRequest(cook, "/pantry/items/onion", {
+      method: "PUT",
+      body: { location: "cupboards" },
+      operationId: firstOperationId,
+    });
+    expect(await json(first)).toMatchObject({
+      operationId: firstOperationId,
+      revision: "1",
+      itemVersions: { onion: "1" },
+    });
+
+    const update = () =>
+      authenticatedRequest(cook, "/pantry/items/onion", {
+        method: "PUT",
+        body: { location: "fresh" },
+        operationId: secondOperationId,
+      });
+    const updated = await update();
+    const duplicate = await update();
+    expect(await json(duplicate)).toEqual(await json(updated));
+
+    const snapshot = await authenticatedRequest(cook, "/pantry");
+    expect(await json(snapshot)).toEqual({
+      resourceId: cook.id,
+      revision: "2",
+      scope: { type: "personal" },
+      stock: { onion: "fresh" },
+      itemVersions: { onion: "2" },
+    });
+  });
+
   it("combines household and followed-cook activity in the following feed", async () => {
     const viewer = await createUser(
       "Following Viewer",
@@ -540,18 +580,44 @@ describe("recipe API PostgreSQL integration", () => {
       await json<{ membershipCreated: boolean }>(acceptResponse),
     ).toMatchObject({ membershipCreated: true });
 
+    const sharedOperationId = "0198f1f0-2222-7222-8222-222222222222";
     const sharedPantryUpdate = await authenticatedRequest(
       invitee,
       "/pantry/items/salt",
       {
         method: "PUT",
         body: { location: "cupboards" },
+        operationId: sharedOperationId,
       },
     );
     expect(sharedPantryUpdate.status).toBe(200);
+    const duplicateSharedPantryUpdate = await authenticatedRequest(
+      invitee,
+      "/pantry/items/salt",
+      {
+        method: "PUT",
+        body: { location: "cupboards" },
+        operationId: sharedOperationId,
+      },
+    );
+    expect(await json(duplicateSharedPantryUpdate)).toEqual(
+      await json(sharedPantryUpdate),
+    );
+    const conflictingSharedPantryUpdate = await authenticatedRequest(
+      invitee,
+      "/pantry/items/salt",
+      {
+        method: "PUT",
+        body: { location: "fresh" },
+        operationId: sharedOperationId,
+      },
+    );
+    expect(conflictingSharedPantryUpdate.status).toBe(409);
 
     const sharedPantry = await authenticatedRequest(owner, "/pantry");
     expect(await json(sharedPantry)).toEqual({
+      resourceId: household.id,
+      revision: "2",
       scope: {
         type: "household",
         household: {
@@ -560,6 +626,7 @@ describe("recipe API PostgreSQL integration", () => {
         },
       },
       stock: { onion: "fresh", salt: "cupboards" },
+      itemVersions: { onion: "1", salt: "1" },
     });
 
     const clearSharedPantry = await authenticatedRequest(invitee, "/pantry", {
@@ -592,6 +659,9 @@ describe("recipe API PostgreSQL integration", () => {
     );
     expect(restoredPantry.status).toBe(200);
     expect(await json(restoredPantry)).toEqual({
+      resourceId: household.id,
+      revision: "5",
+      operationId: expect.any(String),
       scope: {
         type: "household",
         household: {
@@ -603,6 +673,11 @@ describe("recipe API PostgreSQL integration", () => {
         "almond-milk": "fridge",
         onion: "fresh",
         salt: "cupboards",
+      },
+      itemVersions: {
+        "almond-milk": "1",
+        onion: "1",
+        salt: "1",
       },
     });
 
@@ -634,11 +709,18 @@ describe("recipe API PostgreSQL integration", () => {
 
     const inheritedPantry = await authenticatedRequest(owner, "/pantry");
     expect(await json(inheritedPantry)).toEqual({
+      resourceId: owner.id,
+      revision: "5",
       scope: { type: "personal" },
       stock: {
         "almond-milk": "fridge",
         onion: "fresh",
         salt: "cupboards",
+      },
+      itemVersions: {
+        "almond-milk": "1",
+        onion: "1",
+        salt: "1",
       },
     });
 


### PR DESCRIPTION
## Summary

- add a revisioned pantry aggregate, per-item versions, and operation receipts for retry-safe mutations
- centralize pantry writes behind a transactional command path that returns canonical decimal-string revisions
- preserve revision continuity across personal and household ownership changes while scoping idempotency history to the resource identity
- reject stale pantry snapshots and optimistic rollbacks in the TanStack Query cache
- document the optional `Idempotency-Key` pantry mutation header in OpenAPI

## Validation

- `mise //workers/recipe-api:check`
- `mise //workers/recipe-api:test:integration`
- `mise //ui:check`
- `mise //workers/recipe-api:openapi:breaking -- origin/main`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`

## Preview QA

Requires the backend preview because the UI response contract, Worker mutation path, and database schema all change.

- sign in as both members of the seeded household
- confirm pantry additions and location changes are shared through the existing repair poll
- confirm optimistic updates still reconcile after the canonical response
- confirm solo pantry behavior still works outside a household


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable pantry command handling with idempotent updates, preventing duplicate actions when requests are retried.
  - Pantry responses now include revision and item-version information for improved synchronisation.
  - Added support for safely replacing and restoring pantry contents.
  - Pantry ownership transitions now preserve or clear pantry data consistently when household membership changes.

- **Bug Fixes**
  - Prevented delayed or failed updates from overwriting newer pantry changes.
  - Added conflict detection for reused operation identifiers with different commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->