### PR TITLE
Implement risk-aware incremental AI code review

### DIFF
--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -602,12 +602,25 @@ export class Reviewer {
     omitted: string[];
   }> {
     const files = await this.pages<ChangedFile>(`${this.prPath}/files`, 30);
+    const reviewableFiles = files.filter(
+      (file) => file.filename && !ignored(file.filename),
+    );
+    // Forced reviews may include ignored files, but process those files only
+    // after every normally reviewable patch has had access to the bounded diff
+    // budget. A large lockfile or generated patch must never displace source.
+    const selectedFiles = options.includeIgnored
+      ? [
+          ...reviewableFiles,
+          ...files.filter(
+            (file) => file.filename && ignored(file.filename),
+          ),
+        ]
+      : reviewableFiles;
     const blocks: string[] = [];
     const paths: string[] = [];
     const omitted: string[] = [];
     let used = 0;
-    for (const file of files) {
-      if (!file.filename || (!options.includeIgnored && ignored(file.filename))) continue;
+    for (const file of selectedFiles) {
       if (typeof file.patch !== "string" || file.patch.length > MAX_PATCH_CHARS) {
         omitted.push(file.filename);
         continue;

--- a/.github/scripts/ai-review/ai-review.ts
+++ b/.github/scripts/ai-review/ai-review.ts
@@ -596,14 +596,18 @@ export class Reviewer {
     return output;
   }
 
-  async changedFiles(): Promise<{ diff: string; paths: string[]; omitted: string[] }> {
+  async changedFiles(options: { includeIgnored?: boolean } = {}): Promise<{
+    diff: string;
+    paths: string[];
+    omitted: string[];
+  }> {
     const files = await this.pages<ChangedFile>(`${this.prPath}/files`, 30);
     const blocks: string[] = [];
     const paths: string[] = [];
     const omitted: string[] = [];
     let used = 0;
     for (const file of files) {
-      if (!file.filename || ignored(file.filename)) continue;
+      if (!file.filename || (!options.includeIgnored && ignored(file.filename))) continue;
       if (typeof file.patch !== "string" || file.patch.length > MAX_PATCH_CHARS) {
         omitted.push(file.filename);
         continue;
@@ -891,7 +895,7 @@ export class Reviewer {
   async existingComment(
     marker = MARKER,
     botLogins: ReadonlySet<string> = BOT_LOGINS,
-  ): Promise<{ id?: number; state: ReviewState }> {
+  ): Promise<{ body?: string; id?: number; state: ReviewState }> {
     const comments = await this.pages<JsonObject>(
       `/repos/${this.settings.repository}/issues/${this.settings.prNumber}/comments`,
     );
@@ -911,12 +915,13 @@ export class Reviewer {
           // A malformed historical marker should not block a fresh review.
         }
       }
-      return { id: Number(comment.id), state };
+      return { body, id: Number(comment.id), state };
     }
     return { state: { runs: 0, total_usd: 0 } };
   }
 
-  async reviewThreadContext(): Promise<string> {
+  async reviewThreadContext(paths?: string[]): Promise<string> {
+    const relevantPaths = paths ? new Set(paths) : undefined;
     const [owner, repository] = this.settings.repository.split("/", 2);
     const query = `query($owner:String!, $repository:String!, $number:Int!) {
       repository(owner:$owner, name:$repository) {
@@ -946,10 +951,15 @@ export class Reviewer {
       const nodes = isObject(connection) && Array.isArray(connection.nodes) ? connection.nodes : [];
       const comments = nodes
         .filter(isObject)
+        .filter(
+          (comment) =>
+            !relevantPaths || relevantPaths.has(String(comment.path ?? "")),
+        )
         .map((comment) => {
           const author = isObject(comment.author) ? comment.author.login : "unknown";
           return `${String(author ?? "unknown")} at ${String(comment.path ?? "?")}:${String(comment.line ?? "?")}: ${String(comment.body ?? "").slice(0, 1_500)}`;
         });
+      if (comments.length === 0) continue;
       const block = `THREAD ${state}\n${comments.join("\n")}\nEND THREAD`;
       if (used + block.length > MAX_THREAD_CHARS) break;
       blocks.push(block);

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -205,10 +205,10 @@ webhook, waits for its versioned R2 record, and verifies that the visible
 stateful PR comment targets the current head and that at least one scout
 provided actual review coverage.
 Set `AI_REVIEW_E2E_PULL_REQUEST` to test another pull request explicitly.
-After a full staging run establishes a baseline and the PR receives another
-commit, set `AI_REVIEW_E2E_EVENT_MODE=synchronize` to send a non-forced
-`pull_request` event and require incremental coverage with both reviewed and
-unchanged hunks.
+After a full staging run establishes a baseline, add a semantic commit that
+preserves at least one eligible baseline hunk, then set
+`AI_REVIEW_E2E_EVENT_MODE=synchronize` to send a non-forced `pull_request`
+event and require incremental coverage with both reviewed and unchanged hunks.
 
 The deploy task loads `ai-review/prd` when required values are not already in
 the environment. `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` authenticate

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -32,8 +32,19 @@ The service is a visible, stateful publisher:
   engine imported by this service.
 
 Automatic runs cover non-draft PR opens, ready-for-review transitions, reopens,
-and synchronized heads. An exact `/ai-review` issue comment from an owner,
-member, or collaborator requests a run explicitly, including on a draft.
+and synchronized heads. After the first completed review, synchronized heads
+send only new or materially changed hunks, bounded context for their files, and
+unchanged hunks tied to affected open findings. Generated files, lockfiles, and
+whitespace-only hunks are skipped. Authentication, secrets, database-schema,
+infrastructure, and deployment changes escalate deterministically to full
+coverage. The rolling comment always labels coverage as full, incremental, or
+skipped.
+
+An exact `/ai-review` or `/ai-review full` issue comment from an owner, member,
+or collaborator forces a full review of the current head, including on a draft.
+If that same head is subsequently merged, its latest successful full review is
+the final pre-merge review retrospectively; any later commit requires another
+full review.
 Ordinary comments and review-thread activity never schedule paid work. Replies,
 reaction-count snapshots, thread resolution, and trusted
 `/ai-review acknowledge f_<id> <reason>` or
@@ -151,8 +162,11 @@ move. PR-scoped finding IDs hash the path and normalized finding title, excludin
 severity, status, and model provenance. The Durable Object upserts these
 identities into `review_hunks`, `review_findings`, and
 `review_finding_hunks`; first-seen values remain immutable while last-seen
-values advance with later completed runs. R2 retains raw per-model candidates
-separately from the merged findings that were actually published.
+values advance with later completed runs. `review_run_hunks` records both the
+current-head hunk set and which subset was sent for review, allowing the next
+run to compare against the last completed head. R2 retains the trigger decision,
+full coverage accounting, raw per-model candidates, and the merged findings
+that were actually published.
 
 Native review-comment mappings live in `review_finding_comments`, so later
 heads reconcile the same finding instead of publishing another thread.

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -205,6 +205,10 @@ webhook, waits for its versioned R2 record, and verifies that the visible
 stateful PR comment targets the current head and that at least one scout
 provided actual review coverage.
 Set `AI_REVIEW_E2E_PULL_REQUEST` to test another pull request explicitly.
+After a full staging run establishes a baseline and the PR receives another
+commit, set `AI_REVIEW_E2E_EVENT_MODE=synchronize` to send a non-forced
+`pull_request` event and require incremental coverage with both reviewed and
+unchanged hunks.
 
 The deploy task loads `ai-review/prd` when required values are not already in
 the environment. `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` authenticate

--- a/ai-review/scripts/staging-e2e.sh
+++ b/ai-review/scripts/staging-e2e.sh
@@ -26,6 +26,7 @@ done
 
 repository="${AI_REVIEW_E2E_REPOSITORY:-Robbie-Palmer/personal-site}"
 pull_request="${AI_REVIEW_E2E_PULL_REQUEST:-}"
+event_mode="${AI_REVIEW_E2E_EVENT_MODE:-full}"
 if [[ -z "$pull_request" ]]; then
   pull_request="$(gh pr view --json number --jq '.number')"
 fi
@@ -34,7 +35,21 @@ if [[ ! "$pull_request" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 staging_url="${AI_REVIEW_STAGING_URL:-https://ai-review-staging.robbiepalmer95.workers.dev}"
-delivery_id="staging-e2e-$(date -u +%Y%m%dT%H%M%SZ)-${RANDOM}"
+case "$event_mode" in
+  full)
+    event_name="issue_comment"
+    expected_coverage_mode="full"
+    ;;
+  synchronize)
+    event_name="pull_request"
+    expected_coverage_mode="incremental"
+    ;;
+  *)
+    echo "Cannot run staging E2E: event mode must be full or synchronize." >&2
+    exit 1
+    ;;
+esac
+delivery_id="staging-e2e-${event_mode}-$(date -u +%Y%m%dT%H%M%SZ)-${RANDOM}"
 instance_id="review-${delivery_id}"
 
 temporary_root="${TMPDIR:-/tmp}"
@@ -55,22 +70,34 @@ trap cleanup EXIT INT TERM
 head_sha="$(
   gh api "repos/${repository}/pulls/${pull_request}" --jq '.head.sha'
 )"
-actor="${repository%%/*}"
-jq -n \
-  --arg repository "$repository" \
-  --arg actor "$actor" \
-  --argjson pull_request "$pull_request" \
-  '{
-    action: "created",
-    repository: {full_name: $repository},
-    issue: {number: $pull_request, pull_request: {}},
-    sender: {login: $actor},
-    comment: {
-      body: "/ai-review",
-      author_association: "OWNER",
-      user: {login: $actor}
-    }
-  }' > "$payload_file"
+if [[ "$event_mode" == "full" ]]; then
+  actor="${repository%%/*}"
+  jq -n \
+    --arg repository "$repository" \
+    --arg actor "$actor" \
+    --argjson pull_request "$pull_request" \
+    '{
+      action: "created",
+      repository: {full_name: $repository},
+      issue: {number: $pull_request, pull_request: {}},
+      sender: {login: $actor},
+      comment: {
+        body: "/ai-review",
+        author_association: "OWNER",
+        user: {login: $actor}
+      }
+    }' > "$payload_file"
+else
+  jq -n \
+    --arg repository "$repository" \
+    --arg head_sha "$head_sha" \
+    --argjson pull_request "$pull_request" \
+    '{
+      action: "synchronize",
+      repository: {full_name: $repository},
+      pull_request: {number: $pull_request, head: {sha: $head_sha}}
+    }' > "$payload_file"
+fi
 chmod 600 "$payload_file"
 
 signature="$(
@@ -90,7 +117,7 @@ response="$(
     --request POST \
     --header "content-type: application/json" \
     --header "x-github-delivery: ${delivery_id}" \
-    --header "x-github-event: issue_comment" \
+    --header "x-github-event: ${event_name}" \
     --header "x-hub-signature-256: sha256=${signature}" \
     --data-binary "@${payload_file}" \
     "${staging_url}/webhooks/github"
@@ -125,11 +152,13 @@ fi
 
 jq -e \
   --arg head_sha "$head_sha" \
+  --arg coverage_mode "$expected_coverage_mode" \
   '
     .schemaVersion == 2
     and .recordType == "review-run-terminal"
     and .status == "published"
     and .headSha == $head_sha
+    and .coverage.mode == $coverage_mode
     and any(.models[]; .role == "scout" and .ok == true)
   ' \
   "$record_file" >/dev/null
@@ -148,11 +177,31 @@ if ! jq -e \
   echo "The visible stateful comment does not target the expected head." >&2
   exit 1
 fi
+if [[ "$expected_coverage_mode" == "incremental" ]]; then
+  jq -e \
+    '.coverage.reviewedHunkIds | length > 0' \
+    "$record_file" >/dev/null
+  jq -e \
+    '.coverage.unchangedHunkIds | length > 0' \
+    "$record_file" >/dev/null
+  if ! jq -e \
+    '.body | contains("unchanged hunk(s) were not reviewed again")' \
+    <<<"$comment" >/dev/null; then
+    echo "The visible stateful comment does not explain unchanged coverage." >&2
+    exit 1
+  fi
+fi
 
 jq '{
   status,
   headSha,
   runCostUsd,
+  coverage: {
+    mode: .coverage.mode,
+    totalHunks: .coverage.totalHunks,
+    reviewedHunks: (.coverage.reviewedHunkIds | length),
+    unchangedHunks: (.coverage.unchangedHunkIds | length)
+  },
   findingCount: (.findings.published | length),
   candidateCount: ([.candidates[] | length] | add // 0),
   hunkCount: (.hunks | length),

--- a/ai-review/scripts/staging-e2e.sh
+++ b/ai-review/scripts/staging-e2e.sh
@@ -150,7 +150,7 @@ if [[ ! -s "$record_file" ]]; then
   exit 1
 fi
 
-jq -e \
+if ! jq -e \
   --arg head_sha "$head_sha" \
   --arg coverage_mode "$expected_coverage_mode" \
   '
@@ -161,7 +161,10 @@ jq -e \
     and .coverage.mode == $coverage_mode
     and any(.models[]; .role == "scout" and .ok == true)
   ' \
-  "$record_file" >/dev/null
+  "$record_file" >/dev/null; then
+  echo "The staging record did not satisfy the expected review contract." >&2
+  exit 1
+fi
 comment="$(
   gh api "repos/${repository}/issues/${pull_request}/comments" \
     --paginate \
@@ -178,14 +181,16 @@ if ! jq -e \
   exit 1
 fi
 if [[ "$expected_coverage_mode" == "incremental" ]]; then
-  jq -e \
-    '.coverage.reviewedHunkIds | length > 0' \
-    "$record_file" >/dev/null
-  jq -e \
-    '.coverage.unchangedHunkIds | length > 0' \
-    "$record_file" >/dev/null
   if ! jq -e \
-    '.body | contains("unchanged hunk(s) were not reviewed again")' \
+    '(.coverage.reviewedHunkIds | length > 0)
+     and (.coverage.unchangedHunkIds | length > 0)' \
+    "$record_file" >/dev/null; then
+    echo "Incremental coverage did not include reviewed and unchanged hunks." >&2
+    exit 1
+  fi
+  if ! jq -e \
+    '(.body | gsub("\\\\"; ""))
+     | contains("unchanged hunk(s) were not reviewed again")' \
     <<<"$comment" >/dev/null; then
     echo "The visible stateful comment does not explain unchanged coverage." >&2
     exit 1

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -251,6 +251,18 @@ function isReviewHunk(value: unknown): value is ReviewHunk {
   );
 }
 
+function sameReviewHunk(left: ReviewHunk, right: ReviewHunk): boolean {
+  return (
+    left.hunkId === right.hunkId &&
+    left.fingerprint === right.fingerprint &&
+    left.file === right.file &&
+    left.oldStart === right.oldStart &&
+    left.oldLines === right.oldLines &&
+    left.newStart === right.newStart &&
+    left.newLines === right.newLines
+  );
+}
+
 function isIdentifiedFinding(value: unknown): value is IdentifiedMergedFinding {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const finding = value as Partial<IdentifiedMergedFinding>;
@@ -960,7 +972,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const completionHunkIds = new Set(
       reviewedHunks.map(({ hunkId }) => hunkId),
     );
-    const currentHunkIds = new Set(currentHunks.map(({ hunkId }) => hunkId));
+    const currentHunksById = new Map(
+      currentHunks.map((hunk) => [hunk.hunkId, hunk]),
+    );
     const completionFindings = body.findings as IdentifiedMergedFinding[];
     const completionFindingsById = new Map(
       completionFindings.map((finding) => [finding.findingId, finding]),
@@ -968,7 +982,12 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const findingPublications = (body.findingPublications ??
       []) as FindingPublication[];
     if (
-      reviewedHunks.some((hunk) => !currentHunkIds.has(hunk.hunkId)) ||
+      completionHunkIds.size !== reviewedHunks.length ||
+      currentHunksById.size !== currentHunks.length ||
+      reviewedHunks.some((hunk) => {
+        const current = currentHunksById.get(hunk.hunkId);
+        return !current || !sameReviewHunk(hunk, current);
+      }) ||
       completionFindings.some((finding) =>
         finding.hunkIds.some((hunkId) => !completionHunkIds.has(hunkId)),
       ) ||

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -155,6 +155,30 @@ function json(data: unknown, status = 200): Response {
   return Response.json(data, { status, headers: JSON_HEADERS });
 }
 
+function errorType(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+function completionReplayStatus(
+  existing:
+    | { head_sha: string; status: string; completion_hash: string | null }
+    | undefined,
+  headSha: string,
+  completionHash: string,
+): "conflict" | "duplicate" | "missing" {
+  if (
+    !existing ||
+    existing.head_sha !== headSha ||
+    existing.status !== "completed"
+  ) {
+    return "missing";
+  }
+  return existing.completion_hash === null ||
+    existing.completion_hash === completionHash
+    ? "duplicate"
+    : "conflict";
+}
+
 function coordinatorName(
   event: Pick<ReviewWorkflowParams, "repository" | "pullRequestNumber">,
 ): string {
@@ -933,6 +957,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     }
     const reviewedHunks = body.hunks as ReviewHunk[];
     const currentHunks = (body.currentHunks ?? body.hunks) as ReviewHunk[];
+    const completionHeadSha = body.headSha;
     const completionHunkIds = new Set(
       reviewedHunks.map(({ hunkId }) => hunkId),
     );
@@ -993,17 +1018,11 @@ export class PullRequestCoordinator extends DurableObject<Env> {
             body.runId,
           )
           .toArray()[0];
-        if (
-          existing &&
-          existing.head_sha === body.headSha &&
-          existing.status === "completed"
-        ) {
-          return existing.completion_hash === null ||
-            existing.completion_hash === completionHash
-            ? "duplicate"
-            : "conflict";
-        }
-        return "missing";
+        return completionReplayStatus(
+          existing,
+          completionHeadSha,
+          completionHash,
+        );
       }
       for (const hunk of currentHunks) {
         this.ctx.storage.sql.exec(
@@ -1328,8 +1347,7 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
         );
       } catch (stateError) {
         console.error("Could not record failed review state", {
-          type:
-            stateError instanceof Error ? stateError.name : typeof stateError,
+          type: errorType(stateError),
         });
       }
       try {
@@ -1352,9 +1370,7 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
       } catch (recordError) {
         console.error(
           "Could not record failed review analytics",
-          recordError instanceof Error
-            ? { type: recordError.name }
-            : { type: typeof recordError },
+          { type: errorType(recordError) },
         );
       }
       throw error;

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -892,25 +892,13 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     if (!completed) {
       return json({ hunkIds: [], openFindings: [] });
     }
-    let hunkIds = this.ctx.storage.sql
+    const hunkIds = this.ctx.storage.sql
       .exec<{ hunk_id: string }>(
         "SELECT hunk_id FROM review_run_hunks WHERE run_id = ? ORDER BY hunk_id",
         completed.run_id,
       )
       .toArray()
       .map(({ hunk_id }) => hunk_id);
-    // Runs completed before review_run_hunks was introduced still have enough
-    // durable state for a conservative one-time migration baseline.
-    if (hunkIds.length === 0) {
-      hunkIds = this.ctx.storage.sql
-        .exec<{ hunk_id: string }>(
-          `SELECT hunk_id FROM review_hunks
-           WHERE last_seen_head_sha = ? ORDER BY hunk_id`,
-          completed.head_sha,
-        )
-        .toArray()
-        .map(({ hunk_id }) => hunk_id);
-    }
     const findings = this.ctx.storage.sql
       .exec<{ finding_id: string; file_path: string; title: string }>(
         `SELECT finding_id, file_path, title FROM review_findings

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -1200,12 +1200,43 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           pullRequestNumber: event.payload.pullRequestNumber,
           reason: prepared.skipReason,
         });
-        const skippedPublication =
-          prepared.coverage?.mode === "skipped"
-            ? await workflowStep.do("publish-skipped-coverage", () =>
-                publishSkippedReview(this.env, event.payload, prepared!),
-              )
-            : undefined;
+        if (prepared.coverage?.mode !== "skipped") {
+          await workflowStep.do("record-skipped-review", () =>
+            recordReviewTerminal({
+              env: this.env,
+              params: event.payload,
+              instanceId: event.instanceId,
+              status: "skipped",
+              reason: prepared?.skipReason,
+              prepared,
+              timestamp: event.timestamp,
+            }),
+          );
+          return;
+        }
+        failedPhase = "claim-skipped-review";
+        const claim = await workflowStep.do("claim-skipped-review", () =>
+          claimReview(this.env, event.payload, event.instanceId, prepared!),
+        );
+        if (!claim.claimed) {
+          await workflowStep.do("record-denied-skipped-review", () =>
+            recordReviewTerminal({
+              env: this.env,
+              params: event.payload,
+              instanceId: event.instanceId,
+              status: "denied",
+              reason: claim.reason,
+              prepared,
+              timestamp: event.timestamp,
+            }),
+          );
+          return;
+        }
+        failedPhase = "publish-skipped-coverage";
+        const skippedPublication = await workflowStep.do(
+          "publish-skipped-coverage",
+          () => publishSkippedReview(this.env, event.payload, prepared!),
+        );
         await workflowStep.do("record-skipped-review", () =>
           recordReviewTerminal({
             env: this.env,
@@ -1217,6 +1248,17 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
             publication: skippedPublication,
             timestamp: event.timestamp,
           }),
+        );
+        failedPhase = "complete-skipped-review-state";
+        await workflowStep.do("complete-skipped-review-state", () =>
+          completeReview(
+            this.env,
+            event.payload,
+            event.instanceId,
+            prepared!,
+            { hunks: [], candidates: {}, publishedFindings: [] },
+            skippedPublication,
+          ),
         );
         return;
       }

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -20,6 +20,7 @@ import {
   mergeFindings,
   prepareReview,
   publishReview,
+  publishSkippedReview,
   recordReview,
   recordReviewTerminal,
   runScouts,
@@ -73,6 +74,12 @@ const CREATE_REVIEW_HUNKS_TABLE =
   "last_seen_head_sha TEXT NOT NULL, " +
   "first_seen_at TEXT NOT NULL, " +
   "last_seen_at TEXT NOT NULL)";
+const CREATE_REVIEW_RUN_HUNKS_TABLE =
+  "CREATE TABLE IF NOT EXISTS review_run_hunks (" +
+  "run_id TEXT NOT NULL, " +
+  "hunk_id TEXT NOT NULL, " +
+  "reviewed INTEGER NOT NULL, " +
+  "PRIMARY KEY (run_id, hunk_id))";
 const CREATE_REVIEW_FINDINGS_TABLE =
   "CREATE TABLE IF NOT EXISTS review_findings (" +
   "finding_id TEXT PRIMARY KEY, " +
@@ -403,6 +410,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       );
     }
     this.ctx.storage.sql.exec(CREATE_REVIEW_HUNKS_TABLE);
+    this.ctx.storage.sql.exec(CREATE_REVIEW_RUN_HUNKS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDINGS_TABLE);
     const findingColumns = this.ctx.storage.sql
       .exec<{ name: string }>("PRAGMA table_info(review_findings)")
@@ -430,6 +438,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     if (path === "/events") return this.receiveEvent(request);
     if (path === "/interactions") return this.receiveInteraction(request);
     if (path === "/reviews/claim") return this.claimReview(request);
+    if (path === "/reviews/baseline") return this.reviewBaseline();
     if (path === "/reviews/complete") return this.completeReview(request);
     if (path === "/reviews/fail") return this.failReview(request);
     return new Response("Not found", { status: 404 });
@@ -837,6 +846,59 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     return json(result);
   }
 
+  private reviewBaseline(): Response {
+    const completed = this.ctx.storage.sql
+      .exec<{ run_id: string; head_sha: string }>(
+        `SELECT run_id, head_sha FROM review_runs
+         WHERE status = 'completed'
+         ORDER BY completed_at DESC, run_id DESC LIMIT 1`,
+      )
+      .toArray()[0];
+    if (!completed) {
+      return json({ hunkIds: [], openFindings: [] });
+    }
+    let hunkIds = this.ctx.storage.sql
+      .exec<{ hunk_id: string }>(
+        "SELECT hunk_id FROM review_run_hunks WHERE run_id = ? ORDER BY hunk_id",
+        completed.run_id,
+      )
+      .toArray()
+      .map(({ hunk_id }) => hunk_id);
+    // Runs completed before review_run_hunks was introduced still have enough
+    // durable state for a conservative one-time migration baseline.
+    if (hunkIds.length === 0) {
+      hunkIds = this.ctx.storage.sql
+        .exec<{ hunk_id: string }>(
+          `SELECT hunk_id FROM review_hunks
+           WHERE last_seen_head_sha = ? ORDER BY hunk_id`,
+          completed.head_sha,
+        )
+        .toArray()
+        .map(({ hunk_id }) => hunk_id);
+    }
+    const findings = this.ctx.storage.sql
+      .exec<{ finding_id: string; file_path: string; title: string }>(
+        `SELECT finding_id, file_path, title FROM review_findings
+         WHERE status = 'open' AND disposition IS NULL
+         ORDER BY finding_id LIMIT 100`,
+      )
+      .toArray();
+    const openFindings = findings.map((finding) => ({
+      findingId: finding.finding_id,
+      file: finding.file_path,
+      title: finding.title,
+      hunkIds: this.ctx.storage.sql
+        .exec<{ hunk_id: string }>(
+          `SELECT hunk_id FROM review_finding_hunks
+           WHERE finding_id = ? ORDER BY hunk_id`,
+          finding.finding_id,
+        )
+        .toArray()
+        .map(({ hunk_id }) => hunk_id),
+    }));
+    return json({ headSha: completed.head_sha, hunkIds, openFindings });
+  }
+
   private async completeReview(request: Request): Promise<Response> {
     const body = (await request.json().catch(() => null)) as {
       runId?: unknown;
@@ -844,6 +906,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       costUsd?: unknown;
       commentId?: unknown;
       hunks?: unknown;
+      currentHunks?: unknown;
       findings?: unknown;
       findingPublications?: unknown;
     } | null;
@@ -857,6 +920,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       (body.commentId !== undefined && typeof body.commentId !== "number") ||
       !Array.isArray(body.hunks) ||
       !body.hunks.every(isReviewHunk) ||
+      (body.currentHunks !== undefined &&
+        (!Array.isArray(body.currentHunks) ||
+          !body.currentHunks.every(isReviewHunk))) ||
       !Array.isArray(body.findings) ||
       !body.findings.every(isIdentifiedFinding) ||
       (body.findingPublications !== undefined &&
@@ -865,9 +931,12 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     ) {
       return json({ error: "Invalid review completion" }, 400);
     }
+    const reviewedHunks = body.hunks as ReviewHunk[];
+    const currentHunks = (body.currentHunks ?? body.hunks) as ReviewHunk[];
     const completionHunkIds = new Set(
-      (body.hunks as ReviewHunk[]).map(({ hunkId }) => hunkId),
+      reviewedHunks.map(({ hunkId }) => hunkId),
     );
+    const currentHunkIds = new Set(currentHunks.map(({ hunkId }) => hunkId));
     const completionFindings = body.findings as IdentifiedMergedFinding[];
     const completionFindingsById = new Map(
       completionFindings.map((finding) => [finding.findingId, finding]),
@@ -875,6 +944,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const findingPublications = (body.findingPublications ??
       []) as FindingPublication[];
     if (
+      reviewedHunks.some((hunk) => !currentHunkIds.has(hunk.hunkId)) ||
       completionFindings.some((finding) =>
         finding.hunkIds.some((hunkId) => !completionHunkIds.has(hunkId)),
       ) ||
@@ -894,7 +964,8 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         headSha: body.headSha,
         costUsd: body.costUsd,
         commentId: body.commentId ?? null,
-        hunks: body.hunks,
+        hunks: reviewedHunks,
+        currentHunks,
         findings: body.findings,
         findingPublications,
       }),
@@ -934,7 +1005,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         }
         return "missing";
       }
-      for (const hunk of body.hunks as ReviewHunk[]) {
+      for (const hunk of currentHunks) {
         this.ctx.storage.sql.exec(
           `INSERT INTO review_hunks
            (hunk_id, fingerprint, file_path, first_seen_head_sha,
@@ -950,6 +1021,13 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           body.headSha,
           completedAt,
           completedAt,
+        );
+        this.ctx.storage.sql.exec(
+          `INSERT INTO review_run_hunks (run_id, hunk_id, reviewed)
+           VALUES (?, ?, ?)`,
+          body.runId,
+          hunk.hunkId,
+          completionHunkIds.has(hunk.hunkId) ? 1 : 0,
         );
       }
       for (const finding of body.findings as IdentifiedMergedFinding[]) {
@@ -1104,6 +1182,12 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           pullRequestNumber: event.payload.pullRequestNumber,
           reason: prepared.skipReason,
         });
+        const skippedPublication =
+          prepared.coverage?.mode === "skipped"
+            ? await workflowStep.do("publish-skipped-coverage", () =>
+                publishSkippedReview(this.env, event.payload, prepared!),
+              )
+            : undefined;
         await workflowStep.do("record-skipped-review", () =>
           recordReviewTerminal({
             env: this.env,
@@ -1112,6 +1196,7 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
             status: "skipped",
             reason: prepared?.skipReason,
             prepared,
+            publication: skippedPublication,
             timestamp: event.timestamp,
           }),
         );

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -167,9 +167,8 @@ function completionReplayStatus(
   completionHash: string,
 ): "conflict" | "duplicate" | "missing" {
   if (
-    !existing ||
-    existing.head_sha !== headSha ||
-    existing.status !== "completed"
+    existing?.head_sha !== headSha ||
+    existing?.status !== "completed"
   ) {
     return "missing";
   }

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -184,11 +184,11 @@ function coverageStatement(coverage: ReviewCoverage): string {
   if (coverage.mode === "incremental") label = "Incremental coverage";
   const counts =
     coverage.mode === "skipped"
-      ? `${coverage.unchangedHunkIds.length} unchanged hunk(s) were not resent`
+      ? `${coverage.unchangedHunkIds.length} unchanged hunk(s) were not reviewed again`
       : `${coverage.reviewedHunkIds.length}/${coverage.totalHunks} semantic hunk(s) reviewed`;
   const unchanged =
     coverage.mode === "incremental"
-      ? `; ${coverage.unchangedHunkIds.length} unchanged hunk(s) were not resent`
+      ? `; ${coverage.unchangedHunkIds.length} unchanged hunk(s) were not reviewed again`
       : "";
   return `**Coverage: ${label}.** ${counts}${unchanged}. ${coverage.reason}.`;
 }

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -179,12 +179,9 @@ export interface ReviewPublication {
 export type ReviewRecordStatus = "denied" | "failed" | "published" | "skipped";
 
 function coverageStatement(coverage: ReviewCoverage): string {
-  const label =
-    coverage.mode === "full"
-      ? "Full coverage"
-      : coverage.mode === "incremental"
-        ? "Incremental coverage"
-        : "Skipped coverage";
+  let label = "Skipped coverage";
+  if (coverage.mode === "full") label = "Full coverage";
+  if (coverage.mode === "incremental") label = "Incremental coverage";
   const counts =
     coverage.mode === "skipped"
       ? `${coverage.unchangedHunkIds.length} unchanged hunk(s) were not resent`
@@ -615,15 +612,19 @@ export function decideReviewCoverage(options: {
       .filter(({ hunkId }) => baselineIds.has(hunkId) && !reviewedIds.has(hunkId))
       .map(({ hunkId }) => hunkId),
     skippedHunkIds: options.skippedHunkIds ?? [],
-    affectedFindingIds: affectedFindings.map(({ findingId }) => findingId).sort(),
+    affectedFindingIds: affectedFindings
+      .map(({ findingId }) => findingId)
+      .sort((left, right) => left.localeCompare(right)),
     paths: [
       ...new Set(
         options.hunks
           .filter(({ hunkId }) => reviewedIds.has(hunkId))
           .map(({ file }) => file),
       ),
-    ].sort(),
-    skippedPaths: [...new Set(options.skippedPaths ?? [])].sort(),
+    ].sort((left, right) => left.localeCompare(right)),
+    skippedPaths: [...new Set(options.skippedPaths ?? [])].sort((left, right) =>
+      left.localeCompare(right),
+    ),
   };
 }
 
@@ -1226,10 +1227,14 @@ export async function publishReview(
       .filter(({ status }) => status === "open")
       .map(({ findingId }) => findingId),
   );
+  const reviewSummary =
+    typeof merged.result.summary === "string"
+      ? merged.result.summary
+      : "Review complete.";
   const result = prepared.coverage
     ? {
         ...merged.result,
-        summary: `${coverageStatement(prepared.coverage)}\n\n${String(merged.result.summary ?? "Review complete.")}`,
+        summary: `${coverageStatement(prepared.coverage)}\n\n${reviewSummary}`,
       }
     : merged.result;
   const body = renderComment({

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -522,11 +522,11 @@ function hunkHasSemanticChange(hunk: ParsedDiffHunk): boolean {
   // so it deliberately remains material.
   const normalize = (line: string) => line.slice(1).trim();
   const removed = hunk.body
-    .filter((line) => line.startsWith("-") && !line.startsWith("---"))
+    .filter((line) => line.startsWith("-"))
     .map(normalize)
     .filter(Boolean);
   const added = hunk.body
-    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .filter((line) => line.startsWith("+"))
     .map(normalize)
     .filter(Boolean);
   return JSON.stringify(removed) !== JSON.stringify(added);
@@ -815,9 +815,12 @@ export async function prepareReview(
     ...summarizeChange(rawDiff, rawPaths, omitted, rawHunks),
     riskSignals: triggerRiskSignals,
   };
-  const escalated = params.force || triggerRiskSignals.length > 0;
+  const riskEscalated = triggerRiskSignals.length > 0;
   const eligibleParsed = parsedHunks.filter(
-    (hunk) => escalated || (!ignored(hunk.file) && hunkHasSemanticChange(hunk)),
+    (hunk) =>
+      params.force ||
+      (!ignored(hunk.file) &&
+        (riskEscalated || hunkHasSemanticChange(hunk))),
   );
   const eligibleHunkIds = new Set(eligibleParsed.map(({ hunkId }) => hunkId));
   const eligibleHunks = rawHunks.filter(({ hunkId }) => eligibleHunkIds.has(hunkId));
@@ -866,7 +869,7 @@ export async function prepareReview(
     paths: selectedPaths,
     omitted,
     hunks: selectedHunks,
-    allHunks: eligibleHunks,
+    allHunks: rawHunks,
     coverage,
     changeProfile: {
       ...preliminaryProfile,

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -11,6 +11,7 @@ import {
   csv,
   dataPrompt,
   duplicateScoutModels,
+  ignored,
   isEligibleFreeScoutModelId,
   mergerSchema,
   mergerSystem,
@@ -84,11 +85,41 @@ export interface PreparedReview {
   paths: string[];
   omitted: string[];
   hunks?: ReviewHunk[];
+  allHunks?: ReviewHunk[];
   changeProfile?: ChangeProfile;
+  coverage?: ReviewCoverage;
   pullRequest?: PullRequestMetadata;
   context?: string;
   guidelines?: string;
   threads?: string;
+}
+
+export type ReviewCoverageMode = "full" | "incremental" | "skipped";
+
+export interface OpenFindingBaseline {
+  findingId: string;
+  file: string;
+  title: string;
+  hunkIds: string[];
+}
+
+export interface ReviewBaseline {
+  headSha?: string;
+  hunkIds: string[];
+  openFindings: OpenFindingBaseline[];
+}
+
+export interface ReviewCoverage {
+  mode: ReviewCoverageMode;
+  reason: string;
+  baselineHeadSha?: string;
+  totalHunks: number;
+  reviewedHunkIds: string[];
+  unchangedHunkIds: string[];
+  skippedHunkIds: string[];
+  affectedFindingIds: string[];
+  paths: string[];
+  skippedPaths: string[];
 }
 
 export interface ModelMetric {
@@ -147,10 +178,49 @@ export interface ReviewPublication {
 
 export type ReviewRecordStatus = "denied" | "failed" | "published" | "skipped";
 
+function coverageStatement(coverage: ReviewCoverage): string {
+  const label =
+    coverage.mode === "full"
+      ? "Full coverage"
+      : coverage.mode === "incremental"
+        ? "Incremental coverage"
+        : "Skipped coverage";
+  const counts =
+    coverage.mode === "skipped"
+      ? `${coverage.unchangedHunkIds.length} unchanged hunk(s) were not resent`
+      : `${coverage.reviewedHunkIds.length}/${coverage.totalHunks} semantic hunk(s) reviewed`;
+  const unchanged =
+    coverage.mode === "incremental"
+      ? `; ${coverage.unchangedHunkIds.length} unchanged hunk(s) were not resent`
+      : "";
+  return `**Coverage: ${label}.** ${counts}${unchanged}. ${coverage.reason}.`;
+}
+
+function affectedFindingContext(
+  baseline: ReviewBaseline,
+  coverage: ReviewCoverage,
+): string {
+  const affected = new Set(coverage.affectedFindingIds);
+  return baseline.openFindings
+    .filter(({ findingId }) => affected.has(findingId))
+    .map(
+      ({ findingId, file, title }) =>
+        `DURABLE OPEN FINDING ${findingId} at ${file}: ${title.slice(0, 300)}`,
+    )
+    .join("\n")
+    .slice(0, 4_000);
+}
+
 interface ClaimResponse {
   claimed: boolean;
   reason?: string;
   previousState: ReviewState;
+}
+
+interface ParsedDiffHunk extends ReviewHunk {
+  body: string[];
+  header: string;
+  prelude: string[];
 }
 
 function finiteNumber(value: string, fallback: number): number {
@@ -281,18 +351,58 @@ function originatingAgent(
   return undefined;
 }
 
+export function reviewRiskSignals(paths: string[]): string[] {
+  return [
+    paths.some((path) =>
+      /(^|\/)(auth|authentication|authorization|credentials?|oauth|security|secrets?|sessions?)(\/|\.|-|_|$)/i.test(
+        path,
+      ) ||
+      /(^|\/)\.env(?:\.|$)/i.test(path) ||
+      /\.(key|p12|pem|pfx)$/i.test(path),
+    )
+      ? "authentication-or-secrets"
+      : undefined,
+    paths.some(
+      (path) =>
+        /(^|\/)(drizzle|migrations?|schema)(\/|\.|-|_|$)/i.test(path) ||
+        /\.(prisma|sql)$/i.test(path),
+    )
+      ? "database-schema"
+      : undefined,
+    paths.some(
+      (path) =>
+        /(^|\/)(infra|infra-bootstrap|terraform|k8s|kubernetes)(\/|$)/i.test(
+          path,
+        ) || /(^|\/)(Dockerfile|docker-compose[^/]*)$/i.test(path) || /\.tf$/i.test(path),
+    )
+      ? "infrastructure"
+      : undefined,
+    paths.some(
+      (path) =>
+        path.startsWith(".github/workflows/") ||
+        /(^|\/)(deploy|deployment)(\/|\.|-|_|$)/i.test(path) ||
+        /(^|\/)(wrangler|vercel|netlify)\.[^/]+$/i.test(path),
+    )
+      ? "ci-or-deployment"
+      : undefined,
+  ].filter((signal): signal is string => signal !== undefined);
+}
+
 function summarizeChange(
   diff: string,
   paths: string[],
   omitted: string[],
   hunks: ReviewHunk[],
+  skippedPaths: string[] = [],
 ): ChangeProfile {
-  const allPaths = [...new Set([...paths, ...omitted])];
+  const allPaths = [...new Set([...paths, ...omitted, ...skippedPaths])];
   const languages = [
     ...new Set(
       allPaths
         .map((path) => path.split(".").at(-1)?.toLowerCase())
-        .map((extension) => (extension ? EXTENSION_LANGUAGE[extension] : undefined))
+        .map((extension) =>
+          extension ? EXTENSION_LANGUAGE[extension] : undefined,
+        )
         .filter((language): language is string => language !== undefined),
     ),
   ].sort((left, right) => left.localeCompare(right));
@@ -304,20 +414,7 @@ function summarizeChange(
       }),
     ),
   ].sort((left, right) => left.localeCompare(right));
-  const riskSignals = [
-    allPaths.some((path) => /(^|\/)(auth|security|secrets?)(\/|\.|$)/i.test(path))
-      ? "authentication-or-secrets"
-      : undefined,
-    allPaths.some((path) => /(^|\/)(drizzle|migrations?|schema)(\/|\.|$)/i.test(path))
-      ? "database-schema"
-      : undefined,
-    allPaths.some((path) => /(^|\/)(infra|infra-bootstrap)(\/|$)/i.test(path))
-      ? "infrastructure"
-      : undefined,
-    allPaths.some((path) => path.startsWith(".github/workflows/"))
-      ? "ci-or-deployment"
-      : undefined,
-  ].filter((signal): signal is string => signal !== undefined);
+  const riskSignals = reviewRiskSignals(allPaths);
   return {
     diffCharacters: diff.length,
     additions: countPatchLines(diff, "+"),
@@ -348,38 +445,56 @@ function parseHunkHeader(line: string): {
   };
 }
 
-export async function identifyDiffHunks(diff: string): Promise<ReviewHunk[]> {
+async function parseDiffHunks(diff: string): Promise<ParsedDiffHunk[]> {
   const pending: Array<{
     file: string;
     body: string[];
+    header: string;
+    prelude: string[];
     oldStart: number;
     oldLines: number;
     newStart: number;
     newLines: number;
   }> = [];
   let file: string | undefined;
+  let prelude: string[] = [];
   let current: (typeof pending)[number] | undefined;
   for (const line of diff.split("\n")) {
     const fileMatch = /^diff --git a\/.* b\/(.+)$/.exec(line);
     if (fileMatch) {
       file = fileMatch[1];
+      prelude = [line];
       current = undefined;
       continue;
     }
     const header = parseHunkHeader(line);
     if (header && file) {
-      current = { file, body: [], ...header };
+      current = {
+        file,
+        body: [],
+        header: line,
+        prelude: [...prelude],
+        ...header,
+      };
       pending.push(current);
       continue;
     }
     if (current && line !== String.raw`\ No newline at end of file`) {
       current.body.push(line);
+    } else if (file && !current) {
+      prelude.push(line);
     }
   }
 
   const occurrences = new Map<string, number>();
   return Promise.all(
-    pending.map(async ({ file: path, body, ...coordinates }) => {
+    pending.map(async ({
+      file: path,
+      body,
+      header,
+      prelude: filePrelude,
+      ...coordinates
+    }) => {
       const canonical = `${path}\n${body.join("\n")}`;
       const occurrence = (occurrences.get(canonical) ?? 0) + 1;
       occurrences.set(canonical, occurrence);
@@ -389,10 +504,127 @@ export async function identifyDiffHunks(diff: string): Promise<ReviewHunk[]> {
         hunkId: `h_${identity.slice(0, 24)}`,
         fingerprint,
         file: path,
+        body,
+        header,
+        prelude: filePrelude,
         ...coordinates,
       };
     }),
   );
+}
+
+export async function identifyDiffHunks(diff: string): Promise<ReviewHunk[]> {
+  return (await parseDiffHunks(diff)).map(
+    ({ body: _body, header: _header, prelude: _prelude, ...hunk }) => hunk,
+  );
+}
+
+function hunkHasSemanticChange(hunk: ParsedDiffHunk): boolean {
+  // Treat indentation, trailing whitespace, and blank-line-only edits as
+  // non-semantic. Internal whitespace can change strings or language syntax,
+  // so it deliberately remains material.
+  const normalize = (line: string) => line.slice(1).trim();
+  const removed = hunk.body
+    .filter((line) => line.startsWith("-") && !line.startsWith("---"))
+    .map(normalize)
+    .filter(Boolean);
+  const added = hunk.body
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map(normalize)
+    .filter(Boolean);
+  return JSON.stringify(removed) !== JSON.stringify(added);
+}
+
+function renderSelectedDiff(
+  hunks: ParsedDiffHunk[],
+  selected: Set<string>,
+): string {
+  const blocks: string[] = [];
+  let previousFile: string | undefined;
+  for (const hunk of hunks) {
+    if (!selected.has(hunk.hunkId)) continue;
+    if (hunk.file !== previousFile) {
+      blocks.push(...hunk.prelude);
+      previousFile = hunk.file;
+    }
+    blocks.push(hunk.header, ...hunk.body);
+  }
+  return blocks.length > 0 ? `${blocks.join("\n")}\n` : "";
+}
+
+export function decideReviewCoverage(options: {
+  force: boolean;
+  riskSignals: string[];
+  hunks: ReviewHunk[];
+  baseline: ReviewBaseline;
+  skippedHunkIds?: string[];
+  skippedPaths?: string[];
+}): ReviewCoverage {
+  const currentIds = new Set(options.hunks.map(({ hunkId }) => hunkId));
+  const baselineIds = new Set(options.baseline.hunkIds);
+  const newHunks = options.hunks.filter(({ hunkId }) => !baselineIds.has(hunkId));
+  const changedFiles = new Set(newHunks.map(({ file }) => file));
+  const affectedFindings = options.baseline.openFindings.filter((finding) =>
+    changedFiles.has(finding.file),
+  );
+  const affectedIds = new Set(
+    affectedFindings.flatMap(({ hunkIds }) =>
+      hunkIds.filter((id) => currentIds.has(id)),
+    ),
+  );
+  const incrementalIds = new Set([
+    ...newHunks.map(({ hunkId }) => hunkId),
+    ...affectedIds,
+  ]);
+  let mode: ReviewCoverageMode;
+  let reason: string;
+  let reviewedIds: Set<string>;
+  if (options.force) {
+    mode = "full";
+    reason = "explicit forced full review";
+    reviewedIds = currentIds;
+  } else if (options.riskSignals.length > 0) {
+    mode = "full";
+    reason = `risk escalation: ${options.riskSignals.join(", ")}`;
+    reviewedIds = currentIds;
+  } else if (!options.baseline.headSha) {
+    mode = currentIds.size > 0 ? "full" : "skipped";
+    reason =
+      currentIds.size > 0
+        ? "no completed review baseline"
+        : "no semantic hunks to review";
+    reviewedIds = currentIds;
+  } else if (incrementalIds.size > 0) {
+    mode = "incremental";
+    reason = "new or materially changed hunks since the last completed review";
+    reviewedIds = incrementalIds;
+  } else {
+    mode = "skipped";
+    reason = "all current semantic hunks were covered by the last completed review";
+    reviewedIds = new Set();
+  }
+  return {
+    mode,
+    reason,
+    baselineHeadSha: options.baseline.headSha,
+    totalHunks: options.hunks.length,
+    reviewedHunkIds: options.hunks
+      .filter(({ hunkId }) => reviewedIds.has(hunkId))
+      .map(({ hunkId }) => hunkId),
+    unchangedHunkIds: options.hunks
+      .filter(({ hunkId }) => baselineIds.has(hunkId) && !reviewedIds.has(hunkId))
+      .map(({ hunkId }) => hunkId),
+    skippedHunkIds: options.skippedHunkIds ?? [],
+    affectedFindingIds: affectedFindings.map(({ findingId }) => findingId).sort(),
+    paths: [
+      ...new Set(
+        options.hunks
+          .filter(({ hunkId }) => reviewedIds.has(hunkId))
+          .map(({ file }) => file),
+      ),
+    ].sort(),
+    skippedPaths: [...new Set(options.skippedPaths ?? [])].sort(),
+  };
 }
 
 function normalizedFindingTitle(title: string): string {
@@ -509,6 +741,17 @@ async function coordinatorRequest<T>(
   return response.json<T>();
 }
 
+async function reviewBaseline(
+  env: Env,
+  params: ReviewWorkflowParams,
+): Promise<ReviewBaseline> {
+  // Small unit-level consumers of the engine may not bind a coordinator. The
+  // deployed Worker always does; treating the missing binding as an empty
+  // baseline keeps those consumers conservative (a full review).
+  if (!env.PR_STATE) return { hunkIds: [], openFindings: [] };
+  return coordinatorRequest<ReviewBaseline>(env, params, "/reviews/baseline", {});
+}
+
 export async function prepareReview(
   env: Env,
   params: ReviewWorkflowParams,
@@ -534,7 +777,10 @@ export async function prepareReview(
       omitted: [],
     };
   }
-  if (settings.ignoredAuthors.includes(pr.user.login.toLowerCase())) {
+  if (
+    !params.force &&
+    settings.ignoredAuthors.includes(pr.user.login.toLowerCase())
+  ) {
     return {
       skipReason: `ignored author ${pr.user.login}`,
       paths: [],
@@ -543,8 +789,58 @@ export async function prepareReview(
   }
 
   const headSha = pr.head.sha;
-  const { diff, paths, omitted } = await reviewer.changedFiles();
-  const hunks = await identifyDiffHunks(diff);
+  const { diff: rawDiff, paths: rawPaths, omitted } = await reviewer.changedFiles({
+    includeIgnored: true,
+  });
+  const parsedHunks = await parseDiffHunks(rawDiff);
+  const rawHunks = parsedHunks.map(
+    ({ body: _body, header: _header, prelude: _prelude, ...hunk }) => hunk,
+  );
+  const baseline = await reviewBaseline(env, params);
+  const baselineIds = new Set(baseline.hunkIds);
+  const materiallyChangedHunks = baseline.headSha
+    ? rawHunks.filter(({ hunkId }) => !baselineIds.has(hunkId))
+    : rawHunks;
+  const materiallyChangedPaths = [
+    ...new Set(materiallyChangedHunks.map(({ file }) => file)),
+  ];
+  const triggerRiskSignals = summarizeChange(
+    rawDiff,
+    materiallyChangedPaths,
+    omitted,
+    materiallyChangedHunks,
+  ).riskSignals;
+  const preliminaryProfile = {
+    ...summarizeChange(rawDiff, rawPaths, omitted, rawHunks),
+    riskSignals: triggerRiskSignals,
+  };
+  const escalated = params.force || triggerRiskSignals.length > 0;
+  const eligibleParsed = parsedHunks.filter(
+    (hunk) => escalated || (!ignored(hunk.file) && hunkHasSemanticChange(hunk)),
+  );
+  const eligibleHunkIds = new Set(eligibleParsed.map(({ hunkId }) => hunkId));
+  const eligibleHunks = rawHunks.filter(({ hunkId }) => eligibleHunkIds.has(hunkId));
+  const skippedHunks = rawHunks.filter(({ hunkId }) => !eligibleHunkIds.has(hunkId));
+  const skippedPaths = rawPaths.filter(
+    (path) => !eligibleHunks.some((hunk) => hunk.file === path),
+  );
+  const coverage = decideReviewCoverage({
+    force: params.force,
+    riskSignals: triggerRiskSignals,
+    hunks: eligibleHunks,
+    baseline,
+    skippedHunkIds: skippedHunks.map(({ hunkId }) => hunkId),
+    skippedPaths,
+  });
+  const reviewedIds = new Set(coverage.reviewedHunkIds);
+  const selectedParsed = eligibleParsed.filter(({ hunkId }) =>
+    reviewedIds.has(hunkId),
+  );
+  const selectedHunks = eligibleHunks.filter(({ hunkId }) =>
+    reviewedIds.has(hunkId),
+  );
+  const selectedPaths = [...new Set(selectedHunks.map(({ file }) => file))];
+  const selectedDiff = renderSelectedDiff(selectedParsed, reviewedIds);
   const labels = (pr.labels ?? [])
     .map(({ name }) => name?.trim())
     .filter((name): name is string => Boolean(name));
@@ -562,13 +858,21 @@ export async function prepareReview(
   });
   return {
     headSha,
-    diffFingerprint: await sha256(diff),
+    diffFingerprint: await sha256(rawDiff),
     configFingerprint: await sha256(config),
-    diff,
-    paths,
+    ...(coverage.mode === "skipped" ? { skipReason: coverage.reason } : {}),
+    diff: selectedDiff,
+    paths: selectedPaths,
     omitted,
-    hunks,
-    changeProfile: summarizeChange(diff, paths, omitted, hunks),
+    hunks: selectedHunks,
+    allHunks: eligibleHunks,
+    coverage,
+    changeProfile: {
+      ...preliminaryProfile,
+      reviewableFiles: new Set(eligibleHunks.map(({ file }) => file)).size,
+      omittedFiles: omitted.length + skippedPaths.length,
+      hunks: eligibleHunks.length,
+    },
     pullRequest: {
       author: pr.user.login,
       authorAssociation: pr.author_association,
@@ -578,9 +882,18 @@ export async function prepareReview(
       taskType: taskType(labels),
       originatingAgent: originatingAgent(pr.title, pr.head.ref),
     },
-    context: diff.trim() ? await reviewer.fileContext(paths, headSha) : "",
-    guidelines: diff.trim() ? await reviewer.headGuidelines(headSha) : "",
-    threads: diff.trim() ? await reviewer.reviewThreadContext() : "",
+    context: selectedDiff.trim()
+      ? await reviewer.fileContext(selectedPaths, headSha)
+      : "",
+    guidelines: selectedDiff.trim() ? await reviewer.headGuidelines(headSha) : "",
+    threads: selectedDiff.trim()
+      ? [
+          affectedFindingContext(baseline, coverage),
+          await reviewer.reviewThreadContext(selectedPaths),
+        ]
+          .filter(Boolean)
+          .join("\n\n")
+      : "",
   };
 }
 
@@ -913,8 +1226,14 @@ export async function publishReview(
       .filter(({ status }) => status === "open")
       .map(({ findingId }) => findingId),
   );
+  const result = prepared.coverage
+    ? {
+        ...merged.result,
+        summary: `${coverageStatement(prepared.coverage)}\n\n${String(merged.result.summary ?? "Review complete.")}`,
+      }
+    : merged.result;
   const body = renderComment({
-    result: merged.result,
+    result,
     headSha: prepared.headSha,
     models: scouts.models,
     merger: settings.merger,
@@ -947,6 +1266,60 @@ export async function publishReview(
     ),
     runCostUsd,
     findings: findingPublications,
+  };
+}
+
+export async function publishSkippedReview(
+  env: Env,
+  params: ReviewWorkflowParams,
+  prepared: PreparedReview,
+): Promise<ReviewPublication> {
+  if (!prepared.headSha || !prepared.coverage) {
+    throw new Error("Cannot publish skipped coverage for an unprepared review");
+  }
+  const token = await installationToken(env);
+  const reviewer = new Reviewer(modelSettings(env, params, token));
+  const currentHead = (await reviewer.getPr()).head.sha;
+  if (currentHead !== prepared.headSha) {
+    throw new Error("PR head changed before skipped coverage could be published");
+  }
+  const existing = await reviewer.existingComment(
+    STATEFUL_REVIEW_MARKER,
+    new Set([env.AI_REVIEW_APP_BOT_LOGIN]),
+  );
+  const statement = coverageStatement(prepared.coverage);
+  const headStatus = [
+    "<!-- ai-review-coverage-head -->",
+    `Head \`${prepared.headSha.slice(0, 12)}\` did not require model review.`,
+  ].join("\n");
+  let body = existing.body;
+  if (body) {
+    const coveragePattern = /\*\*Coverage: (?:Full|Incremental|Skipped) coverage\.\*\*[^\n]*/;
+    body = coveragePattern.test(body)
+      ? body.replace(coveragePattern, statement)
+      : body.replace(
+          "## Stateful AI code review",
+          `## Stateful AI code review\n\n${statement}`,
+        );
+    const headPattern = /<!-- ai-review-coverage-head -->\n[^\n]*/;
+    body = headPattern.test(body)
+      ? body.replace(headPattern, headStatus)
+      : `${body}\n\n${headStatus}`;
+  } else {
+    body = [
+      STATEFUL_REVIEW_MARKER,
+      `<!-- ai-review-cost:${JSON.stringify(existing.state)} -->`,
+      "## Stateful AI code review",
+      "",
+      statement,
+      "",
+      headStatus,
+    ].join("\n");
+  }
+  return {
+    commentId: await reviewer.writeComment(existing.id, body),
+    runCostUsd: 0,
+    findings: [],
   };
 }
 
@@ -1039,6 +1412,7 @@ export async function recordReviewTerminal(options: {
       change: prepared?.changeProfile,
       coverage: prepared
         ? {
+            ...prepared.coverage,
             paths: prepared.paths,
             omitted: prepared.omitted,
           }
@@ -1088,6 +1462,7 @@ export async function completeReview(
     commentId: publication.commentId,
     findingPublications: publication.findings,
     hunks: artifacts.hunks,
+    currentHunks: prepared.allHunks ?? artifacts.hunks,
     findings: artifacts.publishedFindings,
   });
 }

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -425,14 +425,18 @@ export function parseReviewEvent(
     return parsePullRequestEvent(event, identity);
   }
 
+  const reviewCommand =
+    typeof event.comment?.body === "string"
+      ? /^\/ai-review(?: full)?$/.exec(event.comment.body)
+      : null;
   if (
     eventName !== "issue_comment" ||
     identity.action !== "created" ||
-    event.comment?.body !== "/ai-review" ||
-    typeof event.comment.author_association !== "string" ||
+    !reviewCommand ||
+    typeof event.comment?.author_association !== "string" ||
     !TRUSTED_AUTHOR_ASSOCIATIONS.has(event.comment.author_association) ||
     typeof event.sender?.login !== "string" ||
-    typeof event.comment.user?.login !== "string" ||
+    typeof event.comment?.user?.login !== "string" ||
     event.sender.login.toLowerCase() !== event.comment.user.login.toLowerCase()
   ) {
     return { kind: "ignored", reason: "unsupported-event" };

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -348,4 +348,58 @@ describe("PullRequestCoordinator in workerd", () => {
       ).toEqual([{ action: "resolved", r2_recorded: 1 }]);
     });
   });
+
+  it("uses a zero-cost skipped completion as the next review baseline", async () => {
+    const stub = coordinator();
+    const runId = "workerd-skipped-review";
+    const currentHunk = {
+      hunkId: `h_${"a".repeat(24)}`,
+      fingerprint: "b".repeat(64),
+      file: "pnpm-lock.yaml",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+    };
+    const claim = await stub.fetch("https://coordinator.test/reviews/claim", {
+      method: "POST",
+      body: JSON.stringify({
+        runId,
+        headSha: event.headSha,
+        diffFingerprint: "skipped-diff-hash",
+        configFingerprint: "config-hash",
+        force: false,
+        maxRuns: 20,
+        maxCostUsd: 5,
+      }),
+    });
+    await expect(claim.json()).resolves.toMatchObject({ claimed: true });
+
+    const completion = await stub.fetch(
+      "https://coordinator.test/reviews/complete",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          runId,
+          headSha: event.headSha,
+          costUsd: 0,
+          hunks: [],
+          currentHunks: [currentHunk],
+          findings: [],
+          findingPublications: [],
+        }),
+      },
+    );
+    await expect(completion.json()).resolves.toEqual({ completed: true });
+
+    const baseline = await stub.fetch(
+      "https://coordinator.test/reviews/baseline",
+      { method: "POST", body: "{}" },
+    );
+    await expect(baseline.json()).resolves.toEqual({
+      headSha: event.headSha,
+      hunkIds: [currentHunk.hunkId],
+      openFindings: [],
+    });
+  });
 });

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -127,6 +127,23 @@ describe("PullRequestCoordinator in workerd", () => {
     );
     await expect(completion.json()).resolves.toEqual({ completed: true });
 
+    const firstBaseline = await stub.fetch(
+      "https://coordinator.test/reviews/baseline",
+      { method: "POST", body: "{}" },
+    );
+    await expect(firstBaseline.json()).resolves.toEqual({
+      headSha: event.headSha,
+      hunkIds: [`h_${"c".repeat(24)}`],
+      openFindings: [
+        {
+          findingId: `f_${"b".repeat(24)}`,
+          file: "app.ts",
+          title: "Finding",
+          hunkIds: [`h_${"c".repeat(24)}`],
+        },
+      ],
+    });
+
     const interaction = {
       deliveryId: "workerd-feedback-1",
       eventName: "pull_request_review_thread",
@@ -217,6 +234,26 @@ describe("PullRequestCoordinator in workerd", () => {
           newLines: 1,
         },
       ],
+      currentHunks: [
+        {
+          hunkId: `h_${"c".repeat(24)}`,
+          fingerprint: "d".repeat(64),
+          file: "app.ts",
+          oldStart: 50,
+          oldLines: 1,
+          newStart: 60,
+          newLines: 1,
+        },
+        {
+          hunkId: `h_${"e".repeat(24)}`,
+          fingerprint: "f".repeat(64),
+          file: "unchanged.ts",
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 1,
+        },
+      ],
       findings: [
         {
           findingId: `f_${"b".repeat(24)}`,
@@ -259,6 +296,14 @@ describe("PullRequestCoordinator in workerd", () => {
     await expect(retriedCompletion.json()).resolves.toEqual({
       completed: true,
       duplicate: true,
+    });
+    const laterBaseline = await stub.fetch(
+      "https://coordinator.test/reviews/baseline",
+      { method: "POST", body: "{}" },
+    );
+    await expect(laterBaseline.json()).resolves.toMatchObject({
+      headSha: laterHead,
+      hunkIds: [`h_${"c".repeat(24)}`, `h_${"e".repeat(24)}`],
     });
     await runInDurableObject(stub, async (_instance, state) => {
       expect(

--- a/ai-review/tests-runtime/coverage.test.ts
+++ b/ai-review/tests-runtime/coverage.test.ts
@@ -18,6 +18,35 @@ function hunk(id: string, file = "app.ts"): ReviewHunk {
 }
 
 describe("incremental review coverage in workerd", () => {
+  it("uses deterministic first-review coverage without a completed baseline", () => {
+    const current = hunk("a");
+    const baseline = { hunkIds: [], openFindings: [] };
+
+    expect(
+      decideReviewCoverage({
+        force: false,
+        riskSignals: [],
+        hunks: [current],
+        baseline,
+      }),
+    ).toMatchObject({
+      mode: "full",
+      reason: "no completed review baseline",
+      reviewedHunkIds: [current.hunkId],
+    });
+    expect(
+      decideReviewCoverage({
+        force: false,
+        riskSignals: [],
+        hunks: [],
+        baseline,
+      }),
+    ).toMatchObject({
+      mode: "skipped",
+      reason: "no semantic hunks to review",
+    });
+  });
+
   it("reviews only new hunks and the unchanged hunk of an affected open finding", () => {
     const first = hunk("a");
     const unchanged = hunk("b", "other.ts");

--- a/ai-review/tests-runtime/coverage.test.ts
+++ b/ai-review/tests-runtime/coverage.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideReviewCoverage,
+  reviewRiskSignals,
+  type ReviewHunk,
+} from "../src/review-engine";
+
+function hunk(id: string, file = "app.ts"): ReviewHunk {
+  return {
+    hunkId: `h_${id.repeat(24)}`,
+    fingerprint: id.repeat(64),
+    file,
+    oldStart: 1,
+    oldLines: 1,
+    newStart: 1,
+    newLines: 1,
+  };
+}
+
+describe("incremental review coverage in workerd", () => {
+  it("reviews only new hunks and the unchanged hunk of an affected open finding", () => {
+    const first = hunk("a");
+    const unchanged = hunk("b", "other.ts");
+    const added = hunk("c");
+    const coverage = decideReviewCoverage({
+      force: false,
+      riskSignals: [],
+      hunks: [first, unchanged, added],
+      baseline: {
+        headSha: "1".repeat(40),
+        hunkIds: [first.hunkId, unchanged.hunkId],
+        openFindings: [
+          {
+            findingId: `f_${"d".repeat(24)}`,
+            file: "app.ts",
+            title: "Still open",
+            hunkIds: [first.hunkId],
+          },
+        ],
+      },
+    });
+
+    expect(coverage).toMatchObject({
+      mode: "incremental",
+      reviewedHunkIds: [first.hunkId, added.hunkId],
+      unchangedHunkIds: [unchanged.hunkId],
+      affectedFindingIds: [`f_${"d".repeat(24)}`],
+    });
+  });
+
+  it("deterministically skips an unchanged synchronize event", () => {
+    const current = hunk("a");
+    const options = {
+      force: false,
+      riskSignals: [] as string[],
+      hunks: [current],
+      baseline: {
+        headSha: "1".repeat(40),
+        hunkIds: [current.hunkId],
+        openFindings: [],
+      },
+    };
+    expect(decideReviewCoverage(options)).toEqual(decideReviewCoverage(options));
+    expect(decideReviewCoverage(options)).toMatchObject({
+      mode: "skipped",
+      reviewedHunkIds: [],
+      unchangedHunkIds: [current.hunkId],
+    });
+  });
+
+  it("escalates risk and explicit requests to full coverage", () => {
+    const current = [hunk("a"), hunk("b")];
+    const baseline = {
+      headSha: "1".repeat(40),
+      hunkIds: current.map(({ hunkId }) => hunkId),
+      openFindings: [],
+    };
+    expect(
+      decideReviewCoverage({
+        force: false,
+        riskSignals: ["authentication-or-secrets"],
+        hunks: current,
+        baseline,
+      }),
+    ).toMatchObject({ mode: "full", reviewedHunkIds: baseline.hunkIds });
+    expect(
+      decideReviewCoverage({
+        force: true,
+        riskSignals: [],
+        hunks: current,
+        baseline,
+      }),
+    ).toMatchObject({
+      mode: "full",
+      reason: "explicit forced full review",
+      reviewedHunkIds: baseline.hunkIds,
+    });
+  });
+
+  it("classifies every full-review risk family from changed paths", () => {
+    expect(
+      reviewRiskSignals([
+        "src/auth/session.ts",
+        "drizzle/0001.sql",
+        "infra/main.tf",
+        ".github/workflows/deploy.yml",
+      ]),
+    ).toEqual([
+      "authentication-or-secrets",
+      "database-schema",
+      "infrastructure",
+      "ci-or-deployment",
+    ]);
+    expect(reviewRiskSignals(["src/component.tsx"])).toEqual([]);
+  });
+});

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -665,6 +665,28 @@ describe("PullRequestCoordinator", () => {
     });
   });
 
+  it("rejects conflicting metadata for the same completed hunk", async () => {
+    const { coordinator } = coordinatorFixture();
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/reviews/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          runId: "review-delivery-123",
+          headSha: event.headSha,
+          costUsd: 0,
+          hunks: [identifiedHunk],
+          currentHunks: [{ ...identifiedHunk, file: "different.ts" }],
+          findings: [],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid review completion",
+    });
+  });
+
   it("rejects inconsistent finding publication mappings", async () => {
     const { coordinator } = coordinatorFixture();
     const validPublication = {

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -675,7 +675,9 @@ describe("PullRequestCoordinator", () => {
           headSha: event.headSha,
           costUsd: 0,
           hunks: [identifiedHunk],
-          currentHunks: [{ ...identifiedHunk, file: "different.ts" }],
+          currentHunks: [
+            { ...identifiedHunk, newLines: identifiedHunk.newLines + 1 },
+          ],
           findings: [],
         }),
       }),

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -875,6 +875,7 @@ describe("stateful review engine", () => {
       String(fetchMock.mock.calls[3]?.[1]?.body),
     ) as { body: string };
     expect(update.body).toContain("Coverage: Skipped coverage");
+    expect(update.body).toContain("1 unchanged hunk(s) were not reviewed again");
     expect(update.body).toContain("<!-- ai-review-coverage-head -->");
     expect(update.body).toContain("did not require model review");
     expect(update.body).toContain("Existing fallback finding");

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -82,6 +82,30 @@ afterEach(() => {
 });
 
 describe("stateful review engine", () => {
+  it("reserves the bounded diff budget for reviewable files", async () => {
+    const ignoredPatch = `@@ -1 +1 @@\n-${"a".repeat(27_000)}\n+${"b".repeat(27_000)}`;
+    const sourcePatch = `@@ -1 +1 @@\n-${"a".repeat(5_000)}\n+${"b".repeat(5_000)}`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        json([
+          ...Array.from({ length: 5 }, (_, index) => ({
+            filename: `src/client-${index}.generated.ts`,
+            status: "modified",
+            patch: ignoredPatch,
+          })),
+          { filename: "src/app.ts", status: "modified", patch: sourcePatch },
+        ]),
+      ),
+    );
+
+    const changed = await reviewer().changedFiles({ includeIgnored: true });
+
+    expect(changed.paths[0]).toBe("src/app.ts");
+    expect(changed.diff).toContain("diff --git a/src/app.ts b/src/app.ts");
+    expect(changed.omitted).not.toContain("src/app.ts");
+  });
+
   it("batches exact-head file context instead of fetching every path", async () => {
     const paths = Array.from({ length: 37 }, (_, index) => `src/file-${index}.ts`);
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -186,7 +210,7 @@ describe("stateful review engine", () => {
       author_association: "OWNER",
       user: { login: "robbie" },
       head: {
-        sha: params.headSha,
+        sha: HEAD_SHA,
         repo: { full_name: params.repository },
       },
     };
@@ -237,14 +261,14 @@ describe("stateful review engine", () => {
     });
   });
 
-  it("skips generated, lockfile, and whitespace-only hunks unless forced", async () => {
+  it("skips generated, lockfile, and whitespace-only hunks automatically", async () => {
     const pullRequest = {
       state: "open",
       draft: false,
       author_association: "OWNER",
       user: { login: "robbie" },
       head: {
-        sha: params.headSha,
+        sha: HEAD_SHA,
         repo: { full_name: params.repository },
       },
     };
@@ -287,6 +311,94 @@ describe("stateful review engine", () => {
         ],
       },
     });
+  });
+
+  it("keeps ignored hunks out of risk escalation but includes them when forced", async () => {
+    const pullRequest = {
+      state: "open",
+      draft: false,
+      author_association: "OWNER",
+      user: { login: "robbie" },
+      head: {
+        sha: HEAD_SHA,
+        ref: "feature",
+        repo: { full_name: params.repository },
+      },
+      labels: [],
+    };
+    const diff =
+      "diff --git a/.github/workflows/deploy.yml b/.github/workflows/deploy.yml\n" +
+      "status modified\n@@ -1 +1 @@\n-old\n+new\n" +
+      "diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml\n" +
+      "status modified\n@@ -1 +1 @@\n-old lock\n+new lock\n";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(json({ token: "installation-token" })),
+    );
+    vi.spyOn(Reviewer.prototype, "getPr").mockResolvedValue(pullRequest);
+    vi.spyOn(Reviewer.prototype, "changedFiles").mockResolvedValue({
+      diff,
+      paths: [".github/workflows/deploy.yml", "pnpm-lock.yaml"],
+      omitted: [],
+    });
+    vi.spyOn(Reviewer.prototype, "fileContext").mockResolvedValue("");
+    vi.spyOn(Reviewer.prototype, "headGuidelines").mockResolvedValue("");
+    vi.spyOn(Reviewer.prototype, "reviewThreadContext").mockResolvedValue("");
+
+    const automatic = await prepareReview(environment(), params);
+    expect(automatic.coverage).toMatchObject({
+      mode: "full",
+      skippedPaths: ["pnpm-lock.yaml"],
+    });
+    expect(automatic.paths).toEqual([".github/workflows/deploy.yml"]);
+    expect(automatic.diff).not.toContain("pnpm-lock.yaml");
+    expect(automatic.allHunks).toHaveLength(2);
+
+    const forced = await prepareReview(environment(), {
+      ...params,
+      force: true,
+    });
+    expect(forced.paths).toEqual([
+      ".github/workflows/deploy.yml",
+      "pnpm-lock.yaml",
+    ]);
+    expect(forced.diff).toContain("pnpm-lock.yaml");
+  });
+
+  it("treats hunk content beginning with diff-header characters as semantic", async () => {
+    const diff =
+      "diff --git a/config.txt b/config.txt\n" +
+      "status modified\n@@ -1 +1 @@\n----\n++++\n";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(json({ token: "installation-token" })),
+    );
+    vi.spyOn(Reviewer.prototype, "getPr").mockResolvedValue({
+      state: "open",
+      draft: false,
+      author_association: "OWNER",
+      user: { login: "robbie" },
+      head: {
+        sha: HEAD_SHA,
+        ref: "feature",
+        repo: { full_name: params.repository },
+      },
+      labels: [],
+    });
+    vi.spyOn(Reviewer.prototype, "changedFiles").mockResolvedValue({
+      diff,
+      paths: ["config.txt"],
+      omitted: [],
+    });
+    vi.spyOn(Reviewer.prototype, "fileContext").mockResolvedValue("");
+    vi.spyOn(Reviewer.prototype, "headGuidelines").mockResolvedValue("");
+    vi.spyOn(Reviewer.prototype, "reviewThreadContext").mockResolvedValue("");
+
+    const prepared = await prepareReview(environment(), params);
+
+    expect(prepared.skipReason).toBeUndefined();
+    expect(prepared.coverage).toMatchObject({ mode: "full", totalHunks: 1 });
+    expect(prepared.diff).toContain("----\n++++");
   });
 
   it("does not resend an unchanged hunk after synchronize", async () => {
@@ -763,6 +875,8 @@ describe("stateful review engine", () => {
       String(fetchMock.mock.calls[3]?.[1]?.body),
     ) as { body: string };
     expect(update.body).toContain("Coverage: Skipped coverage");
+    expect(update.body).toContain("<!-- ai-review-coverage-head -->");
+    expect(update.body).toContain("did not require model review");
     expect(update.body).toContain("Existing fallback finding");
     expect(update.body).toContain('ai-review-cost:{"runs":1,"total_usd":0.1}');
   });

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -10,6 +10,7 @@ import {
   claimReview,
   combineScoutRuns,
   completeReview,
+  decideReviewCoverage,
   failReview,
   identifyReviewArtifacts,
   identifyDiffHunks,
@@ -766,6 +767,41 @@ describe("stateful review engine", () => {
     expect(update.body).toContain('ai-review-cost:{"runs":1,"total_usd":0.1}');
   });
 
+  it("rejects unprepared and stale skipped-coverage publication", async () => {
+    await expect(
+      publishSkippedReview(environment(), params, {
+        paths: [],
+        omitted: [],
+      }),
+    ).rejects.toThrow("unprepared review");
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(json({ token: "installation-token" }))
+        .mockResolvedValueOnce(json({ head: { sha: "b".repeat(40) } })),
+    );
+    await expect(
+      publishSkippedReview(environment(), params, {
+        headSha: params.headSha,
+        paths: [],
+        omitted: [],
+        coverage: {
+          mode: "skipped",
+          reason: "unchanged",
+          totalHunks: 0,
+          reviewedHunkIds: [],
+          unchangedHunkIds: [],
+          skippedHunkIds: [],
+          affectedFindingIds: [],
+          paths: [],
+          skippedPaths: [],
+        },
+      }),
+    ).rejects.toThrow("head changed");
+  });
+
   it("runs and visibly publishes the same OpenRouter plus OpenCode ensemble", async () => {
     const publishedBodies: string[] = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1012,6 +1048,66 @@ describe("stateful review engine", () => {
     expect(moved).toHaveLength(1);
     expect(moved[0]?.hunkId).toBe(first[0]?.hunkId);
     expect(moved[0]?.fingerprint).toBe(first[0]?.fingerprint);
+  });
+
+  it("selects risk, affected-finding, and unchanged coverage", () => {
+    const first = {
+      hunkId: `h_${"a".repeat(24)}`,
+      fingerprint: "a".repeat(64),
+      file: "app.ts",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+    };
+    const second = {
+      ...first,
+      hunkId: `h_${"b".repeat(24)}`,
+      fingerprint: "b".repeat(64),
+      newStart: 10,
+    };
+    const baseline = {
+      headSha: "c".repeat(40),
+      hunkIds: [first.hunkId],
+      openFindings: [
+        {
+          findingId: `f_${"d".repeat(24)}`,
+          file: "app.ts",
+          title: "Existing issue",
+          hunkIds: [first.hunkId],
+        },
+      ],
+    };
+
+    expect(
+      decideReviewCoverage({
+        force: false,
+        riskSignals: [],
+        hunks: [first, second],
+        baseline,
+      }),
+    ).toMatchObject({
+      mode: "incremental",
+      reviewedHunkIds: [first.hunkId, second.hunkId],
+      affectedFindingIds: [`f_${"d".repeat(24)}`],
+      paths: ["app.ts"],
+    });
+    expect(
+      decideReviewCoverage({
+        force: false,
+        riskSignals: ["database-schema"],
+        hunks: [first],
+        baseline,
+      }),
+    ).toMatchObject({ mode: "full", reviewedHunkIds: [first.hunkId] });
+    expect(
+      decideReviewCoverage({
+        force: false,
+        riskSignals: [],
+        hunks: [first],
+        baseline: { ...baseline, openFindings: [] },
+      }),
+    ).toMatchObject({ mode: "skipped", reviewedHunkIds: [] });
   });
 
   it("links a merged finding to its published line while retaining its source identity", async () => {

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -16,6 +16,7 @@ import {
   mergeFindings,
   prepareReview,
   publishReview,
+  publishSkippedReview,
   recordReview,
   runScouts,
 } from "../src/review-engine";
@@ -233,6 +234,148 @@ describe("stateful review engine", () => {
       guidelines: "",
       threads: "",
     });
+  });
+
+  it("skips generated, lockfile, and whitespace-only hunks unless forced", async () => {
+    const pullRequest = {
+      state: "open",
+      draft: false,
+      author_association: "OWNER",
+      user: { login: "robbie" },
+      head: {
+        sha: params.headSha,
+        repo: { full_name: params.repository },
+      },
+    };
+    const files = [
+      {
+        filename: "pnpm-lock.yaml",
+        status: "modified",
+        patch: "@@ -1 +1 @@\n-lock: one\n+lock: two",
+      },
+      {
+        filename: "src/client.generated.ts",
+        status: "modified",
+        patch: "@@ -1 +1 @@\n-export const value=1\n+export const value=2",
+      },
+      {
+        filename: "src/app.ts",
+        status: "modified",
+        patch: "@@ -1 +1 @@\n-  export const value = 1\n+    export const value = 1",
+      },
+    ];
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(json({ token: "installation-token" }))
+        .mockResolvedValueOnce(json(pullRequest))
+        .mockResolvedValueOnce(json(files)),
+    );
+
+    await expect(prepareReview(environment(), params)).resolves.toMatchObject({
+      skipReason: "no semantic hunks to review",
+      diff: "",
+      coverage: {
+        mode: "skipped",
+        reviewedHunkIds: [],
+        skippedPaths: [
+          "pnpm-lock.yaml",
+          "src/app.ts",
+          "src/client.generated.ts",
+        ],
+      },
+    });
+  });
+
+  it("does not resend an unchanged hunk after synchronize", async () => {
+    const patch =
+      "@@ -1 +1 @@\n-old first\n+reviewed first\n" +
+      "@@ -10 +10 @@\n-old second\n+new second";
+    const fullDiff =
+      `diff --git a/app.ts b/app.ts\nstatus modified\n${patch}\n`;
+    const [reviewedHunk, newHunk] = await identifyDiffHunks(fullDiff);
+    expect(reviewedHunk).toBeDefined();
+    expect(newHunk).toBeDefined();
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(json({ token: "installation-token" }))
+        .mockResolvedValueOnce(
+          json({
+            state: "open",
+            draft: false,
+            author_association: "OWNER",
+            user: { login: "robbie" },
+            head: {
+              sha: params.headSha,
+              repo: { full_name: params.repository },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          json([{ filename: "app.ts", status: "modified", patch }]),
+        )
+        .mockResolvedValueOnce(
+          json({
+            data: {
+              repository: {
+                file0: {
+                  byteSize: 30,
+                  isBinary: false,
+                  isTruncated: false,
+                  text: "reviewed first\nnew second",
+                },
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          json({
+            encoding: "base64",
+            size: 19,
+            content: Buffer.from("Review correctness.").toString("base64"),
+          }),
+        )
+        .mockResolvedValueOnce(
+          json({
+            data: {
+              repository: { pullRequest: { reviewThreads: { nodes: [] } } },
+            },
+          }),
+        ),
+    );
+    const env = environment();
+    Object.assign(env, {
+      PR_STATE: {
+        idFromName: vi.fn(() => "coordinator-id"),
+        get: vi.fn(() => ({
+          fetch: vi.fn(() =>
+            Promise.resolve(
+              json({
+                headSha: "b".repeat(40),
+                hunkIds: [reviewedHunk!.hunkId],
+                openFindings: [],
+              }),
+            ),
+          ),
+        })),
+      },
+    });
+
+    const prepared = await prepareReview(env, params);
+
+    expect(prepared.coverage).toMatchObject({
+      mode: "incremental",
+      reviewedHunkIds: [newHunk!.hunkId],
+      unchangedHunkIds: [reviewedHunk!.hunkId],
+    });
+    expect(prepared.diff).toContain("+new second");
+    expect(prepared.diff).not.toContain("+reviewed first");
+    expect(prepared.hunks).toEqual([newHunk]);
+    expect(prepared.allHunks).toEqual([reviewedHunk, newHunk]);
   });
 
   it("rejects invalid model configuration before making model calls", async () => {
@@ -568,6 +711,61 @@ describe("stateful review engine", () => {
     ).rejects.toThrow("Cannot record an unprepared review");
   });
 
+  it("publishes skipped coverage without erasing prior fallback findings", async () => {
+    const existingBody = [
+      STATEFUL_REVIEW_MARKER,
+      '<!-- ai-review-cost:{"runs":1,"total_usd":0.1} -->',
+      "## Stateful AI code review",
+      "",
+      "**Coverage: Full coverage.** 1/1 semantic hunk(s) reviewed. Initial.",
+      "",
+      "## Findings without a diff line",
+      "",
+      "- Existing fallback finding",
+    ].join("\n");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(json({ token: "installation-token" }))
+      .mockResolvedValueOnce(json({ head: { sha: params.headSha } }))
+      .mockResolvedValueOnce(
+        json([
+          {
+            id: 99,
+            user: { login: "robbie-palmer-ai-review[bot]" },
+            body: existingBody,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(json({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const publication = await publishSkippedReview(environment(), params, {
+      headSha: params.headSha,
+      paths: [],
+      omitted: [],
+      coverage: {
+        mode: "skipped",
+        reason: "all current semantic hunks were covered",
+        baselineHeadSha: "b".repeat(40),
+        totalHunks: 1,
+        reviewedHunkIds: [],
+        unchangedHunkIds: [`h_${"a".repeat(24)}`],
+        skippedHunkIds: [],
+        affectedFindingIds: [],
+        paths: [],
+        skippedPaths: [],
+      },
+    });
+
+    expect(publication).toMatchObject({ commentId: 99, runCostUsd: 0 });
+    const update = JSON.parse(
+      String(fetchMock.mock.calls[3]?.[1]?.body),
+    ) as { body: string };
+    expect(update.body).toContain("Coverage: Skipped coverage");
+    expect(update.body).toContain("Existing fallback finding");
+    expect(update.body).toContain('ai-review-cost:{"runs":1,"total_usd":0.1}');
+  });
+
   it("runs and visibly publishes the same OpenRouter plus OpenCode ensemble", async () => {
     const publishedBodies: string[] = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -782,6 +980,7 @@ describe("stateful review engine", () => {
     expect(publishedBodies[0]).toContain("Reported by: `moonshotai/kimi-k2.6`");
     expect(publishedBodies[1]).toContain(STATEFUL_REVIEW_MARKER);
     expect(publishedBodies[1]).toContain("## Stateful AI code review");
+    expect(publishedBodies[1]).toContain("Coverage: Full coverage");
     expect(put).toHaveBeenCalledOnce();
     const record = JSON.parse(String(put.mock.calls[0]?.[1])) as {
       schemaVersion: number;

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -161,6 +161,27 @@ describe("parseReviewEvent", () => {
     });
   });
 
+  it("supports an explicit full review command", () => {
+    expect(
+      parseReviewEvent("issue_comment", "delivery-final", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        issue: { number: 816, pull_request: {} },
+        sender: { login: "robbie" },
+        comment: {
+          body: "/ai-review full",
+          author_association: "OWNER",
+          user: { login: "robbie" },
+        },
+      }),
+    ).toEqual({
+      kind: "accepted",
+      event: expect.objectContaining({
+        force: true,
+      }),
+    });
+  });
+
   it("does not spend on review-thread activity", () => {
     expect(
       parseReviewEvent("pull_request_review_thread", "delivery-3", {

--- a/ai-review/tests/workflow.test.ts
+++ b/ai-review/tests/workflow.test.ts
@@ -11,6 +11,7 @@ const engine = vi.hoisted(() => ({
   mergeFindings: vi.fn(),
   prepareReview: vi.fn(),
   publishReview: vi.fn(),
+  publishSkippedReview: vi.fn(),
   recordReview: vi.fn(),
   recordReviewTerminal: vi.fn(),
   runScouts: vi.fn(),
@@ -118,6 +119,11 @@ beforeEach(() => {
   engine.publishReview.mockResolvedValue({
     commentId: 123,
     runCostUsd: 0.6,
+    findings: [],
+  });
+  engine.publishSkippedReview.mockResolvedValue({
+    commentId: 123,
+    runCostUsd: 0,
     findings: [],
   });
   engine.recordReview.mockResolvedValue(undefined);
@@ -240,6 +246,48 @@ describe("ReviewWorkflow orchestration", () => {
     expect(engine.recordReviewTerminal).toHaveBeenCalledWith(
       expect.objectContaining({ status: "denied" }),
     );
+  });
+
+  it("publishes deterministic skipped coverage without claiming or invoking models", async () => {
+    const coverage = {
+      mode: "skipped",
+      reason: "all current semantic hunks were covered",
+      totalHunks: 1,
+      reviewedHunkIds: [],
+      unchangedHunkIds: [`h_${"a".repeat(24)}`],
+      skippedHunkIds: [],
+      affectedFindingIds: [],
+      paths: [],
+      skippedPaths: [],
+    };
+    const skippedPrepared = {
+      ...prepared,
+      skipReason: coverage.reason,
+      coverage,
+    };
+    engine.prepareReview.mockResolvedValueOnce(skippedPrepared);
+    const { workflow, step } = fixture();
+
+    await workflow.run(event, step);
+
+    expect(engine.claimReview).not.toHaveBeenCalled();
+    expect(engine.runScouts).not.toHaveBeenCalled();
+    expect(engine.publishSkippedReview).toHaveBeenCalledWith(
+      expect.anything(),
+      payload,
+      skippedPrepared,
+    );
+    expect(engine.recordReviewTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "skipped",
+        publication: expect.objectContaining({ runCostUsd: 0 }),
+      }),
+    );
+    expect(vi.mocked(step.do).mock.calls.map(([name]) => name)).toEqual([
+      "prepare-review",
+      "publish-skipped-coverage",
+      "record-skipped-review",
+    ]);
   });
 
   it("records known model spend before propagating a failure", async () => {

--- a/ai-review/tests/workflow.test.ts
+++ b/ai-review/tests/workflow.test.ts
@@ -305,6 +305,47 @@ describe("ReviewWorkflow orchestration", () => {
     ]);
   });
 
+  it("records a denied skipped review without publishing coverage", async () => {
+    const skippedPrepared = {
+      ...prepared,
+      skipReason: "all current semantic hunks were covered",
+      coverage: {
+        mode: "skipped",
+        reason: "all current semantic hunks were covered",
+        totalHunks: 1,
+        reviewedHunkIds: [],
+        unchangedHunkIds: [`h_${"a".repeat(24)}`],
+        skippedHunkIds: [],
+        affectedFindingIds: [],
+        paths: [],
+        skippedPaths: [],
+      },
+    };
+    engine.prepareReview.mockResolvedValueOnce(skippedPrepared);
+    engine.claimReview.mockResolvedValueOnce({
+      claimed: false,
+      reason: "this content and reviewer configuration were already reviewed",
+      previousState: { runs: 1, total_usd: 0.6 },
+    });
+    const { workflow, step } = fixture();
+
+    await workflow.run(event, step);
+
+    expect(engine.publishSkippedReview).not.toHaveBeenCalled();
+    expect(engine.completeReview).not.toHaveBeenCalled();
+    expect(engine.recordReviewTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "denied",
+        reason: "this content and reviewer configuration were already reviewed",
+      }),
+    );
+    expect(vi.mocked(step.do).mock.calls.map(([name]) => name)).toEqual([
+      "prepare-review",
+      "claim-skipped-review",
+      "record-denied-skipped-review",
+    ]);
+  });
+
   it("records known model spend before propagating a failure", async () => {
     engine.mergeFindings.mockRejectedValue(new Error("merger unavailable"));
     const { workflow, step } = fixture();

--- a/ai-review/tests/workflow.test.ts
+++ b/ai-review/tests/workflow.test.ts
@@ -248,7 +248,7 @@ describe("ReviewWorkflow orchestration", () => {
     );
   });
 
-  it("publishes deterministic skipped coverage without claiming or invoking models", async () => {
+  it("claims and completes deterministic skipped coverage without invoking models", async () => {
     const coverage = {
       mode: "skipped",
       reason: "all current semantic hunks were covered",
@@ -270,7 +270,12 @@ describe("ReviewWorkflow orchestration", () => {
 
     await workflow.run(event, step);
 
-    expect(engine.claimReview).not.toHaveBeenCalled();
+    expect(engine.claimReview).toHaveBeenCalledWith(
+      expect.anything(),
+      payload,
+      event.instanceId,
+      skippedPrepared,
+    );
     expect(engine.runScouts).not.toHaveBeenCalled();
     expect(engine.publishSkippedReview).toHaveBeenCalledWith(
       expect.anything(),
@@ -283,10 +288,20 @@ describe("ReviewWorkflow orchestration", () => {
         publication: expect.objectContaining({ runCostUsd: 0 }),
       }),
     );
+    expect(engine.completeReview).toHaveBeenCalledWith(
+      expect.anything(),
+      payload,
+      event.instanceId,
+      skippedPrepared,
+      { hunks: [], candidates: {}, publishedFindings: [] },
+      expect.objectContaining({ runCostUsd: 0 }),
+    );
     expect(vi.mocked(step.do).mock.calls.map(([name]) => name)).toEqual([
       "prepare-review",
+      "claim-skipped-review",
       "publish-skipped-coverage",
       "record-skipped-review",
+      "complete-skipped-review-state",
     ]);
   });
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.sourceEncoding=UTF-8
 # test-specific analysis rules. Test inclusions are also source exclusions.
 sonar.sources=.
 sonar.tests=.
-sonar.test.inclusions=**/tests/**/*
+sonar.test.inclusions=**/tests/**/*,**/tests-runtime/**/*
 
 # Vendored design prototypes exported from Claude Design and their generated
 # standalone build are not part of the maintained application source. Binary


### PR DESCRIPTION
## Summary

- compare each review with the last completed head and send only new or materially changed hunks plus affected open findings
- deterministically skip generated, lockfile-only, indentation-only, and unchanged updates while escalating auth, secrets, schema, infrastructure, and deployment changes to full coverage
- persist per-run hunk coverage and schema-v2 trigger decisions, and make full/incremental/skipped coverage visible in the rolling comment
- support `/ai-review full` as the explicit current-head comprehensive review; the review is only final retrospectively if that head merges

## Validation

- `mise //ai-review:check`
- `mise //ai-review:deploy:dry-run`
- `mise //:lint:markdown:check ai-review/README.md`
- pre-commit gitleaks scan
- `git diff --check`

## QA

No browser or backend-preview QA is required. This changes only the standalone AI review Worker and its Durable Object state.

Shortcut: [#421](https://app.shortcut.com/personal-294/story/421)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added incremental review coverage, focusing on new or affected changes while tracking previously reviewed content.
  * Added automatic escalation to full reviews for higher-risk changes, including authentication, database, infrastructure and deployment updates.
  * Added `/ai-review full` for manually requested complete reviews.
  * Added coverage summaries, skipped-review handling and improved review state tracking.
  * Added support for draft pull requests and more precise review context.

* **Documentation**
  * Documented incremental reviews, coverage decisions, full-review requests and review findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->