### PR TITLE
Fix Sonar security gate and version baseline

### DIFF
--- a/.github/workflows/sonarqube-ci.yml
+++ b/.github/workflows/sonarqube-ci.yml
@@ -125,13 +125,25 @@ jobs:
           fi
 
       - name: Read project version
+        if: github.ref == 'refs/heads/main'
         id: project-version
         shell: bash
         run: |
           version=$(node --print "require('./package.json').version")
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::package.json version is not a safe semantic version"
+            exit 1
+          fi
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
-      - name: Scan with SonarQube Cloud
+      - name: Scan without a project version
+        if: github.ref != 'refs/heads/main'
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Scan main branch with SonarQube Cloud
+        if: github.ref == 'refs/heads/main'
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
           args: -Dsonar.projectVersion=${{ steps.project-version.outputs.version }}

--- a/.github/workflows/sonarqube-ci.yml
+++ b/.github/workflows/sonarqube-ci.yml
@@ -124,7 +124,14 @@ jobs:
             exit 1
           fi
 
+      - name: Read project version
+        id: project-version
+        shell: bash
+        run: echo "version=$(node --print \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
       - name: Scan with SonarQube Cloud
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
+        with:
+          args: -Dsonar.projectVersion=${{ steps.project-version.outputs.version }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarqube-ci.yml
+++ b/.github/workflows/sonarqube-ci.yml
@@ -127,7 +127,9 @@ jobs:
       - name: Read project version
         id: project-version
         shell: bash
-        run: echo "version=$(node --print \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          version=$(node --print "require('./package.json').version")
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Scan with SonarQube Cloud
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.test.inclusions=**/tests/**/*
 # public assets are excluded so language sensors do not try to decode them as UTF-8.
 sonar.exclusions=ui/content/projects/*/designs/**,ui/public/recipe-site-design/standalone.html,**/coverage/**,ui/public/**/*.png
 
-# Import coverage for Sonar's trend and built-in new-code gate. The free plan
+# Import coverage for Sonar's trend and built-in "Sonar way" new-code gate. The free plan
 # cannot use a custom gate, so ADR 045 scopes that condition with the project
 # version supplied by CI rather than buying a paid plan solely to remove it.
 sonar.javascript.lcov.reportPaths=ai-review/coverage/lcov.info,ui/coverage/lcov.info,packages/observability/coverage/lcov.info,packages/recipe-parsing/coverage/lcov.info,ml-pipelines/recipe-parsing/coverage/lcov.info,workers/recipe-api/coverage/lcov.info,workers/recipe-ingest/coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,12 +3,6 @@ sonar.projectKey=Robbie-Palmer_personal-site
 sonar.host.url=https://sonarcloud.io
 sonar.sourceEncoding=UTF-8
 
-# Sonar's main-branch new-code definition is "previous version". Keep this in
-# sync with the root package version and bump it only at deliberate release
-# boundaries; using a CI run number or commit SHA would reset the baseline on
-# every analysis and defeat the new-code calculation.
-sonar.projectVersion=0.1.0
-
 # Keep test code out of production-code metrics and let SonarQube apply its
 # test-specific analysis rules. Test inclusions are also source exclusions.
 sonar.sources=.
@@ -21,8 +15,8 @@ sonar.test.inclusions=**/tests/**/*
 sonar.exclusions=ui/content/projects/*/designs/**,ui/public/recipe-site-design/standalone.html,**/coverage/**,ui/public/**/*.png
 
 # Import coverage for Sonar's trend and built-in new-code gate. The free plan
-# cannot use a custom gate, so ADR 045 scopes that condition with the explicit
-# project version above rather than buying a paid plan solely to remove it.
+# cannot use a custom gate, so ADR 045 scopes that condition with the project
+# version supplied by CI rather than buying a paid plan solely to remove it.
 sonar.javascript.lcov.reportPaths=ai-review/coverage/lcov.info,ui/coverage/lcov.info,packages/observability/coverage/lcov.info,packages/recipe-parsing/coverage/lcov.info,ml-pipelines/recipe-parsing/coverage/lcov.info,workers/recipe-api/coverage/lcov.info,workers/recipe-ingest/coverage/lcov.info
 
 # Top-level build/generator scripts are I/O tooling run at build time, not

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,12 @@ sonar.projectKey=Robbie-Palmer_personal-site
 sonar.host.url=https://sonarcloud.io
 sonar.sourceEncoding=UTF-8
 
+# Sonar's main-branch new-code definition is "previous version". Keep this in
+# sync with the root package version and bump it only at deliberate release
+# boundaries; using a CI run number or commit SHA would reset the baseline on
+# every analysis and defeat the new-code calculation.
+sonar.projectVersion=0.1.0
+
 # Keep test code out of production-code metrics and let SonarQube apply its
 # test-specific analysis rules. Test inclusions are also source exclusions.
 sonar.sources=.
@@ -14,7 +20,9 @@ sonar.test.inclusions=**/tests/**/*
 # public assets are excluded so language sensors do not try to decode them as UTF-8.
 sonar.exclusions=ui/content/projects/*/designs/**,ui/public/recipe-site-design/standalone.html,**/coverage/**,ui/public/**/*.png
 
-# Coverage is an advisory trend, not a quality-gate condition (ADR 045).
+# Import coverage for Sonar's trend and built-in new-code gate. The free plan
+# cannot use a custom gate, so ADR 045 scopes that condition with the explicit
+# project version above rather than buying a paid plan solely to remove it.
 sonar.javascript.lcov.reportPaths=ai-review/coverage/lcov.info,ui/coverage/lcov.info,packages/observability/coverage/lcov.info,packages/recipe-parsing/coverage/lcov.info,ml-pipelines/recipe-parsing/coverage/lcov.info,workers/recipe-api/coverage/lcov.info,workers/recipe-ingest/coverage/lcov.info
 
 # Top-level build/generator scripts are I/O tooling run at build time, not

--- a/ui/content/projects/recipe-site/adrs/045-sonarqube.mdx
+++ b/ui/content/projects/recipe-site/adrs/045-sonarqube.mdx
@@ -53,11 +53,13 @@ results land in GitHub and there is no external console to monitor day to day.
 * Full analysis runs: TS/JS bug detection, security rules, security hotspots, cognitive
   complexity, cross-file duplication, and maintainability. Nothing is switched off to avoid
   overlap with CodeQL (see [On Double Gating](#on-double-gating)).
-* The gate blocks on new defects only: bugs, vulnerabilities, and security hotspots a PR
-  introduces (Clean-as-You-Code; legacy code is never blocked, the same way Trivy and CodeQL
-  gate). Complexity, duplication, and maintainability are reported as annotations and tracked as a
-  trend, not as blockers.
-* No coverage condition (see [On Coverage](#on-coverage)).
+* The free plan permits only Sonar's built-in quality gate. It blocks on new reliability, security,
+  maintainability, duplication, security-hotspot-review, and coverage failures. A Team subscription
+  solely to remove the coverage condition is not worth the recurring platform cost.
+* Main-branch analysis supplies the root package version as `sonar.projectVersion`, matching the
+  project's "previous version" new-code definition. It changes only at deliberate release
+  boundaries, not on every CI build or commit. Pull-request analysis continues to define new code
+  from the target-branch diff.
 * The Sonar web project is used for occasional trend drill-down, the role the GitHub Security tab
   already plays. Day-to-day work stays in GitHub.
 
@@ -153,11 +155,20 @@ convention, and Sonar's overlapping findings are accepted as redundant.
 
 # On Coverage
 
-The gate has no coverage condition. Coverage thresholds are a Goodhart target: a number an agent
-will farm rather than a measure of real test quality, and gating on them contradicts the building
-philosophy ("Pre-product-market fit? Incomplete test coverage is fine - ship and learn"). Sonar
-imports LCOV reports from each Vitest workspace and displays the combined trend, but it never
-blocks a merge on it.
+Coverage thresholds remain a Goodhart risk: a number an agent can farm rather than a direct measure
+of test quality. The free SonarQube Cloud plan nevertheless permits only the built-in "Sonar way"
+gate, which includes 80% coverage on new code; custom gates require a paid plan. Paying solely to
+remove that condition is worse than accepting the built-in gate's constraint.
+
+The project limits the condition to an honest release window. `sonar.projectVersion` matches the
+root package version, and Sonar's "previous version" definition therefore starts new-code measures
+at the first analysis of each deliberate release. It must not use a CI build number or commit SHA,
+which would reset the baseline on every scan. Nor should source files be excluded merely to make the
+number pass. Within a release, a coverage failure calls for useful tests or an explicit decision
+about the release boundary rather than threshold farming.
+
+Sonar imports LCOV reports from each Vitest workspace and displays the combined trend. The reporter
+configuration remains valuable independently of the built-in gate:
 
 Vitest reporter tuples pass their options to Istanbul's `lcovonly` reporter. Each workspace
 therefore sets `projectRoot` so the generated `SF:` records are relative to the monorepo root and
@@ -215,21 +226,22 @@ aimed at agent-authored code.
   deterministic findings to the agent before the PR exists.
 * [Short Feedback Loops](/projects?tab=philosophy#short-feedback-loops). Inline PR annotations put
   the signal on the diff, and the MCP loop moves it earlier, into the agent. The opposite risk is
-  that a blocking gate tuned as a gatekeeper slows the path to production, mitigated by gating only
-  new defects.
+  that a blocking gate tuned as a gatekeeper slows the path to production, mitigated by applying
+  its conditions only to a pull request's diff or the current release's new-code window.
 * [Build Flywheels](/projects?tab=philosophy#build-flywheels). A trend line on code health
   compounds; one-off AI review comments do not. Gate configuration learned once carries over to
   every future service in the monorepo.
 * [Respect Goodhart's & Conway's Laws](/projects?tab=philosophy#respect-goodharts-and-conways-laws).
   Maintainability ratings, and coverage especially, are Goodhart targets that an agent can farm
-  rather than satisfy honestly. That is why the gate blocks only on objective defects and keeps
-  metrics, and coverage entirely, advisory.
+  rather than satisfy honestly. The free built-in gate makes those metrics blocking, so the
+  countermeasure is an honest, explicit release boundary and a rule against threshold-driven source
+  exclusions or low-value tests.
 
 # Gaps & Risks
 
-* Advisory metrics can be ignored. Keeping complexity and duplication out of the hard gate (to
-  avoid Goodhart effects) means nothing forces action on a worsening trend; it depends on the trend
-  being seen and acted on.
+* The free built-in gate cannot be tuned. Its maintainability, duplication, and coverage conditions
+  can slow delivery or encourage metric gaming; the project accepts that risk instead of paying for
+  a Team subscription solely to customize the gate.
 * The dashboard still exists. The GitHub App keeps the daily loop in the PR, but findings are
   computed on Sonar's side, so an outage or a free-tier change affects the check. This is the same
   vendor risk as Renovate ([ADR 020](/projects/recipe-site/adrs/020-renovate)).

--- a/ui/content/projects/recipe-site/adrs/045-sonarqube.mdx
+++ b/ui/content/projects/recipe-site/adrs/045-sonarqube.mdx
@@ -53,9 +53,10 @@ results land in GitHub and there is no external console to monitor day to day.
 * Full analysis runs: TS/JS bug detection, security rules, security hotspots, cognitive
   complexity, cross-file duplication, and maintainability. Nothing is switched off to avoid
   overlap with CodeQL (see [On Double Gating](#on-double-gating)).
-* The free plan permits only Sonar's built-in quality gate. It blocks on new reliability, security,
-  maintainability, duplication, security-hotspot-review, and coverage failures. A Team subscription
-  solely to remove the coverage condition is not worth the recurring platform cost.
+* The free plan permits only the built-in "Sonar way" quality gate associated with this project. It
+  blocks on new reliability, security, maintainability, duplication, security-hotspot-review, and
+  coverage failures. A Team subscription solely to remove the coverage condition is not worth the
+  recurring platform cost.
 * Main-branch analysis supplies the root package version as `sonar.projectVersion`, matching the
   project's "previous version" new-code definition. It changes only at deliberate release
   boundaries, not on every CI build or commit. Pull-request analysis continues to define new code
@@ -233,15 +234,15 @@ aimed at agent-authored code.
   every future service in the monorepo.
 * [Respect Goodhart's & Conway's Laws](/projects?tab=philosophy#respect-goodharts-and-conways-laws).
   Maintainability ratings, and coverage especially, are Goodhart targets that an agent can farm
-  rather than satisfy honestly. The free built-in gate makes those metrics blocking, so the
+  rather than satisfy honestly. The free "Sonar way" gate makes those metrics blocking, so the
   countermeasure is an honest, explicit release boundary and a rule against threshold-driven source
   exclusions or low-value tests.
 
 # Gaps & Risks
 
-* The free built-in gate cannot be tuned. Its maintainability, duplication, and coverage conditions
-  can slow delivery or encourage metric gaming; the project accepts that risk instead of paying for
-  a Team subscription solely to customize the gate.
+* The free "Sonar way" gate cannot be tuned. Its maintainability, duplication, and coverage
+  conditions can slow delivery or encourage metric gaming; the project accepts that risk instead
+  of paying for a Team subscription solely to customize the gate.
 * The dashboard still exists. The GitHub App keeps the daily loop in the PR, but findings are
   computed on Sonar's side, so an outage or a free-tier change affects the check. This is the same
   vendor risk as Renovate ([ADR 020](/projects/recipe-site/adrs/020-renovate)).

--- a/workers/recipe-api/scripts/preview-api-url.ts
+++ b/workers/recipe-api/scripts/preview-api-url.ts
@@ -1,8 +1,15 @@
 export function previewApiRequestURL(apiURL: URL, path: string): URL {
   // Some paths contain IDs returned by the preview API. Keep those values from
   // turning a same-origin smoke-test request into an attacker-controlled URL.
-  if (!path.startsWith("/") || path.startsWith("//")) {
-    throw new TypeError(`Preview API path must be root-relative: ${path}`);
+  if (
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.trim() !== path ||
+    /[\u0000-\u001f\u007f]/u.test(path)
+  ) {
+    throw new TypeError(
+      "Preview API path must be root-relative and contain no surrounding whitespace or control characters",
+    );
   }
   const requestURL = new URL(path, apiURL);
   if (requestURL.origin !== apiURL.origin) {

--- a/workers/recipe-api/scripts/preview-api-url.ts
+++ b/workers/recipe-api/scripts/preview-api-url.ts
@@ -1,14 +1,41 @@
+function assertPreviewApiOrigin(apiURL: URL): void {
+  if (
+    apiURL.protocol !== "https:" ||
+    apiURL.username !== "" ||
+    apiURL.password !== "" ||
+    apiURL.pathname !== "/" ||
+    apiURL.search !== "" ||
+    apiURL.hash !== ""
+  ) {
+    throw new TypeError(
+      "PREVIEW_API_URL must be an HTTPS origin without credentials, a path, a query, or a fragment",
+    );
+  }
+}
+
+export function previewApiBaseURL(value: string): URL {
+  let apiURL: URL;
+  try {
+    apiURL = new URL(value);
+  } catch {
+    throw new TypeError("PREVIEW_API_URL must be a valid HTTPS origin");
+  }
+  assertPreviewApiOrigin(apiURL);
+  return apiURL;
+}
+
 export function previewApiRequestURL(apiURL: URL, path: string): URL {
+  assertPreviewApiOrigin(apiURL);
   // Some paths contain IDs returned by the preview API. Keep those values from
   // turning a same-origin smoke-test request into an attacker-controlled URL.
   if (
     !path.startsWith("/") ||
     path.startsWith("//") ||
     path.trim() !== path ||
-    /[\u0000-\u001f\u007f]/u.test(path)
+    /[\p{C}\p{Zl}\p{Zp}]/u.test(path)
   ) {
     throw new TypeError(
-      "Preview API path must be root-relative and contain no surrounding whitespace or control characters",
+      "Preview API path must be root-relative and contain no surrounding whitespace, control characters, or line separators",
     );
   }
   const requestURL = new URL(path, apiURL);

--- a/workers/recipe-api/scripts/preview-api-url.ts
+++ b/workers/recipe-api/scripts/preview-api-url.ts
@@ -1,44 +1,33 @@
-function assertPreviewApiOrigin(apiURL: URL): void {
-  if (
-    apiURL.protocol !== "https:" ||
-    apiURL.username !== "" ||
-    apiURL.password !== "" ||
-    apiURL.pathname !== "/" ||
-    apiURL.search !== "" ||
-    apiURL.hash !== ""
-  ) {
-    throw new TypeError(
-      "PREVIEW_API_URL must be an HTTPS origin without credentials, a path, a query, or a fragment",
-    );
-  }
-}
+import { z } from "zod";
 
-export function previewApiBaseURL(value: string): URL {
-  let apiURL: URL;
-  try {
-    apiURL = new URL(value);
-  } catch {
-    throw new TypeError("PREVIEW_API_URL must be a valid HTTPS origin");
-  }
-  assertPreviewApiOrigin(apiURL);
-  return apiURL;
-}
+const previewApiOriginMessage =
+  "PREVIEW_API_URL must be an HTTPS origin without credentials, a path, a query, or a fragment";
 
-export function previewApiRequestURL(apiURL: URL, path: string): URL {
-  assertPreviewApiOrigin(apiURL);
-  // Some paths contain IDs returned by the preview API. Keep those values from
-  // turning a same-origin smoke-test request into an attacker-controlled URL.
-  if (
-    !path.startsWith("/") ||
-    path.startsWith("//") ||
-    path.trim() !== path ||
-    /[\p{C}\p{Zl}\p{Zp}]/u.test(path)
-  ) {
-    throw new TypeError(
-      "Preview API path must be root-relative and contain no surrounding whitespace, control characters, or line separators",
-    );
-  }
-  const requestURL = new URL(path, apiURL);
+export const previewApiOriginSchema = z
+  .httpUrl({ error: previewApiOriginMessage })
+  .transform((value) => new URL(value))
+  // A canonical HTTPS origin has no components beyond `${origin}/`.
+  .refine(
+    (url) => url.protocol === "https:" && url.href === `${url.origin}/`,
+    previewApiOriginMessage,
+  )
+  .brand<"PreviewApiOrigin">();
+
+export type PreviewApiOrigin = z.infer<typeof previewApiOriginSchema>;
+
+const rootRelativePathSchema = z
+  .string()
+  .startsWith("/", "Preview API path must be root-relative")
+  .refine(
+    (path) => !path.startsWith("//"),
+    "Preview API path must be root-relative",
+  );
+
+export function previewApiRequestURL(
+  apiURL: PreviewApiOrigin,
+  path: string,
+): URL {
+  const requestURL = new URL(rootRelativePathSchema.parse(path), apiURL);
   if (requestURL.origin !== apiURL.origin) {
     throw new TypeError(`Preview API URL must stay on ${apiURL.origin}`);
   }

--- a/workers/recipe-api/scripts/preview-api-url.ts
+++ b/workers/recipe-api/scripts/preview-api-url.ts
@@ -1,0 +1,12 @@
+export function previewApiRequestURL(apiURL: URL, path: string): URL {
+  // Some paths contain IDs returned by the preview API. Keep those values from
+  // turning a same-origin smoke-test request into an attacker-controlled URL.
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    throw new TypeError(`Preview API path must be root-relative: ${path}`);
+  }
+  const requestURL = new URL(path, apiURL);
+  if (requestURL.origin !== apiURL.origin) {
+    throw new TypeError(`Preview API URL must stay on ${apiURL.origin}`);
+  }
+  return requestURL;
+}

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -5,7 +5,10 @@
 import { createDb } from "recipe-db";
 import { createAuth } from "../src/auth";
 import { previewScenarios } from "../src/preview-scenarios";
-import { previewApiRequestURL } from "./preview-api-url";
+import {
+  previewApiBaseURL,
+  previewApiRequestURL,
+} from "./preview-api-url";
 
 function requiredEnv(name: string): string {
   const value = process.env[name];
@@ -64,7 +67,7 @@ type DiscoverFeed = {
 
 const databaseURL = requiredEnv("DATABASE_URL");
 const siteURL = requiredEnv("BETTER_AUTH_URL");
-const apiURL = new URL(requiredEnv("PREVIEW_API_URL"));
+const apiURL = previewApiBaseURL(requiredEnv("PREVIEW_API_URL"));
 const READY_TIMEOUT_MS = 120_000;
 const REQUEST_TIMEOUT_MS = 15_000;
 const RETRY_DELAY_MS = 2_000;

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -5,6 +5,7 @@
 import { createDb } from "recipe-db";
 import { createAuth } from "../src/auth";
 import { previewScenarios } from "../src/preview-scenarios";
+import { previewApiRequestURL } from "./preview-api-url";
 
 function requiredEnv(name: string): string {
   const value = process.env[name];
@@ -63,7 +64,7 @@ type DiscoverFeed = {
 
 const databaseURL = requiredEnv("DATABASE_URL");
 const siteURL = requiredEnv("BETTER_AUTH_URL");
-const apiURL = requiredEnv("PREVIEW_API_URL").replace(/\/$/, "");
+const apiURL = new URL(requiredEnv("PREVIEW_API_URL"));
 const READY_TIMEOUT_MS = 120_000;
 const REQUEST_TIMEOUT_MS = 15_000;
 const RETRY_DELAY_MS = 2_000;
@@ -76,7 +77,7 @@ async function fetchWhenReady(
   let lastError: unknown;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(`${apiURL}${path}`, {
+      const response = await fetch(previewApiRequestURL(apiURL, path), {
         ...init,
         signal: AbortSignal.timeout(
           Math.min(REQUEST_TIMEOUT_MS, Math.max(1, deadline - Date.now())),

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -3,18 +3,23 @@
 // preview database, then exercises the deployed Worker without bypassing
 // Cloudflare Access on the Pages UI.
 import { createDb } from "recipe-db";
+import { z } from "zod";
 import { createAuth } from "../src/auth";
 import { previewScenarios } from "../src/preview-scenarios";
 import {
-  previewApiBaseURL,
+  previewApiOriginSchema,
   previewApiRequestURL,
 } from "./preview-api-url";
 
-function requiredEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) throw new Error(`${name} is required`);
-  return value;
-}
+const smokeEnvSchema = z.object({
+  DATABASE_URL: z.string().min(1),
+  BETTER_AUTH_URL: z
+    .httpUrl()
+    .refine((value) => new URL(value).protocol === "https:"),
+  BETTER_AUTH_SECRET: z.string().min(1),
+  PREVIEW_API_URL: previewApiOriginSchema,
+  PREVIEW_AUTH_PASSWORD: z.string().min(1),
+});
 
 type RecipeBoxProfile = {
   completed: boolean;
@@ -65,9 +70,8 @@ type DiscoverFeed = {
   items: Array<{ recipe: { slug: string }; author: { id: string } }>;
 };
 
-const databaseURL = requiredEnv("DATABASE_URL");
-const siteURL = requiredEnv("BETTER_AUTH_URL");
-const apiURL = previewApiBaseURL(requiredEnv("PREVIEW_API_URL"));
+const env = smokeEnvSchema.parse(process.env);
+const apiURL = env.PREVIEW_API_URL;
 const READY_TIMEOUT_MS = 120_000;
 const REQUEST_TIMEOUT_MS = 15_000;
 const RETRY_DELAY_MS = 2_000;
@@ -133,17 +137,17 @@ async function expectAuthenticationRequired(path: string): Promise<void> {
 async function createSessionCookie(
   email: string = previewScenarios[0].email,
 ): Promise<string> {
-  const { db, client } = createDb(databaseURL);
+  const { db, client } = createDb(env.DATABASE_URL);
   try {
     const auth = createAuth(db, {
       DEPLOYMENT_ENV: "preview",
-      BETTER_AUTH_URL: siteURL,
-      BETTER_AUTH_SECRET: requiredEnv("BETTER_AUTH_SECRET"),
+      BETTER_AUTH_URL: env.BETTER_AUTH_URL,
+      BETTER_AUTH_SECRET: env.BETTER_AUTH_SECRET,
     });
     const signIn = await auth.api.signInEmail({
       body: {
         email,
-        password: requiredEnv("PREVIEW_AUTH_PASSWORD"),
+        password: env.PREVIEW_AUTH_PASSWORD,
       },
       asResponse: true,
     });
@@ -385,7 +389,7 @@ if (!emptyInitialFollow.canFollow || emptyInitialFollow.following) {
 const emptyFollowed = await expectJson<FollowStatus>(
   `/recipes/cooks/${ownerCook.id}/follow`,
   cookie,
-  { method: "PUT", headers: { origin: siteURL } },
+  { method: "PUT", headers: { origin: env.BETTER_AUTH_URL } },
 );
 if (!emptyFollowed.following) {
   throw new Error("Empty account could not follow the household owner");
@@ -393,7 +397,7 @@ if (!emptyFollowed.following) {
 const emptyUnfollowed = await expectJson<FollowStatus>(
   `/recipes/cooks/${ownerCook.id}/follow`,
   cookie,
-  { method: "DELETE", headers: { origin: siteURL } },
+  { method: "DELETE", headers: { origin: env.BETTER_AUTH_URL } },
 );
 if (emptyUnfollowed.following) {
   throw new Error("Empty account could not clean up its preview follow");

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -73,11 +73,12 @@ async function fetchWhenReady(
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
+  const requestURL = previewApiRequestURL(apiURL, path);
   const deadline = Date.now() + READY_TIMEOUT_MS;
   let lastError: unknown;
   while (Date.now() < deadline) {
     try {
-      const response = await fetch(previewApiRequestURL(apiURL, path), {
+      const response = await fetch(requestURL, {
         ...init,
         signal: AbortSignal.timeout(
           Math.min(REQUEST_TIMEOUT_MS, Math.max(1, deadline - Date.now())),

--- a/workers/recipe-api/tests/preview-api-url.test.ts
+++ b/workers/recipe-api/tests/preview-api-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { previewApiRequestURL } from "../scripts/preview-api-url";
+
+const apiURL = new URL("https://preview-api.example.test");
+
+describe("previewApiRequestURL", () => {
+  it("constructs root-relative URLs on the configured API origin", () => {
+    expect(
+      previewApiRequestURL(apiURL, "/households/safe-id/members?limit=2").href,
+    ).toBe(
+      "https://preview-api.example.test/households/safe-id/members?limit=2",
+    );
+  });
+
+  it.each([
+    "households/safe-id/members",
+    "//attacker.example.test/collect",
+    "https://attacker.example.test/collect",
+  ])("rejects a request path outside the root-relative boundary: %s", (path) => {
+    expect(() => previewApiRequestURL(apiURL, path)).toThrow(
+      "Preview API path must be root-relative",
+    );
+  });
+});

--- a/workers/recipe-api/tests/preview-api-url.test.ts
+++ b/workers/recipe-api/tests/preview-api-url.test.ts
@@ -1,7 +1,34 @@
 import { describe, expect, it } from "vitest";
-import { previewApiRequestURL } from "../scripts/preview-api-url";
+import {
+  previewApiBaseURL,
+  previewApiRequestURL,
+} from "../scripts/preview-api-url";
 
-const apiURL = new URL("https://preview-api.example.test");
+const apiURL = previewApiBaseURL("https://preview-api.example.test");
+
+describe("previewApiBaseURL", () => {
+  it("accepts an HTTPS origin with or without its trailing slash", () => {
+    expect(previewApiBaseURL("https://preview-api.example.test").href).toBe(
+      "https://preview-api.example.test/",
+    );
+    expect(previewApiBaseURL("https://preview-api.example.test/").href).toBe(
+      "https://preview-api.example.test/",
+    );
+  });
+
+  it.each([
+    "preview-api.example.test",
+    "http://preview-api.example.test",
+    "https://user:secret@preview-api.example.test",
+    "https://preview-api.example.test/base/",
+    "https://preview-api.example.test/?environment=preview",
+    "https://preview-api.example.test/#preview",
+  ])("rejects a value that is not an HTTPS origin: %s", (value) => {
+    expect(() => previewApiBaseURL(value)).toThrow(
+      "PREVIEW_API_URL must be",
+    );
+  });
+});
 
 describe("previewApiRequestURL", () => {
   it("constructs root-relative URLs on the configured API origin", () => {
@@ -10,15 +37,6 @@ describe("previewApiRequestURL", () => {
     ).toBe(
       "https://preview-api.example.test/households/safe-id/members?limit=2",
     );
-  });
-
-  it("replaces a trailing-slash base path instead of creating a double slash", () => {
-    expect(
-      previewApiRequestURL(
-        new URL("https://preview-api.example.test/base/"),
-        "/health",
-      ).href,
-    ).toBe("https://preview-api.example.test/health");
   });
 
   it.each([
@@ -40,6 +58,8 @@ describe("previewApiRequestURL", () => {
     "\n//attacker.example.test/collect",
     "/\t/attacker.example.test/collect",
     "/\0/attacker.example.test/collect",
+    "/segment\u2028next",
+    "/segment\u2066next",
     "//attacker.example.test/collect",
     "https://attacker.example.test/collect",
   ])("rejects a request path outside the root-relative boundary: %s", (path) => {

--- a/workers/recipe-api/tests/preview-api-url.test.ts
+++ b/workers/recipe-api/tests/preview-api-url.test.ts
@@ -12,6 +12,28 @@ describe("previewApiRequestURL", () => {
     );
   });
 
+  it("replaces a trailing-slash base path instead of creating a double slash", () => {
+    expect(
+      previewApiRequestURL(
+        new URL("https://preview-api.example.test/base/"),
+        "/health",
+      ).href,
+    ).toBe("https://preview-api.example.test/health");
+  });
+
+  it.each([
+    "/%5C%5Cattacker.example.test/collect",
+    "/%2F%2Fattacker.example.test/collect",
+    "/%00/collect",
+    "/／／attacker.example.test/collect",
+    "/раypal.example.test/collect",
+  ])("keeps encoded or Unicode path text on the configured origin: %s", (path) => {
+    const requestURL = previewApiRequestURL(apiURL, path);
+
+    expect(requestURL.origin).toBe(apiURL.origin);
+    expect(requestURL.pathname.startsWith("/")).toBe(true);
+  });
+
   it.each([
     "households/safe-id/members",
     " //attacker.example.test/collect",

--- a/workers/recipe-api/tests/preview-api-url.test.ts
+++ b/workers/recipe-api/tests/preview-api-url.test.ts
@@ -14,11 +14,21 @@ describe("previewApiRequestURL", () => {
 
   it.each([
     "households/safe-id/members",
+    " //attacker.example.test/collect",
+    "\n//attacker.example.test/collect",
+    "/\t/attacker.example.test/collect",
+    "/\0/attacker.example.test/collect",
     "//attacker.example.test/collect",
     "https://attacker.example.test/collect",
   ])("rejects a request path outside the root-relative boundary: %s", (path) => {
     expect(() => previewApiRequestURL(apiURL, path)).toThrow(
       "Preview API path must be root-relative",
     );
+  });
+
+  it("rejects URL normalization that changes the request origin", () => {
+    expect(() =>
+      previewApiRequestURL(apiURL, "/\\attacker.example.test/collect"),
+    ).toThrow("Preview API URL must stay on https://preview-api.example.test");
   });
 });

--- a/workers/recipe-api/tests/preview-api-url.test.ts
+++ b/workers/recipe-api/tests/preview-api-url.test.ts
@@ -1,30 +1,32 @@
 import { describe, expect, it } from "vitest";
 import {
-  previewApiBaseURL,
+  previewApiOriginSchema,
   previewApiRequestURL,
 } from "../scripts/preview-api-url";
 
-const apiURL = previewApiBaseURL("https://preview-api.example.test");
+const apiURL = previewApiOriginSchema.parse("https://preview-api.example.test");
 
-describe("previewApiBaseURL", () => {
+describe("previewApiOriginSchema", () => {
   it("accepts an HTTPS origin with or without its trailing slash", () => {
-    expect(previewApiBaseURL("https://preview-api.example.test").href).toBe(
-      "https://preview-api.example.test/",
-    );
-    expect(previewApiBaseURL("https://preview-api.example.test/").href).toBe(
-      "https://preview-api.example.test/",
-    );
+    expect(
+      previewApiOriginSchema.parse("https://preview-api.example.test").href,
+    ).toBe("https://preview-api.example.test/");
+    expect(
+      previewApiOriginSchema.parse("https://preview-api.example.test/").href,
+    ).toBe("https://preview-api.example.test/");
   });
 
   it.each([
     "preview-api.example.test",
+    "https:preview-api.example.test",
+    "https:/preview-api.example.test",
     "http://preview-api.example.test",
     "https://user:secret@preview-api.example.test",
     "https://preview-api.example.test/base/",
     "https://preview-api.example.test/?environment=preview",
     "https://preview-api.example.test/#preview",
   ])("rejects a value that is not an HTTPS origin: %s", (value) => {
-    expect(() => previewApiBaseURL(value)).toThrow(
+    expect(() => previewApiOriginSchema.parse(value)).toThrow(
       "PREVIEW_API_URL must be",
     );
   });
@@ -40,26 +42,7 @@ describe("previewApiRequestURL", () => {
   });
 
   it.each([
-    "/%5C%5Cattacker.example.test/collect",
-    "/%2F%2Fattacker.example.test/collect",
-    "/%00/collect",
-    "/／／attacker.example.test/collect",
-    "/раypal.example.test/collect",
-  ])("keeps encoded or Unicode path text on the configured origin: %s", (path) => {
-    const requestURL = previewApiRequestURL(apiURL, path);
-
-    expect(requestURL.origin).toBe(apiURL.origin);
-    expect(requestURL.pathname.startsWith("/")).toBe(true);
-  });
-
-  it.each([
     "households/safe-id/members",
-    " //attacker.example.test/collect",
-    "\n//attacker.example.test/collect",
-    "/\t/attacker.example.test/collect",
-    "/\0/attacker.example.test/collect",
-    "/segment\u2028next",
-    "/segment\u2066next",
     "//attacker.example.test/collect",
     "https://attacker.example.test/collect",
   ])("rejects a request path outside the root-relative boundary: %s", (path) => {


### PR DESCRIPTION
## Summary

- constrain preview smoke-test requests to root-relative, same-origin API URLs
- add regression tests for safe and attacker-controlled request paths
- provide Sonar with the stable project version so its previous-version new-code window has a real release boundary
- align the Sonar ADR with the free-plan built-in quality gate

## Validation

- `mise //workers/recipe-api:test -- tests/preview-api-url.test.ts`
- `mise //workers/recipe-api:typecheck`
- `mise //:lint`
- `mise //:lint:mdx:check -- ui/content/projects/recipe-site/adrs/045-sonarqube.mdx`
- `mise //:lint:typos`
- `git diff --check`

## QA

- Backend preview required to exercise the authenticated profile smoke test against a deployed API Worker.
- No user-facing visual changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preview API requests now validate paths and remain restricted to the configured API origin.
  - Invalid relative, protocol-relative and external URLs are rejected, improving preview environment safety.

- **Quality Improvements**
  - Expanded automated coverage verifies valid and invalid preview API URL handling.
  - SonarQube quality checks now enforce reliability, security, maintainability, duplication, coverage and security-hotspot standards for new changes.

- **Documentation**
  - Updated quality-gate guidance to clarify release-based and pull-request coverage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->