### PR TITLE
Document CodeQL action version in security workflows

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -43,7 +43,7 @@ jobs:
         run: mise exec -- gitleaks git --redact --exit-code 0 --report-format sarif --report-path gitleaks.sarif
 
       - name: Upload gitleaks results to GitHub Security
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: gitleaks.sarif
           category: gitleaks

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
           publish_results: true
 
       - name: Upload results to GitHub Security
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         if: always()
         with:
           sarif_file: results.sarif

--- a/.github/workflows/trivy-security.yml
+++ b/.github/workflows/trivy-security.yml
@@ -59,7 +59,7 @@ jobs:
           skip-dirs: "node_modules,.pnpm-store,.terraform"
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         if: always()
         with:
           sarif_file: "trivy-iac-results.sarif"
@@ -88,7 +88,7 @@ jobs:
           timeout: "10m"
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         if: always()
         with:
           sarif_file: "trivy-deps-results.sarif"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -48,7 +48,7 @@ jobs:
         run: mise exec -- zizmor --no-exit-codes --format sarif . > zizmor.sarif
 
       - name: Upload zizmor results to GitHub Security
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: zizmor.sarif
           category: zizmor


### PR DESCRIPTION
## Summary

- Document the CodeQL action version used by SARIF upload steps.
- Update security workflow comments to identify CodeQL v4.37.4.

## Testing

- Not run; workflow comment-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security workflow action version labels to identify CodeQL version 4.37.4.
  * Workflow behaviour and pinned action references remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->