### PR TITLE
Publish AI review findings with per-finding feedback

### DIFF
--- a/.github/scripts/ai-review/ai-review.test.ts
+++ b/.github/scripts/ai-review/ai-review.test.ts
@@ -58,6 +58,16 @@ test("finding validation enforces confidence bounds at runtime", () => {
   assert.equal(validateFindings({ findings: [{ ...finding, confidence: 4 }] }, { merged: false })[0]?.confidence, 1);
 });
 
+test("finding validation accepts only positive or null diff lines", () => {
+  assert.deepEqual(
+    validateFindings(
+      { findings: [{ ...finding, line: 0 }, { ...finding, line: null }] },
+      { merged: false },
+    ),
+    [{ ...finding, line: null }],
+  );
+});
+
 test("completion accepts a null finish reason but rejects truncation", () => {
   assert.equal(completionContent({ finish_reason: null, message: { content: "{}" } }, "model"), "{}");
   assert.throws(

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -525,6 +525,12 @@ export function validateFindings(
     if (!isObject(candidate) || !required.every((key) => key in candidate)) continue;
     if (!["critical", "high", "medium", "low"].includes(String(candidate.severity))) continue;
     if (typeof candidate.file !== "string" || options.allowedFiles && !options.allowedFiles.has(candidate.file)) continue;
+    if (
+      candidate.line !== null &&
+      (typeof candidate.line !== "number" ||
+        !Number.isSafeInteger(candidate.line) ||
+        candidate.line <= 0)
+    ) continue;
     const confidence = Number(candidate.confidence);
     if (!Number.isFinite(confidence)) continue;
     if (options.merged) {

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -994,6 +994,8 @@ export function renderComment(options: {
   previousState: ReviewState;
   marker?: string;
   heading?: string;
+  summaryOnly?: boolean;
+  findingDelivery?: { line: number; fallback: number };
 }): string {
   const findings = validateFindings(options.result, { merged: true }) as MergedFinding[];
   const severityOrder: Record<Severity, number> = { critical: 0, high: 1, medium: 2, low: 3 };
@@ -1050,7 +1052,17 @@ export function renderComment(options: {
         : "No open findings reported.";
     lines.push(message, "");
   }
-  for (const finding of open) {
+  if (options.summaryOnly && open.length) {
+    const delivery = options.findingDelivery ?? {
+      line: open.length,
+      fallback: 0,
+    };
+    lines.push(
+      `${delivery.line} open finding(s) published as review threads; ${delivery.fallback} shown below because GitHub could not attach them to a diff line.`,
+      "",
+    );
+  }
+  for (const finding of options.summaryOnly ? [] : open) {
     const location = `${markdownText(finding.file, 500)}${finding.line && finding.line > 0 ? `:${finding.line}` : ""}`;
     lines.push(
       `### ${finding.severity.toUpperCase()}: ${markdownText(finding.title, 300)}`,
@@ -1063,7 +1075,7 @@ export function renderComment(options: {
       "",
     );
   }
-  if (resolved.length) {
+  if (!options.summaryOnly && resolved.length) {
     lines.push("## Resolved threads", "");
     for (const finding of resolved) {
       const location = `${markdownText(finding.file, 500)}${finding.line && finding.line > 0 ? `:${finding.line}` : ""}`;

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -17,8 +17,10 @@ The service is a visible, stateful publisher:
   period;
 - a Cloudflare Workflow fetches the PR through GitHub App authentication, runs
   the shared OpenRouter and OpenCode scout ensemble,
-  reconciles candidates with the same OpenRouter merger, and publishes a
-  separate rolling comment; OpenRouter and OpenCode scouts use separate
+  reconciles candidates with the same OpenRouter merger, publishes each
+  line-addressable finding as a native review comment with a stable hidden
+  finding ID, and keeps a separate rolling run/cost/coverage comment;
+  OpenRouter and OpenCode scouts use separate
   Workflow steps so a stalled free provider cannot replay completed paid calls,
   while deterministic publication and storage steps remain retryable;
 - the private `ai-review-data` R2 bucket stores versioned terminal records for
@@ -32,7 +34,12 @@ The service is a visible, stateful publisher:
 Automatic runs cover non-draft PR opens, ready-for-review transitions, reopens,
 and synchronized heads. An exact `/ai-review` issue comment from an owner,
 member, or collaborator requests a run explicitly, including on a draft.
-Ordinary comments and review-thread activity never schedule paid work.
+Ordinary comments and review-thread activity never schedule paid work. Replies,
+reaction-count snapshots, thread resolution, and trusted
+`/ai-review acknowledge f_<id> <reason>` or
+`/ai-review reject f_<id> <reason>` commands instead take a storage-only path.
+Findings that GitHub cannot attach to a current diff line remain in the rolling
+comment with those explicit command fallbacks.
 
 OpenRouter is the default paid inference gateway because its broader model and
 provider catalogue, provider failover, model fallbacks, and price/performance
@@ -97,11 +104,16 @@ bucket-level lifecycle rule above is authoritative.
 
 ## GitHub App and review policy
 
-The App requires repository metadata and contents read access, pull-request read
-access, and issues read/write access for its rolling comment. Subscribe it to
-`pull_request` and `issue_comment` events. The Worker re-checks repository,
-PR state, draft state, author, exact command text, command-author association,
-and current head before spending or publishing.
+The App requires repository metadata and contents read access, **pull-request
+read/write access** for native review comments, and issues read/write access for
+its rolling comment and command fallback. Subscribe it to `pull_request`,
+`issue_comment`, `pull_request_review_comment`, and
+`pull_request_review_thread` events. Changes to the existing App are made in
+its GitHub settings and require the installation owner to approve the expanded
+pull-request permission. The Worker verifies every signature and re-checks the
+repository, PR state, draft state, author, exact command text,
+command-author association, feedback actor, and current head before accepting
+an event, spending, or publishing.
 
 Committed non-secret defaults in `wrangler.toml` configure the shared reviewer:
 
@@ -141,6 +153,15 @@ identities into `review_hunks`, `review_findings`, and
 `review_finding_hunks`; first-seen values remain immutable while last-seen
 values advance with later completed runs. R2 retains raw per-model candidates
 separately from the merged findings that were actually published.
+
+Native review-comment mappings live in `review_finding_comments`, so later
+heads reconcile the same finding instead of publishing another thread.
+Accepted feedback deliveries are deduplicated by GitHub delivery ID and stored
+in `review_finding_events`. Each is also appended as schema-v2 evidence at
+`v2/<owner>/<repository>/pr-<number>/findings/<finding-id>/evidence/<delivery>.json`.
+These records preserve the event/action, trusted actor, reply or command body,
+reaction counts present on review-comment events, thread state, explicit
+disposition and timestamps without mutating earlier evidence.
 
 ## Deploy
 

--- a/ai-review/scripts/staging-e2e.sh
+++ b/ai-review/scripts/staging-e2e.sh
@@ -55,14 +55,21 @@ trap cleanup EXIT INT TERM
 head_sha="$(
   gh api "repos/${repository}/pulls/${pull_request}" --jq '.head.sha'
 )"
+actor="${repository%%/*}"
 jq -n \
   --arg repository "$repository" \
+  --arg actor "$actor" \
   --argjson pull_request "$pull_request" \
   '{
     action: "created",
     repository: {full_name: $repository},
     issue: {number: $pull_request, pull_request: {}},
-    comment: {body: "/ai-review", author_association: "OWNER"}
+    sender: {login: $actor},
+    comment: {
+      body: "/ai-review",
+      author_association: "OWNER",
+      user: {login: $actor}
+    }
   }' > "$payload_file"
 chmod 600 "$payload_file"
 

--- a/ai-review/src/env.ts
+++ b/ai-review/src/env.ts
@@ -8,6 +8,28 @@ export type ReviewWorkflowParams = {
   force: boolean;
 };
 
+export type FindingDisposition = "acknowledged" | "rejected";
+
+export type FindingInteractionEvent = {
+  deliveryId: string;
+  eventName: string;
+  action: string;
+  repository: string;
+  pullRequestNumber: number;
+  interactionType: "reply" | "thread" | "disposition";
+  actor: string;
+  actorAssociation?: string;
+  findingId?: string;
+  rootCommentId?: number;
+  commentId?: number;
+  threadId?: string;
+  body?: string;
+  reactions?: Record<string, number>;
+  disposition?: FindingDisposition;
+  reason?: string;
+  occurredAt?: string;
+};
+
 export const TRUSTED_AUTHOR_ASSOCIATIONS = new Set([
   "OWNER",
   "MEMBER",

--- a/ai-review/src/finding-lifecycle.ts
+++ b/ai-review/src/finding-lifecycle.ts
@@ -5,6 +5,8 @@ import {
 } from "../../.github/scripts/ai-review/ai-review.ts";
 
 export const FINDING_MARKER_PREFIX = "ai-review-finding:";
+const FINDING_MARKER_PATTERN =
+  /<!--\s*ai-review-finding:(f_[a-f0-9]{24})\s*-->/i;
 
 export interface PublishableFinding extends MergedFinding {
   findingId: string;
@@ -36,9 +38,8 @@ function findingMarker(findingId: string): string {
 }
 
 export function findingIdFromComment(body: unknown): string | undefined {
-  const match = String(body ?? "").match(
-    /<!--\s*ai-review-finding:(f_[a-f0-9]{24})\s*-->/i,
-  );
+  if (typeof body !== "string") return undefined;
+  const match = FINDING_MARKER_PATTERN.exec(body);
   return match?.[1]?.toLowerCase();
 }
 
@@ -135,6 +136,68 @@ function isUnprocessableReviewComment(error: unknown): boolean {
   return error instanceof Error && /failed \(422\)/.test(error.message);
 }
 
+function publication(
+  finding: PublishableFinding,
+  delivery: FindingPublication["delivery"],
+  reconciled: boolean,
+  commentId?: number,
+): FindingPublication {
+  return {
+    findingId: finding.findingId,
+    delivery,
+    ...(commentId === undefined ? {} : { commentId }),
+    reconciled,
+    path: finding.file,
+    line: finding.line,
+  };
+}
+
+async function reconcileFindingComment(options: {
+  client: JsonClient;
+  repository: string;
+  finding: PublishableFinding;
+  commentId: number;
+}): Promise<FindingPublication> {
+  await options.client.request(
+    "PATCH",
+    `/repos/${options.repository}/pulls/comments/${options.commentId}`,
+    { body: { body: renderFindingComment(options.finding) } },
+  );
+  return publication(options.finding, "line", true, options.commentId);
+}
+
+async function publishLineFinding(options: {
+  client: JsonClient;
+  repository: string;
+  pullRequestNumber: number;
+  headSha: string;
+  finding: PublishableFinding;
+}): Promise<FindingPublication> {
+  try {
+    const response = await options.client.request<ReviewCommentResponse>(
+      "POST",
+      `/repos/${options.repository}/pulls/${options.pullRequestNumber}/comments`,
+      {
+        body: {
+          body: renderFindingComment(options.finding),
+          commit_id: options.headSha,
+          path: options.finding.file,
+          line: options.finding.line,
+          side: "RIGHT",
+        },
+      },
+    );
+    const commentId = Number(response.id);
+    if (!Number.isSafeInteger(commentId)) {
+      throw new TypeError("GitHub returned an invalid review comment ID");
+    }
+    return publication(options.finding, "line", false, commentId);
+  } catch (error) {
+    if (!isUnprocessableReviewComment(error)) throw error;
+    return publication(options.finding, "fallback", false);
+  }
+}
+
 export async function publishFindingComments(options: {
   token: string;
   repository: string;
@@ -159,70 +222,23 @@ export async function publishFindingComments(options: {
     processed.add(finding.findingId);
     const existingCommentId = existing.get(finding.findingId);
     if (existingCommentId !== undefined) {
-      await client.request(
-        "PATCH",
-        `/repos/${options.repository}/pulls/comments/${existingCommentId}`,
-        { body: { body: renderFindingComment(finding) } },
+      publications.push(
+        await reconcileFindingComment({
+          client,
+          repository: options.repository,
+          finding,
+          commentId: existingCommentId,
+        }),
       );
-      publications.push({
-        findingId: finding.findingId,
-        delivery: "line",
-        commentId: existingCommentId,
-        reconciled: true,
-        path: finding.file,
-        line: finding.line,
-      });
       continue;
     }
 
     if (finding.status === "resolved") continue;
     if (!lineIsAddressable(finding, options.hunks)) {
-      publications.push({
-        findingId: finding.findingId,
-        delivery: "fallback",
-        reconciled: false,
-        path: finding.file,
-        line: finding.line,
-      });
+      publications.push(publication(finding, "fallback", false));
       continue;
     }
-
-    try {
-      const response = await client.request<ReviewCommentResponse>(
-        "POST",
-        `/repos/${options.repository}/pulls/${options.pullRequestNumber}/comments`,
-        {
-          body: {
-            body: renderFindingComment(finding),
-            commit_id: options.headSha,
-            path: finding.file,
-            line: finding.line,
-            side: "RIGHT",
-          },
-        },
-      );
-      const commentId = Number(response.id);
-      if (!Number.isSafeInteger(commentId)) {
-        throw new Error("GitHub returned an invalid review comment ID");
-      }
-      publications.push({
-        findingId: finding.findingId,
-        delivery: "line",
-        commentId,
-        reconciled: false,
-        path: finding.file,
-        line: finding.line,
-      });
-    } catch (error) {
-      if (!isUnprocessableReviewComment(error)) throw error;
-      publications.push({
-        findingId: finding.findingId,
-        delivery: "fallback",
-        reconciled: false,
-        path: finding.file,
-        line: finding.line,
-      });
-    }
+    publications.push(await publishLineFinding({ ...options, client, finding }));
   }
   return publications;
 }
@@ -246,7 +262,8 @@ export function renderFallbackFindings(
     "",
   ];
   for (const finding of fallback) {
-    const location = `${markdownText(finding.file, 500)}${finding.line ? `:${finding.line}` : ""}`;
+    const lineSuffix = finding.line ? `:${finding.line}` : "";
+    const location = `${markdownText(finding.file, 500)}${lineSuffix}`;
     lines.push(
       `- **${finding.severity.toUpperCase()}: ` +
         `${markdownText(finding.title, 300)}** (\`${location}\`, ` +

--- a/ai-review/src/finding-lifecycle.ts
+++ b/ai-review/src/finding-lifecycle.ts
@@ -128,6 +128,11 @@ async function existingFindingComments(options: {
       }
     }
     if (comments.length < 100) break;
+    if (page === 10) {
+      throw new Error(
+        "Review comment reconciliation exceeded the 1,000-comment safety limit",
+      );
+    }
   }
   return byFinding;
 }

--- a/ai-review/src/finding-lifecycle.ts
+++ b/ai-review/src/finding-lifecycle.ts
@@ -163,6 +163,8 @@ async function reconcileFindingComment(options: {
     `/repos/${options.repository}/pulls/comments/${options.commentId}`,
     { body: { body: renderFindingComment(options.finding) } },
   );
+  // GitHub can make an existing native comment's current line null on later
+  // heads. It remains a line-delivered finding because the thread still exists.
   return publication(options.finding, "line", true, options.commentId);
 }
 

--- a/ai-review/src/finding-lifecycle.ts
+++ b/ai-review/src/finding-lifecycle.ts
@@ -1,0 +1,259 @@
+import {
+  JsonClient,
+  markdownText,
+  type MergedFinding,
+} from "../../.github/scripts/ai-review/ai-review.ts";
+
+export const FINDING_MARKER_PREFIX = "ai-review-finding:";
+
+export interface PublishableFinding extends MergedFinding {
+  findingId: string;
+  hunkIds: string[];
+}
+
+export interface FindingPublication {
+  findingId: string;
+  delivery: "line" | "fallback";
+  commentId?: number;
+  reconciled: boolean;
+  path: string;
+  line: number | null;
+}
+
+interface ExistingReviewComment {
+  id?: unknown;
+  body?: unknown;
+  in_reply_to_id?: unknown;
+  user?: { login?: unknown };
+}
+
+interface ReviewCommentResponse {
+  id?: unknown;
+}
+
+function findingMarker(findingId: string): string {
+  return `<!-- ${FINDING_MARKER_PREFIX}${findingId} -->`;
+}
+
+export function findingIdFromComment(body: unknown): string | undefined {
+  const match = String(body ?? "").match(
+    /<!--\s*ai-review-finding:(f_[a-f0-9]{24})\s*-->/i,
+  );
+  return match?.[1]?.toLowerCase();
+}
+
+function renderFindingComment(finding: PublishableFinding): string {
+  const status = finding.status === "resolved" ? "RESOLVED" : finding.severity.toUpperCase();
+  const lines = [
+    findingMarker(finding.findingId),
+    `### ${status}: ${markdownText(finding.title, 300)}`,
+    "",
+    markdownText(finding.evidence),
+    "",
+    `Suggested fix: ${markdownText(finding.recommendation)}`,
+    "",
+    `Reported by: ${finding.source_models
+      .map((model) => `\`${markdownText(model, 200)}\``)
+      .join(", ")} · confidence: ${Math.round(finding.confidence * 100)}%`,
+  ];
+  if (finding.status === "resolved" && finding.resolution_note) {
+    lines.push("", `Resolution: ${markdownText(finding.resolution_note, 500)}`);
+  }
+  lines.push(
+    "",
+    `<sub>Finding \`${finding.findingId}\`. Reply or resolve this thread, ` +
+      `or use \`/ai-review acknowledge ${finding.findingId} reason\` / ` +
+      `\`/ai-review reject ${finding.findingId} reason\`.</sub>`,
+  );
+  return lines.join("\n");
+}
+
+function lineIsAddressable(
+  finding: PublishableFinding,
+  hunks: Array<{
+    hunkId: string;
+    file: string;
+    newStart: number;
+    newLines: number;
+  }>,
+): boolean {
+  if (!finding.line || finding.line < 1) return false;
+  const findingHunks = new Set(finding.hunkIds);
+  return hunks.some(
+    (hunk) =>
+      findingHunks.has(hunk.hunkId) &&
+      hunk.file === finding.file &&
+      hunk.newLines > 0 &&
+      finding.line !== null &&
+      finding.line >= hunk.newStart &&
+      finding.line < hunk.newStart + hunk.newLines,
+  );
+}
+
+function githubClient(token: string): JsonClient {
+  return new JsonClient("https://api.github.com", {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+    "User-Agent": "personal-site-ai-review/1",
+    "X-GitHub-Api-Version": "2022-11-28",
+  });
+}
+
+async function existingFindingComments(options: {
+  client: JsonClient;
+  repository: string;
+  pullRequestNumber: number;
+  botLogin: string;
+}): Promise<Map<string, number>> {
+  const byFinding = new Map<string, number>();
+  for (let page = 1; page <= 10; page += 1) {
+    const comments = await options.client.request<ExistingReviewComment[]>(
+      "GET",
+      `/repos/${options.repository}/pulls/${options.pullRequestNumber}/comments`,
+      { query: { per_page: 100, page } },
+    );
+    for (const comment of comments) {
+      if (
+        comment.user?.login !== options.botLogin ||
+        typeof comment.in_reply_to_id === "number"
+      ) {
+        continue;
+      }
+      const findingId = findingIdFromComment(comment.body);
+      const commentId = Number(comment.id);
+      if (findingId && Number.isSafeInteger(commentId) && !byFinding.has(findingId)) {
+        byFinding.set(findingId, commentId);
+      }
+    }
+    if (comments.length < 100) break;
+  }
+  return byFinding;
+}
+
+function isUnprocessableReviewComment(error: unknown): boolean {
+  return error instanceof Error && /failed \(422\)/.test(error.message);
+}
+
+export async function publishFindingComments(options: {
+  token: string;
+  repository: string;
+  pullRequestNumber: number;
+  botLogin: string;
+  headSha: string;
+  findings: PublishableFinding[];
+  hunks: Array<{
+    hunkId: string;
+    file: string;
+    newStart: number;
+    newLines: number;
+  }>;
+}): Promise<FindingPublication[]> {
+  const client = githubClient(options.token);
+  const existing = await existingFindingComments({ ...options, client });
+  const publications: FindingPublication[] = [];
+  const processed = new Set<string>();
+
+  for (const finding of options.findings) {
+    if (processed.has(finding.findingId)) continue;
+    processed.add(finding.findingId);
+    const existingCommentId = existing.get(finding.findingId);
+    if (existingCommentId !== undefined) {
+      await client.request(
+        "PATCH",
+        `/repos/${options.repository}/pulls/comments/${existingCommentId}`,
+        { body: { body: renderFindingComment(finding) } },
+      );
+      publications.push({
+        findingId: finding.findingId,
+        delivery: "line",
+        commentId: existingCommentId,
+        reconciled: true,
+        path: finding.file,
+        line: finding.line,
+      });
+      continue;
+    }
+
+    if (finding.status === "resolved") continue;
+    if (!lineIsAddressable(finding, options.hunks)) {
+      publications.push({
+        findingId: finding.findingId,
+        delivery: "fallback",
+        reconciled: false,
+        path: finding.file,
+        line: finding.line,
+      });
+      continue;
+    }
+
+    try {
+      const response = await client.request<ReviewCommentResponse>(
+        "POST",
+        `/repos/${options.repository}/pulls/${options.pullRequestNumber}/comments`,
+        {
+          body: {
+            body: renderFindingComment(finding),
+            commit_id: options.headSha,
+            path: finding.file,
+            line: finding.line,
+            side: "RIGHT",
+          },
+        },
+      );
+      const commentId = Number(response.id);
+      if (!Number.isSafeInteger(commentId)) {
+        throw new Error("GitHub returned an invalid review comment ID");
+      }
+      publications.push({
+        findingId: finding.findingId,
+        delivery: "line",
+        commentId,
+        reconciled: false,
+        path: finding.file,
+        line: finding.line,
+      });
+    } catch (error) {
+      if (!isUnprocessableReviewComment(error)) throw error;
+      publications.push({
+        findingId: finding.findingId,
+        delivery: "fallback",
+        reconciled: false,
+        path: finding.file,
+        line: finding.line,
+      });
+    }
+  }
+  return publications;
+}
+
+export function renderFallbackFindings(
+  findings: PublishableFinding[],
+  publications: FindingPublication[],
+): string {
+  const fallbackIds = new Set(
+    publications
+      .filter(({ delivery }) => delivery === "fallback")
+      .map(({ findingId }) => findingId),
+  );
+  const fallback = findings.filter(({ findingId }) => fallbackIds.has(findingId));
+  if (fallback.length === 0) return "";
+  const lines = [
+    "## Findings without a diff line",
+    "",
+    "GitHub could not attach these findings to the current diff. " +
+      "Use the commands shown to record an explicit disposition.",
+    "",
+  ];
+  for (const finding of fallback) {
+    const location = `${markdownText(finding.file, 500)}${finding.line ? `:${finding.line}` : ""}`;
+    lines.push(
+      `- **${finding.severity.toUpperCase()}: ` +
+        `${markdownText(finding.title, 300)}** (\`${location}\`, ` +
+        `\`${finding.findingId}\`) — ${markdownText(finding.evidence, 700)}`,
+      `  - \`/ai-review acknowledge ${finding.findingId} <reason>\``,
+      `  - \`/ai-review reject ${finding.findingId} <reason>\``,
+    );
+  }
+  return lines.join("\n");
+}

--- a/ai-review/src/finding-lifecycle.ts
+++ b/ai-review/src/finding-lifecycle.ts
@@ -133,7 +133,10 @@ async function existingFindingComments(options: {
 }
 
 function isUnprocessableReviewComment(error: unknown): boolean {
-  return error instanceof Error && /failed \(422\)/.test(error.message);
+  if (!(error instanceof Error) || !/failed \(422\)/.test(error.message)) {
+    return false;
+  }
+  return /line (?:is not|must be) part of the diff/i.test(error.message);
 }
 
 function publication(

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -261,22 +261,26 @@ function isIdentifiedFinding(value: unknown): value is IdentifiedMergedFinding {
 function isFindingPublication(value: unknown): value is FindingPublication {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const publication = value as Partial<FindingPublication>;
+  const commentIdIsValid =
+    typeof publication.commentId === "number" &&
+    Number.isSafeInteger(publication.commentId) &&
+    publication.commentId > 0;
+  const lineIsValid =
+    typeof publication.line === "number" &&
+    Number.isSafeInteger(publication.line) &&
+    publication.line > 0;
+  const deliveryIsConsistent =
+    publication.delivery === "line"
+      ? commentIdIsValid && lineIsValid
+      : publication.delivery === "fallback" && publication.commentId === undefined;
   return (
     typeof publication.findingId === "string" &&
     /^f_[a-f0-9]{24}$/.test(publication.findingId) &&
-    (publication.delivery === "line" || publication.delivery === "fallback") &&
-    (publication.commentId === undefined ||
-      (typeof publication.commentId === "number" &&
-        Number.isSafeInteger(publication.commentId) &&
-        publication.commentId > 0)) &&
+    deliveryIsConsistent &&
     typeof publication.reconciled === "boolean" &&
     typeof publication.path === "string" &&
     publication.path.length > 0 &&
-    (publication.line === null ||
-      (typeof publication.line === "number" &&
-        Number.isSafeInteger(publication.line) &&
-        publication.line >= 0)) &&
-    (publication.delivery !== "line" || publication.commentId !== undefined)
+    (publication.line === null || lineIsValid)
   );
 }
 
@@ -288,6 +292,7 @@ function isFindingInteractionEvent(
   return (
     typeof event.deliveryId === "string" &&
     event.deliveryId.length > 0 &&
+    event.deliveryId.length <= 255 &&
     typeof event.eventName === "string" &&
     typeof event.action === "string" &&
     typeof event.repository === "string" &&
@@ -299,6 +304,12 @@ function isFindingInteractionEvent(
       event.interactionType === "disposition") &&
     typeof event.actor === "string" &&
     event.actor.length > 0 &&
+    (event.threadId === undefined ||
+      (typeof event.threadId === "string" && event.threadId.length <= 255)) &&
+    (event.body === undefined ||
+      (typeof event.body === "string" && event.body.length <= 4_000)) &&
+    (event.reason === undefined ||
+      (typeof event.reason === "string" && event.reason.length <= 1_000)) &&
     (event.findingId === undefined || /^f_[a-f0-9]{24}$/.test(event.findingId)) &&
     (event.rootCommentId === undefined ||
       (Number.isSafeInteger(event.rootCommentId) && event.rootCommentId > 0)) &&
@@ -857,20 +868,24 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const completionHunkIds = new Set(
       (body.hunks as ReviewHunk[]).map(({ hunkId }) => hunkId),
     );
-    const completionFindingIds = new Set(
-      (body.findings as IdentifiedMergedFinding[]).map(
-        ({ findingId }) => findingId,
-      ),
+    const completionFindings = body.findings as IdentifiedMergedFinding[];
+    const completionFindingsById = new Map(
+      completionFindings.map((finding) => [finding.findingId, finding]),
     );
     const findingPublications = (body.findingPublications ??
       []) as FindingPublication[];
     if (
-      (body.findings as IdentifiedMergedFinding[]).some((finding) =>
+      completionFindings.some((finding) =>
         finding.hunkIds.some((hunkId) => !completionHunkIds.has(hunkId)),
       ) ||
-      findingPublications.some(
-        ({ findingId }) => !completionFindingIds.has(findingId),
-      )
+      findingPublications.some((publication) => {
+        const finding = completionFindingsById.get(publication.findingId);
+        return (
+          !finding ||
+          publication.path !== finding.file ||
+          publication.line !== finding.line
+        );
+      })
     ) {
       return json({ error: "Invalid review completion" }, 400);
     }

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -5,7 +5,12 @@ import {
   type WorkflowStep,
   type WorkflowStepConfig,
 } from "cloudflare:workers";
-import type { Env, ReviewWorkflowParams } from "./env";
+import type {
+  Env,
+  FindingInteractionEvent,
+  ReviewWorkflowParams,
+} from "./env";
+import type { FindingPublication } from "./finding-lifecycle";
 import {
   claimReview,
   combineScoutRuns,
@@ -25,7 +30,11 @@ import {
   type ReviewHunk,
   type ScoutRun,
 } from "./review-engine";
-import { parseReviewEvent, verifyGitHubSignature } from "./webhook";
+import {
+  parseFindingInteraction,
+  parseReviewEvent,
+  verifyGitHubSignature,
+} from "./webhook";
 
 const JSON_HEADERS = {
   "cache-control": "no-store",
@@ -81,6 +90,28 @@ const CREATE_REVIEW_FINDING_HUNKS_TABLE =
   "finding_id TEXT NOT NULL, " +
   "hunk_id TEXT NOT NULL, " +
   "PRIMARY KEY (finding_id, hunk_id))";
+const CREATE_REVIEW_FINDING_COMMENTS_TABLE =
+  "CREATE TABLE IF NOT EXISTS review_finding_comments (" +
+  "comment_id INTEGER PRIMARY KEY, " +
+  "finding_id TEXT NOT NULL UNIQUE, " +
+  "head_sha TEXT NOT NULL, " +
+  "file_path TEXT NOT NULL, " +
+  "line INTEGER, " +
+  "created_at TEXT NOT NULL, " +
+  "updated_at TEXT NOT NULL)";
+const CREATE_REVIEW_FINDING_EVENTS_TABLE =
+  "CREATE TABLE IF NOT EXISTS review_finding_events (" +
+  "delivery_id TEXT PRIMARY KEY, " +
+  "schema_version INTEGER NOT NULL, " +
+  "evidence_version INTEGER NOT NULL, " +
+  "finding_id TEXT NOT NULL, " +
+  "event_type TEXT NOT NULL, " +
+  "action TEXT NOT NULL, " +
+  "actor TEXT NOT NULL, " +
+  "payload_json TEXT NOT NULL, " +
+  "occurred_at TEXT NOT NULL, " +
+  "recorded_at TEXT NOT NULL, " +
+  "r2_recorded INTEGER NOT NULL DEFAULT 0)";
 const DEFAULT_DEBOUNCE_DELAY_MS = 120_000;
 const MINIMUM_DEBOUNCE_DELAY_MS = 1_000;
 const MAXIMUM_DEBOUNCE_DELAY_MS = 3_600_000;
@@ -117,7 +148,9 @@ function json(data: unknown, status = 200): Response {
   return Response.json(data, { status, headers: JSON_HEADERS });
 }
 
-function coordinatorName(event: ReviewWorkflowParams): string {
+function coordinatorName(
+  event: Pick<ReviewWorkflowParams, "repository" | "pullRequestNumber">,
+): string {
   return `${event.repository}#${event.pullRequestNumber}`;
 }
 
@@ -225,6 +258,58 @@ function isIdentifiedFinding(value: unknown): value is IdentifiedMergedFinding {
   );
 }
 
+function isFindingPublication(value: unknown): value is FindingPublication {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const publication = value as Partial<FindingPublication>;
+  return (
+    typeof publication.findingId === "string" &&
+    /^f_[a-f0-9]{24}$/.test(publication.findingId) &&
+    (publication.delivery === "line" || publication.delivery === "fallback") &&
+    (publication.commentId === undefined ||
+      (typeof publication.commentId === "number" &&
+        Number.isSafeInteger(publication.commentId) &&
+        publication.commentId > 0)) &&
+    typeof publication.reconciled === "boolean" &&
+    typeof publication.path === "string" &&
+    publication.path.length > 0 &&
+    (publication.line === null ||
+      (typeof publication.line === "number" &&
+        Number.isSafeInteger(publication.line) &&
+        publication.line >= 0)) &&
+    (publication.delivery !== "line" || publication.commentId !== undefined)
+  );
+}
+
+function isFindingInteractionEvent(
+  value: unknown,
+): value is FindingInteractionEvent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const event = value as Partial<FindingInteractionEvent>;
+  return (
+    typeof event.deliveryId === "string" &&
+    event.deliveryId.length > 0 &&
+    typeof event.eventName === "string" &&
+    typeof event.action === "string" &&
+    typeof event.repository === "string" &&
+    typeof event.pullRequestNumber === "number" &&
+    Number.isSafeInteger(event.pullRequestNumber) &&
+    event.pullRequestNumber > 0 &&
+    (event.interactionType === "reply" ||
+      event.interactionType === "thread" ||
+      event.interactionType === "disposition") &&
+    typeof event.actor === "string" &&
+    event.actor.length > 0 &&
+    (event.findingId === undefined || /^f_[a-f0-9]{24}$/.test(event.findingId)) &&
+    (event.rootCommentId === undefined ||
+      (Number.isSafeInteger(event.rootCommentId) && event.rootCommentId > 0)) &&
+    (event.interactionType !== "disposition" ||
+      (event.findingId !== undefined &&
+        (event.disposition === "acknowledged" ||
+          event.disposition === "rejected"))) &&
+    (event.interactionType === "disposition" || event.rootCommentId !== undefined)
+  );
+}
+
 function healthResponse(env: Env): Response {
   const bindings = bindingHealth(env);
   const ok = Object.values(bindings).every(Boolean);
@@ -258,15 +343,16 @@ async function readWebhookBody(
 }
 
 async function forwardToCoordinator(
-  event: ReviewWorkflowParams,
+  event: ReviewWorkflowParams | FindingInteractionEvent,
   env: Env,
+  path = "/events",
 ): Promise<Response> {
   const id = env.PR_STATE.idFromName(coordinatorName(event));
   try {
     // This fixed URL is the standard Durable Object stub-fetch target; the
     // validated event body contains all provenance the coordinator needs.
     const response = await env.PR_STATE.get(id).fetch(
-      "https://coordinator.internal/events",
+      `https://coordinator.internal${path}`,
       {
         method: "POST",
         body: JSON.stringify(event),
@@ -307,7 +393,22 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     }
     this.ctx.storage.sql.exec(CREATE_REVIEW_HUNKS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDINGS_TABLE);
+    const findingColumns = this.ctx.storage.sql
+      .exec<{ name: string }>("PRAGMA table_info(review_findings)")
+      .toArray();
+    if (!findingColumns.some(({ name }) => name === "disposition")) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE review_findings ADD COLUMN disposition TEXT",
+      );
+    }
+    if (!findingColumns.some(({ name }) => name === "disposition_reason")) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE review_findings ADD COLUMN disposition_reason TEXT",
+      );
+    }
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_HUNKS_TABLE);
+    this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_COMMENTS_TABLE);
+    this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_EVENTS_TABLE);
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -316,6 +417,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     }
     const path = new URL(request.url).pathname;
     if (path === "/events") return this.receiveEvent(request);
+    if (path === "/interactions") return this.receiveInteraction(request);
     if (path === "/reviews/claim") return this.claimReview(request);
     if (path === "/reviews/complete") return this.completeReview(request);
     if (path === "/reviews/fail") return this.failReview(request);
@@ -437,6 +539,150 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     return json({
       accepted: true,
       enabled: this.env.AI_REVIEW_ENABLED === "true",
+    });
+  }
+
+  private async receiveInteraction(request: Request): Promise<Response> {
+    const event = await request.json().catch(() => null);
+    if (!isFindingInteractionEvent(event)) {
+      return json({ error: "Invalid finding interaction" }, 400);
+    }
+
+    const recordedAt = new Date().toISOString();
+    const result = this.ctx.storage.transactionSync(() => {
+      const existing = this.ctx.storage.sql
+        .exec<{
+          finding_id: string;
+          payload_json: string;
+          r2_recorded: number;
+        }>(
+          `SELECT finding_id, payload_json, r2_recorded
+           FROM review_finding_events WHERE delivery_id = ?`,
+          event.deliveryId,
+        )
+        .toArray()[0];
+      if (existing) {
+        return {
+          duplicate: true,
+          findingId: existing.finding_id,
+          evidence: JSON.parse(existing.payload_json) as unknown,
+          r2Recorded: existing.r2_recorded === 1,
+        };
+      }
+
+      const findingId =
+        event.findingId ??
+        this.ctx.storage.sql
+          .exec<{ finding_id: string }>(
+            `SELECT finding_id FROM review_finding_comments
+             WHERE comment_id = ?`,
+            event.rootCommentId ?? null,
+          )
+          .toArray()[0]?.finding_id;
+      if (!findingId) return { unknownFinding: true };
+      const finding = this.ctx.storage.sql
+        .exec<{ finding_id: string }>(
+          "SELECT finding_id FROM review_findings WHERE finding_id = ?",
+          findingId,
+        )
+        .toArray()[0];
+      if (!finding) return { unknownFinding: true };
+
+      const occurredAt = event.occurredAt ?? recordedAt;
+      const evidence = {
+        schemaVersion: 2,
+        recordType: "finding-interaction-evidence",
+        evidenceVersion: 1,
+        repository: event.repository,
+        pullRequestNumber: event.pullRequestNumber,
+        findingId,
+        deliveryId: event.deliveryId,
+        eventName: event.eventName,
+        action: event.action,
+        interactionType: event.interactionType,
+        actor: event.actor,
+        actorAssociation: event.actorAssociation,
+        rootCommentId: event.rootCommentId,
+        commentId: event.commentId,
+        threadId: event.threadId,
+        body: event.body,
+        reactions: event.reactions,
+        disposition: event.disposition,
+        reason: event.reason,
+        occurredAt,
+        recordedAt,
+      };
+      const payloadJson = JSON.stringify(evidence);
+      this.ctx.storage.sql.exec(
+        `INSERT INTO webhook_deliveries
+         (delivery_id, event_name, action, repository, pull_request_number,
+          head_sha, received_at)
+         VALUES (?, ?, ?, ?, ?, NULL, ?)`,
+        event.deliveryId,
+        event.eventName,
+        event.action,
+        event.repository,
+        event.pullRequestNumber,
+        recordedAt,
+      );
+      this.ctx.storage.sql.exec(
+        `INSERT INTO review_finding_events
+         (delivery_id, schema_version, evidence_version, finding_id,
+          event_type, action, actor, payload_json, occurred_at, recorded_at)
+         VALUES (?, 2, 1, ?, ?, ?, ?, ?, ?, ?)`,
+        event.deliveryId,
+        findingId,
+        event.interactionType,
+        event.action,
+        event.actor,
+        payloadJson,
+        occurredAt,
+        recordedAt,
+      );
+      if (event.disposition) {
+        this.ctx.storage.sql.exec(
+          `UPDATE review_findings
+           SET disposition = ?, disposition_reason = ?
+           WHERE finding_id = ?`,
+          event.disposition,
+          event.reason ?? null,
+          findingId,
+        );
+      }
+      return {
+        duplicate: false,
+        findingId,
+        evidence,
+        r2Recorded: false,
+      };
+    });
+
+    if ("unknownFinding" in result) {
+      return json({ accepted: false, reason: "unknown-finding" }, 202);
+    }
+    if (!result.r2Recorded) {
+      const key = [
+        "v2",
+        event.repository,
+        `pr-${event.pullRequestNumber}`,
+        "findings",
+        result.findingId,
+        "evidence",
+        `${event.deliveryId}.json`,
+      ].join("/");
+      await this.env.REVIEW_DATA.put(key, JSON.stringify(result.evidence), {
+        httpMetadata: { contentType: "application/json" },
+      });
+      this.ctx.storage.sql.exec(
+        `UPDATE review_finding_events SET r2_recorded = 1
+         WHERE delivery_id = ?`,
+        event.deliveryId,
+      );
+    }
+    return json({
+      accepted: true,
+      duplicate: result.duplicate,
+      findingId: result.findingId,
     });
   }
 
@@ -588,6 +834,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       commentId?: unknown;
       hunks?: unknown;
       findings?: unknown;
+      findingPublications?: unknown;
     } | null;
     if (
       !body ||
@@ -600,16 +847,29 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       !Array.isArray(body.hunks) ||
       !body.hunks.every(isReviewHunk) ||
       !Array.isArray(body.findings) ||
-      !body.findings.every(isIdentifiedFinding)
+      !body.findings.every(isIdentifiedFinding) ||
+      (body.findingPublications !== undefined &&
+        (!Array.isArray(body.findingPublications) ||
+          !body.findingPublications.every(isFindingPublication)))
     ) {
       return json({ error: "Invalid review completion" }, 400);
     }
     const completionHunkIds = new Set(
       (body.hunks as ReviewHunk[]).map(({ hunkId }) => hunkId),
     );
+    const completionFindingIds = new Set(
+      (body.findings as IdentifiedMergedFinding[]).map(
+        ({ findingId }) => findingId,
+      ),
+    );
+    const findingPublications = (body.findingPublications ??
+      []) as FindingPublication[];
     if (
       (body.findings as IdentifiedMergedFinding[]).some((finding) =>
         finding.hunkIds.some((hunkId) => !completionHunkIds.has(hunkId)),
+      ) ||
+      findingPublications.some(
+        ({ findingId }) => !completionFindingIds.has(findingId),
       )
     ) {
       return json({ error: "Invalid review completion" }, 400);
@@ -621,6 +881,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         commentId: body.commentId ?? null,
         hunks: body.hunks,
         findings: body.findings,
+        findingPublications,
       }),
     );
     const completedAt = new Date().toISOString();
@@ -709,6 +970,29 @@ export class PullRequestCoordinator extends DurableObject<Env> {
             hunkId,
           );
         }
+      }
+      for (const publication of findingPublications) {
+        if (publication.delivery !== "line" || publication.commentId === undefined) {
+          continue;
+        }
+        this.ctx.storage.sql.exec(
+          `INSERT INTO review_finding_comments
+           (comment_id, finding_id, head_sha, file_path, line, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(finding_id) DO UPDATE SET
+             comment_id = excluded.comment_id,
+             head_sha = excluded.head_sha,
+             file_path = excluded.file_path,
+             line = excluded.line,
+             updated_at = excluded.updated_at`,
+          publication.commentId,
+          publication.findingId,
+          body.headSha,
+          publication.path,
+          publication.line,
+          completedAt,
+          completedAt,
+        );
       }
       return "completed";
     });
@@ -904,6 +1188,7 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           prepared!,
           scouts!,
           merged!,
+          artifacts!,
           claim.previousState,
         ),
       );
@@ -1014,14 +1299,30 @@ export default {
       return json({ error: "Malformed JSON payload" }, 400);
     }
 
-    const parsed = parseReviewEvent(eventName, deliveryId, payload);
-    if (parsed.kind === "ignored") {
-      return json({ ignored: true, reason: parsed.reason }, 202);
+    const parsedReview = parseReviewEvent(eventName, deliveryId, payload);
+    const parsedInteraction =
+      parsedReview.kind === "ignored"
+        ? parseFindingInteraction(eventName, deliveryId, payload)
+        : undefined;
+    if (
+      parsedReview.kind === "invalid" ||
+      parsedInteraction?.kind === "invalid"
+    ) {
+      return json({ error: "Malformed webhook payload" }, 400);
     }
-    if (parsed.kind === "invalid") {
-      return json({ error: parsed.reason }, 400);
+    if (
+      parsedReview.kind === "ignored" &&
+      parsedInteraction?.kind === "ignored"
+    ) {
+      return json({ ignored: true, reason: "unsupported-event" }, 202);
     }
-    const event = parsed.event;
+    const event =
+      parsedReview.kind === "accepted"
+        ? parsedReview.event
+        : parsedInteraction?.kind === "accepted"
+          ? parsedInteraction.event
+          : undefined;
+    if (!event) return json({ ignored: true, reason: "unsupported-event" }, 202);
     const allowedRepository = env.AI_REVIEW_REPOSITORY?.trim().toLowerCase();
     if (
       !allowedRepository ||
@@ -1030,6 +1331,10 @@ export default {
       return json({ error: "Repository is not allowed" }, 403);
     }
 
-    return forwardToCoordinator(event, env);
+    return forwardToCoordinator(
+      event,
+      env,
+      "interactionType" in event ? "/interactions" : "/events",
+    );
   },
 } satisfies ExportedHandler<Env>;

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -265,13 +265,13 @@ function isFindingPublication(value: unknown): value is FindingPublication {
     typeof publication.commentId === "number" &&
     Number.isSafeInteger(publication.commentId) &&
     publication.commentId > 0;
-  const lineIsValid =
+  const lineIsPositive =
     typeof publication.line === "number" &&
     Number.isSafeInteger(publication.line) &&
     publication.line > 0;
   const deliveryIsConsistent =
     publication.delivery === "line"
-      ? commentIdIsValid && lineIsValid
+      ? commentIdIsValid
       : publication.delivery === "fallback" && publication.commentId === undefined;
   return (
     typeof publication.findingId === "string" &&
@@ -280,7 +280,7 @@ function isFindingPublication(value: unknown): value is FindingPublication {
     typeof publication.reconciled === "boolean" &&
     typeof publication.path === "string" &&
     publication.path.length > 0 &&
-    (publication.line === null || lineIsValid)
+    (publication.line === null || lineIsPositive)
   );
 }
 

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -232,7 +232,7 @@ function isIdentifiedFinding(value: unknown): value is IdentifiedMergedFinding {
     (finding.line === null ||
       (typeof finding.line === "number" &&
         Number.isSafeInteger(finding.line) &&
-        finding.line >= 0)) &&
+        finding.line > 0)) &&
     typeof finding.title === "string" &&
     finding.title.length > 0 &&
     typeof finding.evidence === "string" &&

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -1262,79 +1262,66 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
   }
 }
 
+function acceptedWebhookEvent(
+  review: ReturnType<typeof parseReviewEvent>,
+  interaction: ReturnType<typeof parseFindingInteraction> | undefined,
+): ReviewWorkflowParams | FindingInteractionEvent | undefined {
+  if (review.kind === "accepted") return review.event;
+  if (interaction?.kind === "accepted") return interaction.event;
+  return undefined;
+}
+
+async function handleGitHubWebhook(request: Request, env: Env): Promise<Response> {
+  const bodyResult = await readWebhookBody(request);
+  if ("response" in bodyResult) return bodyResult.response;
+  const { body } = bodyResult;
+  const eventName = request.headers.get("x-github-event");
+  const deliveryId = request.headers.get("x-github-delivery");
+  const verified = await verifyGitHubSignature(
+    body,
+    request.headers.get("x-hub-signature-256"),
+    env.AI_REVIEW_WEBHOOK_SECRET,
+  );
+  if (!verified) return json({ error: "Invalid webhook signature" }, 401);
+  if (!eventName || !deliveryId) {
+    return json({ error: "Missing GitHub webhook headers" }, 400);
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body) as unknown;
+  } catch {
+    return json({ error: "Malformed JSON payload" }, 400);
+  }
+
+  const parsedReview = parseReviewEvent(eventName, deliveryId, payload);
+  const parsedInteraction =
+    parsedReview.kind === "ignored"
+      ? parseFindingInteraction(eventName, deliveryId, payload)
+      : undefined;
+  if (parsedReview.kind === "invalid" || parsedInteraction?.kind === "invalid") {
+    return json({ error: "Malformed webhook payload" }, 400);
+  }
+  const event = acceptedWebhookEvent(parsedReview, parsedInteraction);
+  if (!event) return json({ ignored: true, reason: "unsupported-event" }, 202);
+
+  const allowedRepository = env.AI_REVIEW_REPOSITORY?.trim().toLowerCase();
+  if (!allowedRepository || event.repository.trim().toLowerCase() !== allowedRepository) {
+    return json({ error: "Repository is not allowed" }, 403);
+  }
+  const coordinatorPath = "interactionType" in event ? "/interactions" : "/events";
+  return forwardToCoordinator(event, env, coordinatorPath);
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     if (request.method === "GET" && url.pathname === "/health") {
       return healthResponse(env);
     }
-
     if (request.method !== "POST" || url.pathname !== "/webhooks/github") {
       return new Response("Not found", { status: 404 });
     }
-
-    const bodyResult = await readWebhookBody(request);
-    if ("response" in bodyResult) {
-      return bodyResult.response;
-    }
-    const { body } = bodyResult;
-    const eventName = request.headers.get("x-github-event");
-    const deliveryId = request.headers.get("x-github-delivery");
-    const verified = await verifyGitHubSignature(
-      body,
-      request.headers.get("x-hub-signature-256"),
-      env.AI_REVIEW_WEBHOOK_SECRET,
-    );
-    if (!verified) {
-      return json({ error: "Invalid webhook signature" }, 401);
-    }
-    if (!eventName || !deliveryId) {
-      return json({ error: "Missing GitHub webhook headers" }, 400);
-    }
-
-    let payload: unknown;
-    try {
-      payload = JSON.parse(body) as unknown;
-    } catch {
-      return json({ error: "Malformed JSON payload" }, 400);
-    }
-
-    const parsedReview = parseReviewEvent(eventName, deliveryId, payload);
-    const parsedInteraction =
-      parsedReview.kind === "ignored"
-        ? parseFindingInteraction(eventName, deliveryId, payload)
-        : undefined;
-    if (
-      parsedReview.kind === "invalid" ||
-      parsedInteraction?.kind === "invalid"
-    ) {
-      return json({ error: "Malformed webhook payload" }, 400);
-    }
-    if (
-      parsedReview.kind === "ignored" &&
-      parsedInteraction?.kind === "ignored"
-    ) {
-      return json({ ignored: true, reason: "unsupported-event" }, 202);
-    }
-    const event =
-      parsedReview.kind === "accepted"
-        ? parsedReview.event
-        : parsedInteraction?.kind === "accepted"
-          ? parsedInteraction.event
-          : undefined;
-    if (!event) return json({ ignored: true, reason: "unsupported-event" }, 202);
-    const allowedRepository = env.AI_REVIEW_REPOSITORY?.trim().toLowerCase();
-    if (
-      !allowedRepository ||
-      event.repository.trim().toLowerCase() !== allowedRepository
-    ) {
-      return json({ error: "Repository is not allowed" }, 403);
-    }
-
-    return forwardToCoordinator(
-      event,
-      env,
-      "interactionType" in event ? "/interactions" : "/events",
-    );
+    return handleGitHubWebhook(request, env);
   },
 } satisfies ExportedHandler<Env>;

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -32,6 +32,11 @@ import {
   type ReviewWorkflowParams,
 } from "./env";
 import { createInstallationToken } from "./github-app";
+import {
+  publishFindingComments,
+  renderFallbackFindings,
+  type FindingPublication,
+} from "./finding-lifecycle";
 
 type JsonObject = Record<string, unknown>;
 
@@ -132,6 +137,12 @@ export interface IdentifiedReviewArtifacts {
   hunks: ReviewHunk[];
   candidates: Record<string, IdentifiedFinding[]>;
   publishedFindings: IdentifiedMergedFinding[];
+}
+
+export interface ReviewPublication {
+  commentId?: number;
+  runCostUsd: number;
+  findings: FindingPublication[];
 }
 
 export type ReviewRecordStatus = "denied" | "failed" | "published" | "skipped";
@@ -864,10 +875,12 @@ export async function publishReview(
   prepared: PreparedReview,
   scouts: ScoutRun,
   merged: MergedRun,
+  artifacts: IdentifiedReviewArtifacts,
   previousState: ReviewState,
-): Promise<{ commentId?: number; runCostUsd: number }> {
+): Promise<ReviewPublication> {
   if (!prepared.headSha) throw new Error("Cannot publish an unprepared review");
-  const settings = modelSettings(env, params, await installationToken(env));
+  const token = await installationToken(env);
+  const settings = modelSettings(env, params, token);
   const reviewer = new Reviewer(settings);
   const currentHead = (await reviewer.getPr()).head.sha;
   if (currentHead !== prepared.headSha) {
@@ -882,6 +895,24 @@ export async function publishReview(
   const runCostUsd =
     Object.values(scouts.costs).reduce((total, cost) => total + cost, 0) +
     merged.cost;
+  const findingPublications = await publishFindingComments({
+    token,
+    repository: params.repository,
+    pullRequestNumber: params.pullRequestNumber,
+    botLogin: env.AI_REVIEW_APP_BOT_LOGIN,
+    headSha: prepared.headSha,
+    findings: artifacts.publishedFindings,
+    hunks: artifacts.hunks,
+  });
+  const fallback = renderFallbackFindings(
+    artifacts.publishedFindings,
+    findingPublications,
+  );
+  const openFindingIds = new Set(
+    artifacts.publishedFindings
+      .filter(({ status }) => status === "open")
+      .map(({ findingId }) => findingId),
+  );
   const body = renderComment({
     result: merged.result,
     headSha: prepared.headSha,
@@ -899,10 +930,23 @@ export async function publishReview(
       existing.id !== undefined ? existing.state : previousState,
     marker: STATEFUL_REVIEW_MARKER,
     heading: "## Stateful AI code review",
+    summaryOnly: true,
+    findingDelivery: {
+      line: findingPublications.filter(({ delivery }) => delivery === "line")
+        .filter(({ findingId }) => openFindingIds.has(findingId)).length,
+      fallback: findingPublications.filter(
+        ({ delivery, findingId }) =>
+          delivery === "fallback" && openFindingIds.has(findingId),
+      ).length,
+    },
   });
   return {
-    commentId: await reviewer.writeComment(existing.id, body),
+    commentId: await reviewer.writeComment(
+      existing.id,
+      fallback ? `${body}\n\n${fallback}` : body,
+    ),
     runCostUsd,
+    findings: findingPublications,
   };
 }
 
@@ -914,7 +958,7 @@ export async function recordReview(options: {
   scouts: ScoutRun;
   merged: MergedRun;
   artifacts: IdentifiedReviewArtifacts;
-  publication: { commentId?: number; runCostUsd: number };
+  publication: ReviewPublication;
   timestamp: Date;
 }): Promise<void> {
   if (!options.prepared.headSha) {
@@ -933,7 +977,7 @@ export async function recordReviewTerminal(options: {
   scouts?: ScoutRun;
   merged?: MergedRun;
   artifacts?: IdentifiedReviewArtifacts;
-  publication?: { commentId?: number; runCostUsd: number };
+  publication?: ReviewPublication;
   reason?: string;
   error?: string;
   failedPhase?: string;
@@ -1013,6 +1057,7 @@ export async function recordReviewTerminal(options: {
         : [],
       runCostUsd: publication?.runCostUsd ?? options.incurredCostUsd ?? 0,
       commentId: publication?.commentId,
+      findingPublications: publication?.findings ?? [],
       terminal: {
         reason: options.reason,
         error: options.error,
@@ -1034,13 +1079,14 @@ export async function completeReview(
   instanceId: string,
   prepared: PreparedReview,
   artifacts: IdentifiedReviewArtifacts,
-  publication: { commentId?: number; runCostUsd: number },
+  publication: ReviewPublication,
 ): Promise<void> {
   await coordinatorRequest(env, params, "/reviews/complete", {
     runId: instanceId,
     headSha: prepared.headSha,
     costUsd: publication.runCostUsd,
     commentId: publication.commentId,
+    findingPublications: publication.findings,
     hunks: artifacts.hunks,
     findings: artifacts.publishedFindings,
   });

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -60,6 +60,7 @@ type GitHubWebhook = {
   repository?: {
     full_name?: unknown;
   };
+  updated_at?: unknown;
   pull_request?: {
     number?: unknown;
     author_association?: unknown;
@@ -84,9 +85,7 @@ type GitHubWebhook = {
   };
   sender?: { login?: unknown };
   thread?: {
-    id?: unknown;
     node_id?: unknown;
-    updated_at?: unknown;
     comments?: unknown;
   };
 };
@@ -188,13 +187,24 @@ function reactionCounts(value: unknown): Record<string, number> | undefined {
 
 function threadRootComment(
   thread: GitHubWebhook["thread"],
-): { id: number; reactions?: Record<string, number> } | undefined {
+): { id: number; threadId: string; reactions?: Record<string, number> } | undefined {
+  const threadId = thread?.node_id;
+  if (typeof threadId !== "string" || threadId.length === 0) return undefined;
   if (!Array.isArray(thread?.comments)) return undefined;
-  const first = thread.comments[0];
-  if (!first || typeof first !== "object" || Array.isArray(first)) return undefined;
-  const comment = first as { id?: unknown; reactions?: unknown };
+  const root = thread.comments.find(
+    (candidate) =>
+      candidate !== null &&
+      typeof candidate === "object" &&
+      !Array.isArray(candidate) &&
+      ((candidate as { in_reply_to_id?: unknown }).in_reply_to_id === null ||
+        (candidate as { in_reply_to_id?: unknown }).in_reply_to_id === undefined),
+  );
+  if (!root) return undefined;
+  const comment = root as { id?: unknown; reactions?: unknown };
   const id = positiveInteger(comment.id);
-  return id ? { id, reactions: reactionCounts(comment.reactions) } : undefined;
+  return id
+    ? { id, threadId, reactions: reactionCounts(comment.reactions) }
+    : undefined;
 }
 
 function webhookActor(event: GitHubWebhook): string | undefined {
@@ -299,7 +309,6 @@ function parseThreadInteraction(
   if (!actorIsTrusted(event, identity.repository)) {
     return { kind: "ignored", reason: "unsupported-event" };
   }
-  const threadId = event.thread?.node_id ?? event.thread?.id;
   return {
     kind: "accepted",
     event: {
@@ -309,14 +318,9 @@ function parseThreadInteraction(
       actor,
       rootCommentId: rootComment.id,
       reactions: rootComment.reactions,
-      threadId:
-        typeof threadId === "string" || typeof threadId === "number"
-          ? String(threadId)
-          : undefined,
+      threadId: rootComment.threadId,
       occurredAt:
-        typeof event.thread?.updated_at === "string"
-          ? event.thread.updated_at
-          : undefined,
+        typeof event.updated_at === "string" ? event.updated_at : undefined,
     },
   };
 }

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -1,5 +1,6 @@
 import {
   TRUSTED_AUTHOR_ASSOCIATIONS,
+  type FindingInteractionEvent,
   type ReviewWorkflowParams,
 } from "./env";
 
@@ -57,6 +58,8 @@ type GitHubWebhook = {
   };
   pull_request?: {
     number?: unknown;
+    author_association?: unknown;
+    user?: { login?: unknown };
     head?: {
       sha?: unknown;
     };
@@ -66,8 +69,21 @@ type GitHubWebhook = {
     pull_request?: unknown;
   };
   comment?: {
+    id?: unknown;
+    in_reply_to_id?: unknown;
     body?: unknown;
     author_association?: unknown;
+    created_at?: unknown;
+    updated_at?: unknown;
+    reactions?: unknown;
+    user?: { login?: unknown };
+  };
+  sender?: { login?: unknown };
+  thread?: {
+    id?: unknown;
+    node_id?: unknown;
+    updated_at?: unknown;
+    comments?: unknown;
   };
 };
 
@@ -80,6 +96,226 @@ export type ReviewEventParseResult =
   | { kind: "accepted"; event: ReviewWorkflowParams }
   | { kind: "ignored"; reason: "unsupported-event" }
   | { kind: "invalid"; reason: "Malformed webhook payload" };
+
+export type FindingInteractionParseResult =
+  | { kind: "accepted"; event: FindingInteractionEvent }
+  | { kind: "ignored"; reason: "unsupported-event" }
+  | { kind: "invalid"; reason: "Malformed webhook payload" };
+
+const FINDING_DISPOSITION_COMMAND =
+  /^\/ai-review\s+(acknowledge|reject)\s+(f_[a-f0-9]{24})(?:\s+([\s\S]*\S))?$/i;
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0
+    ? value
+    : undefined;
+}
+
+function actorIsTrusted(event: GitHubWebhook, repository: string): boolean {
+  const actor = event.sender?.login;
+  if (typeof actor !== "string" || actor.length === 0) return false;
+  const association = event.comment?.author_association;
+  if (
+    typeof association === "string" &&
+    TRUSTED_AUTHOR_ASSOCIATIONS.has(association) &&
+    typeof event.comment?.user?.login === "string" &&
+    event.comment.user.login.toLowerCase() === actor.toLowerCase()
+  ) {
+    return true;
+  }
+  const [owner] = repository.split("/", 1);
+  if (actor.toLowerCase() === owner?.toLowerCase()) return true;
+  return (
+    actor.toLowerCase() ===
+      String(event.pull_request?.user?.login ?? "").toLowerCase() &&
+    typeof event.pull_request?.author_association === "string" &&
+    TRUSTED_AUTHOR_ASSOCIATIONS.has(event.pull_request.author_association)
+  );
+}
+
+function reactionCounts(value: unknown): Record<string, number> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const counts = Object.fromEntries(
+    Object.entries(value)
+      .filter(
+        ([key, count]) =>
+          key !== "url" &&
+          typeof count === "number" &&
+          Number.isSafeInteger(count) &&
+          count >= 0,
+      )
+      .map(([key, count]) => [key, count as number]),
+  );
+  return Object.keys(counts).length > 0 ? counts : undefined;
+}
+
+function threadRootComment(
+  thread: GitHubWebhook["thread"],
+): { id: number; reactions?: Record<string, number> } | undefined {
+  if (!Array.isArray(thread?.comments)) return undefined;
+  const first = thread.comments[0];
+  if (!first || typeof first !== "object" || Array.isArray(first)) return undefined;
+  const comment = first as { id?: unknown; reactions?: unknown };
+  const id = positiveInteger(comment.id);
+  return id ? { id, reactions: reactionCounts(comment.reactions) } : undefined;
+}
+
+export function parseFindingInteraction(
+  eventName: string,
+  deliveryId: string,
+  body: unknown,
+): FindingInteractionParseResult {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { kind: "invalid", reason: "Malformed webhook payload" };
+  }
+  const event = body as GitHubWebhook;
+  const repository = event.repository?.full_name;
+  const action = event.action;
+  if (
+    typeof repository !== "string" ||
+    repository.length === 0 ||
+    typeof action !== "string" ||
+    action.length === 0 ||
+    deliveryId.length === 0
+  ) {
+    return { kind: "invalid", reason: "Malformed webhook payload" };
+  }
+  const actor = event.sender?.login;
+
+  if (eventName === "issue_comment" && action === "created") {
+    if (typeof event.comment?.body !== "string") {
+      return { kind: "ignored", reason: "unsupported-event" };
+    }
+    const command = FINDING_DISPOSITION_COMMAND.exec(event.comment.body);
+    if (!command) return { kind: "ignored", reason: "unsupported-event" };
+    const pullRequestNumber = positiveInteger(event.issue?.number);
+    if (!pullRequestNumber || event.issue?.pull_request === undefined) {
+      return { kind: "invalid", reason: "Malformed webhook payload" };
+    }
+    if (typeof actor !== "string" || actor.length === 0) {
+      return { kind: "invalid", reason: "Malformed webhook payload" };
+    }
+    if (!actorIsTrusted(event, repository)) {
+      return { kind: "ignored", reason: "unsupported-event" };
+    }
+    return {
+      kind: "accepted",
+      event: {
+        deliveryId,
+        eventName,
+        action,
+        repository,
+        pullRequestNumber,
+        interactionType: "disposition",
+        actor,
+        actorAssociation: String(event.comment.author_association ?? ""),
+        findingId: command[2]?.toLowerCase(),
+        disposition:
+          command[1]?.toLowerCase() === "acknowledge"
+            ? "acknowledged"
+            : "rejected",
+        reason: command[3]?.trim(),
+        commentId: positiveInteger(event.comment.id),
+        body: event.comment.body.slice(0, 4_000),
+        occurredAt:
+          typeof event.comment.created_at === "string"
+            ? event.comment.created_at
+            : undefined,
+      },
+    };
+  }
+
+  if (
+    eventName === "pull_request_review_comment" &&
+    new Set(["created", "edited", "deleted"]).has(action)
+  ) {
+    const pullRequestNumber = positiveInteger(event.pull_request?.number);
+    const rootCommentId = positiveInteger(event.comment?.in_reply_to_id);
+    const commentId = positiveInteger(event.comment?.id);
+    if (!pullRequestNumber || !rootCommentId || !commentId) {
+      return { kind: "ignored", reason: "unsupported-event" };
+    }
+    if (typeof actor !== "string" || actor.length === 0) {
+      return { kind: "invalid", reason: "Malformed webhook payload" };
+    }
+    if (!actorIsTrusted(event, repository)) {
+      return { kind: "ignored", reason: "unsupported-event" };
+    }
+    return {
+      kind: "accepted",
+      event: {
+        deliveryId,
+        eventName,
+        action,
+        repository,
+        pullRequestNumber,
+        interactionType: "reply",
+        actor,
+        actorAssociation:
+          typeof event.comment?.author_association === "string"
+            ? event.comment.author_association
+            : undefined,
+        rootCommentId,
+        commentId,
+        body:
+          typeof event.comment?.body === "string"
+            ? event.comment.body.slice(0, 4_000)
+            : undefined,
+        reactions: reactionCounts(event.comment?.reactions),
+        occurredAt:
+          typeof event.comment?.updated_at === "string"
+            ? event.comment.updated_at
+            : typeof event.comment?.created_at === "string"
+              ? event.comment.created_at
+              : undefined,
+      },
+    };
+  }
+
+  if (
+    eventName === "pull_request_review_thread" &&
+    new Set(["resolved", "unresolved"]).has(action)
+  ) {
+    const pullRequestNumber = positiveInteger(event.pull_request?.number);
+    const rootComment = threadRootComment(event.thread);
+    if (!pullRequestNumber || !rootComment) {
+      return { kind: "invalid", reason: "Malformed webhook payload" };
+    }
+    if (typeof actor !== "string" || actor.length === 0) {
+      return { kind: "invalid", reason: "Malformed webhook payload" };
+    }
+    if (!actorIsTrusted(event, repository)) {
+      return { kind: "ignored", reason: "unsupported-event" };
+    }
+    const threadId = event.thread?.node_id ?? event.thread?.id;
+    return {
+      kind: "accepted",
+      event: {
+        deliveryId,
+        eventName,
+        action,
+        repository,
+        pullRequestNumber,
+        interactionType: "thread",
+        actor,
+        rootCommentId: rootComment.id,
+        reactions: rootComment.reactions,
+        threadId:
+          typeof threadId === "string" || typeof threadId === "number"
+            ? String(threadId)
+            : undefined,
+        occurredAt:
+          typeof event.thread?.updated_at === "string"
+            ? event.thread.updated_at
+            : undefined,
+      },
+    };
+  }
+
+  return { kind: "ignored", reason: "unsupported-event" };
+}
 
 function parsePullRequestEvent(
   event: GitHubWebhook,
@@ -142,7 +378,10 @@ export function parseReviewEvent(
     identity.action !== "created" ||
     event.comment?.body !== "/ai-review" ||
     typeof event.comment.author_association !== "string" ||
-    !TRUSTED_AUTHOR_ASSOCIATIONS.has(event.comment.author_association)
+    !TRUSTED_AUTHOR_ASSOCIATIONS.has(event.comment.author_association) ||
+    typeof event.sender?.login !== "string" ||
+    typeof event.comment.user?.login !== "string" ||
+    event.sender.login.toLowerCase() !== event.comment.user.login.toLowerCase()
   ) {
     return { kind: "ignored", reason: "unsupported-event" };
   }

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -11,6 +11,8 @@ const REVIEW_RELEVANT_PULL_REQUEST_ACTIONS = new Set([
   "reopened",
   "ready_for_review",
 ]);
+const REVIEW_COMMENT_ACTIONS = new Set(["created", "edited", "deleted"]);
+const REVIEW_THREAD_ACTIONS = new Set(["resolved", "unresolved"]);
 function hexBytes(value: string): Uint8Array | null {
   if (!/^[\da-f]{64}$/i.test(value)) {
     return null;
@@ -91,6 +93,10 @@ type WebhookIdentity = Pick<
   ReviewWorkflowParams,
   "deliveryId" | "eventName" | "action" | "repository"
 >;
+type FindingInteractionIdentity = Pick<
+  FindingInteractionEvent,
+  "deliveryId" | "eventName" | "action" | "repository"
+>;
 
 export type ReviewEventParseResult =
   | { kind: "accepted"; event: ReviewWorkflowParams }
@@ -153,9 +159,10 @@ function actorIsTrusted(event: GitHubWebhook, repository: string): boolean {
   }
   const [owner] = repository.split("/", 1);
   if (actor.toLowerCase() === owner?.toLowerCase()) return true;
+  const pullRequestAuthor = event.pull_request?.user?.login;
   return (
-    actor.toLowerCase() ===
-      String(event.pull_request?.user?.login ?? "").toLowerCase() &&
+    typeof pullRequestAuthor === "string" &&
+    actor.toLowerCase() === pullRequestAuthor.toLowerCase() &&
     typeof event.pull_request?.author_association === "string" &&
     TRUSTED_AUTHOR_ASSOCIATIONS.has(event.pull_request.author_association)
   );
@@ -188,6 +195,130 @@ function threadRootComment(
   return id ? { id, reactions: reactionCounts(comment.reactions) } : undefined;
 }
 
+function webhookActor(event: GitHubWebhook): string | undefined {
+  const actor = event.sender?.login;
+  return typeof actor === "string" && actor.length > 0 ? actor : undefined;
+}
+
+function commentTimestamp(comment: GitHubWebhook["comment"]): string | undefined {
+  if (typeof comment?.updated_at === "string") return comment.updated_at;
+  return typeof comment?.created_at === "string" ? comment.created_at : undefined;
+}
+
+function parseDispositionInteraction(
+  event: GitHubWebhook,
+  identity: FindingInteractionIdentity,
+): FindingInteractionParseResult {
+  const comment = event.comment;
+  if (typeof comment?.body !== "string") {
+    return { kind: "ignored", reason: "unsupported-event" };
+  }
+  const command = findingDispositionCommand(comment.body);
+  if (!command) return { kind: "ignored", reason: "unsupported-event" };
+  const pullRequestNumber = positiveInteger(event.issue?.number);
+  if (!pullRequestNumber || event.issue?.pull_request === undefined) {
+    return { kind: "invalid", reason: "Malformed webhook payload" };
+  }
+  const actor = webhookActor(event);
+  if (!actor) return { kind: "invalid", reason: "Malformed webhook payload" };
+  if (!actorIsTrusted(event, identity.repository)) {
+    return { kind: "ignored", reason: "unsupported-event" };
+  }
+  const actorAssociation =
+    typeof comment.author_association === "string"
+      ? comment.author_association
+      : undefined;
+  return {
+    kind: "accepted",
+    event: {
+      ...identity,
+      pullRequestNumber,
+      interactionType: "disposition",
+      actor,
+      actorAssociation,
+      findingId: command.findingId,
+      disposition: command.disposition,
+      reason: command.reason,
+      commentId: positiveInteger(comment.id),
+      body: comment.body.slice(0, 4_000),
+      occurredAt: commentTimestamp(comment),
+    },
+  };
+}
+
+function parseReplyInteraction(
+  event: GitHubWebhook,
+  identity: FindingInteractionIdentity,
+): FindingInteractionParseResult {
+  const comment = event.comment;
+  const pullRequestNumber = positiveInteger(event.pull_request?.number);
+  const rootCommentId = positiveInteger(comment?.in_reply_to_id);
+  const commentId = positiveInteger(comment?.id);
+  if (!pullRequestNumber || !rootCommentId || !commentId) {
+    return { kind: "ignored", reason: "unsupported-event" };
+  }
+  const actor = webhookActor(event);
+  if (!actor) return { kind: "invalid", reason: "Malformed webhook payload" };
+  if (!actorIsTrusted(event, identity.repository)) {
+    return { kind: "ignored", reason: "unsupported-event" };
+  }
+  return {
+    kind: "accepted",
+    event: {
+      ...identity,
+      pullRequestNumber,
+      interactionType: "reply",
+      actor,
+      actorAssociation:
+        typeof comment?.author_association === "string"
+          ? comment.author_association
+          : undefined,
+      rootCommentId,
+      commentId,
+      body:
+        typeof comment?.body === "string" ? comment.body.slice(0, 4_000) : undefined,
+      reactions: reactionCounts(comment?.reactions),
+      occurredAt: commentTimestamp(comment),
+    },
+  };
+}
+
+function parseThreadInteraction(
+  event: GitHubWebhook,
+  identity: FindingInteractionIdentity,
+): FindingInteractionParseResult {
+  const pullRequestNumber = positiveInteger(event.pull_request?.number);
+  const rootComment = threadRootComment(event.thread);
+  if (!pullRequestNumber || !rootComment) {
+    return { kind: "invalid", reason: "Malformed webhook payload" };
+  }
+  const actor = webhookActor(event);
+  if (!actor) return { kind: "invalid", reason: "Malformed webhook payload" };
+  if (!actorIsTrusted(event, identity.repository)) {
+    return { kind: "ignored", reason: "unsupported-event" };
+  }
+  const threadId = event.thread?.node_id ?? event.thread?.id;
+  return {
+    kind: "accepted",
+    event: {
+      ...identity,
+      pullRequestNumber,
+      interactionType: "thread",
+      actor,
+      rootCommentId: rootComment.id,
+      reactions: rootComment.reactions,
+      threadId:
+        typeof threadId === "string" || typeof threadId === "number"
+          ? String(threadId)
+          : undefined,
+      occurredAt:
+        typeof event.thread?.updated_at === "string"
+          ? event.thread.updated_at
+          : undefined,
+    },
+  };
+}
+
 export function parseFindingInteraction(
   eventName: string,
   deliveryId: string,
@@ -208,133 +339,23 @@ export function parseFindingInteraction(
   ) {
     return { kind: "invalid", reason: "Malformed webhook payload" };
   }
-  const actor = event.sender?.login;
-
+  const identity = { deliveryId, eventName, action, repository };
   if (eventName === "issue_comment" && action === "created") {
-    if (typeof event.comment?.body !== "string") {
-      return { kind: "ignored", reason: "unsupported-event" };
-    }
-    const command = findingDispositionCommand(event.comment.body);
-    if (!command) return { kind: "ignored", reason: "unsupported-event" };
-    const pullRequestNumber = positiveInteger(event.issue?.number);
-    if (!pullRequestNumber || event.issue?.pull_request === undefined) {
-      return { kind: "invalid", reason: "Malformed webhook payload" };
-    }
-    if (typeof actor !== "string" || actor.length === 0) {
-      return { kind: "invalid", reason: "Malformed webhook payload" };
-    }
-    if (!actorIsTrusted(event, repository)) {
-      return { kind: "ignored", reason: "unsupported-event" };
-    }
-    return {
-      kind: "accepted",
-      event: {
-        deliveryId,
-        eventName,
-        action,
-        repository,
-        pullRequestNumber,
-        interactionType: "disposition",
-        actor,
-        actorAssociation: String(event.comment.author_association ?? ""),
-        findingId: command.findingId,
-        disposition: command.disposition,
-        reason: command.reason,
-        commentId: positiveInteger(event.comment.id),
-        body: event.comment.body.slice(0, 4_000),
-        occurredAt:
-          typeof event.comment.created_at === "string"
-            ? event.comment.created_at
-            : undefined,
-      },
-    };
+    return parseDispositionInteraction(event, identity);
   }
 
   if (
     eventName === "pull_request_review_comment" &&
-    new Set(["created", "edited", "deleted"]).has(action)
+    REVIEW_COMMENT_ACTIONS.has(action)
   ) {
-    const pullRequestNumber = positiveInteger(event.pull_request?.number);
-    const rootCommentId = positiveInteger(event.comment?.in_reply_to_id);
-    const commentId = positiveInteger(event.comment?.id);
-    if (!pullRequestNumber || !rootCommentId || !commentId) {
-      return { kind: "ignored", reason: "unsupported-event" };
-    }
-    if (typeof actor !== "string" || actor.length === 0) {
-      return { kind: "invalid", reason: "Malformed webhook payload" };
-    }
-    if (!actorIsTrusted(event, repository)) {
-      return { kind: "ignored", reason: "unsupported-event" };
-    }
-    return {
-      kind: "accepted",
-      event: {
-        deliveryId,
-        eventName,
-        action,
-        repository,
-        pullRequestNumber,
-        interactionType: "reply",
-        actor,
-        actorAssociation:
-          typeof event.comment?.author_association === "string"
-            ? event.comment.author_association
-            : undefined,
-        rootCommentId,
-        commentId,
-        body:
-          typeof event.comment?.body === "string"
-            ? event.comment.body.slice(0, 4_000)
-            : undefined,
-        reactions: reactionCounts(event.comment?.reactions),
-        occurredAt:
-          typeof event.comment?.updated_at === "string"
-            ? event.comment.updated_at
-            : typeof event.comment?.created_at === "string"
-              ? event.comment.created_at
-              : undefined,
-      },
-    };
+    return parseReplyInteraction(event, identity);
   }
 
   if (
     eventName === "pull_request_review_thread" &&
-    new Set(["resolved", "unresolved"]).has(action)
+    REVIEW_THREAD_ACTIONS.has(action)
   ) {
-    const pullRequestNumber = positiveInteger(event.pull_request?.number);
-    const rootComment = threadRootComment(event.thread);
-    if (!pullRequestNumber || !rootComment) {
-      return { kind: "invalid", reason: "Malformed webhook payload" };
-    }
-    if (typeof actor !== "string" || actor.length === 0) {
-      return { kind: "invalid", reason: "Malformed webhook payload" };
-    }
-    if (!actorIsTrusted(event, repository)) {
-      return { kind: "ignored", reason: "unsupported-event" };
-    }
-    const threadId = event.thread?.node_id ?? event.thread?.id;
-    return {
-      kind: "accepted",
-      event: {
-        deliveryId,
-        eventName,
-        action,
-        repository,
-        pullRequestNumber,
-        interactionType: "thread",
-        actor,
-        rootCommentId: rootComment.id,
-        reactions: rootComment.reactions,
-        threadId:
-          typeof threadId === "string" || typeof threadId === "number"
-            ? String(threadId)
-            : undefined,
-        occurredAt:
-          typeof event.thread?.updated_at === "string"
-            ? event.thread.updated_at
-            : undefined,
-      },
-    };
+    return parseThreadInteraction(event, identity);
   }
 
   return { kind: "ignored", reason: "unsupported-event" };

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -13,6 +13,8 @@ const REVIEW_RELEVANT_PULL_REQUEST_ACTIONS = new Set([
 ]);
 const REVIEW_COMMENT_ACTIONS = new Set(["created", "edited", "deleted"]);
 const REVIEW_THREAD_ACTIONS = new Set(["resolved", "unresolved"]);
+const MAX_DELIVERY_ID_LENGTH = 255;
+const MAX_DISPOSITION_REASON_LENGTH = 1_000;
 function hexBytes(value: string): Uint8Array | null {
   if (!/^[\da-f]{64}$/i.test(value)) {
     return null;
@@ -129,7 +131,7 @@ function findingDispositionCommand(body: string):
   const findingId = body.slice(findingStart, findingEnd).toLowerCase();
   if (!/^f_[a-f0-9]{24}$/.test(findingId)) return undefined;
   const reason = body.slice(findingEnd + 1).trim();
-  if (!reason) return undefined;
+  if (!reason || reason.length > MAX_DISPOSITION_REASON_LENGTH) return undefined;
   return {
     disposition: action === "acknowledge" ? "acknowledged" : "rejected",
     findingId,
@@ -335,7 +337,8 @@ export function parseFindingInteraction(
     repository.length === 0 ||
     typeof action !== "string" ||
     action.length === 0 ||
-    deliveryId.length === 0
+    deliveryId.length === 0 ||
+    deliveryId.length > MAX_DELIVERY_ID_LENGTH
   ) {
     return { kind: "invalid", reason: "Malformed webhook payload" };
   }
@@ -407,7 +410,8 @@ export function parseReviewEvent(
     repository.length === 0 ||
     typeof action !== "string" ||
     action.length === 0 ||
-    deliveryId.length === 0
+    deliveryId.length === 0 ||
+    deliveryId.length > MAX_DELIVERY_ID_LENGTH
   ) {
     return { kind: "invalid", reason: "Malformed webhook payload" };
   }

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -102,8 +102,34 @@ export type FindingInteractionParseResult =
   | { kind: "ignored"; reason: "unsupported-event" }
   | { kind: "invalid"; reason: "Malformed webhook payload" };
 
-const FINDING_DISPOSITION_COMMAND =
-  /^\/ai-review\s+(acknowledge|reject)\s+(f_[a-f0-9]{24})(?:\s+([\s\S]*\S))?$/i;
+function findingDispositionCommand(body: string):
+  | {
+      disposition: "acknowledged" | "rejected";
+      findingId: string;
+      reason: string;
+    }
+  | undefined {
+  if (body !== body.trim() || !body.startsWith("/ai-review ")) {
+    return undefined;
+  }
+  const actionStart = "/ai-review ".length;
+  const actionEnd = body.indexOf(" ", actionStart);
+  if (actionEnd < 0) return undefined;
+  const action = body.slice(actionStart, actionEnd).toLowerCase();
+  if (action !== "acknowledge" && action !== "reject") return undefined;
+  const findingStart = actionEnd + 1;
+  const findingEnd = body.indexOf(" ", findingStart);
+  if (findingEnd < 0) return undefined;
+  const findingId = body.slice(findingStart, findingEnd).toLowerCase();
+  if (!/^f_[a-f0-9]{24}$/.test(findingId)) return undefined;
+  const reason = body.slice(findingEnd + 1).trim();
+  if (!reason) return undefined;
+  return {
+    disposition: action === "acknowledge" ? "acknowledged" : "rejected",
+    findingId,
+    reason,
+  };
+}
 
 function positiveInteger(value: unknown): number | undefined {
   return typeof value === "number" &&
@@ -188,7 +214,7 @@ export function parseFindingInteraction(
     if (typeof event.comment?.body !== "string") {
       return { kind: "ignored", reason: "unsupported-event" };
     }
-    const command = FINDING_DISPOSITION_COMMAND.exec(event.comment.body);
+    const command = findingDispositionCommand(event.comment.body);
     if (!command) return { kind: "ignored", reason: "unsupported-event" };
     const pullRequestNumber = positiveInteger(event.issue?.number);
     if (!pullRequestNumber || event.issue?.pull_request === undefined) {
@@ -211,12 +237,9 @@ export function parseFindingInteraction(
         interactionType: "disposition",
         actor,
         actorAssociation: String(event.comment.author_association ?? ""),
-        findingId: command[2]?.toLowerCase(),
-        disposition:
-          command[1]?.toLowerCase() === "acknowledge"
-            ? "acknowledged"
-            : "rejected",
-        reason: command[3]?.trim(),
+        findingId: command.findingId,
+        disposition: command.disposition,
+        reason: command.reason,
         commentId: positiveInteger(event.comment.id),
         body: event.comment.body.slice(0, 4_000),
         occurredAt:

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -112,10 +112,68 @@ describe("PullRequestCoordinator in workerd", () => {
               resolution_note: "",
             },
           ],
+          findingPublications: [
+            {
+              findingId: `f_${"b".repeat(24)}`,
+              delivery: "line",
+              commentId: 321,
+              reconciled: false,
+              path: "app.ts",
+              line: 1,
+            },
+          ],
         }),
       },
     );
     await expect(completion.json()).resolves.toEqual({ completed: true });
+
+    const interaction = {
+      deliveryId: "workerd-feedback-1",
+      eventName: "pull_request_review_thread",
+      action: "resolved",
+      repository: event.repository,
+      pullRequestNumber: event.pullRequestNumber,
+      interactionType: "thread",
+      actor: "Robbie-Palmer",
+      rootCommentId: 321,
+      threadId: "PRRT_thread",
+      occurredAt: "2026-08-09T12:00:00Z",
+    };
+    const interactionResponse = await stub.fetch(
+      "https://coordinator.test/interactions",
+      { method: "POST", body: JSON.stringify(interaction) },
+    );
+    await expect(interactionResponse.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: false,
+      findingId: `f_${"b".repeat(24)}`,
+    });
+    const duplicateInteraction = await stub.fetch(
+      "https://coordinator.test/interactions",
+      { method: "POST", body: JSON.stringify(interaction) },
+    );
+    await expect(duplicateInteraction.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: true,
+      findingId: `f_${"b".repeat(24)}`,
+    });
+    const evidenceKey = [
+      "v2",
+      event.repository,
+      `pr-${event.pullRequestNumber}`,
+      "findings",
+      `f_${"b".repeat(24)}`,
+      "evidence",
+      `${interaction.deliveryId}.json`,
+    ].join("/");
+    const evidence = await (env as unknown as Env).REVIEW_DATA.get(evidenceKey);
+    expect(await evidence?.json()).toMatchObject({
+      schemaVersion: 2,
+      evidenceVersion: 1,
+      recordType: "finding-interaction-evidence",
+      action: "resolved",
+      findingId: `f_${"b".repeat(24)}`,
+    });
 
     const duplicateClaim = await stub.fetch(
       "https://coordinator.test/reviews/claim",
@@ -175,6 +233,16 @@ describe("PullRequestCoordinator in workerd", () => {
           resolution_note: "Fixed in the later head",
         },
       ],
+      findingPublications: [
+        {
+          findingId: `f_${"b".repeat(24)}`,
+          delivery: "line",
+          commentId: 321,
+          reconciled: true,
+          path: "app.ts",
+          line: 60,
+        },
+      ],
     });
     const laterCompletion = await stub.fetch(
       "https://coordinator.test/reviews/complete",
@@ -226,6 +294,13 @@ describe("PullRequestCoordinator in workerd", () => {
           last_seen_run_id: laterRunId,
         },
       ]);
+      expect(
+        state.storage.sql
+          .exec<{ action: string; r2_recorded: number }>(
+            "SELECT action, r2_recorded FROM review_finding_events",
+          )
+          .toArray(),
+      ).toEqual([{ action: "resolved", r2_recorded: 1 }]);
     });
   });
 });

--- a/ai-review/tests/finding-lifecycle.test.ts
+++ b/ai-review/tests/finding-lifecycle.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  findingIdFromComment,
+  publishFindingComments,
+  renderFallbackFindings,
+  type PublishableFinding,
+} from "../src/finding-lifecycle";
+
+const finding: PublishableFinding = {
+  findingId: `f_${"a".repeat(24)}`,
+  hunkIds: [`h_${"b".repeat(24)}`],
+  severity: "high",
+  file: "app.ts",
+  line: 12,
+  title: "Unsafe fallback",
+  evidence: "The fallback bypasses validation.",
+  recommendation: "Validate before returning.",
+  confidence: 0.9,
+  source_models: ["model/scout"],
+  status: "open",
+  resolution_note: "",
+};
+
+const options = {
+  token: "installation-token",
+  repository: "owner/repository",
+  pullRequestNumber: 42,
+  botLogin: "reviewer[bot]",
+  headSha: "c".repeat(40),
+  findings: [finding],
+  hunks: [
+    {
+      hunkId: finding.hunkIds[0]!,
+      file: finding.file,
+      newStart: 10,
+      newLines: 5,
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("finding lifecycle publication", () => {
+  it("extracts stable hidden finding IDs", () => {
+    expect(
+      findingIdFromComment(`body\n<!-- ai-review-finding:${finding.findingId} -->`),
+    ).toBe(finding.findingId);
+    expect(findingIdFromComment("ordinary comment")).toBeUndefined();
+  });
+
+  it("reconciles an existing bot comment instead of republishing it", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json([
+          {
+            id: 321,
+            body: `old\n<!-- ai-review-finding:${finding.findingId} -->`,
+            user: { login: "reviewer[bot]" },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(publishFindingComments(options)).resolves.toEqual([
+      expect.objectContaining({
+        findingId: finding.findingId,
+        commentId: 321,
+        delivery: "line",
+        reconciled: true,
+      }),
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ method: "PATCH" });
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("/pulls/comments/321");
+  });
+
+  it("publishes an addressable finding as a native review comment", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json([]))
+      .mockResolvedValueOnce(Response.json({ id: 654 }, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const publications = await publishFindingComments(options);
+
+    expect(publications).toEqual([
+      expect.objectContaining({
+        commentId: 654,
+        delivery: "line",
+        reconciled: false,
+      }),
+    ]);
+    const request = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
+    expect(request).toMatchObject({
+      commit_id: options.headSha,
+      path: "app.ts",
+      line: 12,
+      side: "RIGHT",
+    });
+    expect(request.body).toContain(`ai-review-finding:${finding.findingId}`);
+  });
+
+  it("falls back to explicit commands for non-line and rejected locations", async () => {
+    const nonLine = { ...finding, line: null };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(Response.json([])));
+    const nonLinePublications = await publishFindingComments({
+      ...options,
+      findings: [nonLine],
+    });
+    expect(nonLinePublications).toEqual([
+      expect.objectContaining({ delivery: "fallback" }),
+    ]);
+    expect(nonLinePublications[0]).not.toHaveProperty("commentId");
+    expect(renderFallbackFindings([nonLine], nonLinePublications)).toContain(
+      `/ai-review reject ${finding.findingId} <reason>`,
+    );
+
+    const rejectedFetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json([]))
+      .mockResolvedValueOnce(
+        new Response('{"message":"line is not part of the diff"}', {
+          status: 422,
+        }),
+      );
+    vi.stubGlobal("fetch", rejectedFetch);
+    await expect(publishFindingComments(options)).resolves.toEqual([
+      expect.objectContaining({ delivery: "fallback" }),
+    ]);
+  });
+});

--- a/ai-review/tests/finding-lifecycle.test.ts
+++ b/ai-review/tests/finding-lifecycle.test.ts
@@ -95,6 +95,36 @@ describe("finding lifecycle publication", () => {
     );
   });
 
+  it("preserves native delivery when a reconciled comment no longer has a line", async () => {
+    const movedFinding = { ...finding, line: null };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          Response.json([
+            {
+              id: 321,
+              body: `old\n<!-- ai-review-finding:${finding.findingId} -->`,
+              user: { login: "reviewer[bot]" },
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(new Response(null, { status: 200 })),
+    );
+
+    await expect(
+      publishFindingComments({ ...options, findings: [movedFinding] }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        delivery: "line",
+        commentId: 321,
+        reconciled: true,
+        line: null,
+      }),
+    ]);
+  });
+
   it("publishes an addressable finding as a native review comment", async () => {
     const fetchMock = vi
       .fn()

--- a/ai-review/tests/finding-lifecycle.test.ts
+++ b/ai-review/tests/finding-lifecycle.test.ts
@@ -197,4 +197,22 @@ describe("finding lifecycle publication", () => {
       "GitHub returned an invalid review comment ID",
     );
   });
+
+  it("does not hide unrelated GitHub validation failures as fallbacks", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(Response.json([]))
+        .mockResolvedValueOnce(
+          new Response('{"message":"Validation Failed: commit_id is invalid"}', {
+            status: 422,
+          }),
+        ),
+    );
+
+    await expect(publishFindingComments(options)).rejects.toThrow(
+      "commit_id is invalid",
+    );
+  });
 });

--- a/ai-review/tests/finding-lifecycle.test.ts
+++ b/ai-review/tests/finding-lifecycle.test.ts
@@ -151,6 +151,22 @@ describe("finding lifecycle publication", () => {
     expect(request.body).toContain(`ai-review-finding:${finding.findingId}`);
   });
 
+  it("fails safely instead of duplicating findings beyond the reconciliation limit", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      body: "unrelated review comment",
+      user: { login: options.botLogin },
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => Promise.resolve(Response.json(fullPage))),
+    );
+
+    await expect(publishFindingComments(options)).rejects.toThrow(
+      "1,000-comment safety limit",
+    );
+  });
+
   it("falls back to explicit commands for non-line and rejected locations", async () => {
     const nonLine = { ...finding, line: null };
     vi.stubGlobal("fetch", vi.fn().mockResolvedValueOnce(Response.json([])));

--- a/ai-review/tests/finding-lifecycle.test.ts
+++ b/ai-review/tests/finding-lifecycle.test.ts
@@ -48,13 +48,25 @@ describe("finding lifecycle publication", () => {
       findingIdFromComment(`body\n<!-- ai-review-finding:${finding.findingId} -->`),
     ).toBe(finding.findingId);
     expect(findingIdFromComment("ordinary comment")).toBeUndefined();
+    expect(findingIdFromComment({ body: finding.findingId })).toBeUndefined();
   });
 
   it("reconciles an existing bot comment instead of republishing it", async () => {
+    const resolvedFinding = {
+      ...finding,
+      status: "resolved" as const,
+      resolution_note: "Fixed by validating the fallback.",
+    };
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
         Response.json([
+          {
+            id: 320,
+            in_reply_to_id: 100,
+            body: `reply\n<!-- ai-review-finding:${finding.findingId} -->`,
+            user: { login: "reviewer[bot]" },
+          },
           {
             id: 321,
             body: `old\n<!-- ai-review-finding:${finding.findingId} -->`,
@@ -65,7 +77,9 @@ describe("finding lifecycle publication", () => {
       .mockResolvedValueOnce(new Response(null, { status: 200 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(publishFindingComments(options)).resolves.toEqual([
+    await expect(
+      publishFindingComments({ ...options, findings: [resolvedFinding] }),
+    ).resolves.toEqual([
       expect.objectContaining({
         findingId: finding.findingId,
         commentId: 321,
@@ -76,6 +90,9 @@ describe("finding lifecycle publication", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({ method: "PATCH" });
     expect(String(fetchMock.mock.calls[1]?.[0])).toContain("/pulls/comments/321");
+    expect(String(fetchMock.mock.calls[1]?.[1]?.body)).toContain(
+      "Fixed by validating the fallback.",
+    );
   });
 
   it("publishes an addressable finding as a native review comment", async () => {
@@ -128,8 +145,26 @@ describe("finding lifecycle publication", () => {
         }),
       );
     vi.stubGlobal("fetch", rejectedFetch);
-    await expect(publishFindingComments(options)).resolves.toEqual([
+    const rejectedPublications = await publishFindingComments(options);
+    expect(rejectedPublications).toEqual([
       expect.objectContaining({ delivery: "fallback" }),
     ]);
+    expect(renderFallbackFindings([finding], rejectedPublications)).toContain(
+      "app.ts:12",
+    );
+  });
+
+  it("rejects an invalid native review comment identifier", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(Response.json([]))
+        .mockResolvedValueOnce(Response.json({ id: "not-an-id" }, { status: 201 })),
+    );
+
+    await expect(publishFindingComments(options)).rejects.toThrow(
+      "GitHub returned an invalid review comment ID",
+    );
   });
 });

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -498,7 +498,23 @@ describe("PullRequestCoordinator", () => {
 
   it("rejects malformed finding interactions", async () => {
     const { coordinator } = coordinatorFixture();
-    for (const body of [null, [], { ...findingInteraction, actor: "" }]) {
+    for (const body of [
+      null,
+      [],
+      { ...findingInteraction, actor: "" },
+      { ...findingInteraction, deliveryId: "x".repeat(256) },
+      { ...findingInteraction, reason: "x".repeat(1_001) },
+      { ...findingInteraction, body: "x".repeat(4_001) },
+      {
+        ...findingInteraction,
+        interactionType: "thread",
+        disposition: undefined,
+        findingId: undefined,
+        reason: undefined,
+        rootCommentId: 654,
+        threadId: "x".repeat(256),
+      },
+    ]) {
       const response = await coordinator.fetch(
         new Request("https://coordinator.test/interactions", {
           method: "POST",
@@ -626,6 +642,38 @@ describe("PullRequestCoordinator", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Invalid review completion",
     });
+  });
+
+  it("rejects inconsistent finding publication mappings", async () => {
+    const { coordinator } = coordinatorFixture();
+    const validPublication = {
+      findingId: identifiedFinding.findingId,
+      delivery: "line",
+      commentId: 654,
+      reconciled: false,
+      path: identifiedFinding.file,
+      line: identifiedFinding.line,
+    };
+    for (const publication of [
+      { ...validPublication, path: "different.ts" },
+      { ...validPublication, line: 0 },
+      { ...validPublication, delivery: "fallback", commentId: 654 },
+    ]) {
+      const response = await coordinator.fetch(
+        new Request("https://coordinator.test/reviews/complete", {
+          method: "POST",
+          body: JSON.stringify({
+            runId: "review-delivery-123",
+            headSha: event.headSha,
+            costUsd: 0.42,
+            hunks: [identifiedHunk],
+            findings: [identifiedFinding],
+            findingPublications: [publication],
+          }),
+        }),
+      );
+      expect(response.status).toBe(400);
+    }
   });
 
   it.each([

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -921,6 +921,35 @@ describe("HTTP Worker", () => {
     );
   });
 
+  it("routes authorized finding feedback without scheduling review work", async () => {
+    const { env, fetch } = workerEnv();
+    const feedbackBody = JSON.stringify({
+      action: "created",
+      repository: { full_name: "Robbie-Palmer/personal-site" },
+      issue: { number: 821, pull_request: {} },
+      sender: { login: "Robbie-Palmer" },
+      comment: {
+        id: 900,
+        body: `/ai-review acknowledge f_${"a".repeat(24)} deferred`,
+        author_association: "OWNER",
+        user: { login: "Robbie-Palmer" },
+      },
+    });
+
+    const response = await worker.fetch(
+      signedWebhookRequest(feedbackBody, secret, {
+        "x-github-event": "issue_comment",
+      }),
+      env,
+    );
+
+    await expect(response.json()).resolves.toEqual({ accepted: true });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://coordinator.internal/interactions",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("sanitizes coordinator failures", async () => {
     const { env, fetch } = workerEnv();
     const consoleError = vi

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -623,6 +623,27 @@ describe("PullRequestCoordinator", () => {
     });
   });
 
+  it("rejects a zero-based identified finding at the completion boundary", async () => {
+    const { coordinator } = coordinatorFixture();
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/reviews/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          runId: "review-delivery-123",
+          headSha: event.headSha,
+          costUsd: 0.42,
+          hunks: [identifiedHunk],
+          findings: [{ ...identifiedFinding, line: 0 }],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid review completion",
+    });
+  });
+
   it("rejects a finding linked to a hunk absent from its completion", async () => {
     const { coordinator } = coordinatorFixture();
     const response = await coordinator.fetch(

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -39,6 +39,22 @@ const identifiedHunk = {
   newLines: 1,
 };
 
+const findingInteraction = {
+  deliveryId: "feedback-delivery-1",
+  eventName: "issue_comment",
+  action: "created",
+  repository: event.repository,
+  pullRequestNumber: event.pullRequestNumber,
+  interactionType: "disposition",
+  actor: "Robbie-Palmer",
+  actorAssociation: "OWNER",
+  findingId: identifiedFinding.findingId,
+  commentId: 900,
+  disposition: "acknowledged",
+  reason: "Accepted risk",
+  occurredAt: "2026-08-09T12:00:00Z",
+} as const;
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -75,9 +91,11 @@ function coordinatorFixture(existingDeliveries: string[] = []) {
   const workflowGet = vi.fn(() =>
     Promise.resolve({ status: workflowStatus, terminate }),
   );
+  const put = vi.fn();
   const env = {
     AI_REVIEW_ENABLED: "true",
     AI_REVIEW_DEBOUNCE_SECONDS: "2",
+    REVIEW_DATA: { put },
     REVIEW_WORKFLOW: { createBatch, get: workflowGet },
   } as unknown as Env;
   const coordinator = new PullRequestCoordinator(
@@ -89,6 +107,7 @@ function coordinatorFixture(existingDeliveries: string[] = []) {
     coordinator,
     createBatch,
     env,
+    put,
     sqlExec,
     storage,
     terminate,
@@ -371,6 +390,16 @@ describe("PullRequestCoordinator", () => {
           commentId: 987,
           hunks: [identifiedHunk],
           findings: [identifiedFinding],
+          findingPublications: [
+            {
+              findingId: identifiedFinding.findingId,
+              delivery: "line",
+              commentId: 654,
+              reconciled: false,
+              path: identifiedFinding.file,
+              line: identifiedFinding.line,
+            },
+          ],
         }),
       }),
     );
@@ -380,6 +409,104 @@ describe("PullRequestCoordinator", () => {
         String(query).includes("SET status = 'completed'"),
       ),
     ).toBe(true);
+    expect(
+      sqlExec.mock.calls.some(([query]) =>
+        String(query).includes("INSERT INTO review_finding_comments"),
+      ),
+    ).toBe(true);
+  });
+
+  it("records finding dispositions in SQLite and append-only evidence", async () => {
+    const { coordinator, put, sqlExec } = coordinatorFixture();
+    sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: 1,
+      toArray: () =>
+        query.includes("SELECT finding_id FROM review_findings")
+          ? [{ finding_id: identifiedFinding.findingId }]
+          : [],
+    }));
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/interactions", {
+        method: "POST",
+        body: JSON.stringify(findingInteraction),
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: false,
+      findingId: identifiedFinding.findingId,
+    });
+    expect(put).toHaveBeenCalledWith(
+      expect.stringContaining("/evidence/feedback-delivery-1.json"),
+      expect.stringContaining('"disposition":"acknowledged"'),
+      { httpMetadata: { contentType: "application/json" } },
+    );
+    expect(
+      sqlExec.mock.calls.some(([query]) =>
+        String(query).includes("SET disposition = ?"),
+      ),
+    ).toBe(true);
+  });
+
+  it("deduplicates finding evidence and rejects unknown findings", async () => {
+    const duplicate = coordinatorFixture();
+    duplicate.sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: 1,
+      toArray: () =>
+        query.includes("FROM review_finding_events")
+          ? [{
+              finding_id: identifiedFinding.findingId,
+              payload_json: JSON.stringify({ recorded: true }),
+              r2_recorded: 1,
+            }]
+          : [],
+    }));
+    const duplicateResponse = await duplicate.coordinator.fetch(
+      new Request("https://coordinator.test/interactions", {
+        method: "POST",
+        body: JSON.stringify(findingInteraction),
+      }),
+    );
+    await expect(duplicateResponse.json()).resolves.toMatchObject({
+      accepted: true,
+      duplicate: true,
+    });
+    expect(duplicate.put).not.toHaveBeenCalled();
+
+    const unknown = coordinatorFixture();
+    const unknownResponse = await unknown.coordinator.fetch(
+      new Request("https://coordinator.test/interactions", {
+        method: "POST",
+        body: JSON.stringify({
+          ...findingInteraction,
+          findingId: undefined,
+          rootCommentId: 654,
+          interactionType: "reply",
+          disposition: undefined,
+          reason: undefined,
+        }),
+      }),
+    );
+    expect(unknownResponse.status).toBe(202);
+    await expect(unknownResponse.json()).resolves.toEqual({
+      accepted: false,
+      reason: "unknown-finding",
+    });
+  });
+
+  it("rejects malformed finding interactions", async () => {
+    const { coordinator } = coordinatorFixture();
+    for (const body of [null, [], { ...findingInteraction, actor: "" }]) {
+      const response = await coordinator.fetch(
+        new Request("https://coordinator.test/interactions", {
+          method: "POST",
+          body: JSON.stringify(body),
+        }),
+      );
+      expect(response.status).toBe(400);
+    }
   });
 
   it("reports a completion that does not match a claimed run", async () => {

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -676,6 +676,35 @@ describe("PullRequestCoordinator", () => {
     }
   });
 
+  it("accepts a reconciled native comment whose current line is null", async () => {
+    const { coordinator } = coordinatorFixture();
+    const findingWithoutCurrentLine = { ...identifiedFinding, line: null };
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/reviews/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          runId: "review-delivery-123",
+          headSha: event.headSha,
+          costUsd: 0.42,
+          hunks: [identifiedHunk],
+          findings: [findingWithoutCurrentLine],
+          findingPublications: [
+            {
+              findingId: findingWithoutCurrentLine.findingId,
+              delivery: "line",
+              commentId: 654,
+              reconciled: true,
+              path: findingWithoutCurrentLine.file,
+              line: null,
+            },
+          ],
+        }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ completed: true });
+  });
+
   it.each([
     [{ attempts: 20, runs: 18, total_cost: 1 }, "review-run budget"],
     [{ attempts: 2, runs: 2, total_cost: 5 }, "cost budget"],

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -482,7 +482,7 @@ describe("stateful review engine", () => {
       "review-1",
       prepared,
       { hunks: [], candidates: {}, publishedFindings: [] },
-      { commentId: 42, runCostUsd: 0.25 },
+      { commentId: 42, runCostUsd: 0.25, findings: [] },
     );
     await failReview(env, params, "review-1", "failed");
     expect(coordinatorFetch).toHaveBeenCalledTimes(3);
@@ -521,6 +521,7 @@ describe("stateful review engine", () => {
         { paths: [], omitted: [] },
         emptyScouts,
         emptyMerged,
+        { hunks: [], candidates: {}, publishedFindings: [] },
         { runs: 0, total_usd: 0 },
       ),
     ).rejects.toThrow("Cannot publish an unprepared review");
@@ -547,6 +548,7 @@ describe("stateful review engine", () => {
         },
         emptyScouts,
         emptyMerged,
+        { hunks: [], candidates: {}, publishedFindings: [] },
         { runs: 0, total_usd: 0 },
       ),
     ).rejects.toThrow("refusing stale comment");
@@ -560,7 +562,7 @@ describe("stateful review engine", () => {
         scouts: emptyScouts,
         merged: emptyMerged,
         artifacts: { hunks: [], candidates: {}, publishedFindings: [] },
-        publication: { runCostUsd: 0 },
+        publication: { runCostUsd: 0, findings: [] },
         timestamp: new Date(),
       }),
     ).rejects.toThrow("Cannot record an unprepared review");
@@ -712,6 +714,14 @@ describe("stateful review engine", () => {
       if (url.pathname.endsWith("/issues/42/comments") && init?.method === "GET") {
         return json([]);
       }
+      if (url.pathname.endsWith("/pulls/42/comments") && init?.method === "GET") {
+        return json([]);
+      }
+      if (url.pathname.endsWith("/pulls/42/comments") && init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as { body: string };
+        publishedBodies.push(body.body);
+        return json({ id: 654 });
+      }
       if (url.pathname.endsWith("/issues/42/comments") && init?.method === "POST") {
         const body = JSON.parse(String(init.body)) as { body: string };
         publishedBodies.push(body.body);
@@ -733,6 +743,7 @@ describe("stateful review engine", () => {
       prepared,
       scouts,
       merged,
+      artifacts,
       { runs: 0, total_usd: 0 },
     );
     await recordReview({
@@ -756,10 +767,21 @@ describe("stateful review engine", () => {
       "nemotron-3-ultra-free",
     ]);
     expect(merged.result.findings).toHaveLength(1);
-    expect(publication).toEqual({ commentId: 987, runCostUsd: 0.08 });
-    expect(publishedBodies[0]).toContain(STATEFUL_REVIEW_MARKER);
-    expect(publishedBodies[0]).toContain("## Stateful AI code review");
+    expect(publication).toEqual({
+      commentId: 987,
+      runCostUsd: 0.08,
+      findings: [
+        expect.objectContaining({
+          commentId: 654,
+          delivery: "line",
+          reconciled: false,
+        }),
+      ],
+    });
+    expect(publishedBodies[0]).toContain("ai-review-finding:");
     expect(publishedBodies[0]).toContain("Reported by: `moonshotai/kimi-k2.6`");
+    expect(publishedBodies[1]).toContain(STATEFUL_REVIEW_MARKER);
+    expect(publishedBodies[1]).toContain("## Stateful AI code review");
     expect(put).toHaveBeenCalledOnce();
     const record = JSON.parse(String(put.mock.calls[0]?.[1])) as {
       schemaVersion: number;

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -246,6 +246,23 @@ describe("parseFindingInteraction", () => {
     ).toEqual({ kind: "ignored", reason: "unsupported-event" });
   });
 
+  it("rejects incomplete disposition commands without regex backtracking", () => {
+    const body = `/ai-review reject f_${"a".repeat(24)}${" ".repeat(100_000)}`;
+    expect(
+      parseFindingInteraction("issue_comment", "feedback-incomplete", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        issue: { number: 816, pull_request: {} },
+        sender: { login: "robbie" },
+        comment: {
+          body,
+          author_association: "OWNER",
+          user: { login: "robbie" },
+        },
+      }),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
+  });
+
   it("captures replies, reaction snapshots, and thread resolution", () => {
     expect(
       parseFindingInteraction("pull_request_review_comment", "feedback-3", {

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -1,6 +1,10 @@
 import { createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { parseReviewEvent, verifyGitHubSignature } from "../src/webhook";
+import {
+  parseFindingInteraction,
+  parseReviewEvent,
+  verifyGitHubSignature,
+} from "../src/webhook";
 
 describe("verifyGitHubSignature", () => {
   it("accepts a valid sha256 signature", async () => {
@@ -67,9 +71,11 @@ describe("parseReviewEvent", () => {
         action: "created",
         repository: { full_name: "Robbie-Palmer/personal-site" },
         issue: { number: 1, pull_request: true },
+        sender: { login: "robbie" },
         comment: {
           body: "/ai-review",
           author_association: "OWNER",
+          user: { login: "robbie" },
         },
       }),
     ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
@@ -138,9 +144,11 @@ describe("parseReviewEvent", () => {
         action: "created",
         repository: { full_name: "Robbie-Palmer/personal-site" },
         issue: { number: 816, pull_request: {} },
+        sender: { login: "robbie" },
         comment: {
           body: "/ai-review",
           author_association: "OWNER",
+          user: { login: "robbie" },
         },
       }),
     ).toEqual({
@@ -178,5 +186,112 @@ describe("parseReviewEvent", () => {
         }),
       ).toEqual({ kind: "ignored", reason: "unsupported-event" });
     }
+  });
+});
+
+describe("parseFindingInteraction", () => {
+  it("accepts explicit dispositions from trusted pull request commenters", () => {
+    expect(
+      parseFindingInteraction("issue_comment", "feedback-1", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        issue: { number: 816, pull_request: {} },
+        sender: { login: "robbie" },
+        comment: {
+          id: 99,
+          body: `/ai-review reject f_${"a".repeat(24)} false positive`,
+          author_association: "OWNER",
+          user: { login: "robbie" },
+          created_at: "2026-08-09T12:00:00Z",
+        },
+      }),
+    ).toEqual({
+      kind: "accepted",
+      event: expect.objectContaining({
+        interactionType: "disposition",
+        disposition: "rejected",
+        findingId: `f_${"a".repeat(24)}`,
+        reason: "false positive",
+      }),
+    });
+  });
+
+  it("rejects feedback from untrusted actors", () => {
+    expect(
+      parseFindingInteraction("issue_comment", "feedback-2", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        issue: { number: 816, pull_request: {} },
+        sender: { login: "outside" },
+        comment: {
+          body: `/ai-review acknowledge f_${"a".repeat(24)} agreed`,
+          author_association: "CONTRIBUTOR",
+          user: { login: "outside" },
+        },
+      }),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
+
+    expect(
+      parseFindingInteraction("issue_comment", "feedback-spoofed", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        issue: { number: 816, pull_request: {} },
+        sender: { login: "outside" },
+        comment: {
+          body: `/ai-review reject f_${"a".repeat(24)} spoofed actor`,
+          author_association: "OWNER",
+          user: { login: "robbie" },
+        },
+      }),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
+  });
+
+  it("captures replies, reaction snapshots, and thread resolution", () => {
+    expect(
+      parseFindingInteraction("pull_request_review_comment", "feedback-3", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        pull_request: { number: 816 },
+        sender: { login: "maintainer" },
+        comment: {
+          id: 201,
+          in_reply_to_id: 200,
+          body: "Good catch; fixed in the next commit.",
+          author_association: "COLLABORATOR",
+          user: { login: "maintainer" },
+          reactions: { url: "ignored", "+1": 2, confused: 0 },
+        },
+      }),
+    ).toEqual({
+      kind: "accepted",
+      event: expect.objectContaining({
+        interactionType: "reply",
+        rootCommentId: 200,
+        commentId: 201,
+        reactions: { "+1": 2, confused: 0 },
+      }),
+    });
+
+    expect(
+      parseFindingInteraction("pull_request_review_thread", "feedback-4", {
+        action: "resolved",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        pull_request: { number: 816 },
+        sender: { login: "Robbie-Palmer" },
+        thread: {
+          node_id: "PRRT_thread",
+          comments: [{ id: 200, reactions: { "+1": 1, heart: 2 } }],
+          updated_at: "2026-08-09T12:10:00Z",
+        },
+      }),
+    ).toEqual({
+      kind: "accepted",
+      event: expect.objectContaining({
+        interactionType: "thread",
+        action: "resolved",
+        rootCommentId: 200,
+        reactions: { "+1": 1, heart: 2 },
+      }),
+    });
   });
 });

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -406,10 +406,17 @@ describe("parseFindingInteraction", () => {
         repository: { full_name: "Robbie-Palmer/personal-site" },
         pull_request: { number: 816 },
         sender: { login: "Robbie-Palmer" },
+        updated_at: "2026-08-09T12:10:00Z",
         thread: {
           node_id: "PRRT_thread",
-          comments: [{ id: 200, reactions: { "+1": 1, heart: 2 } }],
-          updated_at: "2026-08-09T12:10:00Z",
+          comments: [
+            { id: 201, in_reply_to_id: 200 },
+            {
+              id: 200,
+              in_reply_to_id: null,
+              reactions: { "+1": 1, heart: 2 },
+            },
+          ],
         },
       }),
     ).toEqual({
@@ -418,6 +425,8 @@ describe("parseFindingInteraction", () => {
         interactionType: "thread",
         action: "resolved",
         rootCommentId: 200,
+        threadId: "PRRT_thread",
+        occurredAt: "2026-08-09T12:10:00Z",
         reactions: { "+1": 1, heart: 2 },
       }),
     });

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -261,6 +261,20 @@ describe("parseFindingInteraction", () => {
         },
       }),
     ).toEqual({ kind: "ignored", reason: "unsupported-event" });
+
+    expect(
+      parseFindingInteraction("issue_comment", "feedback-too-long", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        issue: { number: 816, pull_request: {} },
+        sender: { login: "robbie" },
+        comment: {
+          body: `/ai-review reject f_${"a".repeat(24)} ${"x".repeat(1_001)}`,
+          author_association: "OWNER",
+          user: { login: "robbie" },
+        },
+      }),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
   });
 
   it("validates malformed interaction envelopes and event-specific identities", () => {
@@ -272,6 +286,19 @@ describe("parseFindingInteraction", () => {
       kind: "invalid",
       reason: "Malformed webhook payload",
     });
+    expect(
+      parseFindingInteraction("issue_comment", "x".repeat(256), {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+      }),
+    ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
+    expect(
+      parseReviewEvent("pull_request", "x".repeat(256), {
+        action: "opened",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        pull_request: { number: 816, head: { sha: "abc123" } },
+      }),
+    ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
     expect(
       parseFindingInteraction("issue_comment", "feedback", {
         action: "created",

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -263,6 +263,90 @@ describe("parseFindingInteraction", () => {
     ).toEqual({ kind: "ignored", reason: "unsupported-event" });
   });
 
+  it("validates malformed interaction envelopes and event-specific identities", () => {
+    expect(parseFindingInteraction("issue_comment", "feedback", null)).toEqual({
+      kind: "invalid",
+      reason: "Malformed webhook payload",
+    });
+    expect(parseFindingInteraction("issue_comment", "", { action: "created" })).toEqual({
+      kind: "invalid",
+      reason: "Malformed webhook payload",
+    });
+    expect(
+      parseFindingInteraction("issue_comment", "feedback", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+      }),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
+    expect(
+      parseFindingInteraction("issue_comment", "feedback", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        sender: { login: "Robbie-Palmer" },
+        comment: {
+          body: `/ai-review acknowledge f_${"a".repeat(24)} accepted`,
+        },
+      }),
+    ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
+    expect(
+      parseFindingInteraction("pull_request_review_comment", "feedback", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        pull_request: { number: 816 },
+        comment: { id: 201 },
+      }),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
+    expect(
+      parseFindingInteraction("pull_request_review_thread", "feedback", {
+        action: "resolved",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        pull_request: { number: 816 },
+        sender: { login: "Robbie-Palmer" },
+        thread: { comments: [] },
+      }),
+    ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
+  });
+
+  it("accepts a trusted pull request author and rejects untrusted reply actors", () => {
+    const reply = {
+      action: "edited",
+      repository: { full_name: "Robbie-Palmer/personal-site" },
+      pull_request: {
+        number: 816,
+        author_association: "MEMBER",
+        user: { login: "maintainer" },
+      },
+      sender: { login: "maintainer" },
+      comment: {
+        id: 201,
+        in_reply_to_id: 200,
+        body: "Updated reply",
+        created_at: "2026-08-09T12:00:00Z",
+      },
+    };
+    expect(
+      parseFindingInteraction(
+        "pull_request_review_comment",
+        "feedback-author",
+        reply,
+      ),
+    ).toEqual({
+      kind: "accepted",
+      event: expect.objectContaining({ actor: "maintainer", action: "edited" }),
+    });
+    expect(
+      parseFindingInteraction(
+        "pull_request_review_comment",
+        "feedback-outsider",
+        {
+          ...reply,
+          pull_request: { number: 816 },
+          sender: { login: "outside" },
+        },
+      ),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
+  });
+
   it("captures replies, reaction snapshots, and thread resolution", () => {
     expect(
       parseFindingInteraction("pull_request_review_comment", "feedback-3", {

--- a/ai-review/tests/workflow.test.ts
+++ b/ai-review/tests/workflow.test.ts
@@ -118,6 +118,7 @@ beforeEach(() => {
   engine.publishReview.mockResolvedValue({
     commentId: 123,
     runCostUsd: 0.6,
+    findings: [],
   });
   engine.recordReview.mockResolvedValue(undefined);
   engine.recordReviewTerminal.mockResolvedValue(undefined);
@@ -209,6 +210,7 @@ describe("ReviewWorkflow orchestration", () => {
         },
         cost: 0,
       }),
+      artifacts,
       { runs: 0, total_usd: 0 },
     );
   });


### PR DESCRIPTION
## Summary

- publish line-addressable findings as native pull request review comments with stable hidden finding IDs
- reconcile existing comments and keep the rolling issue comment focused on run, cost, and coverage data
- record authorized replies, reaction snapshots, thread state, and explicit dispositions as append-only schema-v2 evidence
- provide issue-comment command fallbacks when GitHub cannot attach a finding to a diff line

## Validation

- `mise run //ai-review:check`
- `mise run //ai-review:deploy:dry-run`
- `mise run //:lint`
- staged pre-commit and gitleaks checks

## QA

No site preview QA is required; this change is isolated to the AI review Worker. Workerd integration tests exercise durable comment mapping, delivery deduplication, thread resolution, and R2 evidence persistence.

## Operational follow-up

Before deployment, update the GitHub App to grant Pull requests read/write and subscribe to `pull_request_review_comment` and `pull_request_review_thread`, then approve the expanded installation permission.

Shortcut: https://app.shortcut.com/personal-294/story/420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review findings can now be published as individual line-level comments, with fallback details for findings that cannot attach to the current diff.
  - Main review comments provide a concise summary of publication results.
  - Reviewers can acknowledge or reject findings through supported comments, replies, reactions and thread actions.
  - Finding interactions are recorded, deduplicated and linked to their corresponding review findings.

- **Documentation**
  - Added guidance for review comments, interaction commands, permissions, events and stored review evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->