### PR TITLE
Derive historical expenditure and FI progress

### DIFF
--- a/ui/components/assettracker/asset-allocation-history-chart.tsx
+++ b/ui/components/assettracker/asset-allocation-history-chart.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { format, parseISO } from "date-fns";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  ASSET_TYPE_COLORS,
+  ASSET_TYPE_LABELS,
+  type AssetAllocationDataPoint,
+  type AssetType,
+} from "@/lib/domain/assettracker";
+
+const ASSET_TYPES = [
+  "cash",
+  "stocks",
+  "bonds",
+  "reits",
+  "crypto",
+  "property",
+] as const satisfies readonly AssetType[];
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function AssetAllocationHistoryChart({
+  data,
+}: Readonly<{ data: AssetAllocationDataPoint[] }>) {
+  const assetTypes = ASSET_TYPES.filter((assetType) =>
+    data.some((point) => point[assetType] != null),
+  );
+  if (data.length === 0 || assetTypes.length === 0) return null;
+  const chartData = data.map((point) => ({
+    ...point,
+    ...Object.fromEntries(
+      assetTypes.map((assetType) => [assetType, point[assetType] ?? 0]),
+    ),
+  }));
+
+  const chartConfig: ChartConfig = {};
+  for (const assetType of assetTypes) {
+    chartConfig[assetType] = {
+      label: ASSET_TYPE_LABELS[assetType],
+      color: ASSET_TYPE_COLORS[assetType],
+    };
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Asset Allocation Over Time</CardTitle>
+        <CardDescription>
+          Percentage of positive net assets by type. Linked mortgages reduce
+          property to home equity; standalone liabilities are excluded from this
+          percentage view.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="px-2 sm:px-6">
+        <ChartContainer
+          config={chartConfig}
+          className="aspect-auto w-full"
+          role="img"
+          aria-label="Percentage of assets by asset type over time"
+        >
+          <ResponsiveContainer width="100%" height={320}>
+            <LineChart
+              data={chartData}
+              margin={{ top: 10, right: 20, left: 0, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis
+                dataKey="date"
+                className="text-xs"
+                minTickGap={24}
+                tickFormatter={(date: string) =>
+                  format(parseISO(date), "MMM yy")
+                }
+              />
+              <YAxis
+                className="text-xs"
+                width={42}
+                domain={[0, 1]}
+                tickFormatter={(value: number) => `${Math.round(value * 100)}%`}
+              />
+              <ChartTooltip
+                content={<ChartTooltipContent />}
+                formatter={(value) => formatPercent(value as number)}
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              {assetTypes.map((assetType) => (
+                <Line
+                  key={assetType}
+                  type="monotone"
+                  dataKey={assetType}
+                  name={ASSET_TYPE_LABELS[assetType]}
+                  stroke={ASSET_TYPE_COLORS[assetType]}
+                  strokeWidth={2.5}
+                  dot={data.length === 1}
+                  connectNulls
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+        <table className="sr-only">
+          <caption>Percentage of assets by asset type over time</caption>
+          <thead>
+            <tr>
+              <th>Date</th>
+              {assetTypes.map((assetType) => (
+                <th key={assetType}>{ASSET_TYPE_LABELS[assetType]}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((point) => (
+              <tr key={point.date}>
+                <td>{point.date}</td>
+                {assetTypes.map((assetType) => (
+                  <td key={assetType}>
+                    {formatPercent(point[assetType] ?? 0)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/components/assettracker/asset-tracker-dashboard.tsx
+++ b/ui/components/assettracker/asset-tracker-dashboard.tsx
@@ -82,11 +82,11 @@ export function AssetTrackerDashboard() {
         </div>
       </div>
       <NetWorthChart data={netWorthData} />
+      <PortfolioGoal />
       <div className="grid gap-8 lg:grid-cols-2">
-        <PortfolioGoal />
         <UpcomingFlows />
+        <FlowSankeyChart />
       </div>
-      <FlowSankeyChart />
       <div className="grid gap-8 lg:grid-cols-2">
         <AssetAllocationChart data={assetAllocation} />
         <AccountBalanceChart accounts={accountDetails} />

--- a/ui/components/assettracker/asset-tracker-dashboard.tsx
+++ b/ui/components/assettracker/asset-tracker-dashboard.tsx
@@ -11,6 +11,7 @@ import { AccountDetailSheet } from "./account-detail-sheet";
 import { AccountsTable } from "./accounts-table";
 import { AddAccountDrawer } from "./add-account-drawer";
 import { AssetAllocationChart } from "./asset-allocation-chart";
+import { AssetAllocationHistoryChart } from "./asset-allocation-history-chart";
 import { useAssetTracker } from "./asset-tracker-provider";
 import { DataControls } from "./data-controls";
 import { FlowSankeyChart } from "./flow-sankey-chart";
@@ -26,6 +27,7 @@ export function AssetTrackerDashboard() {
     accountDetails,
     netWorthData,
     assetAllocation,
+    assetAllocationHistory,
     portfolioReturn,
     inflation,
   } = useAssetTracker();
@@ -82,6 +84,7 @@ export function AssetTrackerDashboard() {
         </div>
       </div>
       <NetWorthChart data={netWorthData} />
+      <AssetAllocationHistoryChart data={assetAllocationHistory} />
       <PortfolioGoal />
       <div className="grid gap-8 lg:grid-cols-2">
         <UpcomingFlows />

--- a/ui/components/assettracker/asset-tracker-provider.tsx
+++ b/ui/components/assettracker/asset-tracker-provider.tsx
@@ -24,16 +24,21 @@ import {
   buildRepository,
   type ClearAccountHistoryInput,
   type CreateAccountInput,
+  DEFAULT_WITHDRAWAL_RATE,
   type DeleteCapitalFlowInput,
   type DeleteSnapshotInput,
   getAllAccountDetails,
   getAllAccountSummaries,
   getNetWorthTimeSeries,
   getPortfolioAnnualReturn,
+  getPortfolioFinancialIndependence,
   getSeedData,
   getTotalByAssetType,
   type ImportAccountHistoryInput,
+  type ImportIncomeHistoryInput,
+  type IncomeRecord,
   type NetWorthDataPoint,
+  type PortfolioFinancialIndependence,
   type RecordBalanceInput,
   type RecordTransferInput,
   type RecurringFlow,
@@ -50,6 +55,8 @@ interface AssetTrackerContextValue {
   assetAllocation: { assetType: AssetType; total: number }[];
   transfers: Transfer[];
   recurringFlows: RecurringFlow[];
+  incomeHistory: IncomeRecord[];
+  financialIndependence: PortfolioFinancialIndependence;
   /** Annualised portfolio growth, excluding recorded external money in/out */
   portfolioReturn: number | null;
   /** Expected annual inflation used to express values in today's money */
@@ -58,6 +65,8 @@ interface AssetTrackerContextValue {
   netWorthTarget: number | null;
   /** Whether the target is expressed in today's money (inflation-adjusted) */
   netWorthTargetIsReal: boolean;
+  /** Sustainable annual withdrawal used to derive the FI target */
+  withdrawalRate: number;
   /** True once the user has made changes that are persisted in this browser */
   hasLocalChanges: boolean;
   createAccount(input: CreateAccountInput): Promise<void>;
@@ -71,11 +80,14 @@ interface AssetTrackerContextValue {
   deleteSnapshot(input: DeleteSnapshotInput): Promise<void>;
   deleteCapitalFlow(input: DeleteCapitalFlowInput): Promise<void>;
   importAccountHistory(input: ImportAccountHistoryInput): Promise<void>;
+  importIncomeHistory(input: ImportIncomeHistoryInput): Promise<void>;
+  clearIncomeHistory(): Promise<void>;
   addRecurringFlow(input: AddRecurringFlowInput): Promise<void>;
   deleteRecurringFlow(id: string): Promise<void>;
   materializeFlow(flowId: string): Promise<void>;
   setExpectedReturn(input: SetExpectedReturnInput): Promise<void>;
   setInflation(rate: number): Promise<void>;
+  setWithdrawalRate(rate: number): Promise<void>;
   setNetWorthTarget(
     target: number | null,
     inTodaysMoney?: boolean,
@@ -147,17 +159,23 @@ export function AssetTrackerProvider({
 
   const views = useMemo(() => {
     const repository = buildRepository(data);
+    const accounts = getAllAccountSummaries(repository);
+    const netWorthData = getNetWorthTimeSeries(repository);
     return {
-      accounts: getAllAccountSummaries(repository),
+      accounts,
       accountDetails: getAllAccountDetails(repository),
-      netWorthData: getNetWorthTimeSeries(repository),
+      netWorthData,
       assetAllocation: getTotalByAssetType(repository),
       transfers: repository.transfers,
       recurringFlows: repository.recurringFlows,
+      incomeHistory: repository.incomeHistory,
+      financialIndependence: getPortfolioFinancialIndependence(repository),
       portfolioReturn: getPortfolioAnnualReturn(repository),
       inflation: repository.settings.expectedAnnualInflation,
       netWorthTarget: repository.settings.targetNetWorth ?? null,
       netWorthTargetIsReal: repository.settings.targetNetWorthIsReal ?? false,
+      withdrawalRate:
+        repository.settings.withdrawalRate ?? DEFAULT_WITHDRAWAL_RATE,
     };
   }, [data]);
 
@@ -183,6 +201,9 @@ export function AssetTrackerProvider({
         mutate((api) => api.deleteCapitalFlow(input)),
       importAccountHistory: (input) =>
         mutate((api) => api.importAccountHistory(input)),
+      importIncomeHistory: (input) =>
+        mutate((api) => api.importIncomeHistory(input)),
+      clearIncomeHistory: () => mutate((api) => api.clearIncomeHistory()),
       addRecurringFlow: (input) => mutate((api) => api.addRecurringFlow(input)),
       deleteRecurringFlow: (id) =>
         mutate((api) => api.deleteRecurringFlow({ id })),
@@ -193,6 +214,8 @@ export function AssetTrackerProvider({
       setExpectedReturn: (input) =>
         mutate((api) => api.setExpectedReturn(input)),
       setInflation: (rate) => mutate((api) => api.setInflation({ rate })),
+      setWithdrawalRate: (rate) =>
+        mutate((api) => api.setWithdrawalRate({ rate })),
       setNetWorthTarget: (target, inTodaysMoney) =>
         mutate((api) => api.setNetWorthTarget({ target, inTodaysMoney })),
       clearData: () => mutate((api) => api.clear()),

--- a/ui/components/assettracker/asset-tracker-provider.tsx
+++ b/ui/components/assettracker/asset-tracker-provider.tsx
@@ -19,6 +19,7 @@ import {
   type AccountId,
   type AccountSummaryView,
   type AddRecurringFlowInput,
+  type AssetAllocationDataPoint,
   type AssetTrackerData,
   type AssetType,
   buildRepository,
@@ -29,6 +30,7 @@ import {
   type DeleteSnapshotInput,
   getAllAccountDetails,
   getAllAccountSummaries,
+  getAssetAllocationTimeSeries,
   getNetWorthTimeSeries,
   getPortfolioAnnualReturn,
   getPortfolioFinancialIndependence,
@@ -53,6 +55,7 @@ interface AssetTrackerContextValue {
   accountDetails: AccountDetailView[];
   netWorthData: NetWorthDataPoint[];
   assetAllocation: { assetType: AssetType; total: number }[];
+  assetAllocationHistory: AssetAllocationDataPoint[];
   transfers: Transfer[];
   recurringFlows: RecurringFlow[];
   incomeHistory: IncomeRecord[];
@@ -166,6 +169,7 @@ export function AssetTrackerProvider({
       accountDetails: getAllAccountDetails(repository),
       netWorthData,
       assetAllocation: getTotalByAssetType(repository),
+      assetAllocationHistory: getAssetAllocationTimeSeries(repository),
       transfers: repository.transfers,
       recurringFlows: repository.recurringFlows,
       incomeHistory: repository.incomeHistory,

--- a/ui/components/assettracker/income-expenditure-chart.tsx
+++ b/ui/components/assettracker/income-expenditure-chart.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { format, parseISO } from "date-fns";
+import { useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Button } from "@/components/ui/button";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  formatAxisTick,
+  formatCurrency,
+  type IncomeRecord,
+  type PortfolioReconciliationPeriod,
+} from "@/lib/domain/assettracker";
+
+const INCOME_COLOR = "hsl(220, 70%, 50%)";
+const EXPENDITURE_COLOR = "hsl(30, 80%, 55%)";
+const DIFFERENCE_COLOR = "hsl(160, 60%, 40%)";
+
+const CHART_CONFIG = {
+  income: { label: "Income", color: INCOME_COLOR },
+  expenditure: { label: "Expenditure", color: EXPENDITURE_COLOR },
+  difference: { label: "Income minus expenditure", color: DIFFERENCE_COLOR },
+} satisfies ChartConfig;
+
+type IncomeExpenditurePoint = {
+  date: string;
+  income: number;
+  expenditure?: number;
+  difference?: number;
+};
+
+export function buildIncomeExpenditureSeries(
+  incomeHistory: readonly IncomeRecord[],
+  periods: readonly PortfolioReconciliationPeriod[],
+): IncomeExpenditurePoint[] {
+  const expenditureByDate = new Map(
+    periods.map((period) => [period.endDate, period.expenditure]),
+  );
+  return incomeHistory
+    .map((record) => {
+      const expenditure = expenditureByDate.get(record.date);
+      return {
+        date: record.date,
+        income: record.amount,
+        expenditure,
+        difference:
+          expenditure == null ? undefined : record.amount - expenditure,
+      };
+    })
+    .toSorted((a, b) => a.date.localeCompare(b.date));
+}
+
+export function IncomeExpenditureChart({
+  incomeHistory,
+  periods,
+}: Readonly<{
+  incomeHistory: readonly IncomeRecord[];
+  periods: readonly PortfolioReconciliationPeriod[];
+}>) {
+  const [view, setView] = useState<"comparison" | "difference">("comparison");
+  const data = buildIncomeExpenditureSeries(incomeHistory, periods);
+  if (data.length === 0) return null;
+
+  const hasExpenditure = data.some((point) => point.expenditure != null);
+
+  return (
+    <div className="min-w-0 space-y-2">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-medium">Income and expenditure</h3>
+          <p className="text-xs text-muted-foreground">
+            {view === "comparison"
+              ? "Period totals from imported income and reconciled account history."
+              : "Income minus expenditure. Values above zero were retained; values below zero were funded from existing wealth."}
+            {!hasExpenditure &&
+              " Expenditure will appear when matching balance-sheet periods are available."}
+          </p>
+        </div>
+        <fieldset className="flex gap-1">
+          <legend className="sr-only">Income and expenditure chart view</legend>
+          <Button
+            type="button"
+            size="sm"
+            variant={view === "comparison" ? "secondary" : "ghost"}
+            onClick={() => setView("comparison")}
+          >
+            Compare
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant={view === "difference" ? "secondary" : "ghost"}
+            disabled={!hasExpenditure}
+            onClick={() => setView("difference")}
+          >
+            Difference
+          </Button>
+        </fieldset>
+      </div>
+      <ChartContainer
+        config={CHART_CONFIG}
+        className="aspect-auto w-full"
+        role="img"
+        aria-label={
+          view === "comparison"
+            ? "Income and expenditure by period"
+            : "Income minus expenditure by period"
+        }
+      >
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={data}
+            margin={{ top: 10, right: 18, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis
+              dataKey="date"
+              className="text-xs"
+              minTickGap={24}
+              tickFormatter={(date: string) => format(parseISO(date), "MMM yy")}
+            />
+            <YAxis
+              className="text-xs"
+              width={48}
+              tickFormatter={(value: number) => `£${formatAxisTick(value)}`}
+            />
+            <ReferenceLine y={0} className="stroke-muted-foreground" />
+            <ChartTooltip
+              content={<ChartTooltipContent />}
+              formatter={(value) => formatCurrency(value as number)}
+            />
+            {view === "comparison" ? (
+              <>
+                <Line
+                  type="monotone"
+                  dataKey="income"
+                  name="Income"
+                  stroke={INCOME_COLOR}
+                  strokeWidth={2.5}
+                  dot={data.length === 1}
+                  connectNulls
+                />
+                {hasExpenditure && (
+                  <Line
+                    type="monotone"
+                    dataKey="expenditure"
+                    name="Expenditure"
+                    stroke={EXPENDITURE_COLOR}
+                    strokeWidth={2.5}
+                    dot={periods.length === 1}
+                    connectNulls={false}
+                  />
+                )}
+              </>
+            ) : (
+              <Line
+                type="monotone"
+                dataKey="difference"
+                name="Income minus expenditure"
+                stroke={DIFFERENCE_COLOR}
+                strokeWidth={2.5}
+                dot={periods.length === 1}
+                connectNulls={false}
+              />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      </ChartContainer>
+      <div className="flex flex-wrap items-center justify-center gap-4 text-xs text-muted-foreground">
+        {view === "comparison" ? (
+          <>
+            <span className="flex items-center gap-1.5">
+              <span
+                aria-hidden="true"
+                className="size-2 rounded-full"
+                style={{ backgroundColor: INCOME_COLOR }}
+              />
+              Income
+            </span>
+            {hasExpenditure && (
+              <span className="flex items-center gap-1.5">
+                <span
+                  aria-hidden="true"
+                  className="size-2 rounded-full"
+                  style={{ backgroundColor: EXPENDITURE_COLOR }}
+                />
+                Expenditure
+              </span>
+            )}
+          </>
+        ) : (
+          <span className="flex items-center gap-1.5">
+            <span
+              aria-hidden="true"
+              className="size-2 rounded-full"
+              style={{ backgroundColor: DIFFERENCE_COLOR }}
+            />
+            Income minus expenditure
+          </span>
+        )}
+      </div>
+      <table className="sr-only">
+        <caption>Income and expenditure by period</caption>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Income</th>
+            <th>Expenditure</th>
+            <th>Difference</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((point) => (
+            <tr key={point.date}>
+              <td>{point.date}</td>
+              <td>{formatCurrency(point.income)}</td>
+              <td>
+                {point.expenditure == null
+                  ? "Awaiting reconciliation"
+                  : formatCurrency(point.expenditure)}
+              </td>
+              <td>
+                {point.difference == null
+                  ? "Awaiting reconciliation"
+                  : formatCurrency(point.difference)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/components/assettracker/income-expenditure-chart.tsx
+++ b/ui/components/assettracker/income-expenditure-chart.tsx
@@ -188,7 +188,7 @@ export function IncomeExpenditureChart({
                 className="size-2 rounded-full"
                 style={{ backgroundColor: INCOME_COLOR }}
               />
-              Income
+              <span>Income</span>
             </span>
             {hasExpenditure && (
               <span className="flex items-center gap-1.5">
@@ -197,7 +197,7 @@ export function IncomeExpenditureChart({
                   className="size-2 rounded-full"
                   style={{ backgroundColor: EXPENDITURE_COLOR }}
                 />
-                Expenditure
+                <span>Expenditure</span>
               </span>
             )}
           </>
@@ -208,7 +208,7 @@ export function IncomeExpenditureChart({
               className="size-2 rounded-full"
               style={{ backgroundColor: DIFFERENCE_COLOR }}
             />
-            Income minus expenditure
+            <span>Income minus expenditure</span>
           </span>
         )}
       </div>

--- a/ui/components/assettracker/income-history-import-drawer.tsx
+++ b/ui/components/assettracker/income-history-import-drawer.tsx
@@ -111,7 +111,7 @@ export function IncomeHistoryImportDrawer() {
             value={source}
             onChange={(event) => setSource(event.target.value)}
           />
-          {result.issues.length > 0 ? (
+          {result.issues.length > 0 && (
             <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md border border-destructive/30 p-2 text-xs text-destructive">
               {result.issues.map((issue) => (
                 <li key={`${issue.line}-${issue.message}`}>
@@ -119,12 +119,13 @@ export function IncomeHistoryImportDrawer() {
                 </li>
               ))}
             </ul>
-          ) : result.rows.length > 0 ? (
+          )}
+          {result.issues.length === 0 && result.rows.length > 0 && (
             <p className="text-xs text-muted-foreground">
               {result.rows.length}{" "}
               {result.rows.length === 1 ? "period" : "periods"} ready.
             </p>
-          ) : null}
+          )}
           <p className="text-xs text-muted-foreground">
             For a meaningful reconciliation, use the same period ends as your
             complete account balance history. Internal account transfers must be

--- a/ui/components/assettracker/income-history-import-drawer.tsx
+++ b/ui/components/assettracker/income-history-import-drawer.tsx
@@ -87,8 +87,9 @@ export function IncomeHistoryImportDrawer() {
           <DrawerTitle>Portfolio income history</DrawerTitle>
           <DrawerDescription>
             Paste income received in each period. Use the period-end date and
-            the total income across the household. This replaces the current
-            income series.
+            the total income across the household.
+            {incomeHistory.length > 0 &&
+              " Importing will replace all existing income history."}
           </DrawerDescription>
         </DrawerHeader>
         <form

--- a/ui/components/assettracker/income-history-import-drawer.tsx
+++ b/ui/components/assettracker/income-history-import-drawer.tsx
@@ -18,6 +18,12 @@ import {
 } from "@/lib/domain/assettracker";
 import { useAssetTracker } from "./asset-tracker-provider";
 
+function parseIncomeSource(source: string) {
+  return source.trim() === ""
+    ? { rows: [], issues: [] }
+    : parsePastedHistory(source);
+}
+
 export function IncomeHistoryImportDrawer() {
   const { incomeHistory, importIncomeHistory, clearIncomeHistory } =
     useAssetTracker();
@@ -25,21 +31,16 @@ export function IncomeHistoryImportDrawer() {
   const [source, setSource] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const result = useMemo(
-    () =>
-      source.trim() === ""
-        ? { rows: [], issues: [] }
-        : parsePastedHistory(source),
-    [source],
-  );
+  const result = useMemo(() => parseIncomeSource(source), [source]);
 
   async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (result.issues.length > 0) {
+    const submitted = parseIncomeSource(source);
+    if (submitted.issues.length > 0) {
       setError("Fix the invalid rows before importing");
       return;
     }
-    if (result.rows.length === 0) {
+    if (submitted.rows.length === 0) {
       setError("Paste at least one income row");
       return;
     }
@@ -47,7 +48,7 @@ export function IncomeHistoryImportDrawer() {
     setError(null);
     try {
       await importIncomeHistory({
-        income: result.rows.map(({ date, value }) => ({
+        income: submitted.rows.map(({ date, value }) => ({
           date,
           amount: value,
         })),

--- a/ui/components/assettracker/income-history-import-drawer.tsx
+++ b/ui/components/assettracker/income-history-import-drawer.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { ClipboardPasteIcon, Trash2Icon } from "lucide-react";
+import { type SubmitEvent, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  formatAssetTrackerError,
+  parsePastedHistory,
+} from "@/lib/domain/assettracker";
+import { useAssetTracker } from "./asset-tracker-provider";
+
+export function IncomeHistoryImportDrawer() {
+  const { incomeHistory, importIncomeHistory, clearIncomeHistory } =
+    useAssetTracker();
+  const [open, setOpen] = useState(false);
+  const [source, setSource] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const result = useMemo(
+    () =>
+      source.trim() === ""
+        ? { rows: [], issues: [] }
+        : parsePastedHistory(source),
+    [source],
+  );
+
+  async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (result.issues.length > 0) {
+      setError("Fix the invalid rows before importing");
+      return;
+    }
+    if (result.rows.length === 0) {
+      setError("Paste at least one income row");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await importIncomeHistory({
+        income: result.rows.map(({ date, value }) => ({
+          date,
+          amount: value,
+        })),
+      });
+      setSource("");
+      setOpen(false);
+    } catch (err) {
+      setError(formatAssetTrackerError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleClear() {
+    try {
+      await clearIncomeHistory();
+      setError(null);
+      setOpen(false);
+    } catch (err) {
+      setError(formatAssetTrackerError(err));
+    }
+  }
+
+  return (
+    <Drawer open={open} onOpenChange={setOpen}>
+      <DrawerTrigger asChild>
+        <Button variant="outline" size="sm">
+          <ClipboardPasteIcon />
+          {incomeHistory.length > 0
+            ? "Replace income history"
+            : "Add income history"}
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader className="mx-auto w-full max-w-2xl">
+          <DrawerTitle>Portfolio income history</DrawerTitle>
+          <DrawerDescription>
+            Paste income received in each period. Use the period-end date and
+            the total income across the household. This replaces the current
+            income series.
+          </DrawerDescription>
+        </DrawerHeader>
+        <form
+          aria-label="Import portfolio income history"
+          onSubmit={handleSubmit}
+          className="mx-auto flex w-full max-w-2xl flex-col gap-3 p-4 pb-[max(1rem,env(safe-area-inset-bottom))]"
+        >
+          <label
+            htmlFor="portfolio-income-history"
+            className="text-sm font-medium"
+          >
+            Period end and income
+          </label>
+          <textarea
+            id="portfolio-income-history"
+            rows={10}
+            wrap="off"
+            spellCheck={false}
+            className="min-h-52 w-full resize-y rounded-md border bg-transparent px-3 py-2 font-mono text-sm leading-5 shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            placeholder={"date,income\n2025-01-31,4500\n2025-02-28,4500"}
+            value={source}
+            onChange={(event) => setSource(event.target.value)}
+          />
+          {result.issues.length > 0 ? (
+            <ul className="max-h-40 space-y-1 overflow-y-auto rounded-md border border-destructive/30 p-2 text-xs text-destructive">
+              {result.issues.map((issue) => (
+                <li key={`${issue.line}-${issue.message}`}>
+                  Line {issue.line}: {issue.message}
+                </li>
+              ))}
+            </ul>
+          ) : result.rows.length > 0 ? (
+            <p className="text-xs text-muted-foreground">
+              {result.rows.length}{" "}
+              {result.rows.length === 1 ? "period" : "periods"} ready.
+            </p>
+          ) : null}
+          <p className="text-xs text-muted-foreground">
+            For a meaningful reconciliation, use the same period ends as your
+            complete account balance history. Internal account transfers must be
+            recorded as equal withdrawals and deposits so they cancel out.
+          </p>
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="submit"
+              disabled={
+                submitting ||
+                result.issues.length > 0 ||
+                result.rows.length === 0
+              }
+            >
+              Import{" "}
+              {result.rows.length > 0
+                ? `${result.rows.length} periods`
+                : "history"}
+            </Button>
+            <DrawerClose asChild>
+              <Button type="button" variant="outline">
+                Cancel
+              </Button>
+            </DrawerClose>
+            {incomeHistory.length > 0 && (
+              <Button type="button" variant="ghost" onClick={handleClear}>
+                <Trash2Icon />
+                Clear income history
+              </Button>
+            )}
+          </div>
+        </form>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/ui/components/assettracker/portfolio-fi-projection-chart.tsx
+++ b/ui/components/assettracker/portfolio-fi-projection-chart.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { format, parseISO } from "date-fns";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  formatAnnualRate,
+  formatAxisTick,
+  formatCurrency,
+  type PortfolioFiProjectionPoint,
+} from "@/lib/domain/assettracker";
+
+const PROJECTION_COLOR = "hsl(160, 60%, 40%)";
+const CHART_CONFIG = {
+  projected: {
+    label: "Projected net worth (today's money)",
+    color: PROJECTION_COLOR,
+  },
+} satisfies ChartConfig;
+
+export function PortfolioFiProjectionChart({
+  projection,
+  target,
+  annualSavings,
+  expectedRealReturn,
+}: Readonly<{
+  projection: PortfolioFiProjectionPoint[];
+  target: number;
+  annualSavings: number;
+  expectedRealReturn: number;
+}>) {
+  if (projection.length < 2) return null;
+  const chartData = projection.filter(
+    (_, index) => index % 12 === 0 || index === projection.length - 1,
+  );
+
+  return (
+    <div className="min-w-0 space-y-2">
+      <div>
+        <h3 className="text-sm font-medium">Portfolio FI projection</h3>
+        <p className="text-xs text-muted-foreground">
+          In today&apos;s money, using{" "}
+          {formatCurrency(Math.round(annualSavings))}
+          /yr median retained income and an expected real portfolio return of{" "}
+          {formatAnnualRate(expectedRealReturn)}/yr.
+        </p>
+      </div>
+      <ChartContainer
+        config={CHART_CONFIG}
+        className="aspect-auto w-full"
+        role="img"
+        aria-label="Projected portfolio net worth against the financial independence target"
+      >
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 10, right: 18, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis
+              dataKey="date"
+              className="text-xs"
+              minTickGap={24}
+              tickFormatter={(date: string) =>
+                format(parseISO(date), "MMM yyyy")
+              }
+            />
+            <YAxis
+              className="text-xs"
+              width={52}
+              tickFormatter={(value: number) => `£${formatAxisTick(value)}`}
+            />
+            <ReferenceLine
+              y={target}
+              stroke="var(--muted-foreground)"
+              strokeDasharray="6 4"
+            />
+            <ChartTooltip
+              content={<ChartTooltipContent />}
+              formatter={(value) => formatCurrency(value as number)}
+            />
+            <Line
+              type="monotone"
+              dataKey="projected"
+              stroke={PROJECTION_COLOR}
+              strokeWidth={2.5}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </ChartContainer>
+      <div className="flex flex-wrap items-center justify-center gap-4 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="size-2 rounded-full"
+            style={{ backgroundColor: PROJECTION_COLOR }}
+          />
+          Projected net worth
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span aria-hidden="true" className="h-px w-3 bg-muted-foreground" />
+          FI target
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/assettracker/portfolio-fi-projection-chart.tsx
+++ b/ui/components/assettracker/portfolio-fi-projection-chart.tsx
@@ -109,11 +109,11 @@ export function PortfolioFiProjectionChart({
             className="size-2 rounded-full"
             style={{ backgroundColor: PROJECTION_COLOR }}
           />
-          Projected net worth
+          <span>Projected net worth</span>
         </span>
         <span className="flex items-center gap-1.5">
           <span aria-hidden="true" className="h-px w-3 bg-muted-foreground" />
-          FI target
+          <span>FI target</span>
         </span>
       </div>
     </div>

--- a/ui/components/assettracker/portfolio-goal.tsx
+++ b/ui/components/assettracker/portfolio-goal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Card,
   CardContent,
@@ -31,14 +31,23 @@ export function PortfolioGoal() {
     setWithdrawalRate,
   } = useAssetTracker();
   const [error, setError] = useState<string | null>(null);
+  const [withdrawalRateDraft, setWithdrawalRateDraft] = useState(() =>
+    String(withdrawalRate * 100),
+  );
   const currentNetWorth = computeTotalBalance(accounts);
   const { periods, representativeAnnualExpenditure, target, progress } =
     financialIndependence;
 
+  useEffect(() => {
+    setWithdrawalRateDraft(String(withdrawalRate * 100));
+  }, [withdrawalRate]);
+
   async function handleWithdrawalRate(value: string) {
-    if (value === "") return;
     const percent = Number(value);
-    if (!Number.isFinite(percent)) return;
+    if (!Number.isFinite(percent) || percent < 0.1 || percent > 100) {
+      setError("Withdrawal rate must be between 0.1% and 100%");
+      return;
+    }
     const rate = percent / 100;
     if (rate === withdrawalRate) return;
     try {
@@ -50,7 +59,7 @@ export function PortfolioGoal() {
   }
 
   return (
-    <Card className="min-w-0 lg:col-span-2">
+    <Card className="min-w-0">
       <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1.5">
           <CardTitle>Financial independence</CardTitle>
@@ -91,10 +100,13 @@ export function PortfolioGoal() {
                   inputMode="decimal"
                   min="0.1"
                   max="100"
-                  step="0.1"
+                  step="any"
                   className="h-7 w-16 text-right"
-                  key={withdrawalRate}
-                  defaultValue={withdrawalRate * 100}
+                  value={withdrawalRateDraft}
+                  onChange={(event) => {
+                    setWithdrawalRateDraft(event.target.value);
+                    setError(null);
+                  }}
                   onBlur={(event) => handleWithdrawalRate(event.target.value)}
                 />
                 <span>%</span>

--- a/ui/components/assettracker/portfolio-goal.tsx
+++ b/ui/components/assettracker/portfolio-goal.tsx
@@ -15,6 +15,7 @@ import {
   formatCurrency,
 } from "@/lib/domain/assettracker";
 import { useAssetTracker } from "./asset-tracker-provider";
+import { IncomeExpenditureChart } from "./income-expenditure-chart";
 import { IncomeHistoryImportDrawer } from "./income-history-import-drawer";
 
 function signedCurrency(value: number): string {
@@ -139,6 +140,11 @@ export function PortfolioGoal() {
             className="h-2 w-full overflow-hidden rounded-full bg-muted [appearance:none] [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-primary [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-muted [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-primary"
           />
         )}
+
+        <IncomeExpenditureChart
+          incomeHistory={incomeHistory}
+          periods={periods}
+        />
 
         {periods.length > 0 ? (
           <div className="min-w-0 space-y-2">

--- a/ui/components/assettracker/portfolio-goal.tsx
+++ b/ui/components/assettracker/portfolio-goal.tsx
@@ -39,8 +39,10 @@ export function PortfolioGoal() {
     if (value === "") return;
     const percent = Number(value);
     if (!Number.isFinite(percent)) return;
+    const rate = percent / 100;
+    if (rate === withdrawalRate) return;
     try {
-      await setWithdrawalRate(percent / 100);
+      await setWithdrawalRate(rate);
       setError(null);
     } catch (err) {
       setError(formatAssetTrackerError(err));
@@ -92,7 +94,7 @@ export function PortfolioGoal() {
                   step="0.1"
                   className="h-7 w-16 text-right"
                   key={withdrawalRate}
-                  defaultValue={(withdrawalRate * 100).toFixed(1)}
+                  defaultValue={withdrawalRate * 100}
                   onBlur={(event) => handleWithdrawalRate(event.target.value)}
                 />
                 <span>%</span>

--- a/ui/components/assettracker/portfolio-goal.tsx
+++ b/ui/components/assettracker/portfolio-goal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { format, parseISO } from "date-fns";
 import { useEffect, useState } from "react";
 import {
   Card,
@@ -11,12 +12,14 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   computeTotalBalance,
+  FI_PROJECTION_MAX_YEARS,
   formatAssetTrackerError,
   formatCurrency,
 } from "@/lib/domain/assettracker";
 import { useAssetTracker } from "./asset-tracker-provider";
 import { IncomeExpenditureChart } from "./income-expenditure-chart";
 import { IncomeHistoryImportDrawer } from "./income-history-import-drawer";
+import { PortfolioFiProjectionChart } from "./portfolio-fi-projection-chart";
 
 function signedCurrency(value: number): string {
   if (value === 0) return formatCurrency(0);
@@ -36,8 +39,29 @@ export function PortfolioGoal() {
     String(withdrawalRate * 100),
   );
   const currentNetWorth = computeTotalBalance(accounts);
-  const { periods, representativeAnnualExpenditure, target, progress } =
-    financialIndependence;
+  const {
+    periods,
+    representativeAnnualExpenditure,
+    representativeAnnualSavings,
+    savingsRate,
+    emergencyFund,
+    emergencyFundMonths,
+    target,
+    progress,
+    expectedRealReturn,
+    projection,
+    projectedFiDate,
+    yearsToFi,
+  } = financialIndependence;
+
+  const yearsToFiLabel =
+    yearsToFi === 0
+      ? "Reached"
+      : yearsToFi != null
+        ? `${yearsToFi.toFixed(1)} years`
+        : projection.length > 0
+          ? `>${FI_PROJECTION_MAX_YEARS} years`
+          : "—";
 
   useEffect(() => {
     setWithdrawalRateDraft(String(withdrawalRate * 100));
@@ -72,7 +96,7 @@ export function PortfolioGoal() {
         <IncomeHistoryImportDrawer />
       </CardHeader>
       <CardContent className="flex min-w-0 flex-col gap-5 px-4 sm:px-6">
-        <div className="grid gap-3 sm:grid-cols-3">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           <div className="rounded-md border p-3">
             <p className="text-xs text-muted-foreground">
               Representative annual expenditure
@@ -130,6 +154,41 @@ export function PortfolioGoal() {
               home equity
             </p>
           </div>
+          <div className="rounded-md border p-3">
+            <p className="text-xs text-muted-foreground">Savings rate</p>
+            <p className="mt-1 text-xl font-semibold">
+              {savingsRate == null ? "—" : `${(savingsRate * 100).toFixed(1)}%`}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {representativeAnnualSavings == null
+                ? "Income retained ÷ income"
+                : `${formatCurrency(Math.round(representativeAnnualSavings))}/yr median retained`}
+            </p>
+          </div>
+          <div className="rounded-md border p-3">
+            <p className="text-xs text-muted-foreground">Emergency fund</p>
+            <p className="mt-1 text-xl font-semibold">
+              {formatCurrency(Math.round(emergencyFund))}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {emergencyFundMonths == null
+                ? "Add reconciled spending to calculate runway"
+                : `${emergencyFundMonths.toFixed(1)} months without income`}
+            </p>
+          </div>
+          <div className="rounded-md border p-3">
+            <p className="text-xs text-muted-foreground">Projected FI</p>
+            <p className="mt-1 text-xl font-semibold">{yearsToFiLabel}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {projectedFiDate == null
+                ? target == null
+                  ? "Needs reconciled income and expenditure"
+                  : "At current real return and savings"
+                : yearsToFi === 0
+                  ? "Current net worth already meets the target"
+                  : `Around ${format(parseISO(projectedFiDate), "MMM yyyy")}`}
+            </p>
+          </div>
         </div>
 
         {progress != null && (
@@ -145,6 +204,17 @@ export function PortfolioGoal() {
           incomeHistory={incomeHistory}
           periods={periods}
         />
+
+        {target != null &&
+          representativeAnnualSavings != null &&
+          expectedRealReturn != null && (
+            <PortfolioFiProjectionChart
+              projection={projection}
+              target={target}
+              annualSavings={representativeAnnualSavings}
+              expectedRealReturn={expectedRealReturn}
+            />
+          )}
 
         {periods.length > 0 ? (
           <div className="min-w-0 space-y-2">

--- a/ui/components/assettracker/portfolio-goal.tsx
+++ b/ui/components/assettracker/portfolio-goal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { type FormEvent, useMemo, useState } from "react";
-import { Button } from "@/components/ui/button";
+import { useState } from "react";
 import {
   Card,
   CardContent,
@@ -11,186 +10,191 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
-  addRealValues,
-  buildPortfolioProjection,
   computeTotalBalance,
-  dateTargetReached,
   formatAssetTrackerError,
   formatCurrency,
-  inflateToPresent,
-  projectedDateForTarget,
-  todayIsoDate,
 } from "@/lib/domain/assettracker";
 import { useAssetTracker } from "./asset-tracker-provider";
+import { IncomeHistoryImportDrawer } from "./income-history-import-drawer";
 
-// A goal like an FI number can be decades out
-const GOAL_SEARCH_MONTHS = 480;
+function signedCurrency(value: number): string {
+  if (value === 0) return formatCurrency(0);
+  return `${value > 0 ? "+" : "−"}${formatCurrency(Math.abs(value))}`;
+}
 
 export function PortfolioGoal() {
   const {
     accounts,
-    accountDetails,
-    netWorthData,
-    recurringFlows,
-    inflation,
-    netWorthTarget,
-    netWorthTargetIsReal,
-    setNetWorthTarget,
+    incomeHistory,
+    financialIndependence,
+    withdrawalRate,
+    setWithdrawalRate,
   } = useAssetTracker();
-  const [draft, setDraft] = useState("");
-  const [draftIsReal, setDraftIsReal] = useState(true);
   const [error, setError] = useState<string | null>(null);
-
   const currentNetWorth = computeTotalBalance(accounts);
+  const { periods, representativeAnnualExpenditure, target, progress } =
+    financialIndependence;
 
-  const goal = useMemo(() => {
-    if (netWorthTarget == null) return null;
-    const today = todayIsoDate();
-    // For a today's-money target, restate past net worth in today's
-    // purchasing power before asking when the target was reached
-    const history = netWorthData.map((point) => ({
-      date: point.date,
-      balance: netWorthTargetIsReal
-        ? inflateToPresent(point.total, point.date, today, inflation)
-        : point.total,
-    }));
-    const reachedOn = dateTargetReached(history, netWorthTarget);
-    let projectedBy: string | null = null;
-    if (reachedOn == null) {
-      const nominal = buildPortfolioProjection({
-        accounts: accountDetails,
-        flows: recurringFlows,
-        startDate: today,
-        months: GOAL_SEARCH_MONTHS,
-      });
-      // ...and compare a today's-money target against deflated projections,
-      // so the projection has to outgrow inflation to hit it
-      const comparable = netWorthTargetIsReal
-        ? addRealValues(nominal, inflation).map((point) => ({
-            date: point.date,
-            projected: point.real ?? point.projected,
-          }))
-        : nominal;
-      projectedBy = projectedDateForTarget(comparable, netWorthTarget);
-    }
-    const progress = Math.min(Math.max(currentNetWorth / netWorthTarget, 0), 1);
-    return { reachedOn, projectedBy, progress };
-  }, [
-    netWorthTarget,
-    netWorthTargetIsReal,
-    netWorthData,
-    accountDetails,
-    recurringFlows,
-    inflation,
-    currentNetWorth,
-  ]);
-
-  async function handleSetTarget(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const target = Number(draft);
-    if (!Number.isFinite(target)) return;
+  async function handleWithdrawalRate(value: string) {
+    if (value === "") return;
+    const percent = Number(value);
+    if (!Number.isFinite(percent)) return;
     try {
-      await setNetWorthTarget(target, draftIsReal);
-      setDraft("");
+      await setWithdrawalRate(percent / 100);
       setError(null);
     } catch (err) {
       setError(formatAssetTrackerError(err));
     }
-  }
-
-  async function handleClear() {
-    try {
-      await setNetWorthTarget(null);
-      setError(null);
-    } catch (err) {
-      setError(formatAssetTrackerError(err));
-    }
-  }
-
-  const moneyLabel = netWorthTargetIsReal ? "in today's money" : "nominal";
-  let statusMessage: string | null = null;
-  if (goal?.reachedOn) {
-    statusMessage = `Reached on ${goal.reachedOn} — time for a bigger goal?`;
-  } else if (goal?.projectedBy) {
-    statusMessage = netWorthTargetIsReal
-      ? `Projected to get there by ${goal.projectedBy} in today's purchasing power — growth has to beat inflation to count.`
-      : `Projected to get there by ${goal.projectedBy}, based on expected returns and regular flows.`;
-  } else if (goal) {
-    statusMessage = `Not projected within ${GOAL_SEARCH_MONTHS / 12} years on current expectations.`;
   }
 
   return (
-    <Card className="min-w-0">
-      <CardHeader>
-        <CardTitle>Net Worth Goal</CardTitle>
-        <CardDescription>
-          Set the number you're working towards — an emergency fund, a house
-          deposit, or your FI number.
-        </CardDescription>
+    <Card className="min-w-0 lg:col-span-2">
+      <CardHeader className="gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1.5">
+          <CardTitle>Financial independence</CardTitle>
+          <CardDescription>
+            Derived from income, complete account balances, and signed capital
+            flows—not a manually chosen net-worth goal.
+          </CardDescription>
+        </div>
+        <IncomeHistoryImportDrawer />
       </CardHeader>
-      <CardContent className="flex min-w-0 flex-col gap-3 px-4 sm:px-6">
-        {netWorthTarget != null && goal ? (
-          <>
-            <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-2">
-              <p className="text-2xl font-bold">
-                {formatCurrency(currentNetWorth)}
-              </p>
-              <p className="text-sm text-muted-foreground sm:text-right">
-                of {formatCurrency(netWorthTarget)} {moneyLabel} (
-                {Math.round(goal.progress * 100)}%)
-              </p>
-            </div>
-            <progress
-              value={goal.progress}
-              max={1}
-              className="h-2 w-full overflow-hidden rounded-full bg-muted [appearance:none] [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-primary [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-muted [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-primary"
-            />
-            {statusMessage && <p className="text-sm">{statusMessage}</p>}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="self-start"
-              onClick={handleClear}
-            >
-              Clear goal
-            </Button>
-          </>
-        ) : (
-          <form onSubmit={handleSetTarget} className="flex flex-col gap-2">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <label htmlFor="net-worth-target" className="sr-only">
-                Target net worth
-              </label>
-              <Input
-                id="net-worth-target"
-                type="number"
-                inputMode="decimal"
-                min="1"
-                step="any"
-                required
-                placeholder="e.g. 500000"
-                className="w-full sm:max-w-44"
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-              />
-              <Button
-                type="submit"
-                variant="outline"
-                className="w-full sm:w-auto"
+      <CardContent className="flex min-w-0 flex-col gap-5 px-4 sm:px-6">
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-md border p-3">
+            <p className="text-xs text-muted-foreground">
+              Representative annual expenditure
+            </p>
+            <p className="mt-1 text-xl font-semibold">
+              {representativeAnnualExpenditure == null
+                ? "—"
+                : formatCurrency(Math.round(representativeAnnualExpenditure))}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Median annualised period
+            </p>
+          </div>
+          <div className="rounded-md border p-3">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-xs text-muted-foreground">FI target</p>
+              <label
+                htmlFor="withdrawal-rate"
+                className="flex items-center gap-1 text-xs text-muted-foreground"
               >
-                Set goal
-              </Button>
+                <span>Withdrawal</span>
+                <Input
+                  id="withdrawal-rate"
+                  aria-label="Withdrawal rate"
+                  type="number"
+                  inputMode="decimal"
+                  min="0.1"
+                  max="100"
+                  step="0.1"
+                  className="h-7 w-16 text-right"
+                  key={withdrawalRate}
+                  defaultValue={(withdrawalRate * 100).toFixed(1)}
+                  onBlur={(event) => handleWithdrawalRate(event.target.value)}
+                />
+                <span>%</span>
+              </label>
             </div>
-            <label className="flex items-center gap-2 text-sm text-muted-foreground">
-              <input
-                type="checkbox"
-                className="size-4 accent-primary"
-                checked={draftIsReal}
-                onChange={(e) => setDraftIsReal(e.target.checked)}
-              />
-              <span>In today's money — the projection must beat inflation</span>
-            </label>
-          </form>
+            <p className="mt-1 text-xl font-semibold">
+              {target == null ? "—" : formatCurrency(Math.round(target))}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Annual expenditure ÷ withdrawal rate
+            </p>
+          </div>
+          <div className="rounded-md border p-3">
+            <p className="text-xs text-muted-foreground">FI progress</p>
+            <p className="mt-1 text-xl font-semibold">
+              {progress == null ? "—" : `${Math.round(progress * 100)}%`}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {formatCurrency(currentNetWorth)} total net worth, including all
+              home equity
+            </p>
+          </div>
+        </div>
+
+        {progress != null && (
+          <progress
+            value={progress}
+            max={1}
+            aria-label="Financial independence progress"
+            className="h-2 w-full overflow-hidden rounded-full bg-muted [appearance:none] [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-primary [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-muted [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-primary"
+          />
+        )}
+
+        {periods.length > 0 ? (
+          <div className="min-w-0 space-y-2">
+            <div>
+              <h3 className="text-sm font-medium">Period reconciliation</h3>
+              <p className="text-xs text-muted-foreground">
+                Opening net worth + income − expenditure + valuation gain =
+                closing net worth. Net capital flow is income retained on the
+                balance sheet.
+              </p>
+            </div>
+            <div className="overflow-x-auto rounded-md border">
+              <table className="w-full min-w-[900px] text-sm">
+                <thead className="bg-muted/50 text-left text-xs text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 font-medium">Period</th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      Opening
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium">Income</th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      Net flow
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      Valuation gain
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      Expenditure
+                    </th>
+                    <th className="px-3 py-2 text-right font-medium">
+                      Closing
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {periods.map((period) => (
+                    <tr key={period.endDate} className="border-t">
+                      <td className="whitespace-nowrap px-3 py-2">
+                        {period.startDate} – {period.endDate}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {formatCurrency(period.openingNetWorth)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {formatCurrency(period.income)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {signedCurrency(period.netCapitalFlow)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {signedCurrency(period.valuationGain)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {formatCurrency(period.expenditure)}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-right">
+                        {formatCurrency(period.closingNetWorth)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        ) : (
+          <p className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+            {incomeHistory.length === 0
+              ? "Add period income history to derive expenditure and an FI target. Account balances and signed deposits or withdrawals provide the rest of the reconciliation."
+              : "Income is saved, but there are not yet two usable balance-sheet dates around an income period. Add complete account balances at matching period ends."}
+          </p>
         )}
         {error && <p className="text-sm text-destructive">{error}</p>}
       </CardContent>

--- a/ui/lib/api/assettracker.ts
+++ b/ui/lib/api/assettracker.ts
@@ -87,7 +87,21 @@ export type AssetTrackerLoadResult = {
 export const ASSET_TRACKER_STORAGE_KEY = "assettracker:data:v1";
 
 function parseStored(raw: string): AssetTrackerData {
-  const data = AssetTrackerDataSchema.parse(JSON.parse(raw));
+  const parsed = AssetTrackerDataSchema.parse(JSON.parse(raw));
+  const incomeByDate = new Map(
+    parsed.incomeHistory.map((record) => [record.date, record]),
+  );
+  // Earlier/hand-edited data may contain duplicate period ends. Keep the last
+  // value so one bad series cannot hide the user's otherwise valid portfolio.
+  const data =
+    incomeByDate.size === parsed.incomeHistory.length
+      ? parsed
+      : {
+          ...parsed,
+          incomeHistory: Array.from(incomeByDate.values()).sort((a, b) =>
+            a.date.localeCompare(b.date),
+          ),
+        };
   buildRepository(data); // referential integrity (duplicate IDs, orphan snapshots)
   return data;
 }

--- a/ui/lib/api/assettracker.ts
+++ b/ui/lib/api/assettracker.ts
@@ -4,18 +4,21 @@ import {
   AssetTrackerDataSchema,
   applyAddRecurringFlow,
   applyClearAccountHistory,
+  applyClearIncomeHistory,
   applyCloseAccount,
   applyCreateAccount,
   applyDeleteCapitalFlow,
   applyDeleteRecurringFlow,
   applyDeleteSnapshot,
   applyImportAccountHistory,
+  applyImportIncomeHistory,
   applyMaterializeFlow,
   applyRecordBalance,
   applyRecordTransfer,
   applySetExpectedReturn,
   applySetInflation,
   applySetNetWorthTarget,
+  applySetWithdrawalRate,
   buildRepository,
   type ClearAccountHistoryInput,
   type CloseAccountInput,
@@ -26,12 +29,14 @@ import {
   getEmptyData,
   getSeedData,
   type ImportAccountHistoryInput,
+  type ImportIncomeHistoryInput,
   type MaterializeFlowInput,
   type RecordBalanceInput,
   type RecordTransferInput,
   type SetExpectedReturnInput,
   type SetInflationInput,
   type SetNetWorthTargetInput,
+  type SetWithdrawalRateInput,
 } from "@/lib/domain/assettracker";
 
 /**
@@ -55,6 +60,10 @@ export interface AssetTrackerApi {
   importAccountHistory(
     input: ImportAccountHistoryInput,
   ): Promise<AssetTrackerData>;
+  importIncomeHistory(
+    input: ImportIncomeHistoryInput,
+  ): Promise<AssetTrackerData>;
+  clearIncomeHistory(): Promise<AssetTrackerData>;
   addRecurringFlow(input: AddRecurringFlowInput): Promise<AssetTrackerData>;
   deleteRecurringFlow(
     input: DeleteRecurringFlowInput,
@@ -63,6 +72,7 @@ export interface AssetTrackerApi {
   setExpectedReturn(input: SetExpectedReturnInput): Promise<AssetTrackerData>;
   setInflation(input: SetInflationInput): Promise<AssetTrackerData>;
   setNetWorthTarget(input: SetNetWorthTargetInput): Promise<AssetTrackerData>;
+  setWithdrawalRate(input: SetWithdrawalRateInput): Promise<AssetTrackerData>;
   importData(raw: unknown): Promise<AssetTrackerData>;
   clear(): Promise<AssetTrackerData>;
   reset(): Promise<AssetTrackerData>;
@@ -133,6 +143,12 @@ export function createLocalAssetTrackerApi(storage: Storage): AssetTrackerApi {
     async importAccountHistory(input) {
       return write(applyImportAccountHistory(current(), input));
     },
+    async importIncomeHistory(input) {
+      return write(applyImportIncomeHistory(current(), input));
+    },
+    async clearIncomeHistory() {
+      return write(applyClearIncomeHistory(current()));
+    },
     async addRecurringFlow(input) {
       return write(applyAddRecurringFlow(current(), input));
     },
@@ -150,6 +166,9 @@ export function createLocalAssetTrackerApi(storage: Storage): AssetTrackerApi {
     },
     async setNetWorthTarget(input) {
       return write(applySetNetWorthTarget(current(), input));
+    },
+    async setWithdrawalRate(input) {
+      return write(applySetWithdrawalRate(current(), input));
     },
     async importData(raw) {
       const data = AssetTrackerDataSchema.parse(raw);

--- a/ui/lib/domain/assettracker/assetTrackerCommands.ts
+++ b/ui/lib/domain/assettracker/assetTrackerCommands.ts
@@ -116,6 +116,20 @@ const HistoryValueSchema = z.object({
   value: z.number(),
 });
 
+export const ImportIncomeHistoryInputSchema = z.object({
+  income: z
+    .array(
+      z.object({
+        date: IsoDateSchema,
+        amount: z.number().nonnegative("Income cannot be negative"),
+      }),
+    )
+    .min(1, "Paste at least one income row"),
+});
+export type ImportIncomeHistoryInput = z.infer<
+  typeof ImportIncomeHistoryInputSchema
+>;
+
 export const ImportAccountHistoryInputSchema = z
   .object({
     accountId: AccountIdSchema,
@@ -203,6 +217,16 @@ export const SetInflationInputSchema = z.object({
   rate: AnnualRateSchema,
 });
 export type SetInflationInput = z.infer<typeof SetInflationInputSchema>;
+
+export const SetWithdrawalRateInputSchema = z.object({
+  rate: z
+    .number()
+    .positive("Withdrawal rate must be positive")
+    .max(1, "Withdrawal rate cannot exceed 100%"),
+});
+export type SetWithdrawalRateInput = z.infer<
+  typeof SetWithdrawalRateInputSchema
+>;
 
 export const SetNetWorthTargetInputSchema = z.object({
   /** Null clears the target */
@@ -391,6 +415,34 @@ export function applyImportAccountHistory(
     snapshots: Array.from(snapshotsByAccountDate.values()),
     capitalFlows: Array.from(capitalFlowsByAccountDate.values()),
   };
+}
+
+/** Replaces the complete portfolio income series atomically. */
+export function applyImportIncomeHistory(
+  data: AssetTrackerData,
+  input: ImportIncomeHistoryInput,
+): AssetTrackerData {
+  const parsed = ImportIncomeHistoryInputSchema.parse(input);
+  const byDate = new Map<string, number>();
+  for (const row of parsed.income) {
+    if (byDate.has(row.date)) {
+      throw new Error(`Duplicate income record on ${row.date}`);
+    }
+    byDate.set(row.date, row.amount);
+  }
+  return {
+    ...data,
+    incomeHistory: Array.from(byDate, ([date, amount]) => ({
+      date,
+      amount,
+    })).sort((a, b) => a.date.localeCompare(b.date)),
+  };
+}
+
+export function applyClearIncomeHistory(
+  data: AssetTrackerData,
+): AssetTrackerData {
+  return { ...data, incomeHistory: [] };
 }
 
 export function applyRecordTransfer(
@@ -658,6 +710,17 @@ export function applySetInflation(
   return {
     ...data,
     settings: { ...data.settings, expectedAnnualInflation: parsed.rate },
+  };
+}
+
+export function applySetWithdrawalRate(
+  data: AssetTrackerData,
+  input: SetWithdrawalRateInput,
+): AssetTrackerData {
+  const parsed = SetWithdrawalRateInputSchema.parse(input);
+  return {
+    ...data,
+    settings: { ...data.settings, withdrawalRate: parsed.rate },
   };
 }
 

--- a/ui/lib/domain/assettracker/assetTrackerCommands.ts
+++ b/ui/lib/domain/assettracker/assetTrackerCommands.ts
@@ -33,6 +33,7 @@ export type AssetTrackerCommandErrorCode =
   | "SNAPSHOT_NOT_FOUND"
   | "CAPITAL_FLOW_NOT_FOUND"
   | "FLOW_NOT_FOUND"
+  | "DUPLICATE_INCOME_DATE"
   | "INVALID_ACCOUNT_NAME";
 
 export class AssetTrackerCommandError extends Error {
@@ -426,7 +427,10 @@ export function applyImportIncomeHistory(
   const byDate = new Map<string, number>();
   for (const row of parsed.income) {
     if (byDate.has(row.date)) {
-      throw new Error(`Duplicate income record on ${row.date}`);
+      throw new AssetTrackerCommandError(
+        "DUPLICATE_INCOME_DATE",
+        `Duplicate income record on ${row.date}`,
+      );
     }
     byDate.set(row.date, row.amount);
   }

--- a/ui/lib/domain/assettracker/assetTrackerData.ts
+++ b/ui/lib/domain/assettracker/assetTrackerData.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { AccountContentSchema } from "./account";
 import { BalanceSnapshotSchema } from "./balanceSnapshot";
 import { CapitalFlowSchema } from "./capitalFlow";
+import { IncomeRecordSchema } from "./incomeRecord";
 import { RecurringFlowSchema } from "./recurringFlow";
 import { TransferSchema } from "./transfer";
 
@@ -14,6 +15,7 @@ import { TransferSchema } from "./transfer";
  * parses as the model evolves.
  */
 export const DEFAULT_EXPECTED_INFLATION = 0.025;
+export const DEFAULT_WITHDRAWAL_RATE = 0.04;
 
 export const AssetTrackerSettingsSchema = z.object({
   /** Used to express projected values and rates in today's money */
@@ -22,6 +24,8 @@ export const AssetTrackerSettingsSchema = z.object({
   targetNetWorth: z.number().positive().optional(),
   /** When true the target is in today's money, so inflation must be beaten */
   targetNetWorthIsReal: z.boolean().optional(),
+  /** Sustainable annual portfolio withdrawal used to derive the FI target */
+  withdrawalRate: z.number().positive().max(1).default(DEFAULT_WITHDRAWAL_RATE),
 });
 export type AssetTrackerSettings = z.infer<typeof AssetTrackerSettingsSchema>;
 
@@ -29,10 +33,12 @@ export const AssetTrackerDataSchema = z.object({
   accounts: z.array(AccountContentSchema),
   snapshots: z.array(BalanceSnapshotSchema),
   capitalFlows: z.array(CapitalFlowSchema).default([]),
+  incomeHistory: z.array(IncomeRecordSchema).default([]),
   transfers: z.array(TransferSchema).default([]),
   recurringFlows: z.array(RecurringFlowSchema).default([]),
   settings: AssetTrackerSettingsSchema.default({
     expectedAnnualInflation: DEFAULT_EXPECTED_INFLATION,
+    withdrawalRate: DEFAULT_WITHDRAWAL_RATE,
   }),
 });
 

--- a/ui/lib/domain/assettracker/assetTrackerQueries.ts
+++ b/ui/lib/domain/assettracker/assetTrackerQueries.ts
@@ -1,4 +1,4 @@
-import type { AccountId, AssetType } from "./account";
+import { type AccountId, type AssetType, isLiability } from "./account";
 import {
   computeMoneyWeightedReturn,
   type ExternalFlow,
@@ -78,6 +78,70 @@ export function getNetWorthTimeSeries(
     Array.from(repository.accounts.values()),
     repository.snapshots,
   );
+}
+
+export type AssetAllocationDataPoint = {
+  date: string;
+  /** Positive net asset buckets used as the percentage denominator. */
+  totalAssets: number;
+} & Partial<Record<AssetType, number>>;
+
+/**
+ * Percentage allocation through time, using the same linkage model as the
+ * current composition chart. A linked mortgage therefore reduces property to
+ * home equity. Standalone liabilities and other negative buckets are excluded
+ * because this is allocation *within assets*, not another net-worth series.
+ */
+export function getAssetAllocationTimeSeries(
+  repository: AssetTrackerRepository,
+): AssetAllocationDataPoint[] {
+  const accounts = Array.from(repository.accounts.values());
+  const dates = Array.from(
+    new Set(repository.snapshots.map((snapshot) => snapshot.date)),
+  ).sort((a, b) => a.localeCompare(b));
+  const snapshots = repository.snapshots.toSorted((a, b) =>
+    a.date.localeCompare(b.date),
+  );
+  const latestByAccount = new Map<AccountId, number>();
+  const { absorbedIds, mortgagesByProperty } = buildLinkage(accounts);
+  let snapshotIndex = 0;
+
+  return dates.flatMap((date) => {
+    let snapshot = snapshots[snapshotIndex];
+    while (snapshot && snapshot.date <= date) {
+      latestByAccount.set(snapshot.accountId, snapshot.balance);
+      snapshotIndex++;
+      snapshot = snapshots[snapshotIndex];
+    }
+
+    const totals = new Map<AssetType, number>();
+    for (const account of accounts) {
+      if (absorbedIds.has(account.id) || isLiability(account.assetType)) {
+        continue;
+      }
+      let balance = latestByAccount.get(account.id);
+      if (balance == null) continue;
+      for (const mortgageId of mortgagesByProperty.get(account.id) ?? []) {
+        balance += latestByAccount.get(mortgageId) ?? 0;
+      }
+      if (balance <= 0) continue;
+      totals.set(
+        account.assetType,
+        (totals.get(account.assetType) ?? 0) + balance,
+      );
+    }
+
+    const totalAssets = Array.from(totals.values()).reduce(
+      (sum, value) => sum + value,
+      0,
+    );
+    if (totalAssets <= 0) return [];
+    const point: AssetAllocationDataPoint = { date, totalAssets };
+    for (const [assetType, total] of totals) {
+      point[assetType] = total / totalAssets;
+    }
+    return [point];
+  });
 }
 
 /**

--- a/ui/lib/domain/assettracker/assetTrackerRepository.ts
+++ b/ui/lib/domain/assettracker/assetTrackerRepository.ts
@@ -8,6 +8,7 @@ import {
 } from "./assetTrackerData";
 import type { BalanceSnapshot } from "./balanceSnapshot";
 import type { CapitalFlow } from "./capitalFlow";
+import type { IncomeRecord } from "./incomeRecord";
 import type { RecurringFlow } from "./recurringFlow";
 import type { Transfer } from "./transfer";
 
@@ -15,6 +16,7 @@ export interface AssetTrackerRepository {
   accounts: Map<AccountId, Account>;
   snapshots: BalanceSnapshot[];
   capitalFlows: CapitalFlow[];
+  incomeHistory: IncomeRecord[];
   transfers: Transfer[];
   recurringFlows: RecurringFlow[];
   settings: AssetTrackerData["settings"];
@@ -84,6 +86,13 @@ function validateReferences(
 ): void {
   assertUniqueAccountDates(data.snapshots, "snapshot");
   assertUniqueAccountDates(data.capitalFlows, "capital flow");
+  const incomeDates = new Set<string>();
+  for (const income of data.incomeHistory) {
+    if (incomeDates.has(income.date)) {
+      throw new Error(`Duplicate income record on ${income.date}`);
+    }
+    incomeDates.add(income.date);
+  }
   for (const account of data.accounts) {
     assertKnownAccount(
       accounts,
@@ -146,6 +155,9 @@ export function buildRepository(
     accounts,
     snapshots,
     capitalFlows,
+    incomeHistory: [...data.incomeHistory].sort((a, b) =>
+      a.date.localeCompare(b.date),
+    ),
     transfers: data.transfers,
     recurringFlows: data.recurringFlows,
     settings: data.settings,

--- a/ui/lib/domain/assettracker/incomeRecord.ts
+++ b/ui/lib/domain/assettracker/incomeRecord.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+/**
+ * Income received across the portfolio during the period ending on `date`.
+ * This is deliberately portfolio-level: allocating salary to an account would
+ * make internal transfers part of income and break the balance-sheet
+ * reconciliation.
+ */
+export const IncomeRecordSchema = z.object({
+  date: z.iso.date(),
+  amount: z.number().nonnegative("Income cannot be negative"),
+});
+
+export type IncomeRecord = z.infer<typeof IncomeRecordSchema>;

--- a/ui/lib/domain/assettracker/index.ts
+++ b/ui/lib/domain/assettracker/index.ts
@@ -10,6 +10,8 @@ export * from "./balanceSnapshot";
 export * from "./capitalFlow";
 export * from "./constants";
 export * from "./flowSankeyData";
+export * from "./incomeRecord";
 export * from "./pastedHistory";
+export * from "./portfolioReconciliation";
 export * from "./recurringFlow";
 export * from "./transfer";

--- a/ui/lib/domain/assettracker/pastedHistory.ts
+++ b/ui/lib/domain/assettracker/pastedHistory.ts
@@ -22,7 +22,7 @@ export type ContributionHistoryFormat = "cumulative" | "changes";
 
 const HEADER_DATE = /^(date|month)$/i;
 const HEADER_VALUE =
-  /^(value|market value|current value|balance|amount|deposits?\/withdrawals?|deposit|withdrawal|flow)$/i;
+  /^(value|market value|current value|balance|amount|income|earnings|deposits?\/withdrawals?|deposit|withdrawal|flow)$/i;
 const MAX_PASTED_HISTORY_CHARACTERS = 1_000_000;
 
 function csvFields(line: string): string[] {

--- a/ui/lib/domain/assettracker/portfolioReconciliation.ts
+++ b/ui/lib/domain/assettracker/portfolioReconciliation.ts
@@ -67,7 +67,9 @@ function median(values: readonly number[]): number | null {
   const sorted = values.toSorted((a, b) => a - b);
   const middle = Math.floor(sorted.length / 2);
   if (sorted.length % 2 === 1) return sorted[middle] ?? null;
-  return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+  const lower = sorted[middle - 1];
+  const upper = sorted[middle];
+  return lower == null || upper == null ? null : (lower + upper) / 2;
 }
 
 /**
@@ -101,7 +103,9 @@ export function reconcilePortfolio(
     const startDate = previousIncome?.date ?? opening.date;
     if (opening.date !== startDate || closing.date !== record.date) continue;
     const days = calendarDaysBetween(startDate, record.date);
-    if (days <= 0 || closing.date <= opening.date) continue;
+    if (!Number.isFinite(days) || days <= 0 || closing.date <= opening.date) {
+      continue;
+    }
 
     const netCapitalFlow = repository.capitalFlows.reduce(
       (sum, flow) =>
@@ -148,7 +152,10 @@ export function getPortfolioFinancialIndependence(
   const withdrawalRate =
     repository.settings.withdrawalRate ?? DEFAULT_WITHDRAWAL_RATE;
   const target =
-    annualExpenditure == null || withdrawalRate == null
+    annualExpenditure == null ||
+    !Number.isFinite(withdrawalRate) ||
+    withdrawalRate <= 0 ||
+    withdrawalRate > 1
       ? null
       : annualExpenditure / withdrawalRate;
   const currentNetWorth = getNetWorthTimeSeries(repository).at(-1)?.total ?? 0;

--- a/ui/lib/domain/assettracker/portfolioReconciliation.ts
+++ b/ui/lib/domain/assettracker/portfolioReconciliation.ts
@@ -1,9 +1,14 @@
+import { addMonths, format, parseISO } from "date-fns";
+import { effectiveExpectedReturn } from "./account";
+import { realRate } from "./assetTrackerAnalytics";
+import { todayIsoDate } from "./assetTrackerCommands";
 import { DEFAULT_WITHDRAWAL_RATE } from "./assetTrackerData";
 import { getNetWorthTimeSeries } from "./assetTrackerQueries";
 import type { AssetTrackerRepository } from "./assetTrackerRepository";
 import type { NetWorthDataPoint } from "./assetTrackerViews";
 
 const DAYS_PER_YEAR = 365.2425;
+export const FI_PROJECTION_MAX_YEARS = 100;
 
 export type PortfolioReconciliationPeriod = {
   startDate: string;
@@ -24,8 +29,25 @@ export type PortfolioReconciliationPeriod = {
 export type PortfolioFinancialIndependence = {
   periods: PortfolioReconciliationPeriod[];
   representativeAnnualExpenditure: number | null;
+  representativeAnnualSavings: number | null;
+  /** Income retained divided by income across all reconciled periods. */
+  savingsRate: number | null;
+  /** Positive balances in open cash accounts. */
+  emergencyFund: number;
+  emergencyFundMonths: number | null;
   target: number | null;
   progress: number | null;
+  /** Expected annual portfolio return after inflation, weighted by balance. */
+  expectedRealReturn: number | null;
+  projection: PortfolioFiProjectionPoint[];
+  projectedFiDate: string | null;
+  yearsToFi: number | null;
+};
+
+export type PortfolioFiProjectionPoint = {
+  date: string;
+  /** Projected portfolio value expressed in today's money. */
+  projected: number;
 };
 
 function calendarDaysBetween(start: string, end: string): number {
@@ -144,11 +166,120 @@ export function representativeAnnualExpenditure(
   );
 }
 
+/** Median annualised retained income resists one unusually lumpy period. */
+export function representativeAnnualSavings(
+  periods: readonly PortfolioReconciliationPeriod[],
+): number | null {
+  return median(
+    periods
+      .map((period) => (period.netCapitalFlow * DAYS_PER_YEAR) / period.days)
+      .filter(Number.isFinite),
+  );
+}
+
+function latestBalances(
+  repository: AssetTrackerRepository,
+): Map<string, number> {
+  const balances = new Map<string, { date: string; balance: number }>();
+  for (const snapshot of repository.snapshots) {
+    const latest = balances.get(snapshot.accountId);
+    if (latest == null || snapshot.date > latest.date) {
+      balances.set(snapshot.accountId, {
+        date: snapshot.date,
+        balance: snapshot.balance,
+      });
+    }
+  }
+  return new Map(
+    Array.from(balances, ([accountId, snapshot]) => [
+      accountId,
+      snapshot.balance,
+    ]),
+  );
+}
+
+function expectedPortfolioRealReturn(
+  repository: AssetTrackerRepository,
+  balances: ReadonlyMap<string, number>,
+  currentNetWorth: number,
+  asOfDate: string,
+): number | null {
+  if (!Number.isFinite(currentNetWorth) || currentNetWorth === 0) return null;
+  let expectedAnnualChange = 0;
+  for (const account of repository.accounts.values()) {
+    if (account.closedAt != null) continue;
+    expectedAnnualChange +=
+      (balances.get(account.id) ?? 0) *
+      effectiveExpectedReturn(account, asOfDate);
+  }
+  const nominal = expectedAnnualChange / currentNetWorth;
+  const inflation = repository.settings.expectedAnnualInflation;
+  if (!Number.isFinite(nominal) || nominal <= -1 || inflation <= -1) {
+    return null;
+  }
+  const expectedReal = realRate(nominal, inflation);
+  return Number.isFinite(expectedReal) && expectedReal > -1
+    ? expectedReal
+    : null;
+}
+
+function buildFiProjection(input: {
+  startDate: string;
+  currentNetWorth: number;
+  target: number;
+  annualSavings: number;
+  expectedRealReturn: number;
+}): {
+  projection: PortfolioFiProjectionPoint[];
+  projectedFiDate: string | null;
+  yearsToFi: number | null;
+} {
+  const projection: PortfolioFiProjectionPoint[] = [
+    { date: input.startDate, projected: input.currentNetWorth },
+  ];
+  if (input.currentNetWorth >= input.target) {
+    return {
+      projection,
+      projectedFiDate: input.startDate,
+      yearsToFi: 0,
+    };
+  }
+
+  const monthlyReturn = (1 + input.expectedRealReturn) ** (1 / 12) - 1;
+  const monthlySavings = input.annualSavings / 12;
+  const start = parseISO(input.startDate);
+  let balance = input.currentNetWorth;
+  const maxMonths = FI_PROJECTION_MAX_YEARS * 12;
+  for (let month = 1; month <= maxMonths; month++) {
+    balance = balance * (1 + monthlyReturn) + monthlySavings;
+    const date = format(addMonths(start, month), "yyyy-MM-dd");
+    projection.push({
+      date,
+      projected: Math.round(balance * 100) / 100,
+    });
+    if (balance >= input.target) {
+      return {
+        projection,
+        projectedFiDate: date,
+        yearsToFi: month / 12,
+      };
+    }
+  }
+  return { projection, projectedFiDate: null, yearsToFi: null };
+}
+
 export function getPortfolioFinancialIndependence(
   repository: AssetTrackerRepository,
 ): PortfolioFinancialIndependence {
   const periods = reconcilePortfolio(repository);
   const annualExpenditure = representativeAnnualExpenditure(periods);
+  const annualSavings = representativeAnnualSavings(periods);
+  const totalIncome = periods.reduce((sum, period) => sum + period.income, 0);
+  const totalSavings = periods.reduce(
+    (sum, period) => sum + period.income - period.expenditure,
+    0,
+  );
+  const savingsRate = totalIncome > 0 ? totalSavings / totalIncome : null;
   const withdrawalRate =
     repository.settings.withdrawalRate ?? DEFAULT_WITHDRAWAL_RATE;
   const target =
@@ -159,13 +290,51 @@ export function getPortfolioFinancialIndependence(
       ? null
       : annualExpenditure / withdrawalRate;
   const currentNetWorth = getNetWorthTimeSeries(repository).at(-1)?.total ?? 0;
+  const balances = latestBalances(repository);
+  const emergencyFund = Array.from(repository.accounts.values()).reduce(
+    (sum, account) =>
+      account.assetType === "cash" && account.closedAt == null
+        ? sum + Math.max(balances.get(account.id) ?? 0, 0)
+        : sum,
+    0,
+  );
+  const emergencyFundMonths =
+    annualExpenditure != null && annualExpenditure > 0
+      ? (emergencyFund * 12) / annualExpenditure
+      : null;
+  const startDate = todayIsoDate();
+  const expectedRealReturn = expectedPortfolioRealReturn(
+    repository,
+    balances,
+    currentNetWorth,
+    startDate,
+  );
+  const fiProjection =
+    target != null &&
+    target > 0 &&
+    annualSavings != null &&
+    expectedRealReturn != null
+      ? buildFiProjection({
+          startDate,
+          currentNetWorth,
+          target,
+          annualSavings,
+          expectedRealReturn,
+        })
+      : { projection: [], projectedFiDate: null, yearsToFi: null };
   return {
     periods,
     representativeAnnualExpenditure: annualExpenditure,
+    representativeAnnualSavings: annualSavings,
+    savingsRate,
+    emergencyFund,
+    emergencyFundMonths,
     target,
     progress:
       target == null || target <= 0
         ? null
         : Math.min(Math.max(currentNetWorth / target, 0), 1),
+    expectedRealReturn,
+    ...fiProjection,
   };
 }

--- a/ui/lib/domain/assettracker/portfolioReconciliation.ts
+++ b/ui/lib/domain/assettracker/portfolioReconciliation.ts
@@ -99,6 +99,7 @@ export function reconcilePortfolio(
     if (opening == null || closing == null) continue;
 
     const startDate = previousIncome?.date ?? opening.date;
+    if (opening.date !== startDate || closing.date !== record.date) continue;
     const days = calendarDaysBetween(startDate, record.date);
     if (days <= 0 || closing.date <= opening.date) continue;
 

--- a/ui/lib/domain/assettracker/portfolioReconciliation.ts
+++ b/ui/lib/domain/assettracker/portfolioReconciliation.ts
@@ -1,0 +1,163 @@
+import { DEFAULT_WITHDRAWAL_RATE } from "./assetTrackerData";
+import { getNetWorthTimeSeries } from "./assetTrackerQueries";
+import type { AssetTrackerRepository } from "./assetTrackerRepository";
+import type { NetWorthDataPoint } from "./assetTrackerViews";
+
+const DAYS_PER_YEAR = 365.2425;
+
+export type PortfolioReconciliationPeriod = {
+  startDate: string;
+  endDate: string;
+  openingNetWorth: number;
+  closingNetWorth: number;
+  income: number;
+  /** Deposits less withdrawals across every account during the period. */
+  netCapitalFlow: number;
+  /** Closing net worth − opening net worth − net capital flow. */
+  valuationGain: number;
+  /** Income not retained on the complete balance sheet. */
+  expenditure: number;
+  days: number;
+  annualizedExpenditure: number;
+};
+
+export type PortfolioFinancialIndependence = {
+  periods: PortfolioReconciliationPeriod[];
+  representativeAnnualExpenditure: number | null;
+  target: number | null;
+  progress: number | null;
+};
+
+function calendarDaysBetween(start: string, end: string): number {
+  const [startYear, startMonth, startDay] = start.split("-").map(Number);
+  const [endYear, endMonth, endDay] = end.split("-").map(Number);
+  return (
+    (Date.UTC(endYear ?? 0, (endMonth ?? 1) - 1, endDay ?? 1) -
+      Date.UTC(startYear ?? 0, (startMonth ?? 1) - 1, startDay ?? 1)) /
+    86_400_000
+  );
+}
+
+function latestPointBefore(
+  series: readonly NetWorthDataPoint[],
+  date: string,
+): NetWorthDataPoint | null {
+  let latest: NetWorthDataPoint | null = null;
+  for (const point of series) {
+    if (point.date >= date) break;
+    latest = point;
+  }
+  return latest;
+}
+
+function pointAsOf(
+  series: readonly NetWorthDataPoint[],
+  date: string,
+): NetWorthDataPoint | null {
+  let latest: NetWorthDataPoint | null = null;
+  for (const point of series) {
+    if (point.date > date) break;
+    latest = point;
+  }
+  return latest;
+}
+
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = values.toSorted((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[middle] ?? null;
+  return ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2;
+}
+
+/**
+ * Reconciles each imported income period against the complete balance sheet:
+ *
+ * opening net worth + income − expenditure + valuation gain = closing net worth
+ *
+ * Signed capital flows across all accounts cancel internal transfers. Their
+ * net is therefore the part of income retained (or prior wealth spent), which
+ * makes expenditure `income − net capital flow`. The first income row uses the
+ * latest earlier balance-sheet observation as its opening boundary; subsequent
+ * rows use the previous income date.
+ */
+export function reconcilePortfolio(
+  repository: AssetTrackerRepository,
+): PortfolioReconciliationPeriod[] {
+  const netWorth = getNetWorthTimeSeries(repository);
+  const income = repository.incomeHistory.toSorted((a, b) =>
+    a.date.localeCompare(b.date),
+  );
+
+  const periods: PortfolioReconciliationPeriod[] = [];
+  for (const [index, record] of income.entries()) {
+    const previousIncome = income[index - 1];
+    const opening = previousIncome
+      ? pointAsOf(netWorth, previousIncome.date)
+      : latestPointBefore(netWorth, record.date);
+    const closing = pointAsOf(netWorth, record.date);
+    if (opening == null || closing == null) continue;
+
+    const startDate = previousIncome?.date ?? opening.date;
+    const days = calendarDaysBetween(startDate, record.date);
+    if (days <= 0 || closing.date <= opening.date) continue;
+
+    const netCapitalFlow = repository.capitalFlows.reduce(
+      (sum, flow) =>
+        flow.date > startDate && flow.date <= record.date
+          ? sum + flow.amount
+          : sum,
+      0,
+    );
+    const valuationGain = closing.total - opening.total - netCapitalFlow;
+    const expenditure = record.amount - netCapitalFlow;
+
+    periods.push({
+      startDate,
+      endDate: record.date,
+      openingNetWorth: opening.total,
+      closingNetWorth: closing.total,
+      income: record.amount,
+      netCapitalFlow,
+      valuationGain,
+      expenditure,
+      days,
+      annualizedExpenditure: (expenditure * DAYS_PER_YEAR) / days,
+    });
+  }
+  return periods;
+}
+
+/** Median annualised period expenditure resists one unusually lumpy period. */
+export function representativeAnnualExpenditure(
+  periods: readonly PortfolioReconciliationPeriod[],
+): number | null {
+  return median(
+    periods
+      .map((period) => period.annualizedExpenditure)
+      .filter((value) => Number.isFinite(value) && value >= 0),
+  );
+}
+
+export function getPortfolioFinancialIndependence(
+  repository: AssetTrackerRepository,
+): PortfolioFinancialIndependence {
+  const periods = reconcilePortfolio(repository);
+  const annualExpenditure = representativeAnnualExpenditure(periods);
+  const withdrawalRate =
+    repository.settings.withdrawalRate ?? DEFAULT_WITHDRAWAL_RATE;
+  const target =
+    annualExpenditure == null || withdrawalRate == null
+      ? null
+      : annualExpenditure / withdrawalRate;
+  const currentNetWorth = getNetWorthTimeSeries(repository).at(-1)?.total ?? 0;
+  return {
+    periods,
+    representativeAnnualExpenditure: annualExpenditure,
+    target,
+    progress:
+      target == null || target <= 0
+        ? null
+        : Math.min(Math.max(currentNetWorth / target, 0), 1),
+  };
+}

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -35,10 +35,18 @@ function mockAssetTracker(
     assetAllocation: [],
     transfers: [],
     recurringFlows: [],
+    incomeHistory: [],
+    financialIndependence: {
+      periods: [],
+      representativeAnnualExpenditure: null,
+      target: null,
+      progress: null,
+    },
     portfolioReturn: null,
     inflation: 0.025,
     netWorthTarget: null,
     netWorthTargetIsReal: false,
+    withdrawalRate: 0.04,
     hasLocalChanges: false,
     createAccount: vi.fn(),
     recordBalance: vi.fn(),
@@ -50,7 +58,10 @@ function mockAssetTracker(
     materializeFlow: vi.fn(),
     setExpectedReturn: vi.fn(),
     setInflation: vi.fn(),
+    setWithdrawalRate: vi.fn(),
     setNetWorthTarget: vi.fn(),
+    importIncomeHistory: vi.fn(),
+    clearIncomeHistory: vi.fn(),
     resetData: vi.fn(),
     exportData: vi.fn(),
     exportCsv: vi.fn(),
@@ -68,22 +79,18 @@ describe("PortfolioGoal", () => {
     vi.clearAllMocks();
   });
 
-  it("accepts whole-number goals that are not offset from the minimum", async () => {
-    const setNetWorthTarget = vi.fn().mockResolvedValue(undefined);
-    mockAssetTracker({ setNetWorthTarget });
+  it("updates the withdrawal rate used to derive the FI target", async () => {
+    const setWithdrawalRate = vi.fn().mockResolvedValue(undefined);
+    mockAssetTracker({ setWithdrawalRate });
 
     render(<PortfolioGoal />);
 
-    const input = screen.getByLabelText("Target net worth") as HTMLInputElement;
-    await userEvent.type(input, "500000");
+    const input = screen.getByLabelText("Withdrawal rate");
+    await userEvent.clear(input);
+    await userEvent.type(input, "3.5");
+    await userEvent.tab();
 
-    expect(input).toHaveAttribute("step", "any");
-    expect(input.validity.stepMismatch).toBe(false);
-    expect(input.checkValidity()).toBe(true);
-
-    await userEvent.click(screen.getByRole("button", { name: "Set goal" }));
-
-    expect(setNetWorthTarget).toHaveBeenCalledWith(500000, true);
+    expect(setWithdrawalRate).toHaveBeenCalledWith(0.035);
   });
 
   it("uses constrained mobile layout classes", () => {
@@ -94,21 +101,29 @@ describe("PortfolioGoal", () => {
     expect(container.querySelector('[data-slot="card"]')).toHaveClass(
       "min-w-0",
     );
-    expect(screen.getByRole("button", { name: "Set goal" })).toHaveClass(
-      "w-full",
-      "sm:w-auto",
-    );
+    expect(
+      screen.getByRole("button", { name: "Add income history" }),
+    ).toBeVisible();
   });
 
   it("uses a native progress element for an active goal", () => {
-    mockAssetTracker({ netWorthTarget: 500_000 });
+    mockAssetTracker({
+      financialIndependence: {
+        periods: [],
+        representativeAnnualExpenditure: 20_000,
+        target: 500_000,
+        progress: 0.25,
+      },
+    });
 
     render(<PortfolioGoal />);
 
-    const progress = screen.getByRole("progressbar");
+    const progress = screen.getByRole("progressbar", {
+      name: "Financial independence progress",
+    });
     expect(progress.tagName).toBe("PROGRESS");
     expect(progress).toHaveAttribute("max", "1");
-    expect(progress).toHaveAttribute("value", "0");
+    expect(progress).toHaveAttribute("value", "0.25");
   });
 });
 

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -12,6 +12,17 @@ vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
+  LineChart: ({ children, data }: { children: ReactNode; data: unknown[] }) => (
+    <div data-chart-data={JSON.stringify(data)} data-testid="line-chart">
+      {children}
+    </div>
+  ),
+  Line: ({ dataKey }: { dataKey: string }) => <div data-series={dataKey} />,
+  CartesianGrid: () => null,
+  ReferenceLine: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Legend: () => null,
   Sankey: ({ align }: { align?: string }) => (
     <div data-align={align} data-testid="flow-sankey" />
   ),
@@ -155,6 +166,68 @@ describe("PortfolioGoal", () => {
     expect(progress.tagName).toBe("PROGRESS");
     expect(progress).toHaveAttribute("max", "1");
     expect(progress).toHaveAttribute("value", "0.25");
+  });
+
+  it("plots income and expenditure and switches to their difference", async () => {
+    mockAssetTracker({
+      incomeHistory: [
+        { date: "2026-01-31", amount: 4_000 },
+        { date: "2026-02-28", amount: 4_200 },
+      ],
+      financialIndependence: {
+        periods: [
+          {
+            startDate: "2025-12-31",
+            endDate: "2026-01-31",
+            openingNetWorth: 100_000,
+            closingNetWorth: 101_500,
+            income: 4_000,
+            netCapitalFlow: 1_500,
+            valuationGain: 0,
+            expenditure: 2_500,
+            days: 31,
+            annualizedExpenditure: 29_455.04,
+          },
+        ],
+        representativeAnnualExpenditure: 29_455.04,
+        target: 736_376,
+        progress: 0.14,
+      },
+    });
+
+    render(<PortfolioGoal />);
+
+    expect(
+      screen.getByRole("img", { name: "Income and expenditure by period" }),
+    ).toBeVisible();
+    expect(screen.getByTestId("line-chart")).toHaveAttribute(
+      "data-chart-data",
+      JSON.stringify([
+        {
+          date: "2026-01-31",
+          income: 4_000,
+          expenditure: 2_500,
+          difference: 1_500,
+        },
+        { date: "2026-02-28", income: 4_200 },
+      ]),
+    );
+    expect(document.querySelector('[data-series="income"]')).toBeVisible();
+    expect(document.querySelector('[data-series="expenditure"]')).toBeVisible();
+    expect(
+      screen.getByRole("table", { name: "Income and expenditure by period" }),
+    ).toHaveTextContent(
+      "2026-01-31£4,000£2,500£1,5002026-02-28£4,200Awaiting reconciliationAwaiting reconciliation",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Difference" }));
+
+    expect(
+      screen.getByRole("img", { name: "Income minus expenditure by period" }),
+    ).toBeVisible();
+    expect(document.querySelector('[data-series="income"]')).toBeNull();
+    expect(document.querySelector('[data-series="expenditure"]')).toBeNull();
+    expect(document.querySelector('[data-series="difference"]')).toBeVisible();
   });
 });
 

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -93,6 +93,20 @@ describe("PortfolioGoal", () => {
     expect(setWithdrawalRate).toHaveBeenCalledWith(0.035);
   });
 
+  it("preserves a stored withdrawal rate without persisting on an unchanged blur", async () => {
+    const setWithdrawalRate = vi.fn().mockResolvedValue(undefined);
+    mockAssetTracker({ withdrawalRate: 0.0355, setWithdrawalRate });
+
+    render(<PortfolioGoal />);
+
+    const input = screen.getByLabelText("Withdrawal rate");
+    expect(input).toHaveValue(3.55);
+    await userEvent.click(input);
+    await userEvent.tab();
+
+    expect(setWithdrawalRate).not.toHaveBeenCalled();
+  });
+
   it("uses constrained mobile layout classes", () => {
     mockAssetTracker();
 

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -2,11 +2,16 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssetAllocationHistoryChart } from "@/components/assettracker/asset-allocation-history-chart";
 import { useAssetTracker } from "@/components/assettracker/asset-tracker-provider";
 import { FlowSankeyChart } from "@/components/assettracker/flow-sankey-chart";
 import { PortfolioGoal } from "@/components/assettracker/portfolio-goal";
 import { UpcomingFlows } from "@/components/assettracker/upcoming-flows";
-import { buildFlowSankeyData, todayIsoDate } from "@/lib/domain/assettracker";
+import {
+  buildFlowSankeyData,
+  type PortfolioFinancialIndependence,
+  todayIsoDate,
+} from "@/lib/domain/assettracker";
 
 vi.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: ReactNode }) => (
@@ -35,6 +40,20 @@ vi.mock("@/components/assettracker/asset-tracker-provider", () => ({
 
 const mockUseAssetTracker = vi.mocked(useAssetTracker);
 const FIXED_NOW = new Date("2026-07-03T12:00:00+01:00");
+const EMPTY_FI: PortfolioFinancialIndependence = {
+  periods: [],
+  representativeAnnualExpenditure: null,
+  representativeAnnualSavings: null,
+  savingsRate: null,
+  emergencyFund: 0,
+  emergencyFundMonths: null,
+  target: null,
+  progress: null,
+  expectedRealReturn: null,
+  projection: [],
+  projectedFiDate: null,
+  yearsToFi: null,
+};
 
 function mockAssetTracker(
   overrides: Partial<ReturnType<typeof useAssetTracker>> = {},
@@ -44,15 +63,11 @@ function mockAssetTracker(
     accountDetails: [],
     netWorthData: [],
     assetAllocation: [],
+    assetAllocationHistory: [],
     transfers: [],
     recurringFlows: [],
     incomeHistory: [],
-    financialIndependence: {
-      periods: [],
-      representativeAnnualExpenditure: null,
-      target: null,
-      progress: null,
-    },
+    financialIndependence: EMPTY_FI,
     portfolioReturn: null,
     inflation: 0.025,
     netWorthTarget: null,
@@ -151,6 +166,7 @@ describe("PortfolioGoal", () => {
   it("uses a native progress element for an active goal", () => {
     mockAssetTracker({
       financialIndependence: {
+        ...EMPTY_FI,
         periods: [],
         representativeAnnualExpenditure: 20_000,
         target: 500_000,
@@ -175,6 +191,7 @@ describe("PortfolioGoal", () => {
         { date: "2026-02-28", amount: 4_200 },
       ],
       financialIndependence: {
+        ...EMPTY_FI,
         periods: [
           {
             startDate: "2025-12-31",
@@ -228,6 +245,69 @@ describe("PortfolioGoal", () => {
     expect(document.querySelector('[data-series="income"]')).toBeNull();
     expect(document.querySelector('[data-series="expenditure"]')).toBeNull();
     expect(document.querySelector('[data-series="difference"]')).toBeVisible();
+  });
+
+  it("shows emergency runway, savings rate, and a portfolio years-to-FI projection", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+    mockAssetTracker({
+      financialIndependence: {
+        ...EMPTY_FI,
+        representativeAnnualExpenditure: 24_000,
+        representativeAnnualSavings: 12_000,
+        savingsRate: 0.333,
+        emergencyFund: 9_000,
+        emergencyFundMonths: 4.5,
+        target: 600_000,
+        progress: 0.25,
+        expectedRealReturn: 0.04,
+        projection: [
+          { date: "2026-07-03", projected: 150_000 },
+          { date: "2038-07-03", projected: 600_100 },
+        ],
+        projectedFiDate: "2038-07-03",
+        yearsToFi: 12,
+      },
+    });
+
+    render(<PortfolioGoal />);
+
+    expect(screen.getByText("33.3%")).toBeVisible();
+    expect(screen.getByText("£9,000")).toBeVisible();
+    expect(screen.getByText("4.5 months without income")).toBeVisible();
+    expect(screen.getByText("12.0 years")).toBeVisible();
+    expect(screen.getByText("Around Jul 2038")).toBeVisible();
+    expect(
+      screen.getByRole("img", {
+        name: "Projected portfolio net worth against the financial independence target",
+      }),
+    ).toBeVisible();
+  });
+});
+
+describe("AssetAllocationHistoryChart", () => {
+  it("plots percentage series and exposes an accessible data table", () => {
+    render(
+      <AssetAllocationHistoryChart
+        data={[
+          { date: "2025-01-01", totalAssets: 100_000, cash: 0.2, stocks: 0.8 },
+          { date: "2026-01-01", totalAssets: 120_000, cash: 0.1, stocks: 0.9 },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", {
+        name: "Percentage of assets by asset type over time",
+      }),
+    ).toBeVisible();
+    expect(document.querySelector('[data-series="cash"]')).toBeVisible();
+    expect(document.querySelector('[data-series="stocks"]')).toBeVisible();
+    expect(
+      screen.getByRole("table", {
+        name: "Percentage of assets by asset type over time",
+      }),
+    ).toHaveTextContent("2025-01-0120.0%80.0%2026-01-0110.0%90.0%");
   });
 });
 

--- a/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
+++ b/ui/tests/components/assettracker/asset-tracker-cards.test.tsx
@@ -107,6 +107,23 @@ describe("PortfolioGoal", () => {
     expect(setWithdrawalRate).not.toHaveBeenCalled();
   });
 
+  it("rejects an out-of-range withdrawal rate before saving", async () => {
+    const setWithdrawalRate = vi.fn().mockResolvedValue(undefined);
+    mockAssetTracker({ setWithdrawalRate });
+
+    render(<PortfolioGoal />);
+
+    const input = screen.getByLabelText("Withdrawal rate");
+    await userEvent.clear(input);
+    await userEvent.type(input, "0");
+    await userEvent.tab();
+
+    expect(setWithdrawalRate).not.toHaveBeenCalled();
+    expect(
+      screen.getByText("Withdrawal rate must be between 0.1% and 100%"),
+    ).toBeVisible();
+  });
+
   it("uses constrained mobile layout classes", () => {
     mockAssetTracker();
 

--- a/ui/tests/components/assettracker/income-history-import-drawer.test.tsx
+++ b/ui/tests/components/assettracker/income-history-import-drawer.test.tsx
@@ -1,5 +1,14 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import { useAssetTracker } from "@/components/assettracker/asset-tracker-provider";
 import { IncomeHistoryImportDrawer } from "@/components/assettracker/income-history-import-drawer";
 
@@ -8,6 +17,29 @@ vi.mock("@/components/assettracker/asset-tracker-provider", () => ({
 }));
 
 const mockUseAssetTracker = vi.mocked(useAssetTracker);
+
+beforeAll(() => {
+  for (const method of [
+    "setPointerCapture",
+    "releasePointerCapture",
+    "hasPointerCapture",
+  ]) {
+    Object.defineProperty(HTMLElement.prototype, method, {
+      configurable: true,
+      value: vi.fn(),
+    });
+  }
+});
+
+afterAll(() => {
+  for (const method of [
+    "setPointerCapture",
+    "releasePointerCapture",
+    "hasPointerCapture",
+  ]) {
+    Reflect.deleteProperty(HTMLElement.prototype, method);
+  }
+});
 
 describe("IncomeHistoryImportDrawer", () => {
   const importIncomeHistory = vi.fn().mockResolvedValue(undefined);
@@ -25,13 +57,16 @@ describe("IncomeHistoryImportDrawer", () => {
   it("imports sorted portfolio income rows and accepts an income header", async () => {
     render(<IncomeHistoryImportDrawer />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Add income history" }));
-    fireEvent.change(screen.getByLabelText("Period end and income"), {
-      target: {
-        value: "date,income\n2025-02-28,4200\n2025-01-31,4100",
-      },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Import 2 periods" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add income history" }),
+    );
+    await userEvent.type(
+      screen.getByLabelText("Period end and income"),
+      "date,income\n2025-02-28,4200\n2025-01-31,4100",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Import 2 periods" }),
+    );
 
     expect(importIncomeHistory).toHaveBeenCalledWith({
       income: [
@@ -49,10 +84,10 @@ describe("IncomeHistoryImportDrawer", () => {
     } as unknown as ReturnType<typeof useAssetTracker>);
     render(<IncomeHistoryImportDrawer />);
 
-    fireEvent.click(
+    await userEvent.click(
       screen.getByRole("button", { name: "Replace income history" }),
     );
-    fireEvent.click(
+    await userEvent.click(
       screen.getByRole("button", { name: "Clear income history" }),
     );
 

--- a/ui/tests/components/assettracker/income-history-import-drawer.test.tsx
+++ b/ui/tests/components/assettracker/income-history-import-drawer.test.tsx
@@ -60,6 +60,9 @@ describe("IncomeHistoryImportDrawer", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Add income history" }),
     );
+    expect(
+      screen.queryByText(/replace all existing income history/i),
+    ).not.toBeInTheDocument();
     await userEvent.type(
       screen.getByLabelText("Period end and income"),
       "date,income\n2025-02-28,4200\n2025-01-31,4100",
@@ -76,7 +79,7 @@ describe("IncomeHistoryImportDrawer", () => {
     });
   });
 
-  it("can clear an existing income series", async () => {
+  it("warns before replacing and can clear existing income history", async () => {
     mockUseAssetTracker.mockReturnValue({
       incomeHistory: [{ date: "2025-01-31", amount: 4100 }],
       importIncomeHistory,
@@ -87,6 +90,9 @@ describe("IncomeHistoryImportDrawer", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Replace income history" }),
     );
+    expect(
+      screen.getByText(/importing will replace all existing income history/i),
+    ).toBeInTheDocument();
     await userEvent.click(
       screen.getByRole("button", { name: "Clear income history" }),
     );

--- a/ui/tests/components/assettracker/income-history-import-drawer.test.tsx
+++ b/ui/tests/components/assettracker/income-history-import-drawer.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAssetTracker } from "@/components/assettracker/asset-tracker-provider";
+import { IncomeHistoryImportDrawer } from "@/components/assettracker/income-history-import-drawer";
+
+vi.mock("@/components/assettracker/asset-tracker-provider", () => ({
+  useAssetTracker: vi.fn(),
+}));
+
+const mockUseAssetTracker = vi.mocked(useAssetTracker);
+
+describe("IncomeHistoryImportDrawer", () => {
+  const importIncomeHistory = vi.fn().mockResolvedValue(undefined);
+  const clearIncomeHistory = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAssetTracker.mockReturnValue({
+      incomeHistory: [],
+      importIncomeHistory,
+      clearIncomeHistory,
+    } as unknown as ReturnType<typeof useAssetTracker>);
+  });
+
+  it("imports sorted portfolio income rows and accepts an income header", async () => {
+    render(<IncomeHistoryImportDrawer />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add income history" }));
+    fireEvent.change(screen.getByLabelText("Period end and income"), {
+      target: {
+        value: "date,income\n2025-02-28,4200\n2025-01-31,4100",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Import 2 periods" }));
+
+    expect(importIncomeHistory).toHaveBeenCalledWith({
+      income: [
+        { date: "2025-01-31", amount: 4100 },
+        { date: "2025-02-28", amount: 4200 },
+      ],
+    });
+  });
+
+  it("can clear an existing income series", async () => {
+    mockUseAssetTracker.mockReturnValue({
+      incomeHistory: [{ date: "2025-01-31", amount: 4100 }],
+      importIncomeHistory,
+      clearIncomeHistory,
+    } as unknown as ReturnType<typeof useAssetTracker>);
+    render(<IncomeHistoryImportDrawer />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Replace income history" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear income history" }),
+    );
+
+    expect(clearIncomeHistory).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/tests/lib/api/assettracker.test.ts
+++ b/ui/tests/lib/api/assettracker.test.ts
@@ -133,6 +133,50 @@ describe("createLocalAssetTrackerApi", () => {
     expect(data.capitalFlows).toEqual([]);
   });
 
+  it("loads older saved data with no income history", async () => {
+    const { incomeHistory: _incomeHistory, ...legacy } = getSeedData();
+    window.localStorage.setItem(
+      ASSET_TRACKER_STORAGE_KEY,
+      JSON.stringify(legacy),
+    );
+
+    const { data, persisted } = await createApi().load();
+
+    expect(persisted).toBe(true);
+    expect(data.incomeHistory).toEqual([]);
+  });
+
+  it("defaults the withdrawal rate in older saved settings", async () => {
+    const seed = getSeedData();
+    const legacy = {
+      ...seed,
+      settings: {
+        expectedAnnualInflation: seed.settings.expectedAnnualInflation,
+      },
+    };
+    window.localStorage.setItem(
+      ASSET_TRACKER_STORAGE_KEY,
+      JSON.stringify(legacy),
+    );
+
+    const { data, persisted } = await createApi().load();
+
+    expect(persisted).toBe(true);
+    expect(data.settings.withdrawalRate).toBe(0.04);
+  });
+
+  it("persists portfolio income history and the withdrawal rate", async () => {
+    const api = createApi();
+    await api.importIncomeHistory({
+      income: [{ date: "2025-01-31", amount: 4_500 }],
+    });
+    await api.setWithdrawalRate({ rate: 0.035 });
+
+    const { data } = await createApi().load();
+    expect(data.incomeHistory).toEqual([{ date: "2025-01-31", amount: 4_500 }]);
+    expect(data.settings.withdrawalRate).toBe(0.035);
+  });
+
   it("rejects importing data that fails validation", async () => {
     await expect(
       createApi().importData({ accounts: "nope" }),

--- a/ui/tests/lib/api/assettracker.test.ts
+++ b/ui/tests/lib/api/assettracker.test.ts
@@ -165,6 +165,26 @@ describe("createLocalAssetTrackerApi", () => {
     expect(data.settings.withdrawalRate).toBe(0.04);
   });
 
+  it("repairs duplicate persisted income dates without hiding the portfolio", async () => {
+    const seed = getSeedData();
+    window.localStorage.setItem(
+      ASSET_TRACKER_STORAGE_KEY,
+      JSON.stringify({
+        ...seed,
+        incomeHistory: [
+          { date: "2025-01-31", amount: 4_100 },
+          { date: "2025-01-31", amount: 4_200 },
+        ],
+      }),
+    );
+
+    const { data, persisted } = await createApi().load();
+
+    expect(persisted).toBe(true);
+    expect(data.accounts).toEqual(seed.accounts);
+    expect(data.incomeHistory).toEqual([{ date: "2025-01-31", amount: 4_200 }]);
+  });
+
   it("persists portfolio income history and the withdrawal rate", async () => {
     const api = createApi();
     await api.importIncomeHistory({

--- a/ui/tests/lib/domain/assettracker/assetTrackerCommands.test.ts
+++ b/ui/tests/lib/domain/assettracker/assetTrackerCommands.test.ts
@@ -3,17 +3,20 @@ import {
   AssetTrackerCommandError,
   applyAddRecurringFlow,
   applyClearAccountHistory,
+  applyClearIncomeHistory,
   applyCloseAccount,
   applyCreateAccount,
   applyDeleteCapitalFlow,
   applyDeleteRecurringFlow,
   applyDeleteSnapshot,
   applyImportAccountHistory,
+  applyImportIncomeHistory,
   applyMaterializeFlow,
   applyRecordBalance,
   applyRecordTransfer,
   applySetExpectedReturn,
   applySetNetWorthTarget,
+  applySetWithdrawalRate,
   formatAssetTrackerError,
 } from "@/lib/domain/assettracker/assetTrackerCommands";
 import type { AssetTrackerData } from "@/lib/domain/assettracker/assetTrackerData";
@@ -68,9 +71,10 @@ function baseData(): AssetTrackerData {
       { accountId: "old-pension", date: "2023-06-30", balance: 0 },
     ],
     capitalFlows: [],
+    incomeHistory: [],
     transfers: [],
     recurringFlows: [],
-    settings: { expectedAnnualInflation: 0.025 },
+    settings: { expectedAnnualInflation: 0.025, withdrawalRate: 0.04 },
   };
 }
 
@@ -377,6 +381,44 @@ describe("applyImportAccountHistory", () => {
         date: "2024-06-01",
       }),
     ).toThrow(/No deposit or withdrawal/);
+  });
+});
+
+describe("portfolio income settings", () => {
+  it("replaces and sorts the complete income history", () => {
+    const imported = applyImportIncomeHistory(baseData(), {
+      income: [
+        { date: "2025-02-28", amount: 4_200 },
+        { date: "2025-01-31", amount: 4_100 },
+      ],
+    });
+
+    expect(imported.incomeHistory).toEqual([
+      { date: "2025-01-31", amount: 4_100 },
+      { date: "2025-02-28", amount: 4_200 },
+    ]);
+    expect(applyClearIncomeHistory(imported).incomeHistory).toEqual([]);
+  });
+
+  it("rejects duplicate income dates and invalid withdrawal rates", () => {
+    expect(() =>
+      applyImportIncomeHistory(baseData(), {
+        income: [
+          { date: "2025-01-31", amount: 4_100 },
+          { date: "2025-01-31", amount: 4_200 },
+        ],
+      }),
+    ).toThrow("Duplicate income record on 2025-01-31");
+    expect(() => applySetWithdrawalRate(baseData(), { rate: 0 })).toThrow(
+      "Withdrawal rate must be positive",
+    );
+  });
+
+  it("stores an editable withdrawal rate", () => {
+    expect(
+      applySetWithdrawalRate(baseData(), { rate: 0.035 }).settings
+        .withdrawalRate,
+    ).toBe(0.035);
   });
 });
 

--- a/ui/tests/lib/domain/assettracker/assetTrackerCommands.test.ts
+++ b/ui/tests/lib/domain/assettracker/assetTrackerCommands.test.ts
@@ -401,14 +401,20 @@ describe("portfolio income settings", () => {
   });
 
   it("rejects duplicate income dates and invalid withdrawal rates", () => {
-    expect(() =>
+    let duplicateError: unknown;
+    try {
       applyImportIncomeHistory(baseData(), {
         income: [
           { date: "2025-01-31", amount: 4_100 },
           { date: "2025-01-31", amount: 4_200 },
         ],
-      }),
-    ).toThrow("Duplicate income record on 2025-01-31");
+      });
+    } catch (error) {
+      duplicateError = error;
+    }
+    expect(formatAssetTrackerError(duplicateError)).toBe(
+      "Duplicate income record on 2025-01-31",
+    );
     expect(() => applySetWithdrawalRate(baseData(), { rate: 0 })).toThrow(
       "Withdrawal rate must be positive",
     );

--- a/ui/tests/lib/domain/assettracker/assetTrackerCsv.test.ts
+++ b/ui/tests/lib/domain/assettracker/assetTrackerCsv.test.ts
@@ -20,9 +20,10 @@ function csvData(): AssetTrackerData {
       { accountId: "isa", date: "2024-01-01", balance: 10000 },
     ],
     capitalFlows: [],
+    incomeHistory: [],
     transfers: [],
     recurringFlows: [],
-    settings: { expectedAnnualInflation: 0.025 },
+    settings: { expectedAnnualInflation: 0.025, withdrawalRate: 0.04 },
   };
 }
 

--- a/ui/tests/lib/domain/assettracker/assetTrackerQueries.test.ts
+++ b/ui/tests/lib/domain/assettracker/assetTrackerQueries.test.ts
@@ -45,9 +45,10 @@ function homeData(): AssetTrackerData {
       { accountId: "card", date: "2024-01-01", balance: -2000 },
     ],
     capitalFlows: [],
+    incomeHistory: [],
     transfers: [],
     recurringFlows: [],
-    settings: { expectedAnnualInflation: 0.025 },
+    settings: { expectedAnnualInflation: 0.025, withdrawalRate: 0.04 },
   };
 }
 

--- a/ui/tests/lib/domain/assettracker/assetTrackerQueries.test.ts
+++ b/ui/tests/lib/domain/assettracker/assetTrackerQueries.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AssetTrackerData } from "@/lib/domain/assettracker/assetTrackerData";
 import {
   getAccountDetail,
+  getAssetAllocationTimeSeries,
   getNetWorthTimeSeries,
   getTotalByAssetType,
 } from "@/lib/domain/assettracker/assetTrackerQueries";
@@ -65,6 +66,45 @@ describe("getTotalByAssetType", () => {
     expect(byType.mortgage).toBeUndefined();
     // Standalone debt still surfaces as its own negative total
     expect(byType.debt).toBe(-2000);
+  });
+});
+
+describe("getAssetAllocationTimeSeries", () => {
+  it("tracks asset-type percentages over time and treats property as home equity", () => {
+    const data = homeData();
+    data.accounts.push({
+      id: "cash",
+      name: "Emergency fund",
+      provider: "Bank",
+      currency: "GBP",
+      assetType: "cash",
+      expectedAnnualReturn: 0,
+      createdAt: "2023-01-01",
+    });
+    data.snapshots.push(
+      { accountId: "cash", date: "2024-01-01", balance: 10_000 },
+      { accountId: "home", date: "2025-01-01", balance: 320_000 },
+      { accountId: "mortgage", date: "2025-01-01", balance: -200_000 },
+      { accountId: "cash", date: "2025-01-01", balance: 20_000 },
+    );
+
+    const series = getAssetAllocationTimeSeries(buildRepository(data));
+
+    expect(series).toHaveLength(2);
+    expect(series[0]).toMatchObject({
+      date: "2024-01-01",
+      totalAssets: 100_000,
+      cash: 0.1,
+      property: 0.9,
+    });
+    expect(series[1]).toMatchObject({
+      date: "2025-01-01",
+      totalAssets: 140_000,
+    });
+    expect(series[1]?.cash).toBeCloseTo(1 / 7);
+    expect(series[1]?.property).toBeCloseTo(6 / 7);
+    expect(series[1]?.debt).toBeUndefined();
+    expect(series[1]?.mortgage).toBeUndefined();
   });
 });
 

--- a/ui/tests/lib/domain/assettracker/portfolioReconciliation.test.ts
+++ b/ui/tests/lib/domain/assettracker/portfolioReconciliation.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { AssetTrackerData } from "@/lib/domain/assettracker";
+import {
+  buildRepository,
+  getNetWorthTimeSeries,
+  getPortfolioFinancialIndependence,
+  reconcilePortfolio,
+  representativeAnnualExpenditure,
+} from "@/lib/domain/assettracker";
+
+function portfolioData(): AssetTrackerData {
+  return {
+    accounts: [
+      {
+        id: "portfolio",
+        name: "Portfolio",
+        provider: "Broker",
+        currency: "GBP",
+        assetType: "stocks",
+        expectedAnnualReturn: 0.05,
+        createdAt: "2024-01-01",
+      },
+    ],
+    snapshots: [
+      { accountId: "portfolio", date: "2024-01-31", balance: 100_000 },
+      { accountId: "portfolio", date: "2024-02-29", balance: 108_000 },
+      { accountId: "portfolio", date: "2024-03-31", balance: 113_000 },
+    ],
+    capitalFlows: [
+      { accountId: "portfolio", date: "2024-02-15", amount: 5_000 },
+      { accountId: "portfolio", date: "2024-03-15", amount: 2_000 },
+    ],
+    incomeHistory: [
+      { date: "2024-02-29", amount: 10_000 },
+      { date: "2024-03-31", amount: 8_000 },
+    ],
+    transfers: [],
+    recurringFlows: [],
+    settings: { expectedAnnualInflation: 0.025, withdrawalRate: 0.04 },
+  };
+}
+
+describe("reconcilePortfolio", () => {
+  it("separates balance changes into retained income, expenditure, and valuation gains", () => {
+    const periods = reconcilePortfolio(buildRepository(portfolioData()));
+
+    expect(periods).toHaveLength(2);
+    expect(periods[0]).toMatchObject({
+      startDate: "2024-01-31",
+      endDate: "2024-02-29",
+      openingNetWorth: 100_000,
+      closingNetWorth: 108_000,
+      income: 10_000,
+      netCapitalFlow: 5_000,
+      valuationGain: 3_000,
+      expenditure: 5_000,
+    });
+    expect(periods[1]).toMatchObject({
+      startDate: "2024-02-29",
+      endDate: "2024-03-31",
+      openingNetWorth: 108_000,
+      closingNetWorth: 113_000,
+      income: 8_000,
+      netCapitalFlow: 2_000,
+      valuationGain: 3_000,
+      expenditure: 6_000,
+    });
+
+    for (const period of periods) {
+      expect(
+        period.openingNetWorth +
+          period.income -
+          period.expenditure +
+          period.valuationGain,
+      ).toBe(period.closingNetWorth);
+    }
+  });
+
+  it("cancels signed internal transfers across accounts", () => {
+    const data = portfolioData();
+    data.accounts.push({
+      id: "cash",
+      name: "Cash",
+      provider: "Bank",
+      currency: "GBP",
+      assetType: "cash",
+      expectedAnnualReturn: 0,
+      createdAt: "2024-01-01",
+    });
+    data.snapshots.push(
+      { accountId: "cash", date: "2024-01-31", balance: 10_000 },
+      { accountId: "cash", date: "2024-02-29", balance: 5_000 },
+    );
+    data.capitalFlows.push(
+      { accountId: "cash", date: "2024-02-10", amount: -1_000 },
+      { accountId: "portfolio", date: "2024-02-10", amount: 1_000 },
+    );
+
+    expect(reconcilePortfolio(buildRepository(data))[0]?.netCapitalFlow).toBe(
+      5_000,
+    );
+  });
+
+  it("uses the median annualised expenditure as the representative amount", () => {
+    const periods = reconcilePortfolio(buildRepository(portfolioData()));
+    const expected = (5_000 * (365.2425 / 29) + 6_000 * (365.2425 / 31)) / 2;
+
+    expect(representativeAnnualExpenditure(periods)).toBeCloseTo(expected);
+  });
+
+  it("includes complete home equity in net worth and FI progress", () => {
+    const data = portfolioData();
+    data.accounts = [
+      {
+        id: "home",
+        name: "Home",
+        provider: "Owned",
+        currency: "GBP",
+        assetType: "property",
+        expectedAnnualReturn: 0.03,
+        createdAt: "2024-01-01",
+      },
+      {
+        id: "mortgage",
+        name: "Mortgage",
+        provider: "Lender",
+        currency: "GBP",
+        assetType: "mortgage",
+        expectedAnnualReturn: 0.04,
+        linkedAccountId: "home",
+        createdAt: "2024-01-01",
+      },
+    ];
+    data.snapshots = [
+      { accountId: "home", date: "2024-01-31", balance: 300_000 },
+      { accountId: "mortgage", date: "2024-01-31", balance: -200_000 },
+      { accountId: "home", date: "2024-02-29", balance: 300_000 },
+      { accountId: "mortgage", date: "2024-02-29", balance: -200_000 },
+    ];
+    data.capitalFlows = [];
+    data.incomeHistory = [{ date: "2024-02-29", amount: 3_200 }];
+    const repository = buildRepository(data);
+    const currentNetWorth =
+      getNetWorthTimeSeries(repository).at(-1)?.total ?? 0;
+    const result = getPortfolioFinancialIndependence(repository);
+
+    expect(currentNetWorth).toBe(100_000);
+    expect(result.progress).toBeGreaterThan(0);
+  });
+});

--- a/ui/tests/lib/domain/assettracker/portfolioReconciliation.test.ts
+++ b/ui/tests/lib/domain/assettracker/portfolioReconciliation.test.ts
@@ -101,6 +101,16 @@ describe("reconcilePortfolio", () => {
     );
   });
 
+  it("skips periods whose income boundaries do not match balance observations", () => {
+    const data = portfolioData();
+    data.snapshots = [
+      { accountId: "portfolio", date: "2024-01-31", balance: 100_000 },
+      { accountId: "portfolio", date: "2024-03-31", balance: 113_000 },
+    ];
+
+    expect(reconcilePortfolio(buildRepository(data))).toEqual([]);
+  });
+
   it("uses the median annualised expenditure as the representative amount", () => {
     const periods = reconcilePortfolio(buildRepository(portfolioData()));
     const expected = (5_000 * (365.2425 / 29) + 6_000 * (365.2425 / 31)) / 2;

--- a/ui/tests/lib/domain/assettracker/portfolioReconciliation.test.ts
+++ b/ui/tests/lib/domain/assettracker/portfolioReconciliation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AssetTrackerData } from "@/lib/domain/assettracker";
 import {
   buildRepository,
@@ -6,7 +6,12 @@ import {
   getPortfolioFinancialIndependence,
   reconcilePortfolio,
   representativeAnnualExpenditure,
+  representativeAnnualSavings,
 } from "@/lib/domain/assettracker";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function portfolioData(): AssetTrackerData {
   return {
@@ -116,6 +121,42 @@ describe("reconcilePortfolio", () => {
     const expected = (5_000 * (365.2425 / 29) + 6_000 * (365.2425 / 31)) / 2;
 
     expect(representativeAnnualExpenditure(periods)).toBeCloseTo(expected);
+  });
+
+  it("derives savings rate, cash runway, and a portfolio FI date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00Z"));
+    const data = portfolioData();
+    data.accounts.push({
+      id: "cash",
+      name: "Emergency fund",
+      provider: "Bank",
+      currency: "GBP",
+      assetType: "cash",
+      expectedAnnualReturn: 0.01,
+      createdAt: "2024-01-01",
+    });
+    data.snapshots.push(
+      { accountId: "cash", date: "2024-01-31", balance: 12_000 },
+      { accountId: "cash", date: "2024-02-29", balance: 12_000 },
+      { accountId: "cash", date: "2024-03-31", balance: 12_000 },
+    );
+
+    const result = getPortfolioFinancialIndependence(buildRepository(data));
+    const expectedAnnualSavings = representativeAnnualSavings(result.periods);
+
+    expect(result.savingsRate).toBeCloseTo(7_000 / 18_000);
+    expect(result.representativeAnnualSavings).toBe(expectedAnnualSavings);
+    expect(result.emergencyFund).toBe(12_000);
+    expect(result.emergencyFundMonths).toBeCloseTo(
+      (12_000 * 12) / (result.representativeAnnualExpenditure ?? 1),
+    );
+    expect(result.expectedRealReturn).toBeGreaterThan(0);
+    expect(result.yearsToFi).toBeGreaterThan(0);
+    expect(result.projectedFiDate).not.toBeNull();
+    expect(result.projection.at(-1)?.projected).toBeGreaterThanOrEqual(
+      result.target ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("includes complete home equity in net worth and FI progress", () => {


### PR DESCRIPTION
## Summary

- add portfolio-level income history import with browser persistence and backward-compatible defaults
- reconcile each period from complete balances and signed capital flows to derive valuation gains and economic expenditure
- plot imported income and reconciled expenditure over time, with a switchable income-minus-expenditure view
- derive representative annual expenditure, savings rate, FI target, and FI progress from the reconciled periods
- show the current emergency fund from positive cash balances and its spending runway in months
- chart percentage allocation by asset type over time, with linked mortgages consistently represented as home equity
- project the whole portfolio in today's money and estimate years/date to FI from expected account returns, inflation, and median retained income
- keep total net worth and FI progress based on the complete balance sheet, including all home equity
- surface the reconciliation equation and every term in a per-period dashboard table

Closes SC-429.

## Validation

- `mise //ui:typecheck`
- `mise //ui:lint`
- `mise //ui:format:check`
- `mise //ui:test` — 123 files, 900 tests
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:build`

## Preview QA

No backend preview is required. On `/assettracker`:

1. Open **Add income history**, paste two-column period-end income data, and confirm the imported periods appear.
2. Verify the income/expenditure chart shows both series, then switch to **Difference** and confirm it shows income minus expenditure around a zero baseline.
3. Verify the FI summary derives annual expenditure, savings rate, target, progress, emergency-fund balance, and cash runway.
4. Verify **Projected FI** shows portfolio-level years/date and the projection line reaches the FI target using the stated real-return and retained-income assumptions.
5. Verify **Asset Allocation Over Time** shows percentage lines for each available asset type and that the values sum to 100% at each date.
6. Change the withdrawal rate and confirm the target, progress, and years-to-FI projection update.
7. Check all new cards and charts at desktop and mobile widths; the wide reconciliation table should scroll without overflowing the page.
8. Confirm total net worth, allocation history, and FI progress include linked property and mortgage equity consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added income-history import and clearing with validation for comma-separated data.
  - Added editable withdrawal-rate settings and financial-independence targets based on income and portfolio balances.
  - Added portfolio reconciliation, including expenditure, savings, emergency-fund and valuation insights.
  - Added income-versus-expenditure, financial-independence projection and asset-allocation history charts.
  - Updated the dashboard to present financial-independence progress and portfolio allocation trends.

- **Improvements**
  - Added clearer empty states when income history or balance-sheet dates are unavailable.
  - Income and earnings headers are now recognised during data import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->