### PR TITLE
Attribute AI review finding outcomes

### DIFF
--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -190,8 +190,9 @@ current diff and file context, recording `fixed`, `still-present`, or `uncertain
 with direct code evidence. Replay is evidence, not adjudication: the coordinator
 adds a `confirmed-fixed` outcome only after a trusted actor submits
 `/ai-review confirm-fixed <finding-id> <reason>` for a recorded `fixed` replay.
-The outcome links the trusted actor and reason to that replay's head, run, and
-evidence. PR content, model omission, or a manually resolved GitHub thread
+The replay head must still be the coordinator's latest observed PR head. The
+outcome links the trusted actor and reason to that replay's head, run, and
+evidence. PR content, stale replay, model omission, or a resolved GitHub thread
 cannot mint a confirmed label by itself. On
 `pull_request.closed`, any finding without an outcome becomes `superseded` when
 the final reviewed diff no longer contains its affected hunks, or

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -15,6 +15,9 @@ The service is a visible, stateful publisher:
 - Durable Object alarms provide a trailing-edge debounce boundary, coalescing
   rapid events to one review of the latest pull request state after a quiet
   period;
+- the same alarm handler retries committed finding outcomes that could not be
+  published to R2, so a finalization-time outage cannot strand them in SQLite
+  when no later pull-request event arrives;
 - a Cloudflare Workflow fetches the PR through GitHub App authentication, runs
   the shared OpenRouter and OpenCode scout ensemble,
   reconciles candidates with the same OpenRouter merger, publishes each

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -177,6 +177,24 @@ These records preserve the event/action, trusted actor, reply or command body,
 reaction counts present on review-comment events, thread state, explicit
 disposition and timestamps without mutating earlier evidence.
 
+`review_finding_outcomes` turns that evidence into a versioned evaluation
+label. An explicit acknowledgement or rejection creates an outcome immediately.
+When a later reviewed head resolves an existing finding, the coordinator adds a
+higher-confidence `confirmed-fixed` outcome linked to the original and resolving
+heads, runs, hunk IDs, and merger resolution note. On `pull_request.closed`, any
+finding without an outcome becomes `superseded` when the final reviewed diff no
+longer contains its affected hunks, or `no-observable-response` otherwise. The
+closure evidence records whether the final head was actually reviewed so censored
+outcomes remain distinguishable from complete coverage.
+
+Outcome revisions are immutable schema-v2 objects at
+`v2/<owner>/<repository>/pr-<number>/findings/<finding-id>/outcomes/v<version>.json`.
+The highest version is the current outcome; earlier labels remain available to
+show how later code evidence changed the attribution. SQLite commits the outcome
+before R2 publication and retains an `r2_recorded` flag, so a retried webhook or
+review completion repairs an interrupted object write without creating another
+revision.
+
 ## Deploy
 
 Sync the environment after changing Doppler:

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -182,10 +182,12 @@ disposition and timestamps without mutating earlier evidence.
 
 `review_finding_outcomes` turns that evidence into a versioned evaluation
 label. An explicit acknowledgement or rejection creates an outcome immediately.
-When a later review covers the finding's file after its affected hunks change
-and does not rediscover the finding, the coordinator adds a higher-confidence
-`confirmed-fixed` outcome linked to the original and confirming heads, runs, and
-hunk IDs. A manually resolved GitHub thread is not fix evidence by itself. On
+When a later review covers the finding's file after its affected hunks change,
+the merger performs a controlled replay of the durable finding against the
+current diff and file context. The coordinator adds a `confirmed-fixed` outcome
+only for an affirmative `fixed` verdict with direct code evidence, linking the
+original and confirming heads, runs, hunk IDs, and replay evidence. A model
+omission or manually resolved GitHub thread is not fix evidence by itself. On
 `pull_request.closed`, any finding without an outcome becomes `superseded` when
 the final reviewed diff no longer contains its affected hunks, or
 `no-observable-response` otherwise. A legacy finding with a persisted explicit

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -52,6 +52,8 @@ Ordinary comments and review-thread activity never schedule paid work. Replies,
 reaction-count snapshots, thread resolution, and trusted
 `/ai-review acknowledge f_<id> <reason>` or
 `/ai-review reject f_<id> <reason>` commands instead take a storage-only path.
+After a controlled replay returns `fixed`, a trusted
+`/ai-review confirm-fixed f_<id> <reason>` command adjudicates that evidence.
 Findings that GitHub cannot attach to a current diff line remain in the rolling
 comment with those explicit command fallbacks.
 
@@ -184,10 +186,13 @@ disposition and timestamps without mutating earlier evidence.
 label. An explicit acknowledgement or rejection creates an outcome immediately.
 When a later review covers the finding's file after its affected hunks change,
 the merger performs a controlled replay of the durable finding against the
-current diff and file context. The coordinator adds a `confirmed-fixed` outcome
-only for an affirmative `fixed` verdict with direct code evidence, linking the
-original and confirming heads, runs, hunk IDs, and replay evidence. A model
-omission or manually resolved GitHub thread is not fix evidence by itself. On
+current diff and file context, recording `fixed`, `still-present`, or `uncertain`
+with direct code evidence. Replay is evidence, not adjudication: the coordinator
+adds a `confirmed-fixed` outcome only after a trusted actor submits
+`/ai-review confirm-fixed <finding-id> <reason>` for a recorded `fixed` replay.
+The outcome links the trusted actor and reason to that replay's head, run, and
+evidence. PR content, model omission, or a manually resolved GitHub thread
+cannot mint a confirmed label by itself. On
 `pull_request.closed`, any finding without an outcome becomes `superseded` when
 the final reviewed diff no longer contains its affected hunks, or
 `no-observable-response` otherwise. A legacy finding with a persisted explicit

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -179,13 +179,17 @@ disposition and timestamps without mutating earlier evidence.
 
 `review_finding_outcomes` turns that evidence into a versioned evaluation
 label. An explicit acknowledgement or rejection creates an outcome immediately.
-When a later reviewed head resolves an existing finding, the coordinator adds a
-higher-confidence `confirmed-fixed` outcome linked to the original and resolving
-heads, runs, hunk IDs, and merger resolution note. On `pull_request.closed`, any
-finding without an outcome becomes `superseded` when the final reviewed diff no
-longer contains its affected hunks, or `no-observable-response` otherwise. The
-closure evidence records whether the final head was actually reviewed so censored
-outcomes remain distinguishable from complete coverage.
+When a later review covers the finding's file after its affected hunks change
+and does not rediscover the finding, the coordinator adds a higher-confidence
+`confirmed-fixed` outcome linked to the original and confirming heads, runs, and
+hunk IDs. A manually resolved GitHub thread is not fix evidence by itself. On
+`pull_request.closed`, any finding without an outcome becomes `superseded` when
+the final reviewed diff no longer contains its affected hunks, or
+`no-observable-response` otherwise. A legacy finding with a persisted explicit
+disposition but no outcome row receives the matching `acknowledged` or
+`rejected` label. The closure evidence records whether the final head was
+actually reviewed so censored outcomes remain distinguishable from complete
+coverage.
 
 Outcome revisions are immutable schema-v2 objects at
 `v2/<owner>/<repository>/pr-<number>/findings/<finding-id>/outcomes/v<version>.json`.

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -190,8 +190,9 @@ current diff and file context, recording `fixed`, `still-present`, or `uncertain
 with direct code evidence. Replay is evidence, not adjudication: the coordinator
 adds a `confirmed-fixed` outcome only after a trusted actor submits
 `/ai-review confirm-fixed <finding-id> <reason>` for a recorded `fixed` replay.
-The replay head must still be the coordinator's latest observed PR head. The
-outcome links the trusted actor and reason to that replay's head, run, and
+The replay head must match the authoritative current PR head fetched from
+GitHub when the trusted command is handled. The outcome links the trusted actor
+and reason to that replay's head, run, and
 evidence. PR content, stale replay, model omission, or a resolved GitHub thread
 cannot mint a confirmed label by itself. On
 `pull_request.closed`, any finding without an outcome becomes `superseded` when

--- a/ai-review/README.md
+++ b/ai-review/README.md
@@ -194,7 +194,8 @@ The replay head must match the authoritative current PR head fetched from
 GitHub when the trusted command is handled. The outcome links the trusted actor
 and reason to that replay's head, run, and
 evidence. PR content, stale replay, model omission, or a resolved GitHub thread
-cannot mint a confirmed label by itself. On
+cannot mint a confirmed label by itself. Confirmation suppresses replay only on
+that exact head; a later head makes the finding eligible for replay again. On
 `pull_request.closed`, any finding without an outcome becomes `superseded` when
 the final reviewed diff no longer contains its affected hunks, or
 `no-observable-response` otherwise. A legacy finding with a persisted explicit

--- a/ai-review/src/env.ts
+++ b/ai-review/src/env.ts
@@ -10,6 +10,24 @@ export type ReviewWorkflowParams = {
 
 export type FindingDisposition = "acknowledged" | "rejected";
 
+export type FindingOutcome =
+  | "confirmed-fixed"
+  | "acknowledged"
+  | "rejected"
+  | "superseded"
+  | "no-observable-response";
+
+export type PullRequestFinalizationEvent = {
+  deliveryId: string;
+  eventName: "pull_request";
+  action: "closed";
+  repository: string;
+  pullRequestNumber: number;
+  headSha: string;
+  finalState: "merged" | "closed";
+  occurredAt?: string;
+};
+
 export type FindingInteractionEvent = {
   deliveryId: string;
   eventName: string;

--- a/ai-review/src/env.ts
+++ b/ai-review/src/env.ts
@@ -8,7 +8,10 @@ export type ReviewWorkflowParams = {
   force: boolean;
 };
 
-export type FindingDisposition = "acknowledged" | "rejected";
+export type FindingDisposition =
+  | "acknowledged"
+  | "confirmed-fixed"
+  | "rejected";
 
 export type FindingOutcome =
   | "confirmed-fixed"

--- a/ai-review/src/env.ts
+++ b/ai-review/src/env.ts
@@ -37,6 +37,7 @@ export type FindingInteractionEvent = {
   action: string;
   repository: string;
   pullRequestNumber: number;
+  headSha?: string;
   interactionType: "reply" | "thread" | "disposition";
   actor: string;
   actorAssociation?: string;

--- a/ai-review/src/finding-lifecycle.ts
+++ b/ai-review/src/finding-lifecycle.ts
@@ -64,6 +64,7 @@ function renderFindingComment(finding: PublishableFinding): string {
     "",
     `<sub>Finding \`${finding.findingId}\`. Reply or resolve this thread, ` +
       `or use \`/ai-review acknowledge ${finding.findingId} reason\` / ` +
+      `\`/ai-review confirm-fixed ${finding.findingId} reason\` / ` +
       `\`/ai-review reject ${finding.findingId} reason\`.</sub>`,
   );
   return lines.join("\n");
@@ -279,6 +280,7 @@ export function renderFallbackFindings(
         `${markdownText(finding.title, 300)}** (\`${location}\`, ` +
         `\`${finding.findingId}\`) — ${markdownText(finding.evidence, 700)}`,
       `  - \`/ai-review acknowledge ${finding.findingId} <reason>\``,
+      `  - \`/ai-review confirm-fixed ${finding.findingId} <reason>\``,
       `  - \`/ai-review reject ${finding.findingId} <reason>\``,
     );
   }

--- a/ai-review/src/finding-outcomes.ts
+++ b/ai-review/src/finding-outcomes.ts
@@ -67,6 +67,7 @@ export function classifyFinalizedFinding(options: {
 export function confirmsFindingFixed(options: {
   alreadyConfirmed: boolean;
   rediscovered: boolean;
+  replayVerdict: "fixed" | "still-present" | "uncertain" | undefined;
   firstSeenHeadSha: string;
   reviewedHeadSha: string;
   file: string;
@@ -77,6 +78,7 @@ export function confirmsFindingFixed(options: {
   if (
     options.alreadyConfirmed ||
     options.rediscovered ||
+    options.replayVerdict !== "fixed" ||
     options.firstSeenHeadSha === options.reviewedHeadSha ||
     options.priorHunkIds.length === 0
   ) {

--- a/ai-review/src/finding-outcomes.ts
+++ b/ai-review/src/finding-outcomes.ts
@@ -1,0 +1,74 @@
+import type { FindingOutcome } from "./env";
+
+export type FindingOutcomeBasis =
+  | "explicit-disposition"
+  | "later-reviewed-head"
+  | "pull-request-finalization";
+
+export type FindingOutcomeRecord = {
+  schemaVersion: 2;
+  recordType: "finding-outcome";
+  outcomeVersion: number;
+  repository: string;
+  pullRequestNumber: number;
+  findingId: string;
+  outcome: FindingOutcome;
+  basis: FindingOutcomeBasis;
+  sourceId: string;
+  evidence: Record<string, unknown>;
+  occurredAt: string;
+  recordedAt: string;
+};
+
+export function buildFindingOutcomeRecord(options: {
+  repository: string;
+  pullRequestNumber: number;
+  findingId: string;
+  outcome: FindingOutcome;
+  basis: FindingOutcomeBasis;
+  sourceId: string;
+  outcomeVersion: number;
+  occurredAt: string;
+  recordedAt: string;
+  evidence: Record<string, unknown>;
+}): FindingOutcomeRecord {
+  return {
+    schemaVersion: 2,
+    recordType: "finding-outcome",
+    outcomeVersion: options.outcomeVersion,
+    repository: options.repository,
+    pullRequestNumber: options.pullRequestNumber,
+    findingId: options.findingId,
+    outcome: options.outcome,
+    basis: options.basis,
+    sourceId: options.sourceId,
+    evidence: options.evidence,
+    occurredAt: options.occurredAt,
+    recordedAt: options.recordedAt,
+  };
+}
+
+export function classifyFinalizedFinding(options: {
+  disposition: string | null;
+  status: string;
+  firstSeenHeadSha: string;
+  lastSeenHeadSha: string;
+  finalHeadWasReviewed: boolean;
+  affectedCodeRemains: boolean;
+}): FindingOutcome {
+  if (
+    options.disposition === "acknowledged" ||
+    options.disposition === "rejected"
+  ) {
+    return options.disposition;
+  }
+  if (
+    options.status === "resolved" &&
+    options.firstSeenHeadSha !== options.lastSeenHeadSha
+  ) {
+    return "confirmed-fixed";
+  }
+  return options.finalHeadWasReviewed && !options.affectedCodeRemains
+    ? "superseded"
+    : "no-observable-response";
+}

--- a/ai-review/src/finding-outcomes.ts
+++ b/ai-review/src/finding-outcomes.ts
@@ -50,9 +50,6 @@ export function buildFindingOutcomeRecord(options: {
 
 export function classifyFinalizedFinding(options: {
   disposition: string | null;
-  status: string;
-  firstSeenHeadSha: string;
-  lastSeenHeadSha: string;
   finalHeadWasReviewed: boolean;
   affectedCodeRemains: boolean;
 }): FindingOutcome {
@@ -62,13 +59,33 @@ export function classifyFinalizedFinding(options: {
   ) {
     return options.disposition;
   }
-  if (
-    options.status === "resolved" &&
-    options.firstSeenHeadSha !== options.lastSeenHeadSha
-  ) {
-    return "confirmed-fixed";
-  }
   return options.finalHeadWasReviewed && !options.affectedCodeRemains
     ? "superseded"
     : "no-observable-response";
+}
+
+export function confirmsFindingFixed(options: {
+  alreadyConfirmed: boolean;
+  rediscovered: boolean;
+  firstSeenHeadSha: string;
+  reviewedHeadSha: string;
+  file: string;
+  priorHunkIds: string[];
+  currentHunkIds: Set<string>;
+  reviewedFiles: Set<string>;
+}): boolean {
+  if (
+    options.alreadyConfirmed ||
+    options.rediscovered ||
+    options.firstSeenHeadSha === options.reviewedHeadSha ||
+    options.priorHunkIds.length === 0
+  ) {
+    return false;
+  }
+  if (
+    options.priorHunkIds.some((hunkId) => options.currentHunkIds.has(hunkId))
+  ) {
+    return false;
+  }
+  return options.reviewedFiles.has(options.file);
 }

--- a/ai-review/src/finding-outcomes.ts
+++ b/ai-review/src/finding-outcomes.ts
@@ -63,31 +63,3 @@ export function classifyFinalizedFinding(options: {
     ? "superseded"
     : "no-observable-response";
 }
-
-export function confirmsFindingFixed(options: {
-  alreadyConfirmed: boolean;
-  rediscovered: boolean;
-  replayVerdict: "fixed" | "still-present" | "uncertain" | undefined;
-  firstSeenHeadSha: string;
-  reviewedHeadSha: string;
-  file: string;
-  priorHunkIds: string[];
-  currentHunkIds: Set<string>;
-  reviewedFiles: Set<string>;
-}): boolean {
-  if (
-    options.alreadyConfirmed ||
-    options.rediscovered ||
-    options.replayVerdict !== "fixed" ||
-    options.firstSeenHeadSha === options.reviewedHeadSha ||
-    options.priorHunkIds.length === 0
-  ) {
-    return false;
-  }
-  if (
-    options.priorHunkIds.some((hunkId) => options.currentHunkIds.has(hunkId))
-  ) {
-    return false;
-  }
-  return options.reviewedFiles.has(options.file);
-}

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -583,6 +583,47 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     return inserted.rowsWritten > 0;
   }
 
+  private appendConfirmedFixOutcome(options: {
+    repository: string;
+    pullRequestNumber: number;
+    runId: string;
+    headSha: string;
+    completedAt: string;
+    finding: IdentifiedMergedFinding;
+  }): void {
+    if (options.finding.status !== "resolved") return;
+    const persisted = this.ctx.storage.sql
+      .exec<{
+        first_seen_head_sha: string;
+        first_seen_run_id: string;
+      }>(
+        `SELECT first_seen_head_sha, first_seen_run_id
+         FROM review_findings WHERE finding_id = ?`,
+        options.finding.findingId,
+      )
+      .toArray()[0];
+    if (!persisted || persisted.first_seen_head_sha === options.headSha) return;
+
+    this.appendFindingOutcome({
+      repository: options.repository,
+      pullRequestNumber: options.pullRequestNumber,
+      findingId: options.finding.findingId,
+      outcome: "confirmed-fixed",
+      basis: "later-reviewed-head",
+      sourceId: `review:${options.runId}:${options.finding.findingId}`,
+      occurredAt: options.completedAt,
+      recordedAt: options.completedAt,
+      evidence: {
+        firstSeenHeadSha: persisted.first_seen_head_sha,
+        firstSeenRunId: persisted.first_seen_run_id,
+        outcomeHeadSha: options.headSha,
+        outcomeRunId: options.runId,
+        hunkIds: options.finding.hunkIds,
+        resolutionNote: options.finding.resolution_note,
+      },
+    });
+  }
+
   private async flushFindingOutcomes(
     repository: string,
     pullRequestNumber: number,
@@ -1255,6 +1296,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const currentHunks = (body.currentHunks ?? body.hunks) as ReviewHunk[];
     const completionRepository = body.repository;
     const completionPullRequestNumber = body.pullRequestNumber;
+    const completionRunId = body.runId;
     const completionHeadSha = body.headSha;
     const completionHunkIds = new Set(
       reviewedHunks.map(({ hunkId }) => hunkId),
@@ -1387,41 +1429,14 @@ export class PullRequestCoordinator extends DurableObject<Env> {
             hunkId,
           );
         }
-        if (finding.status === "resolved") {
-          const persisted = this.ctx.storage.sql
-            .exec<{
-              first_seen_head_sha: string;
-              first_seen_run_id: string;
-            }>(
-              `SELECT first_seen_head_sha, first_seen_run_id
-               FROM review_findings WHERE finding_id = ?`,
-              finding.findingId,
-            )
-            .toArray()[0];
-          if (
-            persisted &&
-            persisted.first_seen_head_sha !== body.headSha
-          ) {
-            this.appendFindingOutcome({
-              repository: completionRepository,
-              pullRequestNumber: completionPullRequestNumber,
-              findingId: finding.findingId,
-              outcome: "confirmed-fixed",
-              basis: "later-reviewed-head",
-              sourceId: `review:${body.runId}:${finding.findingId}`,
-              occurredAt: completedAt,
-              recordedAt: completedAt,
-              evidence: {
-                firstSeenHeadSha: persisted.first_seen_head_sha,
-                firstSeenRunId: persisted.first_seen_run_id,
-                outcomeHeadSha: body.headSha,
-                outcomeRunId: body.runId,
-                hunkIds: finding.hunkIds,
-                resolutionNote: finding.resolution_note,
-              },
-            });
-          }
-        }
+        this.appendConfirmedFixOutcome({
+          repository: completionRepository,
+          pullRequestNumber: completionPullRequestNumber,
+          runId: completionRunId,
+          headSha: completionHeadSha,
+          completedAt,
+          finding,
+        });
       }
       for (const publication of findingPublications) {
         if (publication.delivery !== "line" || publication.commentId === undefined) {
@@ -1779,6 +1794,17 @@ function acceptedWebhookEvent(
   return undefined;
 }
 
+function coordinatorPathForEvent(
+  event:
+    | ReviewWorkflowParams
+    | FindingInteractionEvent
+    | PullRequestFinalizationEvent,
+): "/events" | "/interactions" | "/finalizations" {
+  if ("interactionType" in event) return "/interactions";
+  if ("finalState" in event) return "/finalizations";
+  return "/events";
+}
+
 async function handleGitHubWebhook(request: Request, env: Env): Promise<Response> {
   const bodyResult = await readWebhookBody(request);
   if ("response" in bodyResult) return bodyResult.response;
@@ -1829,13 +1855,7 @@ async function handleGitHubWebhook(request: Request, env: Env): Promise<Response
   if (!allowedRepository || event.repository.trim().toLowerCase() !== allowedRepository) {
     return json({ error: "Repository is not allowed" }, 403);
   }
-  const coordinatorPath =
-    "interactionType" in event
-      ? "/interactions"
-      : "finalState" in event
-        ? "/finalizations"
-        : "/events";
-  return forwardToCoordinator(event, env, coordinatorPath);
+  return forwardToCoordinator(event, env, coordinatorPathForEvent(event));
 }
 
 export default {

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -34,6 +34,7 @@ import {
   runScouts,
   type IdentifiedMergedFinding,
   type IdentifiedReviewArtifacts,
+  type FindingResolution,
   type MergedRun,
   type PreparedReview,
   type ReviewHunk,
@@ -191,6 +192,10 @@ async function sha256(value: string): Promise<string> {
 
 function json(data: unknown, status = 200): Response {
   return Response.json(data, { status, headers: JSON_HEADERS });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function errorType(error: unknown): string {
@@ -362,6 +367,56 @@ function isFindingPublication(value: unknown): value is FindingPublication {
     publication.path.length > 0 &&
     (publication.line === null || lineIsPositive)
   );
+}
+
+function isFindingResolution(value: unknown): value is FindingResolution {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.findingId === "string" &&
+    /^f_[a-f0-9]{24}$/.test(value.findingId) &&
+    ["fixed", "still-present", "uncertain"].includes(
+      String(value.verdict),
+    ) &&
+    typeof value.evidence === "string" &&
+    value.evidence.trim().length > 0 &&
+    value.evidence.length <= 2_000
+  );
+}
+
+function storedFindingContext(
+  findingsJson: string | null | undefined,
+  findingId: string,
+): {
+  severity?: string;
+  line?: number | null;
+  evidence?: string;
+  recommendation?: string;
+} {
+  if (!findingsJson) return {};
+  try {
+    const parsed = JSON.parse(findingsJson) as unknown;
+    if (!Array.isArray(parsed)) return {};
+    const original = parsed.find(
+      (candidate) => isRecord(candidate) && candidate.findingId === findingId,
+    );
+    if (!isRecord(original)) return {};
+    return {
+      severity:
+        typeof original.severity === "string" ? original.severity : undefined,
+      line:
+        typeof original.line === "number" || original.line === null
+          ? original.line
+          : undefined,
+      evidence:
+        typeof original.evidence === "string" ? original.evidence : undefined,
+      recommendation:
+        typeof original.recommendation === "string"
+          ? original.recommendation
+          : undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 function isFindingInteractionEvent(
@@ -633,12 +688,12 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           .map(({ hunk_id }) => hunk_id),
         alreadyConfirmed:
           this.ctx.storage.sql
-            .exec<{ outcome: string }>(
-              `SELECT outcome FROM review_finding_outcomes
-               WHERE finding_id = ? ORDER BY outcome_version DESC LIMIT 1`,
+            .exec<{ finding_id: string }>(
+              `SELECT finding_id FROM review_finding_outcomes
+               WHERE finding_id = ? AND outcome = 'confirmed-fixed' LIMIT 1`,
               finding.finding_id,
             )
-            .toArray()[0]?.outcome === "confirmed-fixed",
+            .toArray()[0] !== undefined,
       }));
   }
 
@@ -649,15 +704,19 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     headSha: string;
     completedAt: string;
     candidates: FindingOutcomeCandidate[];
+    findingResolutions: Map<string, FindingResolution>;
     currentFindingIds: Set<string>;
     currentHunkIds: Set<string>;
     reviewedFiles: Set<string>;
   }): void {
     for (const candidate of options.candidates) {
       if (
+        !options.findingResolutions.has(candidate.findingId) ||
         !confirmsFindingFixed({
           alreadyConfirmed: candidate.alreadyConfirmed,
           rediscovered: options.currentFindingIds.has(candidate.findingId),
+          replayVerdict: options.findingResolutions.get(candidate.findingId)
+            ?.verdict,
           firstSeenHeadSha: candidate.firstSeenHeadSha,
           reviewedHeadSha: options.headSha,
           file: candidate.file,
@@ -678,7 +737,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         occurredAt: options.completedAt,
         recordedAt: options.completedAt,
         evidence: {
-          confirmation: "not-rediscovered-after-affected-code-change",
+          confirmation: "affirmative-controlled-replay",
+          replayEvidence: options.findingResolutions.get(candidate.findingId)
+            ?.evidence,
           firstSeenHeadSha: candidate.firstSeenHeadSha,
           firstSeenRunId: candidate.firstSeenRunId,
           outcomeHeadSha: options.headSha,
@@ -1337,13 +1398,30 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       .toArray()
       .map(({ hunk_id }) => hunk_id);
     const findings = this.ctx.storage.sql
-      .exec<{ finding_id: string; file_path: string; title: string }>(
-        `SELECT finding_id, file_path, title FROM review_findings
-         WHERE status = 'open' AND disposition IS NULL
-         ORDER BY finding_id LIMIT 100`,
+      .exec<{
+        finding_id: string;
+        file_path: string;
+        title: string;
+        first_seen_run_id: string;
+        findings_json: string | null;
+      }>(
+        `SELECT finding.finding_id, finding.file_path, finding.title,
+                finding.first_seen_run_id, run.findings_json
+         FROM review_findings finding
+         LEFT JOIN review_runs run ON run.run_id = finding.first_seen_run_id
+         WHERE NOT EXISTS (
+           SELECT 1 FROM review_finding_outcomes outcome
+           WHERE outcome.finding_id = finding.finding_id
+             AND outcome.outcome = 'confirmed-fixed'
+         )
+         ORDER BY finding.finding_id LIMIT 100`,
       )
       .toArray();
     const openFindings = findings.map((finding) => ({
+      ...storedFindingContext(
+        finding.findings_json,
+        finding.finding_id,
+      ),
       findingId: finding.finding_id,
       file: finding.file_path,
       title: finding.title,
@@ -1371,6 +1449,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       currentHunks?: unknown;
       findings?: unknown;
       findingPublications?: unknown;
+      findingResolutions?: unknown;
     } | null;
     if (
       !body ||
@@ -1392,6 +1471,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           !body.currentHunks.every(isReviewHunk))) ||
       !Array.isArray(body.findings) ||
       !body.findings.every(isIdentifiedFinding) ||
+      (body.findingResolutions !== undefined &&
+        (!Array.isArray(body.findingResolutions) ||
+          !body.findingResolutions.every(isFindingResolution))) ||
       (body.findingPublications !== undefined &&
         (!Array.isArray(body.findingPublications) ||
           !body.findingPublications.every(isFindingPublication)))
@@ -1419,9 +1501,15 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     );
     const findingPublications = (body.findingPublications ??
       []) as FindingPublication[];
+    const findingResolutions = (body.findingResolutions ??
+      []) as FindingResolution[];
+    const findingResolutionsById = new Map(
+      findingResolutions.map((resolution) => [resolution.findingId, resolution]),
+    );
     if (
       completionHunkIds.size !== reviewedHunks.length ||
       currentHunksById.size !== currentHunks.length ||
+      findingResolutionsById.size !== findingResolutions.length ||
       reviewedHunks.some((hunk) => {
         const current = currentHunksById.get(hunk.hunkId);
         return !current || !sameReviewHunk(hunk, current);
@@ -1449,6 +1537,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         currentHunks,
         findings: body.findings,
         findingPublications,
+        findingResolutions,
       }),
     );
     const completedAt = new Date().toISOString();
@@ -1549,6 +1638,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         headSha: completionHeadSha,
         completedAt,
         candidates: outcomeCandidates,
+        findingResolutions: findingResolutionsById,
         currentFindingIds: new Set(completionFindingsById.keys()),
         currentHunkIds: new Set(currentHunksById.keys()),
         reviewedFiles: completionReviewedFiles,
@@ -1751,6 +1841,7 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
             event.payload,
             event.instanceId,
             prepared!,
+            { result: { finding_resolutions: [] }, cost: 0 },
             { hunks: [], candidates: {}, publishedFindings: [] },
             skippedPublication,
           ),
@@ -1868,6 +1959,7 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
           event.payload,
           event.instanceId,
           prepared!,
+          merged!,
           artifacts!,
           publication,
         ),

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -15,6 +15,7 @@ import type {
 import {
   buildFindingOutcomeRecord,
   classifyFinalizedFinding,
+  confirmsFindingFixed,
   type FindingOutcomeBasis,
 } from "./finding-outcomes";
 import type { FindingPublication } from "./finding-lifecycle";
@@ -48,6 +49,16 @@ import {
 const JSON_HEADERS = {
   "cache-control": "no-store",
   "content-type": "application/json; charset=utf-8",
+};
+const OUTCOME_FLUSH_CONCURRENCY = 20;
+const OUTCOME_FLUSH_LIMIT = 100;
+type FindingOutcomeCandidate = {
+  findingId: string;
+  file: string;
+  firstSeenHeadSha: string;
+  firstSeenRunId: string;
+  hunkIds: string[];
+  alreadyConfirmed: boolean;
 };
 const CREATE_WEBHOOK_DELIVERIES_TABLE =
   "CREATE TABLE IF NOT EXISTS webhook_deliveries (" +
@@ -401,8 +412,10 @@ function isPullRequestFinalizationEvent(
     event.pullRequestNumber > 0 &&
     typeof event.headSha === "string" &&
     event.headSha.length > 0 &&
+    event.headSha.length <= 64 &&
     (event.finalState === "merged" || event.finalState === "closed") &&
-    (event.occurredAt === undefined || typeof event.occurredAt === "string")
+    (event.occurredAt === undefined ||
+      (typeof event.occurredAt === "string" && event.occurredAt.length <= 64))
   );
 }
 
@@ -583,45 +596,90 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     return inserted.rowsWritten > 0;
   }
 
-  private appendConfirmedFixOutcome(options: {
+  private findingOutcomeCandidates(
+    reviewedFiles: Set<string>,
+  ): FindingOutcomeCandidate[] {
+    return this.ctx.storage.sql
+      .exec<{
+        finding_id: string;
+        file_path: string;
+        first_seen_head_sha: string;
+        first_seen_run_id: string;
+      }>(
+        `SELECT finding_id, file_path, first_seen_head_sha, first_seen_run_id
+         FROM review_findings ORDER BY finding_id`,
+      )
+      .toArray()
+      .filter((finding) => reviewedFiles.has(finding.file_path))
+      .map((finding) => ({
+        findingId: finding.finding_id,
+        file: finding.file_path,
+        firstSeenHeadSha: finding.first_seen_head_sha,
+        firstSeenRunId: finding.first_seen_run_id,
+        hunkIds: this.ctx.storage.sql
+          .exec<{ hunk_id: string }>(
+            `SELECT hunk_id FROM review_finding_hunks
+             WHERE finding_id = ? ORDER BY hunk_id`,
+            finding.finding_id,
+          )
+          .toArray()
+          .map(({ hunk_id }) => hunk_id),
+        alreadyConfirmed:
+          this.ctx.storage.sql
+            .exec<{ outcome: string }>(
+              `SELECT outcome FROM review_finding_outcomes
+               WHERE finding_id = ? ORDER BY outcome_version DESC LIMIT 1`,
+              finding.finding_id,
+            )
+            .toArray()[0]?.outcome === "confirmed-fixed",
+      }));
+  }
+
+  private appendConfirmedFixOutcomes(options: {
     repository: string;
     pullRequestNumber: number;
     runId: string;
     headSha: string;
     completedAt: string;
-    finding: IdentifiedMergedFinding;
+    candidates: FindingOutcomeCandidate[];
+    currentFindingIds: Set<string>;
+    currentHunkIds: Set<string>;
+    reviewedFiles: Set<string>;
   }): void {
-    if (options.finding.status !== "resolved") return;
-    const persisted = this.ctx.storage.sql
-      .exec<{
-        first_seen_head_sha: string;
-        first_seen_run_id: string;
-      }>(
-        `SELECT first_seen_head_sha, first_seen_run_id
-         FROM review_findings WHERE finding_id = ?`,
-        options.finding.findingId,
-      )
-      .toArray()[0];
-    if (!persisted || persisted.first_seen_head_sha === options.headSha) return;
-
-    this.appendFindingOutcome({
-      repository: options.repository,
-      pullRequestNumber: options.pullRequestNumber,
-      findingId: options.finding.findingId,
-      outcome: "confirmed-fixed",
-      basis: "later-reviewed-head",
-      sourceId: `review:${options.runId}:${options.finding.findingId}`,
-      occurredAt: options.completedAt,
-      recordedAt: options.completedAt,
-      evidence: {
-        firstSeenHeadSha: persisted.first_seen_head_sha,
-        firstSeenRunId: persisted.first_seen_run_id,
-        outcomeHeadSha: options.headSha,
-        outcomeRunId: options.runId,
-        hunkIds: options.finding.hunkIds,
-        resolutionNote: options.finding.resolution_note,
-      },
-    });
+    for (const candidate of options.candidates) {
+      if (
+        !confirmsFindingFixed({
+          alreadyConfirmed: candidate.alreadyConfirmed,
+          rediscovered: options.currentFindingIds.has(candidate.findingId),
+          firstSeenHeadSha: candidate.firstSeenHeadSha,
+          reviewedHeadSha: options.headSha,
+          file: candidate.file,
+          priorHunkIds: candidate.hunkIds,
+          currentHunkIds: options.currentHunkIds,
+          reviewedFiles: options.reviewedFiles,
+        })
+      ) {
+        continue;
+      }
+      this.appendFindingOutcome({
+        repository: options.repository,
+        pullRequestNumber: options.pullRequestNumber,
+        findingId: candidate.findingId,
+        outcome: "confirmed-fixed",
+        basis: "later-reviewed-head",
+        sourceId: `review:${options.runId}:${candidate.findingId}`,
+        occurredAt: options.completedAt,
+        recordedAt: options.completedAt,
+        evidence: {
+          confirmation: "not-rediscovered-after-affected-code-change",
+          firstSeenHeadSha: candidate.firstSeenHeadSha,
+          firstSeenRunId: candidate.firstSeenRunId,
+          outcomeHeadSha: options.headSha,
+          outcomeRunId: options.runId,
+          priorHunkIds: candidate.hunkIds,
+        },
+      });
+    }
   }
 
   private async flushFindingOutcomes(
@@ -636,27 +694,52 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       }>(
         `SELECT finding_id, outcome_version, payload_json
          FROM review_finding_outcomes WHERE r2_recorded = 0
-         ORDER BY finding_id, outcome_version`,
+         ORDER BY finding_id, outcome_version LIMIT ?`,
+        OUTCOME_FLUSH_LIMIT,
       )
       .toArray();
-    for (const outcome of pending) {
-      const key = [
-        "v2",
-        repository,
-        `pr-${pullRequestNumber}`,
-        "findings",
-        outcome.finding_id,
-        "outcomes",
-        `v${outcome.outcome_version}.json`,
-      ].join("/");
-      await this.env.REVIEW_DATA.put(key, outcome.payload_json, {
-        httpMetadata: { contentType: "application/json" },
-      });
-      this.ctx.storage.sql.exec(
-        `UPDATE review_finding_outcomes SET r2_recorded = 1
-         WHERE finding_id = ? AND outcome_version = ?`,
-        outcome.finding_id,
-        outcome.outcome_version,
+    let recorded = 0;
+    for (
+      let index = 0;
+      index < pending.length;
+      index += OUTCOME_FLUSH_CONCURRENCY
+    ) {
+      const batch = pending.slice(index, index + OUTCOME_FLUSH_CONCURRENCY);
+      const results = await Promise.all(
+        batch.map(async (outcome) => {
+          const key = [
+            "v2",
+            repository,
+            `pr-${pullRequestNumber}`,
+            "findings",
+            outcome.finding_id,
+            "outcomes",
+            `v${outcome.outcome_version}.json`,
+          ].join("/");
+          try {
+            await this.env.REVIEW_DATA.put(key, outcome.payload_json, {
+              httpMetadata: { contentType: "application/json" },
+            });
+          } catch (error) {
+            console.error("Could not publish a finding outcome", {
+              type: errorType(error),
+            });
+            return false;
+          }
+          this.ctx.storage.sql.exec(
+            `UPDATE review_finding_outcomes SET r2_recorded = 1
+             WHERE finding_id = ? AND outcome_version = ?`,
+            outcome.finding_id,
+            outcome.outcome_version,
+          );
+          return true;
+        }),
+      );
+      recorded += results.filter(Boolean).length;
+    }
+    if (pending.length === OUTCOME_FLUSH_LIMIT && recorded > 0) {
+      this.ctx.waitUntil(
+        this.flushFindingOutcomes(repository, pullRequestNumber),
       );
     }
   }
@@ -994,7 +1077,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       const findings = this.ctx.storage.sql
         .exec<{
           finding_id: string;
-          status: string;
           disposition: string | null;
           disposition_reason: string | null;
           first_seen_head_sha: string;
@@ -1002,7 +1084,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           first_seen_run_id: string;
           last_seen_run_id: string;
         }>(
-          `SELECT finding_id, status, disposition, disposition_reason,
+          `SELECT finding_id, disposition, disposition_reason,
                   first_seen_head_sha, last_seen_head_sha,
                   first_seen_run_id, last_seen_run_id
            FROM review_findings ORDER BY finding_id`,
@@ -1032,9 +1114,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         );
         const outcome = classifyFinalizedFinding({
           disposition: finding.disposition,
-          status: finding.status,
-          firstSeenHeadSha: finding.first_seen_head_sha,
-          lastSeenHeadSha: finding.last_seen_head_sha,
           finalHeadWasReviewed,
           affectedCodeRemains,
         });
@@ -1308,6 +1387,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const completionFindingsById = new Map(
       completionFindings.map((finding) => [finding.findingId, finding]),
     );
+    const completionReviewedFiles = new Set(
+      reviewedHunks.map(({ file }) => file),
+    );
     const findingPublications = (body.findingPublications ??
       []) as FindingPublication[];
     if (
@@ -1371,6 +1453,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           completionHash,
         );
       }
+      const outcomeCandidates = this.findingOutcomeCandidates(
+        completionReviewedFiles,
+      );
       for (const hunk of currentHunks) {
         this.ctx.storage.sql.exec(
           `INSERT INTO review_hunks
@@ -1429,15 +1514,18 @@ export class PullRequestCoordinator extends DurableObject<Env> {
             hunkId,
           );
         }
-        this.appendConfirmedFixOutcome({
-          repository: completionRepository,
-          pullRequestNumber: completionPullRequestNumber,
-          runId: completionRunId,
-          headSha: completionHeadSha,
-          completedAt,
-          finding,
-        });
       }
+      this.appendConfirmedFixOutcomes({
+        repository: completionRepository,
+        pullRequestNumber: completionPullRequestNumber,
+        runId: completionRunId,
+        headSha: completionHeadSha,
+        completedAt,
+        candidates: outcomeCandidates,
+        currentFindingIds: new Set(completionFindingsById.keys()),
+        currentHunkIds: new Set(currentHunksById.keys()),
+        reviewedFiles: completionReviewedFiles,
+      });
       for (const publication of findingPublications) {
         if (publication.delivery !== "line" || publication.commentId === undefined) {
           continue;

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -15,7 +15,6 @@ import type {
 import {
   buildFindingOutcomeRecord,
   classifyFinalizedFinding,
-  confirmsFindingFixed,
   type FindingOutcomeBasis,
 } from "./finding-outcomes";
 import type { FindingPublication } from "./finding-lifecycle";
@@ -60,14 +59,6 @@ type FindingOutcomeFlushRetry = {
   repository: string;
   pullRequestNumber: number;
 };
-type FindingOutcomeCandidate = {
-  findingId: string;
-  file: string;
-  firstSeenHeadSha: string;
-  firstSeenRunId: string;
-  hunkIds: string[];
-  alreadyConfirmed: boolean;
-};
 const CREATE_WEBHOOK_DELIVERIES_TABLE =
   "CREATE TABLE IF NOT EXISTS webhook_deliveries (" +
   "delivery_id TEXT PRIMARY KEY, " +
@@ -90,6 +81,7 @@ const CREATE_REVIEW_RUNS_TABLE =
   "cost_usd REAL NOT NULL DEFAULT 0, " +
   "comment_id INTEGER, " +
   "findings_json TEXT, " +
+  "finding_resolutions_json TEXT, " +
   "completion_hash TEXT, " +
   "error TEXT)";
 const CREATE_REVIEW_HUNKS_TABLE =
@@ -419,6 +411,23 @@ function storedFindingContext(
   }
 }
 
+function storedFindingResolution(
+  resolutionsJson: string | null | undefined,
+  findingId: string,
+): FindingResolution | undefined {
+  if (!resolutionsJson) return undefined;
+  try {
+    const parsed = JSON.parse(resolutionsJson) as unknown;
+    if (!Array.isArray(parsed)) return undefined;
+    return parsed.find(
+      (candidate): candidate is FindingResolution =>
+        isFindingResolution(candidate) && candidate.findingId === findingId,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
 function isFindingInteractionEvent(
   value: unknown,
 ): value is FindingInteractionEvent {
@@ -451,6 +460,7 @@ function isFindingInteractionEvent(
     (event.interactionType !== "disposition" ||
       (event.findingId !== undefined &&
         (event.disposition === "acknowledged" ||
+          event.disposition === "confirmed-fixed" ||
           event.disposition === "rejected"))) &&
     (event.interactionType === "disposition" || event.rootCommentId !== undefined)
   );
@@ -565,6 +575,13 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         "ALTER TABLE review_runs ADD COLUMN completion_hash TEXT",
       );
     }
+    if (
+      !reviewRunColumns.some(({ name }) => name === "finding_resolutions_json")
+    ) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE review_runs ADD COLUMN finding_resolutions_json TEXT",
+      );
+    }
     this.ctx.storage.sql.exec(CREATE_REVIEW_HUNKS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_RUN_HUNKS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDINGS_TABLE);
@@ -656,98 +673,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       options.recordedAt,
     );
     return inserted.rowsWritten > 0;
-  }
-
-  private findingOutcomeCandidates(
-    reviewedFiles: Set<string>,
-  ): FindingOutcomeCandidate[] {
-    return this.ctx.storage.sql
-      .exec<{
-        finding_id: string;
-        file_path: string;
-        first_seen_head_sha: string;
-        first_seen_run_id: string;
-      }>(
-        `SELECT finding_id, file_path, first_seen_head_sha, first_seen_run_id
-         FROM review_findings ORDER BY finding_id`,
-      )
-      .toArray()
-      .filter((finding) => reviewedFiles.has(finding.file_path))
-      .map((finding) => ({
-        findingId: finding.finding_id,
-        file: finding.file_path,
-        firstSeenHeadSha: finding.first_seen_head_sha,
-        firstSeenRunId: finding.first_seen_run_id,
-        hunkIds: this.ctx.storage.sql
-          .exec<{ hunk_id: string }>(
-            `SELECT hunk_id FROM review_finding_hunks
-             WHERE finding_id = ? ORDER BY hunk_id`,
-            finding.finding_id,
-          )
-          .toArray()
-          .map(({ hunk_id }) => hunk_id),
-        alreadyConfirmed:
-          this.ctx.storage.sql
-            .exec<{ finding_id: string }>(
-              `SELECT finding_id FROM review_finding_outcomes
-               WHERE finding_id = ? AND outcome = 'confirmed-fixed' LIMIT 1`,
-              finding.finding_id,
-            )
-            .toArray()[0] !== undefined,
-      }));
-  }
-
-  private appendConfirmedFixOutcomes(options: {
-    repository: string;
-    pullRequestNumber: number;
-    runId: string;
-    headSha: string;
-    completedAt: string;
-    candidates: FindingOutcomeCandidate[];
-    findingResolutions: Map<string, FindingResolution>;
-    currentFindingIds: Set<string>;
-    currentHunkIds: Set<string>;
-    reviewedFiles: Set<string>;
-  }): void {
-    for (const candidate of options.candidates) {
-      if (
-        !options.findingResolutions.has(candidate.findingId) ||
-        !confirmsFindingFixed({
-          alreadyConfirmed: candidate.alreadyConfirmed,
-          rediscovered: options.currentFindingIds.has(candidate.findingId),
-          replayVerdict: options.findingResolutions.get(candidate.findingId)
-            ?.verdict,
-          firstSeenHeadSha: candidate.firstSeenHeadSha,
-          reviewedHeadSha: options.headSha,
-          file: candidate.file,
-          priorHunkIds: candidate.hunkIds,
-          currentHunkIds: options.currentHunkIds,
-          reviewedFiles: options.reviewedFiles,
-        })
-      ) {
-        continue;
-      }
-      this.appendFindingOutcome({
-        repository: options.repository,
-        pullRequestNumber: options.pullRequestNumber,
-        findingId: candidate.findingId,
-        outcome: "confirmed-fixed",
-        basis: "later-reviewed-head",
-        sourceId: `review:${options.runId}:${candidate.findingId}`,
-        occurredAt: options.completedAt,
-        recordedAt: options.completedAt,
-        evidence: {
-          confirmation: "affirmative-controlled-replay",
-          replayEvidence: options.findingResolutions.get(candidate.findingId)
-            ?.evidence,
-          firstSeenHeadSha: candidate.firstSeenHeadSha,
-          firstSeenRunId: candidate.firstSeenRunId,
-          outcomeHeadSha: options.headSha,
-          outcomeRunId: options.runId,
-          priorHunkIds: candidate.hunkIds,
-        },
-      });
-    }
   }
 
   private async flushFindingOutcomes(
@@ -997,6 +922,43 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       if (!finding) return { unknownFinding: true };
 
       const occurredAt = event.occurredAt ?? recordedAt;
+      const controlledReplay =
+        event.disposition === "confirmed-fixed"
+          ? this.ctx.storage.sql
+              .exec<{
+                run_id: string;
+                head_sha: string;
+                finding_resolutions_json: string;
+              }>(
+                `SELECT run_id, head_sha, finding_resolutions_json
+                 FROM review_runs
+                 WHERE status = 'completed'
+                   AND finding_resolutions_json IS NOT NULL
+                 ORDER BY completed_at DESC, run_id DESC LIMIT 100`,
+              )
+              .toArray()
+              .map((run) => {
+                const resolution = storedFindingResolution(
+                  run.finding_resolutions_json,
+                  findingId,
+                );
+                return resolution
+                  ? {
+                      runId: run.run_id,
+                      headSha: run.head_sha,
+                      verdict: resolution.verdict,
+                      evidence: resolution.evidence,
+                    }
+                  : undefined;
+              })
+              .find((resolution) => resolution !== undefined)
+          : undefined;
+      if (
+        event.disposition === "confirmed-fixed" &&
+        controlledReplay?.verdict !== "fixed"
+      ) {
+        return { unconfirmedFix: true };
+      }
       const evidence = {
         schemaVersion: 2,
         recordType: "finding-interaction-evidence",
@@ -1017,6 +979,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         reactions: event.reactions,
         disposition: event.disposition,
         reason: event.reason,
+        controlledReplay,
         occurredAt,
         recordedAt,
       };
@@ -1070,6 +1033,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
             actor: event.actor,
             actorAssociation: event.actorAssociation,
             reason: event.reason,
+            controlledReplay,
           },
         });
       }
@@ -1083,6 +1047,9 @@ export class PullRequestCoordinator extends DurableObject<Env> {
 
     if ("unknownFinding" in result) {
       return json({ accepted: false, reason: "unknown-finding" }, 202);
+    }
+    if ("unconfirmedFix" in result) {
+      return json({ accepted: false, reason: "no-fixed-replay" }, 202);
     }
     if (!result.r2Recorded) {
       const key = [
@@ -1484,7 +1451,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const currentHunks = (body.currentHunks ?? body.hunks) as ReviewHunk[];
     const completionRepository = body.repository;
     const completionPullRequestNumber = body.pullRequestNumber;
-    const completionRunId = body.runId;
     const completionHeadSha = body.headSha;
     const completionHunkIds = new Set(
       reviewedHunks.map(({ hunkId }) => hunkId),
@@ -1495,9 +1461,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const completionFindings = body.findings as IdentifiedMergedFinding[];
     const completionFindingsById = new Map(
       completionFindings.map((finding) => [finding.findingId, finding]),
-    );
-    const completionReviewedFiles = new Set(
-      reviewedHunks.map(({ file }) => file),
     );
     const findingPublications = (body.findingPublications ??
       []) as FindingPublication[];
@@ -1545,12 +1508,14 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       const update = this.ctx.storage.sql.exec(
         `UPDATE review_runs
          SET status = 'completed', completed_at = ?, cost_usd = ?,
-             comment_id = ?, findings_json = ?, completion_hash = ?, error = NULL
+             comment_id = ?, findings_json = ?, finding_resolutions_json = ?,
+             completion_hash = ?, error = NULL
          WHERE run_id = ? AND head_sha = ? AND status = 'running'`,
         completedAt,
         body.costUsd,
         body.commentId ?? null,
         JSON.stringify(body.findings),
+        JSON.stringify(findingResolutions),
         completionHash,
         body.runId,
         body.headSha,
@@ -1569,9 +1534,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           completionHash,
         );
       }
-      const outcomeCandidates = this.findingOutcomeCandidates(
-        completionReviewedFiles,
-      );
       for (const hunk of currentHunks) {
         this.ctx.storage.sql.exec(
           `INSERT INTO review_hunks
@@ -1631,18 +1593,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           );
         }
       }
-      this.appendConfirmedFixOutcomes({
-        repository: completionRepository,
-        pullRequestNumber: completionPullRequestNumber,
-        runId: completionRunId,
-        headSha: completionHeadSha,
-        completedAt,
-        candidates: outcomeCandidates,
-        findingResolutions: findingResolutionsById,
-        currentFindingIds: new Set(completionFindingsById.keys()),
-        currentHunkIds: new Set(currentHunksById.keys()),
-        reviewedFiles: completionReviewedFiles,
-      });
       for (const publication of findingPublications) {
         if (publication.delivery !== "line" || publication.commentId === undefined) {
           continue;

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -8,8 +8,15 @@ import {
 import type {
   Env,
   FindingInteractionEvent,
+  FindingOutcome,
+  PullRequestFinalizationEvent,
   ReviewWorkflowParams,
 } from "./env";
+import {
+  buildFindingOutcomeRecord,
+  classifyFinalizedFinding,
+  type FindingOutcomeBasis,
+} from "./finding-outcomes";
 import type { FindingPublication } from "./finding-lifecycle";
 import {
   claimReview,
@@ -33,6 +40,7 @@ import {
 } from "./review-engine";
 import {
   parseFindingInteraction,
+  parsePullRequestFinalization,
   parseReviewEvent,
   verifyGitHubSignature,
 } from "./webhook";
@@ -119,6 +127,18 @@ const CREATE_REVIEW_FINDING_EVENTS_TABLE =
   "occurred_at TEXT NOT NULL, " +
   "recorded_at TEXT NOT NULL, " +
   "r2_recorded INTEGER NOT NULL DEFAULT 0)";
+const CREATE_REVIEW_FINDING_OUTCOMES_TABLE =
+  "CREATE TABLE IF NOT EXISTS review_finding_outcomes (" +
+  "finding_id TEXT NOT NULL, " +
+  "outcome_version INTEGER NOT NULL, " +
+  "outcome TEXT NOT NULL, " +
+  "basis TEXT NOT NULL, " +
+  "source_id TEXT NOT NULL UNIQUE, " +
+  "payload_json TEXT NOT NULL, " +
+  "occurred_at TEXT NOT NULL, " +
+  "recorded_at TEXT NOT NULL, " +
+  "r2_recorded INTEGER NOT NULL DEFAULT 0, " +
+  "PRIMARY KEY (finding_id, outcome_version))";
 const DEFAULT_DEBOUNCE_DELAY_MS = 120_000;
 const MINIMUM_DEBOUNCE_DELAY_MS = 1_000;
 const MAXIMUM_DEBOUNCE_DELAY_MS = 3_600_000;
@@ -363,6 +383,29 @@ function isFindingInteractionEvent(
   );
 }
 
+function isPullRequestFinalizationEvent(
+  value: unknown,
+): value is PullRequestFinalizationEvent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const event = value as Partial<PullRequestFinalizationEvent>;
+  return (
+    typeof event.deliveryId === "string" &&
+    event.deliveryId.length > 0 &&
+    event.deliveryId.length <= 255 &&
+    event.eventName === "pull_request" &&
+    event.action === "closed" &&
+    typeof event.repository === "string" &&
+    event.repository.length > 0 &&
+    typeof event.pullRequestNumber === "number" &&
+    Number.isSafeInteger(event.pullRequestNumber) &&
+    event.pullRequestNumber > 0 &&
+    typeof event.headSha === "string" &&
+    event.headSha.length > 0 &&
+    (event.finalState === "merged" || event.finalState === "closed") &&
+    (event.occurredAt === undefined || typeof event.occurredAt === "string")
+  );
+}
+
 function healthResponse(env: Env): Response {
   const bindings = bindingHealth(env);
   const ok = Object.values(bindings).every(Boolean);
@@ -396,7 +439,10 @@ async function readWebhookBody(
 }
 
 async function forwardToCoordinator(
-  event: ReviewWorkflowParams | FindingInteractionEvent,
+  event:
+    | ReviewWorkflowParams
+    | FindingInteractionEvent
+    | PullRequestFinalizationEvent,
   env: Env,
   path = "/events",
 ): Promise<Response> {
@@ -463,6 +509,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_HUNKS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_COMMENTS_TABLE);
     this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_EVENTS_TABLE);
+    this.ctx.storage.sql.exec(CREATE_REVIEW_FINDING_OUTCOMES_TABLE);
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -472,11 +519,105 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     const path = new URL(request.url).pathname;
     if (path === "/events") return this.receiveEvent(request);
     if (path === "/interactions") return this.receiveInteraction(request);
+    if (path === "/finalizations") return this.receiveFinalization(request);
     if (path === "/reviews/claim") return this.claimReview(request);
     if (path === "/reviews/baseline") return this.reviewBaseline();
     if (path === "/reviews/complete") return this.completeReview(request);
     if (path === "/reviews/fail") return this.failReview(request);
     return new Response("Not found", { status: 404 });
+  }
+
+  private appendFindingOutcome(options: {
+    repository: string;
+    pullRequestNumber: number;
+    findingId: string;
+    outcome: FindingOutcome;
+    basis: FindingOutcomeBasis;
+    sourceId: string;
+    occurredAt: string;
+    recordedAt: string;
+    evidence: Record<string, unknown>;
+  }): boolean {
+    const existing = this.ctx.storage.sql
+      .exec<{ source_id: string }>(
+        "SELECT source_id FROM review_finding_outcomes WHERE source_id = ?",
+        options.sourceId,
+      )
+      .toArray()[0];
+    if (existing) return false;
+
+    const latest = this.ctx.storage.sql
+      .exec<{ outcome_version: number }>(
+        `SELECT outcome_version FROM review_finding_outcomes
+         WHERE finding_id = ? ORDER BY outcome_version DESC LIMIT 1`,
+        options.findingId,
+      )
+      .toArray()[0];
+    const outcomeVersion = Number(latest?.outcome_version ?? 0) + 1;
+    const payload = buildFindingOutcomeRecord({
+      repository: options.repository,
+      pullRequestNumber: options.pullRequestNumber,
+      findingId: options.findingId,
+      outcome: options.outcome,
+      basis: options.basis,
+      sourceId: options.sourceId,
+      outcomeVersion,
+      evidence: options.evidence,
+      occurredAt: options.occurredAt,
+      recordedAt: options.recordedAt,
+    });
+    const inserted = this.ctx.storage.sql.exec(
+      `INSERT OR IGNORE INTO review_finding_outcomes
+       (finding_id, outcome_version, outcome, basis, source_id, payload_json,
+        occurred_at, recorded_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      options.findingId,
+      outcomeVersion,
+      options.outcome,
+      options.basis,
+      options.sourceId,
+      JSON.stringify(payload),
+      options.occurredAt,
+      options.recordedAt,
+    );
+    return inserted.rowsWritten > 0;
+  }
+
+  private async flushFindingOutcomes(
+    repository: string,
+    pullRequestNumber: number,
+  ): Promise<void> {
+    const pending = this.ctx.storage.sql
+      .exec<{
+        finding_id: string;
+        outcome_version: number;
+        payload_json: string;
+      }>(
+        `SELECT finding_id, outcome_version, payload_json
+         FROM review_finding_outcomes WHERE r2_recorded = 0
+         ORDER BY finding_id, outcome_version`,
+      )
+      .toArray();
+    for (const outcome of pending) {
+      const key = [
+        "v2",
+        repository,
+        `pr-${pullRequestNumber}`,
+        "findings",
+        outcome.finding_id,
+        "outcomes",
+        `v${outcome.outcome_version}.json`,
+      ].join("/");
+      await this.env.REVIEW_DATA.put(key, outcome.payload_json, {
+        httpMetadata: { contentType: "application/json" },
+      });
+      this.ctx.storage.sql.exec(
+        `UPDATE review_finding_outcomes SET r2_recorded = 1
+         WHERE finding_id = ? AND outcome_version = ?`,
+        outcome.finding_id,
+        outcome.outcome_version,
+      );
+    }
   }
 
   private async terminateExpiredReview(
@@ -703,6 +844,22 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           event.reason ?? null,
           findingId,
         );
+        this.appendFindingOutcome({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
+          findingId,
+          outcome: event.disposition,
+          basis: "explicit-disposition",
+          sourceId: `delivery:${event.deliveryId}`,
+          occurredAt,
+          recordedAt,
+          evidence: {
+            deliveryId: event.deliveryId,
+            actor: event.actor,
+            actorAssociation: event.actorAssociation,
+            reason: event.reason,
+          },
+        });
       }
       return {
         duplicate: false,
@@ -734,11 +891,144 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         event.deliveryId,
       );
     }
+    await this.flushFindingOutcomes(
+      event.repository,
+      event.pullRequestNumber,
+    );
     return json({
       accepted: true,
       duplicate: result.duplicate,
       findingId: result.findingId,
     });
+  }
+
+  private async receiveFinalization(request: Request): Promise<Response> {
+    const event = await request.json().catch(() => null);
+    if (!isPullRequestFinalizationEvent(event)) {
+      return json({ error: "Invalid pull request finalization" }, 400);
+    }
+
+    const recordedAt = new Date().toISOString();
+    const result = this.ctx.storage.transactionSync(() => {
+      const existing = this.ctx.storage.sql
+        .exec<{ delivery_id: string }>(
+          "SELECT delivery_id FROM webhook_deliveries WHERE delivery_id = ?",
+          event.deliveryId,
+        )
+        .toArray()[0];
+      if (existing) return { duplicate: true, outcomes: 0 };
+
+      this.ctx.storage.sql.exec(
+        `INSERT INTO webhook_deliveries
+         (delivery_id, event_name, action, repository, pull_request_number,
+          head_sha, received_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        event.deliveryId,
+        event.eventName,
+        event.action,
+        event.repository,
+        event.pullRequestNumber,
+        event.headSha,
+        recordedAt,
+      );
+      const completed = this.ctx.storage.sql
+        .exec<{ run_id: string; head_sha: string }>(
+          `SELECT run_id, head_sha FROM review_runs
+           WHERE status = 'completed'
+           ORDER BY completed_at DESC, run_id DESC LIMIT 1`,
+        )
+        .toArray()[0];
+      const currentHunkIds = new Set(
+        completed
+          ? this.ctx.storage.sql
+              .exec<{ hunk_id: string }>(
+                "SELECT hunk_id FROM review_run_hunks WHERE run_id = ?",
+                completed.run_id,
+              )
+              .toArray()
+              .map(({ hunk_id }) => hunk_id)
+          : [],
+      );
+      const finalHeadWasReviewed = completed?.head_sha === event.headSha;
+      const findings = this.ctx.storage.sql
+        .exec<{
+          finding_id: string;
+          status: string;
+          disposition: string | null;
+          disposition_reason: string | null;
+          first_seen_head_sha: string;
+          last_seen_head_sha: string;
+          first_seen_run_id: string;
+          last_seen_run_id: string;
+        }>(
+          `SELECT finding_id, status, disposition, disposition_reason,
+                  first_seen_head_sha, last_seen_head_sha,
+                  first_seen_run_id, last_seen_run_id
+           FROM review_findings ORDER BY finding_id`,
+        )
+        .toArray();
+      let outcomes = 0;
+      for (const finding of findings) {
+        const priorOutcome = this.ctx.storage.sql
+          .exec<{ outcome: string }>(
+            `SELECT outcome FROM review_finding_outcomes
+             WHERE finding_id = ? ORDER BY outcome_version DESC LIMIT 1`,
+            finding.finding_id,
+          )
+          .toArray()[0];
+        if (priorOutcome) continue;
+
+        const findingHunkIds = this.ctx.storage.sql
+          .exec<{ hunk_id: string }>(
+            `SELECT hunk_id FROM review_finding_hunks
+             WHERE finding_id = ?`,
+            finding.finding_id,
+          )
+          .toArray()
+          .map(({ hunk_id }) => hunk_id);
+        const affectedCodeRemains = findingHunkIds.some((hunkId) =>
+          currentHunkIds.has(hunkId),
+        );
+        const outcome = classifyFinalizedFinding({
+          disposition: finding.disposition,
+          status: finding.status,
+          firstSeenHeadSha: finding.first_seen_head_sha,
+          lastSeenHeadSha: finding.last_seen_head_sha,
+          finalHeadWasReviewed,
+          affectedCodeRemains,
+        });
+        const inserted = this.appendFindingOutcome({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
+          findingId: finding.finding_id,
+          outcome,
+          basis: "pull-request-finalization",
+          sourceId: `finalization:${event.deliveryId}:${finding.finding_id}`,
+          occurredAt: event.occurredAt ?? recordedAt,
+          recordedAt,
+          evidence: {
+            finalState: event.finalState,
+            finalHeadSha: event.headSha,
+            latestReviewedHeadSha: completed?.head_sha,
+            finalHeadWasReviewed,
+            affectedCodeRemains,
+            dispositionReason: finding.disposition_reason,
+            firstSeenHeadSha: finding.first_seen_head_sha,
+            lastSeenHeadSha: finding.last_seen_head_sha,
+            firstSeenRunId: finding.first_seen_run_id,
+            lastSeenRunId: finding.last_seen_run_id,
+          },
+        });
+        if (inserted) outcomes += 1;
+      }
+      return { duplicate: false, outcomes };
+    });
+
+    await this.flushFindingOutcomes(
+      event.repository,
+      event.pullRequestNumber,
+    );
+    return json({ accepted: true, ...result });
   }
 
   private async claimReview(request: Request): Promise<Response> {
@@ -924,6 +1214,8 @@ export class PullRequestCoordinator extends DurableObject<Env> {
 
   private async completeReview(request: Request): Promise<Response> {
     const body = (await request.json().catch(() => null)) as {
+      repository?: unknown;
+      pullRequestNumber?: unknown;
       runId?: unknown;
       headSha?: unknown;
       costUsd?: unknown;
@@ -935,6 +1227,11 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     } | null;
     if (
       !body ||
+      typeof body.repository !== "string" ||
+      body.repository.length === 0 ||
+      typeof body.pullRequestNumber !== "number" ||
+      !Number.isSafeInteger(body.pullRequestNumber) ||
+      body.pullRequestNumber <= 0 ||
       typeof body.runId !== "string" ||
       typeof body.headSha !== "string" ||
       typeof body.costUsd !== "number" ||
@@ -956,6 +1253,8 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     }
     const reviewedHunks = body.hunks as ReviewHunk[];
     const currentHunks = (body.currentHunks ?? body.hunks) as ReviewHunk[];
+    const completionRepository = body.repository;
+    const completionPullRequestNumber = body.pullRequestNumber;
     const completionHeadSha = body.headSha;
     const completionHunkIds = new Set(
       reviewedHunks.map(({ hunkId }) => hunkId),
@@ -1088,6 +1387,41 @@ export class PullRequestCoordinator extends DurableObject<Env> {
             hunkId,
           );
         }
+        if (finding.status === "resolved") {
+          const persisted = this.ctx.storage.sql
+            .exec<{
+              first_seen_head_sha: string;
+              first_seen_run_id: string;
+            }>(
+              `SELECT first_seen_head_sha, first_seen_run_id
+               FROM review_findings WHERE finding_id = ?`,
+              finding.findingId,
+            )
+            .toArray()[0];
+          if (
+            persisted &&
+            persisted.first_seen_head_sha !== body.headSha
+          ) {
+            this.appendFindingOutcome({
+              repository: completionRepository,
+              pullRequestNumber: completionPullRequestNumber,
+              findingId: finding.findingId,
+              outcome: "confirmed-fixed",
+              basis: "later-reviewed-head",
+              sourceId: `review:${body.runId}:${finding.findingId}`,
+              occurredAt: completedAt,
+              recordedAt: completedAt,
+              evidence: {
+                firstSeenHeadSha: persisted.first_seen_head_sha,
+                firstSeenRunId: persisted.first_seen_run_id,
+                outcomeHeadSha: body.headSha,
+                outcomeRunId: body.runId,
+                hunkIds: finding.hunkIds,
+                resolutionNote: finding.resolution_note,
+              },
+            });
+          }
+        }
       }
       for (const publication of findingPublications) {
         if (publication.delivery !== "line" || publication.commentId === undefined) {
@@ -1120,6 +1454,10 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     if (completion === "conflict") {
       return json({ error: "Review completion payload does not match" }, 409);
     }
+    await this.flushFindingOutcomes(
+      completionRepository,
+      completionPullRequestNumber,
+    );
     return json(
       completion === "duplicate"
         ? { completed: true, duplicate: true }
@@ -1429,9 +1767,15 @@ export class ReviewWorkflow extends WorkflowEntrypoint<
 function acceptedWebhookEvent(
   review: ReturnType<typeof parseReviewEvent>,
   interaction: ReturnType<typeof parseFindingInteraction> | undefined,
-): ReviewWorkflowParams | FindingInteractionEvent | undefined {
+  finalization: ReturnType<typeof parsePullRequestFinalization> | undefined,
+):
+  | ReviewWorkflowParams
+  | FindingInteractionEvent
+  | PullRequestFinalizationEvent
+  | undefined {
   if (review.kind === "accepted") return review.event;
   if (interaction?.kind === "accepted") return interaction.event;
+  if (finalization?.kind === "accepted") return finalization.event;
   return undefined;
 }
 
@@ -1463,17 +1807,34 @@ async function handleGitHubWebhook(request: Request, env: Env): Promise<Response
     parsedReview.kind === "ignored"
       ? parseFindingInteraction(eventName, deliveryId, payload)
       : undefined;
-  if (parsedReview.kind === "invalid" || parsedInteraction?.kind === "invalid") {
+  const parsedFinalization =
+    parsedReview.kind === "ignored" && parsedInteraction?.kind === "ignored"
+      ? parsePullRequestFinalization(eventName, deliveryId, payload)
+      : undefined;
+  if (
+    parsedReview.kind === "invalid" ||
+    parsedInteraction?.kind === "invalid" ||
+    parsedFinalization?.kind === "invalid"
+  ) {
     return json({ error: "Malformed webhook payload" }, 400);
   }
-  const event = acceptedWebhookEvent(parsedReview, parsedInteraction);
+  const event = acceptedWebhookEvent(
+    parsedReview,
+    parsedInteraction,
+    parsedFinalization,
+  );
   if (!event) return json({ ignored: true, reason: "unsupported-event" }, 202);
 
   const allowedRepository = env.AI_REVIEW_REPOSITORY?.trim().toLowerCase();
   if (!allowedRepository || event.repository.trim().toLowerCase() !== allowedRepository) {
     return json({ error: "Repository is not allowed" }, 403);
   }
-  const coordinatorPath = "interactionType" in event ? "/interactions" : "/events";
+  const coordinatorPath =
+    "interactionType" in event
+      ? "/interactions"
+      : "finalState" in event
+        ? "/finalizations"
+        : "/events";
   return forwardToCoordinator(event, env, coordinatorPath);
 }
 

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -652,7 +652,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     if (path === "/interactions") return this.receiveInteraction(request);
     if (path === "/finalizations") return this.receiveFinalization(request);
     if (path === "/reviews/claim") return this.claimReview(request);
-    if (path === "/reviews/baseline") return this.reviewBaseline();
+    if (path === "/reviews/baseline") return this.reviewBaseline(request);
     if (path === "/reviews/complete") return this.completeReview(request);
     if (path === "/reviews/fail") return this.failReview(request);
     return new Response("Not found", { status: 404 });
@@ -1081,6 +1081,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
             actor: event.actor,
             actorAssociation: event.actorAssociation,
             reason: event.reason,
+            currentHeadSha: event.headSha,
             controlledReplay,
           },
         });
@@ -1394,7 +1395,18 @@ export class PullRequestCoordinator extends DurableObject<Env> {
     return json(result);
   }
 
-  private reviewBaseline(): Response {
+  private async reviewBaseline(request: Request): Promise<Response> {
+    const body = (await request.json().catch(() => null)) as {
+      headSha?: unknown;
+    } | null;
+    if (
+      !body ||
+      typeof body.headSha !== "string" ||
+      body.headSha.length === 0 ||
+      body.headSha.length > 64
+    ) {
+      return json({ error: "Invalid review baseline" }, 400);
+    }
     const completed = this.ctx.storage.sql
       .exec<{ run_id: string; head_sha: string }>(
         `SELECT run_id, head_sha FROM review_runs
@@ -1428,8 +1440,12 @@ export class PullRequestCoordinator extends DurableObject<Env> {
            SELECT 1 FROM review_finding_outcomes outcome
            WHERE outcome.finding_id = finding.finding_id
              AND outcome.outcome = 'confirmed-fixed'
+             AND json_extract(
+               outcome.payload_json, '$.evidence.currentHeadSha'
+             ) = ?
          )
          ORDER BY finding.finding_id LIMIT 100`,
+        body.headSha,
       )
       .toArray();
     const openFindings = findings.map((finding) => ({

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -52,6 +52,13 @@ const JSON_HEADERS = {
 };
 const OUTCOME_FLUSH_CONCURRENCY = 20;
 const OUTCOME_FLUSH_LIMIT = 100;
+const OUTCOME_FLUSH_RETRY_DELAY_MS = 60_000;
+const OUTCOME_FLUSH_RETRY_KEY = "pending-finding-outcome-flush";
+type FindingOutcomeFlushRetry = {
+  kind: "finding-outcomes";
+  repository: string;
+  pullRequestNumber: number;
+};
 type FindingOutcomeCandidate = {
   findingId: string;
   file: string;
@@ -736,6 +743,26 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         }),
       );
       recorded += results.filter(Boolean).length;
+    }
+    const failed = pending.length - recorded;
+    if (failed > 0) {
+      this.ctx.storage.kv.put(OUTCOME_FLUSH_RETRY_KEY, {
+        kind: "finding-outcomes",
+        repository,
+        pullRequestNumber,
+      } satisfies FindingOutcomeFlushRetry);
+      const now = Date.now();
+      const retryAt = now + OUTCOME_FLUSH_RETRY_DELAY_MS;
+      const scheduledAlarm = await this.ctx.storage.getAlarm();
+      if (
+        scheduledAlarm === null ||
+        scheduledAlarm <= now ||
+        scheduledAlarm > retryAt
+      ) {
+        await this.ctx.storage.setAlarm(retryAt);
+      }
+    } else if (pending.length < OUTCOME_FLUSH_LIMIT) {
+      await this.ctx.storage.delete(OUTCOME_FLUSH_RETRY_KEY);
     }
     if (pending.length === OUTCOME_FLUSH_LIMIT && recorded > 0) {
       this.ctx.waitUntil(
@@ -1597,9 +1624,29 @@ export class PullRequestCoordinator extends DurableObject<Env> {
   }
 
   override async alarm(): Promise<void> {
+    const outcomeRetry =
+      await this.ctx.storage.get<FindingOutcomeFlushRetry>(
+        OUTCOME_FLUSH_RETRY_KEY,
+      );
+    if (
+      outcomeRetry?.kind === "finding-outcomes" &&
+      typeof outcomeRetry.repository === "string" &&
+      Number.isSafeInteger(outcomeRetry.pullRequestNumber) &&
+      outcomeRetry.pullRequestNumber > 0
+    ) {
+      await this.flushFindingOutcomes(
+        outcomeRetry.repository,
+        outcomeRetry.pullRequestNumber,
+      );
+    }
+
     const event =
       await this.ctx.storage.get<ReviewWorkflowParams>(PENDING_EVENT_KEY);
-    if (!event || this.env.AI_REVIEW_ENABLED !== "true") {
+    if (
+      !event ||
+      !isReviewWorkflowParams(event) ||
+      this.env.AI_REVIEW_ENABLED !== "true"
+    ) {
       return;
     }
 

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -922,6 +922,16 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       if (!finding) return { unknownFinding: true };
 
       const occurredAt = event.occurredAt ?? recordedAt;
+      const latestObservedHead =
+        event.disposition === "confirmed-fixed"
+          ? this.ctx.storage.sql
+              .exec<{ head_sha: string }>(
+                `SELECT head_sha FROM webhook_deliveries
+                 WHERE head_sha IS NOT NULL
+                 ORDER BY rowid DESC LIMIT 1`,
+              )
+              .toArray()[0]?.head_sha
+          : undefined;
       const controlledReplay =
         event.disposition === "confirmed-fixed"
           ? this.ctx.storage.sql
@@ -955,9 +965,17 @@ export class PullRequestCoordinator extends DurableObject<Env> {
           : undefined;
       if (
         event.disposition === "confirmed-fixed" &&
-        controlledReplay?.verdict !== "fixed"
+        (controlledReplay?.verdict !== "fixed" ||
+          !latestObservedHead ||
+          controlledReplay.headSha !== latestObservedHead)
       ) {
-        return { unconfirmedFix: true };
+        return {
+          unconfirmedFix: true,
+          reason:
+            controlledReplay?.verdict === "fixed" && latestObservedHead
+              ? "stale-fixed-replay"
+              : "no-fixed-replay",
+        };
       }
       const evidence = {
         schemaVersion: 2,
@@ -1049,7 +1067,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       return json({ accepted: false, reason: "unknown-finding" }, 202);
     }
     if ("unconfirmedFix" in result) {
-      return json({ accepted: false, reason: "no-fixed-replay" }, 202);
+      return json({ accepted: false, reason: result.reason }, 202);
     }
     if (!result.r2Recorded) {
       const key = [

--- a/ai-review/src/index.ts
+++ b/ai-review/src/index.ts
@@ -17,6 +17,7 @@ import {
   classifyFinalizedFinding,
   type FindingOutcomeBasis,
 } from "./finding-outcomes";
+import { createInstallationToken } from "./github-app";
 import type { FindingPublication } from "./finding-lifecycle";
 import {
   claimReview,
@@ -443,6 +444,10 @@ function isFindingInteractionEvent(
     typeof event.pullRequestNumber === "number" &&
     Number.isSafeInteger(event.pullRequestNumber) &&
     event.pullRequestNumber > 0 &&
+    (event.headSha === undefined ||
+      (typeof event.headSha === "string" &&
+        event.headSha.length > 0 &&
+        event.headSha.length <= 64)) &&
     (event.interactionType === "reply" ||
       event.interactionType === "thread" ||
       event.interactionType === "disposition") &&
@@ -462,8 +467,42 @@ function isFindingInteractionEvent(
         (event.disposition === "acknowledged" ||
           event.disposition === "confirmed-fixed" ||
           event.disposition === "rejected"))) &&
+    (event.disposition !== "confirmed-fixed" || event.headSha !== undefined) &&
     (event.interactionType === "disposition" || event.rootCommentId !== undefined)
   );
+}
+
+async function currentPullRequestHead(
+  env: Env,
+  event: FindingInteractionEvent,
+): Promise<string | undefined> {
+  const [owner, repository, ...extra] = event.repository.split("/");
+  if (!owner || !repository || extra.length > 0) return undefined;
+  const token = await createInstallationToken({
+    appId: env.AI_REVIEW_APP_ID,
+    installationId: env.AI_REVIEW_APP_INSTALLATION_ID,
+    privateKey: env.AI_REVIEW_APP_PRIVATE_KEY,
+  });
+  const response = await fetch(
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}/pulls/${event.pullRequestNumber}`,
+    {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "user-agent": "personal-site-ai-review",
+        "x-github-api-version": "2022-11-28",
+      },
+      signal: AbortSignal.timeout(COORDINATOR_TIMEOUT_MS),
+    },
+  );
+  if (!response.ok) return undefined;
+  const pullRequest = (await response.json().catch(() => null)) as
+    | { head?: { sha?: unknown } }
+    | null;
+  return typeof pullRequest?.head?.sha === "string" &&
+      pullRequest.head.sha.length > 0
+    ? pullRequest.head.sha
+    : undefined;
 }
 
 function isPullRequestFinalizationEvent(
@@ -922,16 +961,6 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       if (!finding) return { unknownFinding: true };
 
       const occurredAt = event.occurredAt ?? recordedAt;
-      const latestObservedHead =
-        event.disposition === "confirmed-fixed"
-          ? this.ctx.storage.sql
-              .exec<{ head_sha: string }>(
-                `SELECT head_sha FROM webhook_deliveries
-                 WHERE head_sha IS NOT NULL
-                 ORDER BY rowid DESC LIMIT 1`,
-              )
-              .toArray()[0]?.head_sha
-          : undefined;
       const controlledReplay =
         event.disposition === "confirmed-fixed"
           ? this.ctx.storage.sql
@@ -966,13 +995,13 @@ export class PullRequestCoordinator extends DurableObject<Env> {
       if (
         event.disposition === "confirmed-fixed" &&
         (controlledReplay?.verdict !== "fixed" ||
-          !latestObservedHead ||
-          controlledReplay.headSha !== latestObservedHead)
+          !event.headSha ||
+          controlledReplay.headSha !== event.headSha)
       ) {
         return {
           unconfirmedFix: true,
           reason:
-            controlledReplay?.verdict === "fixed" && latestObservedHead
+            controlledReplay?.verdict === "fixed" && event.headSha
               ? "stale-fixed-replay"
               : "no-fixed-replay",
         };
@@ -983,6 +1012,7 @@ export class PullRequestCoordinator extends DurableObject<Env> {
         evidenceVersion: 1,
         repository: event.repository,
         pullRequestNumber: event.pullRequestNumber,
+        currentHeadSha: event.headSha,
         findingId,
         deliveryId: event.deliveryId,
         eventName: event.eventName,
@@ -2050,7 +2080,29 @@ async function handleGitHubWebhook(request: Request, env: Env): Promise<Response
   if (!allowedRepository || event.repository.trim().toLowerCase() !== allowedRepository) {
     return json({ error: "Repository is not allowed" }, 403);
   }
-  return forwardToCoordinator(event, env, coordinatorPathForEvent(event));
+  let forwardedEvent = event;
+  if (
+    "interactionType" in event &&
+    event.disposition === "confirmed-fixed"
+  ) {
+    let headSha: string | undefined;
+    try {
+      headSha = await currentPullRequestHead(env, event);
+    } catch (error) {
+      console.error("Could not load the authoritative pull request head", {
+        type: errorType(error),
+      });
+    }
+    if (!headSha) {
+      return json({ error: "Could not verify current pull request head" }, 503);
+    }
+    forwardedEvent = { ...event, headSha };
+  }
+  return forwardToCoordinator(
+    forwardedEvent,
+    env,
+    coordinatorPathForEvent(forwardedEvent),
+  );
 }
 
 export default {

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -1182,11 +1182,21 @@ export async function mergeFindings(
   scouts: ScoutRun,
 ): Promise<MergedRun> {
   if (Object.keys(scouts.candidates).length === 0) {
+    const findingResolutions = (prepared.replayFindings ?? []).map(
+      ({ findingId }) => ({
+        finding_id: findingId,
+        verdict: "uncertain" as const,
+        evidence: "No scout produced coverage, so controlled replay could not be evaluated.",
+      }),
+    );
     return {
       result: {
         summary:
           "All scouts failed or were unavailable, so this run has no review coverage.",
         findings: [],
+        ...(findingResolutions.length > 0
+          ? { finding_resolutions: findingResolutions }
+          : {}),
       },
       cost: 0,
     };
@@ -1268,6 +1278,11 @@ ${prepared.threads ?? ""}
           evidence: String(resolution.evidence).slice(0, 2_000),
         }))
     : [];
+  if (seenResolutionIds.size !== replayIds.size) {
+    throw new Error(
+      "Merger omitted or invalidated a required controlled replay resolution",
+    );
+  }
   return {
     result: merged.payload,
     cost: merged.cost,

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -791,12 +791,18 @@ async function coordinatorRequest<T>(
 async function reviewBaseline(
   env: Env,
   params: ReviewWorkflowParams,
+  headSha: string,
 ): Promise<ReviewBaseline> {
   // Small unit-level consumers of the engine may not bind a coordinator. The
   // deployed Worker always does; treating the missing binding as an empty
   // baseline keeps those consumers conservative (a full review).
   if (!env.PR_STATE) return { hunkIds: [], openFindings: [] };
-  return coordinatorRequest<ReviewBaseline>(env, params, "/reviews/baseline", {});
+  return coordinatorRequest<ReviewBaseline>(
+    env,
+    params,
+    "/reviews/baseline",
+    { headSha },
+  );
 }
 
 export async function prepareReview(
@@ -843,7 +849,7 @@ export async function prepareReview(
   const rawHunks = parsedHunks.map(
     ({ body: _body, header: _header, prelude: _prelude, ...hunk }) => hunk,
   );
-  const baseline = await reviewBaseline(env, params);
+  const baseline = await reviewBaseline(env, params, headSha);
   const baselineIds = new Set(baseline.hunkIds);
   const materiallyChangedHunks = baseline.headSha
     ? rawHunks.filter(({ hunkId }) => !baselineIds.has(hunkId))

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -92,6 +92,7 @@ export interface PreparedReview {
   context?: string;
   guidelines?: string;
   threads?: string;
+  replayFindings?: OpenFindingBaseline[];
 }
 
 export type ReviewCoverageMode = "full" | "incremental" | "skipped";
@@ -101,6 +102,16 @@ export interface OpenFindingBaseline {
   file: string;
   title: string;
   hunkIds: string[];
+  severity?: string;
+  line?: number | null;
+  evidence?: string;
+  recommendation?: string;
+}
+
+export interface FindingResolution {
+  findingId: string;
+  verdict: "fixed" | "still-present" | "uncertain";
+  evidence: string;
 }
 
 export interface ReviewBaseline {
@@ -153,6 +164,41 @@ export interface MergedRun {
   cost: number;
   metric?: ModelMetric;
 }
+
+const findingResolutionProperties = {
+  finding_id: { type: "string" },
+  verdict: {
+    type: "string",
+    enum: ["fixed", "still-present", "uncertain"],
+  },
+  evidence: { type: "string" },
+};
+
+const statefulMergerSchema = {
+  ...mergerSchema,
+  properties: {
+    ...mergerSchema.properties,
+    finding_resolutions: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: findingResolutionProperties,
+        required: Object.keys(findingResolutionProperties),
+        additionalProperties: false,
+      },
+    },
+  },
+  required: [...mergerSchema.required, "finding_resolutions"],
+};
+
+const statefulMergerSystem = `${mergerSystem}
+For every durable open finding supplied for controlled replay, also return one
+finding_resolutions entry. Mark it fixed only when the supplied current diff and
+file context directly demonstrate that the finding's root cause was removed.
+Mark it still-present when the defect is directly visible, and uncertain when
+the evidence is insufficient. A missing scout finding or a resolved GitHub
+thread is never by itself evidence of a fix. Copy each durable finding_id
+exactly and give concise code evidence for the verdict.`;
 
 export interface IdentifiedFinding extends Finding {
   findingId: string;
@@ -857,8 +903,8 @@ export async function prepareReview(
     requireZdr: settings.requireZdr,
     scoutSystem,
     scoutSchema,
-    mergerSystem,
-    mergerSchema,
+    statefulMergerSystem,
+    statefulMergerSchema,
   });
   return {
     headSha,
@@ -890,6 +936,9 @@ export async function prepareReview(
       ? await reviewer.fileContext(selectedPaths, headSha)
       : "",
     guidelines: selectedDiff.trim() ? await reviewer.headGuidelines(headSha) : "",
+    replayFindings: baseline.openFindings.filter((finding) =>
+      coverage.affectedFindingIds.includes(finding.findingId),
+    ),
     threads: selectedDiff.trim()
       ? [
           affectedFindingContext(baseline, coverage),
@@ -1141,16 +1190,25 @@ export async function mergeFindings(
   const prompt = `<DATA kind=scout-candidates>
 ${JSON.stringify(scouts.candidates)}
 </DATA>
+<DATA kind=durable-open-findings-for-controlled-replay>
+${JSON.stringify(prepared.replayFindings ?? [])}
+</DATA>
+<DATA kind=current-reviewed-diff>
+${prepared.diff ?? ""}
+</DATA>
+<DATA kind=current-file-context>
+${prepared.context ?? ""}
+</DATA>
 <DATA kind=github-review-threads>
 ${prepared.threads ?? ""}
 </DATA>`;
   const started = Date.now();
   const merged = await reviewer.callMerger(
     settings.merger,
-    mergerSystem,
+    statefulMergerSystem,
     prompt,
     "merged_code_review",
-    mergerSchema,
+    statefulMergerSchema,
     MERGER_MAX_TOKENS,
   );
   const allowedFiles = new Set(prepared.paths);
@@ -1171,6 +1229,39 @@ ${prepared.threads ?? ""}
       ],
     }))
     .filter((finding) => finding.source_models.length > 0);
+  const replayIds = new Set(
+    (prepared.replayFindings ?? []).map(({ findingId }) => findingId),
+  );
+  const seenResolutionIds = new Set<string>();
+  merged.payload.finding_resolutions = Array.isArray(
+    merged.payload.finding_resolutions,
+  )
+    ? merged.payload.finding_resolutions.filter((resolution): boolean => {
+        if (
+          typeof resolution !== "object" ||
+          resolution === null ||
+          !("finding_id" in resolution) ||
+          typeof resolution.finding_id !== "string" ||
+          !replayIds.has(resolution.finding_id) ||
+          seenResolutionIds.has(resolution.finding_id) ||
+          !("verdict" in resolution) ||
+          !["fixed", "still-present", "uncertain"].includes(
+            String(resolution.verdict),
+          ) ||
+          !("evidence" in resolution) ||
+          typeof resolution.evidence !== "string" ||
+          resolution.evidence.trim().length === 0
+        ) {
+          return false;
+        }
+        seenResolutionIds.add(resolution.finding_id);
+        return true;
+      })
+        .map((resolution) => ({
+          ...resolution,
+          evidence: String(resolution.evidence).slice(0, 2_000),
+        }))
+    : [];
   return {
     result: merged.payload,
     cost: merged.cost,
@@ -1460,9 +1551,24 @@ export async function completeReview(
   params: ReviewWorkflowParams,
   instanceId: string,
   prepared: PreparedReview,
+  merged: MergedRun,
   artifacts: IdentifiedReviewArtifacts,
   publication: ReviewPublication,
 ): Promise<void> {
+  const findingResolutions = Array.isArray(merged.result.finding_resolutions)
+    ? merged.result.finding_resolutions.map((resolution) => {
+        const record = resolution as {
+          finding_id: string;
+          verdict: FindingResolution["verdict"];
+          evidence: string;
+        };
+        return {
+          findingId: record.finding_id,
+          verdict: record.verdict,
+          evidence: record.evidence,
+        };
+      })
+    : [];
   await coordinatorRequest(env, params, "/reviews/complete", {
     repository: params.repository,
     pullRequestNumber: params.pullRequestNumber,
@@ -1474,6 +1580,7 @@ export async function completeReview(
     hunks: artifacts.hunks,
     currentHunks: prepared.allHunks ?? artifacts.hunks,
     findings: artifacts.publishedFindings,
+    findingResolutions,
   });
 }
 

--- a/ai-review/src/review-engine.ts
+++ b/ai-review/src/review-engine.ts
@@ -1464,6 +1464,8 @@ export async function completeReview(
   publication: ReviewPublication,
 ): Promise<void> {
   await coordinatorRequest(env, params, "/reviews/complete", {
+    repository: params.repository,
+    pullRequestNumber: params.pullRequestNumber,
     runId: instanceId,
     headSha: prepared.headSha,
     costUsd: publication.runCostUsd,

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -120,7 +120,7 @@ export type PullRequestFinalizationParseResult =
 
 function findingDispositionCommand(body: string):
   | {
-      disposition: "acknowledged" | "rejected";
+      disposition: "acknowledged" | "confirmed-fixed" | "rejected";
       findingId: string;
       reason: string;
     }
@@ -132,7 +132,13 @@ function findingDispositionCommand(body: string):
   const actionEnd = body.indexOf(" ", actionStart);
   if (actionEnd < 0) return undefined;
   const action = body.slice(actionStart, actionEnd).toLowerCase();
-  if (action !== "acknowledge" && action !== "reject") return undefined;
+  if (
+    action !== "acknowledge" &&
+    action !== "confirm-fixed" &&
+    action !== "reject"
+  ) {
+    return undefined;
+  }
   const findingStart = actionEnd + 1;
   const findingEnd = body.indexOf(" ", findingStart);
   if (findingEnd < 0) return undefined;
@@ -141,7 +147,12 @@ function findingDispositionCommand(body: string):
   const reason = body.slice(findingEnd + 1).trim();
   if (!reason || reason.length > MAX_DISPOSITION_REASON_LENGTH) return undefined;
   return {
-    disposition: action === "acknowledge" ? "acknowledged" : "rejected",
+    disposition:
+      action === "acknowledge"
+        ? "acknowledged"
+        : action === "confirm-fixed"
+          ? "confirmed-fixed"
+          : "rejected",
     findingId,
     reason,
   };

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -1,6 +1,7 @@
 import {
   TRUSTED_AUTHOR_ASSOCIATIONS,
   type FindingInteractionEvent,
+  type PullRequestFinalizationEvent,
   type ReviewWorkflowParams,
 } from "./env";
 
@@ -63,6 +64,8 @@ type GitHubWebhook = {
   updated_at?: unknown;
   pull_request?: {
     number?: unknown;
+    merged?: unknown;
+    closed_at?: unknown;
     author_association?: unknown;
     user?: { login?: unknown };
     head?: {
@@ -106,6 +109,11 @@ export type ReviewEventParseResult =
 
 export type FindingInteractionParseResult =
   | { kind: "accepted"; event: FindingInteractionEvent }
+  | { kind: "ignored"; reason: "unsupported-event" }
+  | { kind: "invalid"; reason: "Malformed webhook payload" };
+
+export type PullRequestFinalizationParseResult =
+  | { kind: "accepted"; event: PullRequestFinalizationEvent }
   | { kind: "ignored"; reason: "unsupported-event" }
   | { kind: "invalid"; reason: "Malformed webhook payload" };
 
@@ -366,6 +374,51 @@ export function parseFindingInteraction(
   }
 
   return { kind: "ignored", reason: "unsupported-event" };
+}
+
+export function parsePullRequestFinalization(
+  eventName: string,
+  deliveryId: string,
+  body: unknown,
+): PullRequestFinalizationParseResult {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { kind: "invalid", reason: "Malformed webhook payload" };
+  }
+  const event = body as GitHubWebhook;
+  if (eventName !== "pull_request" || event.action !== "closed") {
+    return { kind: "ignored", reason: "unsupported-event" };
+  }
+  const repository = event.repository?.full_name;
+  const pullRequestNumber = positiveInteger(event.pull_request?.number);
+  const headSha = event.pull_request?.head?.sha;
+  if (
+    typeof repository !== "string" ||
+    repository.length === 0 ||
+    !pullRequestNumber ||
+    typeof headSha !== "string" ||
+    headSha.length === 0 ||
+    typeof event.pull_request?.merged !== "boolean" ||
+    deliveryId.length === 0 ||
+    deliveryId.length > MAX_DELIVERY_ID_LENGTH
+  ) {
+    return { kind: "invalid", reason: "Malformed webhook payload" };
+  }
+  return {
+    kind: "accepted",
+    event: {
+      deliveryId,
+      eventName: "pull_request",
+      action: "closed",
+      repository,
+      pullRequestNumber,
+      headSha,
+      finalState: event.pull_request.merged ? "merged" : "closed",
+      occurredAt:
+        typeof event.pull_request.closed_at === "string"
+          ? event.pull_request.closed_at
+          : undefined,
+    },
+  };
 }
 
 function parsePullRequestEvent(

--- a/ai-review/src/webhook.ts
+++ b/ai-review/src/webhook.ts
@@ -58,6 +58,7 @@ export async function verifyGitHubSignature(
 
 type GitHubWebhook = {
   action?: unknown;
+  number?: unknown;
   repository?: {
     full_name?: unknown;
   };
@@ -152,6 +153,15 @@ function positiveInteger(value: unknown): number | undefined {
     value > 0
     ? value
     : undefined;
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= 64 &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(value) &&
+    !Number.isNaN(Date.parse(value))
+  );
 }
 
 function actorIsTrusted(event: GitHubWebhook, repository: string): boolean {
@@ -389,8 +399,9 @@ export function parsePullRequestFinalization(
     return { kind: "ignored", reason: "unsupported-event" };
   }
   const repository = event.repository?.full_name;
-  const pullRequestNumber = positiveInteger(event.pull_request?.number);
+  const pullRequestNumber = positiveInteger(event.number);
   const headSha = event.pull_request?.head?.sha;
+  const occurredAt = event.pull_request?.closed_at;
   if (
     typeof repository !== "string" ||
     repository.length === 0 ||
@@ -398,6 +409,7 @@ export function parsePullRequestFinalization(
     typeof headSha !== "string" ||
     headSha.length === 0 ||
     typeof event.pull_request?.merged !== "boolean" ||
+    (occurredAt !== undefined && !isIsoTimestamp(occurredAt)) ||
     deliveryId.length === 0 ||
     deliveryId.length > MAX_DELIVERY_ID_LENGTH
   ) {
@@ -413,10 +425,7 @@ export function parsePullRequestFinalization(
       pullRequestNumber,
       headSha,
       finalState: event.pull_request.merged ? "merged" : "closed",
-      occurredAt:
-        typeof event.pull_request.closed_at === "string"
-          ? event.pull_request.closed_at
-          : undefined,
+      occurredAt: typeof occurredAt === "string" ? occurredAt : undefined,
     },
   };
 }
@@ -428,7 +437,7 @@ function parsePullRequestEvent(
   if (!REVIEW_RELEVANT_PULL_REQUEST_ACTIONS.has(identity.action)) {
     return { kind: "ignored", reason: "unsupported-event" };
   }
-  const pullRequestNumber = event.pull_request?.number;
+  const pullRequestNumber = event.number;
   const headSha = event.pull_request?.head?.sha;
   if (
     typeof pullRequestNumber !== "number" ||

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -365,6 +365,15 @@ describe("PullRequestCoordinator in workerd", () => {
       newStart: 60,
       newLines: 1,
     };
+    const fixedTrigger = await stub.fetch("https://coordinator.test/events", {
+      method: "POST",
+      body: JSON.stringify({
+        ...event,
+        deliveryId: "workerd-fixed-head-trigger",
+        headSha: fixedHead,
+      }),
+    });
+    await expect(fixedTrigger.json()).resolves.toMatchObject({ accepted: true });
     const fixedClaim = await stub.fetch(
       "https://coordinator.test/reviews/claim",
       {

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -81,6 +81,8 @@ describe("PullRequestCoordinator in workerd", () => {
       {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: claimBody.runId,
           headSha: event.headSha,
           costUsd: 0.25,
@@ -191,6 +193,51 @@ describe("PullRequestCoordinator in workerd", () => {
       action: "resolved",
       findingId: `f_${"b".repeat(24)}`,
     });
+    const dispositionInteraction = {
+      deliveryId: "workerd-feedback-2",
+      eventName: "issue_comment",
+      action: "created",
+      repository: event.repository,
+      pullRequestNumber: event.pullRequestNumber,
+      interactionType: "disposition",
+      actor: "Robbie-Palmer",
+      actorAssociation: "OWNER",
+      findingId: `f_${"b".repeat(24)}`,
+      disposition: "acknowledged",
+      reason: "Accepted and fixing now",
+      occurredAt: "2026-08-09T12:05:00Z",
+    };
+    const dispositionResponse = await stub.fetch(
+      "https://coordinator.test/interactions",
+      { method: "POST", body: JSON.stringify(dispositionInteraction) },
+    );
+    await expect(dispositionResponse.json()).resolves.toMatchObject({
+      accepted: true,
+      duplicate: false,
+      findingId: dispositionInteraction.findingId,
+    });
+    const outcomePrefix = [
+      "v2",
+      event.repository,
+      `pr-${event.pullRequestNumber}`,
+      "findings",
+      `f_${"b".repeat(24)}`,
+      "outcomes",
+    ].join("/");
+    const acknowledgedOutcome = await (env as unknown as Env).REVIEW_DATA.get(
+      `${outcomePrefix}/v1.json`,
+    );
+    expect(await acknowledgedOutcome?.json()).toMatchObject({
+      schemaVersion: 2,
+      recordType: "finding-outcome",
+      outcomeVersion: 1,
+      outcome: "acknowledged",
+      basis: "explicit-disposition",
+      evidence: {
+        deliveryId: dispositionInteraction.deliveryId,
+        actor: dispositionInteraction.actor,
+      },
+    });
 
     const duplicateClaim = await stub.fetch(
       "https://coordinator.test/reviews/claim",
@@ -220,6 +267,8 @@ describe("PullRequestCoordinator in workerd", () => {
     );
     await expect(laterClaim.json()).resolves.toMatchObject({ claimed: true });
     const laterCompletionBody = JSON.stringify({
+      repository: event.repository,
+      pullRequestNumber: event.pullRequestNumber,
       runId: laterRunId,
       headSha: laterHead,
       costUsd: 0.1,
@@ -297,6 +346,22 @@ describe("PullRequestCoordinator in workerd", () => {
       completed: true,
       duplicate: true,
     });
+    const fixedOutcome = await (env as unknown as Env).REVIEW_DATA.get(
+      `${outcomePrefix}/v2.json`,
+    );
+    expect(await fixedOutcome?.json()).toMatchObject({
+      schemaVersion: 2,
+      recordType: "finding-outcome",
+      outcomeVersion: 2,
+      outcome: "confirmed-fixed",
+      basis: "later-reviewed-head",
+      evidence: {
+        firstSeenHeadSha: event.headSha,
+        outcomeHeadSha: laterHead,
+        outcomeRunId: laterRunId,
+        resolutionNote: "Fixed in the later head",
+      },
+    });
     const laterBaseline = await stub.fetch(
       "https://coordinator.test/reviews/baseline",
       { method: "POST", body: "{}" },
@@ -342,10 +407,40 @@ describe("PullRequestCoordinator in workerd", () => {
       expect(
         state.storage.sql
           .exec<{ action: string; r2_recorded: number }>(
-            "SELECT action, r2_recorded FROM review_finding_events",
+            `SELECT action, r2_recorded FROM review_finding_events
+             ORDER BY occurred_at`,
           )
           .toArray(),
-      ).toEqual([{ action: "resolved", r2_recorded: 1 }]);
+      ).toEqual([
+        { action: "resolved", r2_recorded: 1 },
+        { action: "created", r2_recorded: 1 },
+      ]);
+      expect(
+        state.storage.sql
+          .exec<{
+            outcome_version: number;
+            outcome: string;
+            basis: string;
+            r2_recorded: number;
+          }>(
+            `SELECT outcome_version, outcome, basis, r2_recorded
+             FROM review_finding_outcomes ORDER BY outcome_version`,
+          )
+          .toArray(),
+      ).toEqual([
+        {
+          outcome_version: 1,
+          outcome: "acknowledged",
+          basis: "explicit-disposition",
+          r2_recorded: 1,
+        },
+        {
+          outcome_version: 2,
+          outcome: "confirmed-fixed",
+          basis: "later-reviewed-head",
+          r2_recorded: 1,
+        },
+      ]);
     });
   });
 
@@ -380,6 +475,8 @@ describe("PullRequestCoordinator in workerd", () => {
       {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId,
           headSha: event.headSha,
           costUsd: 0,
@@ -400,6 +497,157 @@ describe("PullRequestCoordinator in workerd", () => {
       headSha: event.headSha,
       hunkIds: [currentHunk.hunkId],
       openFindings: [],
+    });
+  });
+
+  it("finalizes unanswered and superseded findings when a pull request closes", async () => {
+    const bindings = env as unknown as Env;
+    const pullRequestNumber = 43;
+    const repository = event.repository;
+    const stub = bindings.PR_STATE.getByName(
+      `${repository}#${pullRequestNumber}`,
+    );
+    const initialHead = "1".repeat(40);
+    const finalHead = "2".repeat(40);
+    const remainingHunk = {
+      hunkId: `h_${"1".repeat(24)}`,
+      fingerprint: "1".repeat(64),
+      file: "remaining.ts",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+    };
+    const removedHunk = {
+      hunkId: `h_${"2".repeat(24)}`,
+      fingerprint: "2".repeat(64),
+      file: "removed.ts",
+      oldStart: 1,
+      oldLines: 1,
+      newStart: 1,
+      newLines: 1,
+    };
+    const finding = (suffix: string, hunk: typeof remainingHunk) => ({
+      findingId: `f_${suffix.repeat(24)}`,
+      hunkIds: [hunk.hunkId],
+      severity: "medium",
+      file: hunk.file,
+      line: 1,
+      title: `${hunk.file} finding`,
+      evidence: "Evidence",
+      recommendation: "Fix it",
+      confidence: 0.8,
+      source_models: ["model/scout"],
+      status: "open",
+      resolution_note: "",
+    });
+    const remainingFinding = finding("3", remainingHunk);
+    const removedFinding = finding("4", removedHunk);
+
+    const claim = async (runId: string, headSha: string, fingerprint: string) =>
+      stub.fetch("https://coordinator.test/reviews/claim", {
+        method: "POST",
+        body: JSON.stringify({
+          runId,
+          headSha,
+          diffFingerprint: fingerprint,
+          configFingerprint: "config-hash",
+          force: false,
+          maxRuns: 20,
+          maxCostUsd: 5,
+        }),
+      });
+    await expect(
+      (await claim("outcome-initial", initialHead, "initial-diff")).json(),
+    ).resolves.toMatchObject({ claimed: true });
+    const initialCompletion = await stub.fetch(
+      "https://coordinator.test/reviews/complete",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          repository,
+          pullRequestNumber,
+          runId: "outcome-initial",
+          headSha: initialHead,
+          costUsd: 0.1,
+          hunks: [remainingHunk, removedHunk],
+          findings: [remainingFinding, removedFinding],
+        }),
+      },
+    );
+    await expect(initialCompletion.json()).resolves.toEqual({ completed: true });
+
+    await expect(
+      (await claim("outcome-final", finalHead, "final-diff")).json(),
+    ).resolves.toMatchObject({ claimed: true });
+    const finalCompletion = await stub.fetch(
+      "https://coordinator.test/reviews/complete",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          repository,
+          pullRequestNumber,
+          runId: "outcome-final",
+          headSha: finalHead,
+          costUsd: 0,
+          hunks: [],
+          currentHunks: [remainingHunk],
+          findings: [],
+        }),
+      },
+    );
+    await expect(finalCompletion.json()).resolves.toEqual({ completed: true });
+
+    const finalization = {
+      deliveryId: "outcome-finalization",
+      eventName: "pull_request",
+      action: "closed",
+      repository,
+      pullRequestNumber,
+      headSha: finalHead,
+      finalState: "merged",
+      occurredAt: "2026-08-15T12:00:00Z",
+    };
+    const finalized = await stub.fetch(
+      "https://coordinator.test/finalizations",
+      { method: "POST", body: JSON.stringify(finalization) },
+    );
+    await expect(finalized.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: false,
+      outcomes: 2,
+    });
+    const duplicate = await stub.fetch(
+      "https://coordinator.test/finalizations",
+      { method: "POST", body: JSON.stringify(finalization) },
+    );
+    await expect(duplicate.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: true,
+      outcomes: 0,
+    });
+
+    const outcome = async (findingId: string) => {
+      const key = [
+        "v2",
+        repository,
+        `pr-${pullRequestNumber}`,
+        "findings",
+        findingId,
+        "outcomes",
+        "v1.json",
+      ].join("/");
+      return bindings.REVIEW_DATA.get(key).then((record) => record?.json());
+    };
+    await expect(outcome(remainingFinding.findingId)).resolves.toMatchObject({
+      outcome: "no-observable-response",
+      basis: "pull-request-finalization",
+      evidence: { finalHeadWasReviewed: true, affectedCodeRemains: true },
+    });
+    await expect(outcome(removedFinding.findingId)).resolves.toMatchObject({
+      outcome: "superseded",
+      basis: "pull-request-finalization",
+      evidence: { finalHeadWasReviewed: true, affectedCodeRemains: false },
     });
   });
 });

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -346,6 +346,62 @@ describe("PullRequestCoordinator in workerd", () => {
       completed: true,
       duplicate: true,
     });
+    expect(
+      await (env as unknown as Env).REVIEW_DATA.get(`${outcomePrefix}/v2.json`),
+    ).toBeNull();
+
+    const fixedHead = "f".repeat(40);
+    const fixedRunId = "workerd-review-4";
+    const fixedHunk = {
+      hunkId: `h_${"f".repeat(24)}`,
+      fingerprint: "1".repeat(64),
+      file: "app.ts",
+      oldStart: 50,
+      oldLines: 1,
+      newStart: 60,
+      newLines: 1,
+    };
+    const fixedClaim = await stub.fetch(
+      "https://coordinator.test/reviews/claim",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ...claimBody,
+          runId: fixedRunId,
+          headSha: fixedHead,
+          diffFingerprint: "fixed-diff-hash",
+        }),
+      },
+    );
+    await expect(fixedClaim.json()).resolves.toMatchObject({ claimed: true });
+    const fixedCompletion = await stub.fetch(
+      "https://coordinator.test/reviews/complete",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
+          runId: fixedRunId,
+          headSha: fixedHead,
+          costUsd: 0.1,
+          hunks: [fixedHunk],
+          currentHunks: [
+            fixedHunk,
+            {
+              hunkId: `h_${"e".repeat(24)}`,
+              fingerprint: "f".repeat(64),
+              file: "unchanged.ts",
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+            },
+          ],
+          findings: [],
+        }),
+      },
+    );
+    await expect(fixedCompletion.json()).resolves.toEqual({ completed: true });
     const fixedOutcome = await (env as unknown as Env).REVIEW_DATA.get(
       `${outcomePrefix}/v2.json`,
     );
@@ -356,10 +412,11 @@ describe("PullRequestCoordinator in workerd", () => {
       outcome: "confirmed-fixed",
       basis: "later-reviewed-head",
       evidence: {
+        confirmation: "not-rediscovered-after-affected-code-change",
         firstSeenHeadSha: event.headSha,
-        outcomeHeadSha: laterHead,
-        outcomeRunId: laterRunId,
-        resolutionNote: "Fixed in the later head",
+        outcomeHeadSha: fixedHead,
+        outcomeRunId: fixedRunId,
+        priorHunkIds: [`h_${"c".repeat(24)}`],
       },
     });
     const laterBaseline = await stub.fetch(
@@ -367,8 +424,8 @@ describe("PullRequestCoordinator in workerd", () => {
       { method: "POST", body: "{}" },
     );
     await expect(laterBaseline.json()).resolves.toMatchObject({
-      headSha: laterHead,
-      hunkIds: [`h_${"c".repeat(24)}`, `h_${"e".repeat(24)}`],
+      headSha: fixedHead,
+      hunkIds: [`h_${"e".repeat(24)}`, fixedHunk.hunkId],
     });
     await runInDurableObject(stub, async (_instance, state) => {
       expect(

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -131,7 +131,7 @@ describe("PullRequestCoordinator in workerd", () => {
 
     const firstBaseline = await stub.fetch(
       "https://coordinator.test/reviews/baseline",
-      { method: "POST", body: "{}" },
+      { method: "POST", body: JSON.stringify({ headSha: event.headSha }) },
     );
     await expect(firstBaseline.json()).resolves.toEqual({
       headSha: event.headSha,
@@ -459,11 +459,24 @@ describe("PullRequestCoordinator in workerd", () => {
     });
     const laterBaseline = await stub.fetch(
       "https://coordinator.test/reviews/baseline",
-      { method: "POST", body: "{}" },
+      { method: "POST", body: JSON.stringify({ headSha: fixedHead }) },
     );
     await expect(laterBaseline.json()).resolves.toMatchObject({
       headSha: fixedHead,
       hunkIds: [`h_${"e".repeat(24)}`, fixedHunk.hunkId],
+      openFindings: [],
+    });
+    const nextHeadBaseline = await stub.fetch(
+      "https://coordinator.test/reviews/baseline",
+      {
+        method: "POST",
+        body: JSON.stringify({ headSha: "3".repeat(40) }),
+      },
+    );
+    await expect(nextHeadBaseline.json()).resolves.toMatchObject({
+      openFindings: [expect.objectContaining({
+        findingId: `f_${"b".repeat(24)}`,
+      })],
     });
     await runInDurableObject(stub, async (_instance, state) => {
       expect(
@@ -587,12 +600,14 @@ describe("PullRequestCoordinator in workerd", () => {
 
     const baseline = await stub.fetch(
       "https://coordinator.test/reviews/baseline",
-      { method: "POST", body: "{}" },
+      { method: "POST", body: JSON.stringify({ headSha: event.headSha }) },
     );
     await expect(baseline.json()).resolves.toEqual({
       headSha: event.headSha,
       hunkIds: [currentHunk.hunkId],
-      openFindings: [],
+      openFindings: [expect.objectContaining({
+        findingId: `f_${"b".repeat(24)}`,
+      })],
     });
   });
 

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -411,6 +411,28 @@ describe("PullRequestCoordinator in workerd", () => {
       },
     );
     await expect(fixedCompletion.json()).resolves.toEqual({ completed: true });
+    const confirmation = {
+      deliveryId: "workerd-feedback-confirmed-fixed",
+      eventName: "issue_comment",
+      action: "created",
+      repository: event.repository,
+      pullRequestNumber: event.pullRequestNumber,
+      interactionType: "disposition",
+      actor: "Robbie-Palmer",
+      actorAssociation: "OWNER",
+      findingId: `f_${"b".repeat(24)}`,
+      disposition: "confirmed-fixed",
+      reason: "Reviewed the replay evidence and verified the retry repair",
+      occurredAt: "2026-08-09T12:10:00Z",
+    };
+    const confirmationResponse = await stub.fetch(
+      "https://coordinator.test/interactions",
+      { method: "POST", body: JSON.stringify(confirmation) },
+    );
+    await expect(confirmationResponse.json()).resolves.toMatchObject({
+      accepted: true,
+      duplicate: false,
+    });
     const fixedOutcome = await (env as unknown as Env).REVIEW_DATA.get(
       `${outcomePrefix}/v2.json`,
     );
@@ -419,14 +441,10 @@ describe("PullRequestCoordinator in workerd", () => {
       recordType: "finding-outcome",
       outcomeVersion: 2,
       outcome: "confirmed-fixed",
-      basis: "later-reviewed-head",
+      basis: "explicit-disposition",
       evidence: {
-        confirmation: "affirmative-controlled-replay",
-        replayEvidence: "The later diff removes the defective branch.",
-        firstSeenHeadSha: event.headSha,
-        outcomeHeadSha: fixedHead,
-        outcomeRunId: fixedRunId,
-        priorHunkIds: [`h_${"c".repeat(24)}`],
+        actor: "Robbie-Palmer",
+        reason: "Reviewed the replay evidence and verified the retry repair",
       },
     });
     const laterBaseline = await stub.fetch(
@@ -481,6 +499,7 @@ describe("PullRequestCoordinator in workerd", () => {
       ).toEqual([
         { action: "resolved", r2_recorded: 1 },
         { action: "created", r2_recorded: 1 },
+        { action: "created", r2_recorded: 1 },
       ]);
       expect(
         state.storage.sql
@@ -504,7 +523,7 @@ describe("PullRequestCoordinator in workerd", () => {
         {
           outcome_version: 2,
           outcome: "confirmed-fixed",
-          basis: "later-reviewed-head",
+          basis: "explicit-disposition",
           r2_recorded: 1,
         },
       ]);

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -141,6 +141,10 @@ describe("PullRequestCoordinator in workerd", () => {
           findingId: `f_${"b".repeat(24)}`,
           file: "app.ts",
           title: "Finding",
+          severity: "high",
+          line: 1,
+          evidence: "Evidence",
+          recommendation: "Fix it",
           hunkIds: [`h_${"c".repeat(24)}`],
         },
       ],
@@ -398,6 +402,11 @@ describe("PullRequestCoordinator in workerd", () => {
             },
           ],
           findings: [],
+          findingResolutions: [{
+            findingId: `f_${"b".repeat(24)}`,
+            verdict: "fixed",
+            evidence: "The later diff removes the defective branch.",
+          }],
         }),
       },
     );
@@ -412,7 +421,8 @@ describe("PullRequestCoordinator in workerd", () => {
       outcome: "confirmed-fixed",
       basis: "later-reviewed-head",
       evidence: {
-        confirmation: "not-rediscovered-after-affected-code-change",
+        confirmation: "affirmative-controlled-replay",
+        replayEvidence: "The later diff removes the defective branch.",
         firstSeenHeadSha: event.headSha,
         outcomeHeadSha: fixedHead,
         outcomeRunId: fixedRunId,

--- a/ai-review/tests-runtime/coordinator.test.ts
+++ b/ai-review/tests-runtime/coordinator.test.ts
@@ -426,6 +426,7 @@ describe("PullRequestCoordinator in workerd", () => {
       action: "created",
       repository: event.repository,
       pullRequestNumber: event.pullRequestNumber,
+      headSha: fixedHead,
       interactionType: "disposition",
       actor: "Robbie-Palmer",
       actorAssociation: "OWNER",

--- a/ai-review/tests/finding-lifecycle.test.ts
+++ b/ai-review/tests/finding-lifecycle.test.ts
@@ -181,6 +181,9 @@ describe("finding lifecycle publication", () => {
     expect(renderFallbackFindings([nonLine], nonLinePublications)).toContain(
       `/ai-review reject ${finding.findingId} <reason>`,
     );
+    expect(renderFallbackFindings([nonLine], nonLinePublications)).toContain(
+      `/ai-review confirm-fixed ${finding.findingId} <reason>`,
+    );
 
     const rejectedFetch = vi
       .fn()

--- a/ai-review/tests/finding-outcomes.test.ts
+++ b/ai-review/tests/finding-outcomes.test.ts
@@ -30,10 +30,11 @@ describe("finding outcomes", () => {
     },
   );
 
-  it("confirms a fix only when changed affected code is not rediscovered", () => {
+  it("confirms a fix only with an affirmative controlled replay", () => {
     const baseline = {
       alreadyConfirmed: false,
       rediscovered: false,
+      replayVerdict: "fixed" as const,
       firstSeenHeadSha: "a",
       reviewedHeadSha: "b",
       file: "app.ts",
@@ -43,6 +44,10 @@ describe("finding outcomes", () => {
     };
     expect(confirmsFindingFixed(baseline)).toBe(true);
     expect(confirmsFindingFixed({ ...baseline, rediscovered: true })).toBe(false);
+    expect(confirmsFindingFixed({
+      ...baseline,
+      replayVerdict: "uncertain",
+    })).toBe(false);
     expect(confirmsFindingFixed({
       ...baseline,
       currentHunkIds: new Set(["old-hunk"]),

--- a/ai-review/tests/finding-outcomes.test.ts
+++ b/ai-review/tests/finding-outcomes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFindingOutcomeRecord,
+  classifyFinalizedFinding,
+} from "../src/finding-outcomes";
+
+describe("finding outcomes", () => {
+  it.each([
+    ["acknowledged", "open", "a", "a", false, true, "acknowledged"],
+    ["rejected", "open", "a", "a", false, true, "rejected"],
+    [null, "resolved", "a", "b", true, true, "confirmed-fixed"],
+    [null, "open", "a", "a", true, false, "superseded"],
+    [null, "open", "a", "a", true, true, "no-observable-response"],
+    [null, "open", "a", "a", false, false, "no-observable-response"],
+  ])(
+    "classifies disposition=%s status=%s final coverage=%s",
+    (
+      disposition,
+      status,
+      firstSeenHeadSha,
+      lastSeenHeadSha,
+      finalHeadWasReviewed,
+      affectedCodeRemains,
+      expected,
+    ) => {
+      expect(
+        classifyFinalizedFinding({
+          disposition,
+          status,
+          firstSeenHeadSha,
+          lastSeenHeadSha,
+          finalHeadWasReviewed,
+          affectedCodeRemains,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("builds a portable versioned record", () => {
+    expect(
+      buildFindingOutcomeRecord({
+        repository: "owner/repository",
+        pullRequestNumber: 42,
+        findingId: `f_${"a".repeat(24)}`,
+        outcome: "confirmed-fixed",
+        basis: "later-reviewed-head",
+        sourceId: "review:run:finding",
+        outcomeVersion: 2,
+        occurredAt: "2026-08-15T12:00:00Z",
+        recordedAt: "2026-08-15T12:00:01Z",
+        evidence: { outcomeHeadSha: "abc" },
+      }),
+    ).toMatchObject({
+      schemaVersion: 2,
+      recordType: "finding-outcome",
+      outcomeVersion: 2,
+      outcome: "confirmed-fixed",
+      evidence: { outcomeHeadSha: "abc" },
+    });
+  });
+});

--- a/ai-review/tests/finding-outcomes.test.ts
+++ b/ai-review/tests/finding-outcomes.test.ts
@@ -2,23 +2,20 @@ import { describe, expect, it } from "vitest";
 import {
   buildFindingOutcomeRecord,
   classifyFinalizedFinding,
+  confirmsFindingFixed,
 } from "../src/finding-outcomes";
 
 describe("finding outcomes", () => {
   it.each([
-    ["acknowledged", "open", "a", "a", false, true, "acknowledged"],
-    ["rejected", "open", "a", "a", false, true, "rejected"],
-    [null, "resolved", "a", "b", true, true, "confirmed-fixed"],
-    [null, "open", "a", "a", true, false, "superseded"],
-    [null, "open", "a", "a", true, true, "no-observable-response"],
-    [null, "open", "a", "a", false, false, "no-observable-response"],
+    ["acknowledged", false, true, "acknowledged"],
+    ["rejected", false, true, "rejected"],
+    [null, true, false, "superseded"],
+    [null, true, true, "no-observable-response"],
+    [null, false, false, "no-observable-response"],
   ])(
-    "classifies disposition=%s status=%s final coverage=%s",
+    "classifies disposition=%s final coverage=%s",
     (
       disposition,
-      status,
-      firstSeenHeadSha,
-      lastSeenHeadSha,
       finalHeadWasReviewed,
       affectedCodeRemains,
       expected,
@@ -26,15 +23,44 @@ describe("finding outcomes", () => {
       expect(
         classifyFinalizedFinding({
           disposition,
-          status,
-          firstSeenHeadSha,
-          lastSeenHeadSha,
           finalHeadWasReviewed,
           affectedCodeRemains,
         }),
       ).toBe(expected);
     },
   );
+
+  it("confirms a fix only when changed affected code is not rediscovered", () => {
+    const baseline = {
+      alreadyConfirmed: false,
+      rediscovered: false,
+      firstSeenHeadSha: "a",
+      reviewedHeadSha: "b",
+      file: "app.ts",
+      priorHunkIds: ["old-hunk"],
+      currentHunkIds: new Set(["new-hunk"]),
+      reviewedFiles: new Set(["app.ts"]),
+    };
+    expect(confirmsFindingFixed(baseline)).toBe(true);
+    expect(confirmsFindingFixed({ ...baseline, rediscovered: true })).toBe(false);
+    expect(confirmsFindingFixed({
+      ...baseline,
+      currentHunkIds: new Set(["old-hunk"]),
+    })).toBe(false);
+    expect(confirmsFindingFixed({
+      ...baseline,
+      reviewedFiles: new Set(["other.ts"]),
+    })).toBe(false);
+    expect(confirmsFindingFixed({
+      ...baseline,
+      alreadyConfirmed: true,
+    })).toBe(false);
+    expect(confirmsFindingFixed({
+      ...baseline,
+      reviewedHeadSha: "a",
+    })).toBe(false);
+    expect(confirmsFindingFixed({ ...baseline, priorHunkIds: [] })).toBe(false);
+  });
 
   it("builds a portable versioned record", () => {
     expect(

--- a/ai-review/tests/finding-outcomes.test.ts
+++ b/ai-review/tests/finding-outcomes.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   buildFindingOutcomeRecord,
   classifyFinalizedFinding,
-  confirmsFindingFixed,
 } from "../src/finding-outcomes";
 
 describe("finding outcomes", () => {
@@ -29,43 +28,6 @@ describe("finding outcomes", () => {
       ).toBe(expected);
     },
   );
-
-  it("confirms a fix only with an affirmative controlled replay", () => {
-    const baseline = {
-      alreadyConfirmed: false,
-      rediscovered: false,
-      replayVerdict: "fixed" as const,
-      firstSeenHeadSha: "a",
-      reviewedHeadSha: "b",
-      file: "app.ts",
-      priorHunkIds: ["old-hunk"],
-      currentHunkIds: new Set(["new-hunk"]),
-      reviewedFiles: new Set(["app.ts"]),
-    };
-    expect(confirmsFindingFixed(baseline)).toBe(true);
-    expect(confirmsFindingFixed({ ...baseline, rediscovered: true })).toBe(false);
-    expect(confirmsFindingFixed({
-      ...baseline,
-      replayVerdict: "uncertain",
-    })).toBe(false);
-    expect(confirmsFindingFixed({
-      ...baseline,
-      currentHunkIds: new Set(["old-hunk"]),
-    })).toBe(false);
-    expect(confirmsFindingFixed({
-      ...baseline,
-      reviewedFiles: new Set(["other.ts"]),
-    })).toBe(false);
-    expect(confirmsFindingFixed({
-      ...baseline,
-      alreadyConfirmed: true,
-    })).toBe(false);
-    expect(confirmsFindingFixed({
-      ...baseline,
-      reviewedHeadSha: "a",
-    })).toBe(false);
-    expect(confirmsFindingFixed({ ...baseline, priorHunkIds: [] })).toBe(false);
-  });
 
   it("builds a portable versioned record", () => {
     expect(

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -657,8 +657,10 @@ describe("PullRequestCoordinator", () => {
   });
 
   it("keeps committed finalization successful when outcome publication fails", async () => {
-    const { coordinator, put, sqlExec } = coordinatorFixture();
+    const { coordinator, put, sqlExec, storage } = coordinatorFixture();
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    storage.getAlarm.mockResolvedValue(null);
     put.mockRejectedValueOnce(new Error("R2 unavailable"));
     sqlExec.mockImplementation((query: string) => ({
       rowsWritten: 1,
@@ -693,7 +695,55 @@ describe("PullRequestCoordinator", () => {
         String(query).includes("SET r2_recorded = 1"),
       ),
     ).toBe(false);
+    expect(storage.kv.put).toHaveBeenCalledWith(
+      "pending-finding-outcome-flush",
+      {
+        kind: "finding-outcomes",
+        repository: event.repository,
+        pullRequestNumber: event.pullRequestNumber,
+      },
+    );
+    expect(storage.setAlarm).toHaveBeenCalledWith(1_060_000);
+    now.mockRestore();
     consoleError.mockRestore();
+  });
+
+  it("retries pending outcome publication from an alarm", async () => {
+    const { coordinator, put, sqlExec, storage } = coordinatorFixture();
+    const pendingOutcome = {
+      finding_id: identifiedFinding.findingId,
+      outcome_version: 1,
+      payload_json: "{}",
+    };
+    storage.get.mockImplementation((key: string) =>
+      Promise.resolve(
+        key === "pending-finding-outcome-flush"
+          ? {
+              kind: "finding-outcomes",
+              repository: event.repository,
+              pullRequestNumber: event.pullRequestNumber,
+            }
+          : undefined,
+      ),
+    );
+    sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: 1,
+      toArray: () =>
+        query.includes("WHERE r2_recorded = 0") ? [pendingOutcome] : [],
+    }));
+
+    await coordinator.alarm();
+
+    expect(put).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `/findings/${identifiedFinding.findingId}/outcomes/v1.json`,
+      ),
+      pendingOutcome.payload_json,
+      { httpMetadata: { contentType: "application/json" } },
+    );
+    expect(storage.delete).toHaveBeenCalledWith(
+      "pending-finding-outcome-flush",
+    );
   });
 
   it("deduplicates finding evidence and rejects unknown findings", async () => {

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -521,6 +521,7 @@ describe("PullRequestCoordinator", () => {
         body: JSON.stringify({
           ...findingInteraction,
           deliveryId: "feedback-confirmation-without-replay",
+          headSha: "2".repeat(40),
           disposition: "confirmed-fixed",
           reason: "Looks fixed",
         }),
@@ -535,7 +536,7 @@ describe("PullRequestCoordinator", () => {
     expect(put).not.toHaveBeenCalled();
   });
 
-  it("rejects trusted confirmation after a newer head arrives", async () => {
+  it("rejects trusted confirmation against a newer authoritative head", async () => {
     const { coordinator, put, sqlExec } = coordinatorFixture();
     const replayHead = "1".repeat(40);
     const currentHead = "2".repeat(40);
@@ -544,9 +545,6 @@ describe("PullRequestCoordinator", () => {
       toArray: () => {
         if (query.includes("SELECT finding_id FROM review_findings")) {
           return [{ finding_id: identifiedFinding.findingId }];
-        }
-        if (query.includes("SELECT head_sha FROM webhook_deliveries")) {
-          return [{ head_sha: currentHead }];
         }
         if (query.includes("finding_resolutions_json IS NOT NULL")) {
           return [{
@@ -569,6 +567,7 @@ describe("PullRequestCoordinator", () => {
         body: JSON.stringify({
           ...findingInteraction,
           deliveryId: "feedback-stale-confirmation",
+          headSha: currentHead,
           disposition: "confirmed-fixed",
           reason: "Looks fixed",
         }),
@@ -1559,6 +1558,100 @@ describe("HTTP Worker", () => {
       "https://coordinator.internal/interactions",
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("binds trusted fix confirmation to GitHub's current pull request head", async () => {
+    const { env, fetch: coordinatorFetch } = workerEnv();
+    const privateKey = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    }).privateKey
+      .export({ type: "pkcs8", format: "pem" })
+      .toString();
+    Object.assign(env, {
+      AI_REVIEW_APP_ID: "123",
+      AI_REVIEW_APP_INSTALLATION_ID: "456",
+      AI_REVIEW_APP_PRIVATE_KEY: privateKey,
+    });
+    const githubFetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+      .mockResolvedValueOnce(Response.json({ head: { sha: "2".repeat(40) } }));
+    vi.stubGlobal("fetch", githubFetch);
+    const feedbackBody = JSON.stringify({
+      action: "created",
+      repository: { full_name: "Robbie-Palmer/personal-site" },
+      issue: { number: 821, pull_request: {} },
+      sender: { login: "Robbie-Palmer" },
+      comment: {
+        id: 901,
+        body: `/ai-review confirm-fixed f_${"a".repeat(24)} verified`,
+        author_association: "OWNER",
+        user: { login: "Robbie-Palmer" },
+      },
+    });
+
+    const response = await worker.fetch(
+      signedWebhookRequest(feedbackBody, secret, {
+        "x-github-event": "issue_comment",
+      }),
+      env,
+    );
+
+    await expect(response.json()).resolves.toEqual({ accepted: true });
+    expect(githubFetch).toHaveBeenCalledTimes(2);
+    expect(coordinatorFetch).toHaveBeenCalledWith(
+      "https://coordinator.internal/interactions",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining(`"headSha":"${"2".repeat(40)}"`),
+      }),
+    );
+  });
+
+  it("fails closed when GitHub's current pull request head is unavailable", async () => {
+    const { env, fetch: coordinatorFetch } = workerEnv();
+    const privateKey = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+    }).privateKey
+      .export({ type: "pkcs8", format: "pem" })
+      .toString();
+    Object.assign(env, {
+      AI_REVIEW_APP_ID: "123",
+      AI_REVIEW_APP_INSTALLATION_ID: "456",
+      AI_REVIEW_APP_PRIVATE_KEY: privateKey,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(Response.json({ token: "installation-token" }))
+        .mockResolvedValueOnce(new Response("unavailable", { status: 503 })),
+    );
+    const feedbackBody = JSON.stringify({
+      action: "created",
+      repository: { full_name: "Robbie-Palmer/personal-site" },
+      issue: { number: 821, pull_request: {} },
+      sender: { login: "Robbie-Palmer" },
+      comment: {
+        id: 902,
+        body: `/ai-review confirm-fixed f_${"a".repeat(24)} verified`,
+        author_association: "OWNER",
+        user: { login: "Robbie-Palmer" },
+      },
+    });
+
+    const response = await worker.fetch(
+      signedWebhookRequest(feedbackBody, secret, {
+        "x-github-event": "issue_comment",
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "Could not verify current pull request head",
+    });
+    expect(coordinatorFetch).not.toHaveBeenCalled();
   });
 
   it("routes pull request closure to outcome finalization", async () => {

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -384,6 +384,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "review-delivery-123",
           headSha: event.headSha,
           costUsd: 0.42,
@@ -536,6 +538,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "missing-review",
           headSha: event.headSha,
           costUsd: 0.42,
@@ -569,6 +573,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "review-delivery-123",
           headSha: event.headSha,
           costUsd: 0.43,
@@ -608,6 +614,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "review-delivery-123",
           headSha: event.headSha,
           costUsd: 0.42,
@@ -629,6 +637,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "review-delivery-123",
           headSha: event.headSha,
           costUsd: 0.42,
@@ -650,6 +660,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "review-delivery-123",
           headSha: event.headSha,
           costUsd: 0.42,
@@ -671,6 +683,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "review-delivery-123",
           headSha: event.headSha,
           costUsd: 0,
@@ -708,6 +722,8 @@ describe("PullRequestCoordinator", () => {
         new Request("https://coordinator.test/reviews/complete", {
           method: "POST",
           body: JSON.stringify({
+            repository: event.repository,
+            pullRequestNumber: event.pullRequestNumber,
             runId: "review-delivery-123",
             headSha: event.headSha,
             costUsd: 0.42,
@@ -728,6 +744,8 @@ describe("PullRequestCoordinator", () => {
       new Request("https://coordinator.test/reviews/complete", {
         method: "POST",
         body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
           runId: "review-delivery-123",
           headSha: event.headSha,
           costUsd: 0.42,
@@ -1195,6 +1213,31 @@ describe("HTTP Worker", () => {
     await expect(response.json()).resolves.toEqual({ accepted: true });
     expect(fetch).toHaveBeenCalledWith(
       "https://coordinator.internal/interactions",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("routes pull request closure to outcome finalization", async () => {
+    const { env, fetch } = workerEnv();
+    const closedBody = JSON.stringify({
+      action: "closed",
+      repository: { full_name: "Robbie-Palmer/personal-site" },
+      pull_request: {
+        number: 821,
+        merged: true,
+        closed_at: "2026-08-15T12:00:00Z",
+        head: { sha: "abcdef123456" },
+      },
+    });
+
+    const response = await worker.fetch(
+      signedWebhookRequest(closedBody, secret),
+      env,
+    );
+
+    await expect(response.json()).resolves.toEqual({ accepted: true });
+    expect(fetch).toHaveBeenCalledWith(
+      "https://coordinator.internal/finalizations",
       expect.objectContaining({ method: "POST" }),
     );
   });

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -535,6 +535,54 @@ describe("PullRequestCoordinator", () => {
     expect(put).not.toHaveBeenCalled();
   });
 
+  it("rejects trusted confirmation after a newer head arrives", async () => {
+    const { coordinator, put, sqlExec } = coordinatorFixture();
+    const replayHead = "1".repeat(40);
+    const currentHead = "2".repeat(40);
+    sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: 1,
+      toArray: () => {
+        if (query.includes("SELECT finding_id FROM review_findings")) {
+          return [{ finding_id: identifiedFinding.findingId }];
+        }
+        if (query.includes("SELECT head_sha FROM webhook_deliveries")) {
+          return [{ head_sha: currentHead }];
+        }
+        if (query.includes("finding_resolutions_json IS NOT NULL")) {
+          return [{
+            run_id: "fixed-replay",
+            head_sha: replayHead,
+            finding_resolutions_json: JSON.stringify([{
+              findingId: identifiedFinding.findingId,
+              verdict: "fixed",
+              evidence: "The old head removed the defect.",
+            }]),
+          }];
+        }
+        return [];
+      },
+    }));
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/interactions", {
+        method: "POST",
+        body: JSON.stringify({
+          ...findingInteraction,
+          deliveryId: "feedback-stale-confirmation",
+          disposition: "confirmed-fixed",
+          reason: "Looks fixed",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      accepted: false,
+      reason: "stale-fixed-replay",
+    });
+    expect(put).not.toHaveBeenCalled();
+  });
+
   it("finalizes and flushes outstanding finding outcomes", async () => {
     const { coordinator, put, sqlExec } = coordinatorFixture();
     const removedFindingId = `f_${"d".repeat(24)}`;

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -55,6 +55,17 @@ const findingInteraction = {
   occurredAt: "2026-08-09T12:00:00Z",
 } as const;
 
+const pullRequestFinalization = {
+  deliveryId: "finalization-delivery-1",
+  eventName: "pull_request",
+  action: "closed",
+  repository: event.repository,
+  pullRequestNumber: event.pullRequestNumber,
+  headSha: event.headSha,
+  finalState: "merged",
+  occurredAt: "2026-08-15T12:00:00Z",
+} as const;
+
 afterEach(() => {
   vi.unstubAllGlobals();
 });
@@ -63,10 +74,11 @@ function coordinatorFixture(existingDeliveries: string[] = []) {
   const sqlExec = vi.fn(
     (
       query: string,
+      ..._params: unknown[]
     ): { rowsWritten: number; toArray: () => unknown[] } => ({
       rowsWritten: 1,
       toArray: () =>
-        query.startsWith("SELECT") &&
+        query.includes("FROM webhook_deliveries") &&
         existingDeliveries.includes(event.deliveryId)
           ? [{ delivery_id: event.deliveryId }]
           : [],
@@ -418,6 +430,71 @@ describe("PullRequestCoordinator", () => {
     ).toBe(true);
   });
 
+  it("records a confirmed fix from a later reviewed head", async () => {
+    const { coordinator, put, sqlExec } = coordinatorFixture();
+    const resolvedFinding = {
+      ...identifiedFinding,
+      status: "resolved",
+      resolution_note: "Fixed in the later head",
+    };
+    const priorHeadSha = "1".repeat(40);
+    const pendingOutcome = JSON.stringify({
+      schemaVersion: 2,
+      recordType: "finding-outcome",
+      outcomeVersion: 1,
+      findingId: resolvedFinding.findingId,
+      outcome: "confirmed-fixed",
+    });
+    sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: 1,
+      toArray: () => {
+        if (query.includes("SELECT first_seen_head_sha")) {
+          return [{
+            first_seen_head_sha: priorHeadSha,
+            first_seen_run_id: "earlier-run",
+          }];
+        }
+        if (query.includes("WHERE r2_recorded = 0")) {
+          return [{
+            finding_id: resolvedFinding.findingId,
+            outcome_version: 1,
+            payload_json: pendingOutcome,
+          }];
+        }
+        return [];
+      },
+    }));
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/reviews/complete", {
+        method: "POST",
+        body: JSON.stringify({
+          repository: event.repository,
+          pullRequestNumber: event.pullRequestNumber,
+          runId: "later-run",
+          headSha: event.headSha,
+          costUsd: 0.25,
+          hunks: [identifiedHunk],
+          findings: [resolvedFinding],
+        }),
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({ completed: true });
+    expect(put).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `/findings/${resolvedFinding.findingId}/outcomes/v1.json`,
+      ),
+      pendingOutcome,
+      { httpMetadata: { contentType: "application/json" } },
+    );
+    expect(
+      sqlExec.mock.calls.some(([query]) =>
+        String(query).includes("outcome, basis, source_id"),
+      ),
+    ).toBe(true);
+  });
+
   it("records finding dispositions in SQLite and append-only evidence", async () => {
     const { coordinator, put, sqlExec } = coordinatorFixture();
     sqlExec.mockImplementation((query: string) => ({
@@ -450,6 +527,122 @@ describe("PullRequestCoordinator", () => {
         String(query).includes("SET disposition = ?"),
       ),
     ).toBe(true);
+  });
+
+  it("finalizes and flushes outstanding finding outcomes", async () => {
+    const { coordinator, put, sqlExec } = coordinatorFixture();
+    const removedFindingId = `f_${"d".repeat(24)}`;
+    const removedHunkId = `h_${"e".repeat(24)}`;
+    const findings = [
+      {
+        finding_id: identifiedFinding.findingId,
+        status: "open",
+        disposition: null,
+        disposition_reason: null,
+        first_seen_head_sha: "1".repeat(40),
+        last_seen_head_sha: event.headSha,
+        first_seen_run_id: "initial-run",
+        last_seen_run_id: "latest-run",
+      },
+      {
+        finding_id: removedFindingId,
+        status: "open",
+        disposition: null,
+        disposition_reason: null,
+        first_seen_head_sha: "1".repeat(40),
+        last_seen_head_sha: "1".repeat(40),
+        first_seen_run_id: "initial-run",
+        last_seen_run_id: "initial-run",
+      },
+    ];
+    const pendingOutcomes = findings.map((finding) => ({
+      finding_id: finding.finding_id,
+      outcome_version: 1,
+      payload_json: JSON.stringify({
+        schemaVersion: 2,
+        recordType: "finding-outcome",
+        outcomeVersion: 1,
+        findingId: finding.finding_id,
+      }),
+    }));
+    sqlExec.mockImplementation((query: string, ...params: unknown[]) => ({
+      rowsWritten: 1,
+      toArray: () => {
+        if (query.includes("FROM review_runs")) {
+          return [{ run_id: "latest-run", head_sha: event.headSha }];
+        }
+        if (query.includes("FROM review_run_hunks")) {
+          return [{ hunk_id: identifiedHunk.hunkId }];
+        }
+        if (query.includes("FROM review_findings ORDER BY")) return findings;
+        if (query.includes("FROM review_finding_hunks")) {
+          return [{
+            hunk_id:
+              params[0] === identifiedFinding.findingId
+                ? identifiedHunk.hunkId
+                : removedHunkId,
+          }];
+        }
+        if (query.includes("WHERE r2_recorded = 0")) return pendingOutcomes;
+        return [];
+      },
+    }));
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/finalizations", {
+        method: "POST",
+        body: JSON.stringify(pullRequestFinalization),
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: false,
+      outcomes: 2,
+    });
+    expect(put).toHaveBeenCalledTimes(2);
+    expect(put).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `/findings/${identifiedFinding.findingId}/outcomes/v1.json`,
+      ),
+      pendingOutcomes[0]?.payload_json,
+      { httpMetadata: { contentType: "application/json" } },
+    );
+    expect(put).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `/findings/${removedFindingId}/outcomes/v1.json`,
+      ),
+      pendingOutcomes[1]?.payload_json,
+      { httpMetadata: { contentType: "application/json" } },
+    );
+  });
+
+  it("rejects malformed finalizations and deduplicates recorded ones", async () => {
+    const invalid = coordinatorFixture();
+    const invalidResponse = await invalid.coordinator.fetch(
+      new Request("https://coordinator.test/finalizations", {
+        method: "POST",
+        body: "{}",
+      }),
+    );
+    expect(invalidResponse.status).toBe(400);
+
+    const duplicate = coordinatorFixture([event.deliveryId]);
+    const duplicateResponse = await duplicate.coordinator.fetch(
+      new Request("https://coordinator.test/finalizations", {
+        method: "POST",
+        body: JSON.stringify({
+          ...pullRequestFinalization,
+          deliveryId: event.deliveryId,
+        }),
+      }),
+    );
+    await expect(duplicateResponse.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: true,
+      outcomes: 0,
+    });
+    expect(duplicate.put).not.toHaveBeenCalled();
   });
 
   it("deduplicates finding evidence and rejects unknown findings", async () => {

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -481,6 +481,11 @@ describe("PullRequestCoordinator", () => {
           costUsd: 0.25,
           hunks: [changedHunk],
           findings: [],
+          findingResolutions: [{
+            findingId: identifiedFinding.findingId,
+            verdict: "fixed",
+            evidence: "The later diff adds the missing retry alarm.",
+          }],
         }),
       }),
     );

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -432,31 +432,36 @@ describe("PullRequestCoordinator", () => {
 
   it("records a confirmed fix from a later reviewed head", async () => {
     const { coordinator, put, sqlExec } = coordinatorFixture();
-    const resolvedFinding = {
-      ...identifiedFinding,
-      status: "resolved",
-      resolution_note: "Fixed in the later head",
+    const changedHunk = {
+      ...identifiedHunk,
+      hunkId: `h_${"d".repeat(24)}`,
+      fingerprint: "e".repeat(64),
     };
     const priorHeadSha = "1".repeat(40);
     const pendingOutcome = JSON.stringify({
       schemaVersion: 2,
       recordType: "finding-outcome",
       outcomeVersion: 1,
-      findingId: resolvedFinding.findingId,
+      findingId: identifiedFinding.findingId,
       outcome: "confirmed-fixed",
     });
     sqlExec.mockImplementation((query: string) => ({
       rowsWritten: 1,
       toArray: () => {
-        if (query.includes("SELECT first_seen_head_sha")) {
+        if (query.includes("FROM review_findings ORDER BY")) {
           return [{
+            finding_id: identifiedFinding.findingId,
+            file_path: identifiedFinding.file,
             first_seen_head_sha: priorHeadSha,
             first_seen_run_id: "earlier-run",
           }];
         }
+        if (query.includes("FROM review_finding_hunks")) {
+          return [{ hunk_id: identifiedHunk.hunkId }];
+        }
         if (query.includes("WHERE r2_recorded = 0")) {
           return [{
-            finding_id: resolvedFinding.findingId,
+            finding_id: identifiedFinding.findingId,
             outcome_version: 1,
             payload_json: pendingOutcome,
           }];
@@ -474,8 +479,8 @@ describe("PullRequestCoordinator", () => {
           runId: "later-run",
           headSha: event.headSha,
           costUsd: 0.25,
-          hunks: [identifiedHunk],
-          findings: [resolvedFinding],
+          hunks: [changedHunk],
+          findings: [],
         }),
       }),
     );
@@ -483,7 +488,7 @@ describe("PullRequestCoordinator", () => {
     await expect(response.json()).resolves.toEqual({ completed: true });
     expect(put).toHaveBeenCalledWith(
       expect.stringContaining(
-        `/findings/${resolvedFinding.findingId}/outcomes/v1.json`,
+        `/findings/${identifiedFinding.findingId}/outcomes/v1.json`,
       ),
       pendingOutcome,
       { httpMetadata: { contentType: "application/json" } },
@@ -619,13 +624,19 @@ describe("PullRequestCoordinator", () => {
 
   it("rejects malformed finalizations and deduplicates recorded ones", async () => {
     const invalid = coordinatorFixture();
-    const invalidResponse = await invalid.coordinator.fetch(
-      new Request("https://coordinator.test/finalizations", {
-        method: "POST",
-        body: "{}",
-      }),
-    );
-    expect(invalidResponse.status).toBe(400);
+    for (const body of [
+      {},
+      { ...pullRequestFinalization, headSha: "x".repeat(65) },
+      { ...pullRequestFinalization, occurredAt: "x".repeat(65) },
+    ]) {
+      const invalidResponse = await invalid.coordinator.fetch(
+        new Request("https://coordinator.test/finalizations", {
+          method: "POST",
+          body: JSON.stringify(body),
+        }),
+      );
+      expect(invalidResponse.status).toBe(400);
+    }
 
     const duplicate = coordinatorFixture([event.deliveryId]);
     const duplicateResponse = await duplicate.coordinator.fetch(
@@ -643,6 +654,46 @@ describe("PullRequestCoordinator", () => {
       outcomes: 0,
     });
     expect(duplicate.put).not.toHaveBeenCalled();
+  });
+
+  it("keeps committed finalization successful when outcome publication fails", async () => {
+    const { coordinator, put, sqlExec } = coordinatorFixture();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    put.mockRejectedValueOnce(new Error("R2 unavailable"));
+    sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: 1,
+      toArray: () =>
+        query.includes("WHERE r2_recorded = 0")
+          ? [{
+              finding_id: identifiedFinding.findingId,
+              outcome_version: 1,
+              payload_json: "{}",
+            }]
+          : [],
+    }));
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/finalizations", {
+        method: "POST",
+        body: JSON.stringify(pullRequestFinalization),
+      }),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      accepted: true,
+      duplicate: false,
+      outcomes: 0,
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Could not publish a finding outcome",
+      { type: "Error" },
+    );
+    expect(
+      sqlExec.mock.calls.some(([query]) =>
+        String(query).includes("SET r2_recorded = 1"),
+      ),
+    ).toBe(false);
+    consoleError.mockRestore();
   });
 
   it("deduplicates finding evidence and rejects unknown findings", async () => {
@@ -1203,8 +1254,9 @@ describe("HTTP Worker", () => {
   const secret = "webhook-secret";
   const validBody = JSON.stringify({
     action: "opened",
+    number: 821,
     repository: { full_name: "Robbie-Palmer/personal-site" },
-    pull_request: { number: 821, head: { sha: "abcdef123456" } },
+    pull_request: { head: { sha: "abcdef123456" } },
   });
 
   function workerEnv() {
@@ -1414,9 +1466,9 @@ describe("HTTP Worker", () => {
     const { env, fetch } = workerEnv();
     const closedBody = JSON.stringify({
       action: "closed",
+      number: 821,
       repository: { full_name: "Robbie-Palmer/personal-site" },
       pull_request: {
-        number: 821,
         merged: true,
         closed_at: "2026-08-15T12:00:00Z",
         head: { sha: "abcdef123456" },

--- a/ai-review/tests/index.test.ts
+++ b/ai-review/tests/index.test.ts
@@ -430,44 +430,16 @@ describe("PullRequestCoordinator", () => {
     ).toBe(true);
   });
 
-  it("records a confirmed fix from a later reviewed head", async () => {
+  it("does not mint a confirmed fix from model replay alone", async () => {
     const { coordinator, put, sqlExec } = coordinatorFixture();
     const changedHunk = {
       ...identifiedHunk,
       hunkId: `h_${"d".repeat(24)}`,
       fingerprint: "e".repeat(64),
     };
-    const priorHeadSha = "1".repeat(40);
-    const pendingOutcome = JSON.stringify({
-      schemaVersion: 2,
-      recordType: "finding-outcome",
-      outcomeVersion: 1,
-      findingId: identifiedFinding.findingId,
-      outcome: "confirmed-fixed",
-    });
-    sqlExec.mockImplementation((query: string) => ({
+    sqlExec.mockImplementation((_query: string) => ({
       rowsWritten: 1,
-      toArray: () => {
-        if (query.includes("FROM review_findings ORDER BY")) {
-          return [{
-            finding_id: identifiedFinding.findingId,
-            file_path: identifiedFinding.file,
-            first_seen_head_sha: priorHeadSha,
-            first_seen_run_id: "earlier-run",
-          }];
-        }
-        if (query.includes("FROM review_finding_hunks")) {
-          return [{ hunk_id: identifiedHunk.hunkId }];
-        }
-        if (query.includes("WHERE r2_recorded = 0")) {
-          return [{
-            finding_id: identifiedFinding.findingId,
-            outcome_version: 1,
-            payload_json: pendingOutcome,
-          }];
-        }
-        return [];
-      },
+      toArray: () => [],
     }));
 
     const response = await coordinator.fetch(
@@ -491,18 +463,12 @@ describe("PullRequestCoordinator", () => {
     );
 
     await expect(response.json()).resolves.toEqual({ completed: true });
-    expect(put).toHaveBeenCalledWith(
-      expect.stringContaining(
-        `/findings/${identifiedFinding.findingId}/outcomes/v1.json`,
-      ),
-      pendingOutcome,
-      { httpMetadata: { contentType: "application/json" } },
-    );
+    expect(put).not.toHaveBeenCalled();
     expect(
       sqlExec.mock.calls.some(([query]) =>
         String(query).includes("outcome, basis, source_id"),
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("records finding dispositions in SQLite and append-only evidence", async () => {
@@ -537,6 +503,36 @@ describe("PullRequestCoordinator", () => {
         String(query).includes("SET disposition = ?"),
       ),
     ).toBe(true);
+  });
+
+  it("requires a fixed controlled replay before trusted confirmation", async () => {
+    const { coordinator, put, sqlExec } = coordinatorFixture();
+    sqlExec.mockImplementation((query: string) => ({
+      rowsWritten: 1,
+      toArray: () =>
+        query.includes("SELECT finding_id FROM review_findings")
+          ? [{ finding_id: identifiedFinding.findingId }]
+          : [],
+    }));
+
+    const response = await coordinator.fetch(
+      new Request("https://coordinator.test/interactions", {
+        method: "POST",
+        body: JSON.stringify({
+          ...findingInteraction,
+          deliveryId: "feedback-confirmation-without-replay",
+          disposition: "confirmed-fixed",
+          reason: "Looks fixed",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      accepted: false,
+      reason: "no-fixed-replay",
+    });
+    expect(put).not.toHaveBeenCalled();
   });
 
   it("finalizes and flushes outstanding finding outcomes", async () => {

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -699,6 +699,68 @@ describe("stateful review engine", () => {
     });
   });
 
+  it("keeps only evidence-backed controlled replay verdicts", async () => {
+    const findingId = `f_${"d".repeat(24)}`;
+    const callMerger = vi
+      .spyOn(Reviewer.prototype, "callMerger")
+      .mockResolvedValue({
+        payload: {
+          summary: "Replay complete.",
+          findings: [],
+          finding_resolutions: [
+            {
+              finding_id: findingId,
+              verdict: "fixed",
+              evidence: "The current branch now schedules an alarm retry.",
+            },
+            {
+              finding_id: `f_${"e".repeat(24)}`,
+              verdict: "fixed",
+              evidence: "Unknown finding.",
+            },
+          ],
+        },
+        cost: 0.01,
+        usage: {},
+      } as never);
+    const merged = await mergeFindings(
+      environment(),
+      params,
+      {
+        paths: ["app.ts"],
+        omitted: [],
+        diff: "+scheduleRetry()",
+        context: "FILE app.ts\nscheduleRetry();",
+        replayFindings: [{
+          findingId,
+          file: "app.ts",
+          title: "Outcome is never retried",
+          hunkIds: [`h_${"a".repeat(24)}`],
+          evidence: "A failed R2 put remains pending forever.",
+        }],
+      },
+      {
+        models: ["model/scout"],
+        candidates: { "model/scout": [] },
+        failed: [],
+        candidateCounts: { "model/scout": 0 },
+        invalidCounts: { "model/scout": 0 },
+        outOfScopeCounts: { "model/scout": 0 },
+        costs: { "model/scout": 0 },
+        metrics: [],
+      },
+    );
+
+    expect(callMerger.mock.calls[0]?.[2]).toContain(
+      "A failed R2 put remains pending forever.",
+    );
+    expect(merged.result.finding_resolutions).toEqual([{
+      finding_id: findingId,
+      verdict: "fixed",
+      evidence: "The current branch now schedules an alarm retry.",
+    }]);
+  });
+
   it("uses durable claims and records completion and failure state", async () => {
     const coordinatorFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const path = new URL(String(input)).pathname;
@@ -737,6 +799,7 @@ describe("stateful review engine", () => {
       params,
       "review-1",
       prepared,
+      { result: { finding_resolutions: [] }, cost: 0 },
       { hunks: [], candidates: {}, publishedFindings: [] },
       { commentId: 42, runCostUsd: 0.25, findings: [] },
     );

--- a/ai-review/tests/review-engine.test.ts
+++ b/ai-review/tests/review-engine.test.ts
@@ -697,6 +697,41 @@ describe("stateful review engine", () => {
       },
       cost: 0,
     });
+
+    const replayFindingId = `f_${"d".repeat(24)}`;
+    await expect(
+      mergeFindings(
+        environment(),
+        params,
+        {
+          paths: [],
+          omitted: [],
+          replayFindings: [{
+            findingId: replayFindingId,
+            file: "app.ts",
+            title: "Replay unavailable",
+            hunkIds: [],
+          }],
+        },
+        {
+          models: [],
+          candidates: {},
+          failed: [],
+          candidateCounts: {},
+          invalidCounts: {},
+          outOfScopeCounts: {},
+          costs: {},
+          metrics: [],
+        },
+      ),
+    ).resolves.toMatchObject({
+      result: {
+        finding_resolutions: [{
+          finding_id: replayFindingId,
+          verdict: "uncertain",
+        }],
+      },
+    });
   });
 
   it("keeps only evidence-backed controlled replay verdicts", async () => {
@@ -759,6 +794,50 @@ describe("stateful review engine", () => {
       verdict: "fixed",
       evidence: "The current branch now schedules an alarm retry.",
     }]);
+  });
+
+  it("rejects a merger response that omits a controlled replay verdict", async () => {
+    const findingId = `f_${"d".repeat(24)}`;
+    vi.spyOn(Reviewer.prototype, "callMerger").mockResolvedValue({
+      payload: {
+        summary: "Replay omitted.",
+        findings: [],
+        finding_resolutions: [],
+      },
+      cost: 0.01,
+      usage: {},
+    } as never);
+
+    await expect(
+      mergeFindings(
+        environment(),
+        params,
+        {
+          paths: ["app.ts"],
+          omitted: [],
+          diff: "+scheduleRetry()",
+          context: "FILE app.ts\nscheduleRetry();",
+          replayFindings: [{
+            findingId,
+            file: "app.ts",
+            title: "Outcome is never retried",
+            hunkIds: [`h_${"a".repeat(24)}`],
+          }],
+        },
+        {
+          models: ["model/scout"],
+          candidates: { "model/scout": [] },
+          failed: [],
+          candidateCounts: { "model/scout": 0 },
+          invalidCounts: { "model/scout": 0 },
+          outOfScopeCounts: { "model/scout": 0 },
+          costs: { "model/scout": 0 },
+          metrics: [],
+        },
+      ),
+    ).rejects.toThrow(
+      "Merger omitted or invalidated a required controlled replay resolution",
+    );
   });
 
   it("uses durable claims and records completion and failure state", async () => {

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -297,6 +297,28 @@ describe("parseFindingInteraction", () => {
         reason: "false positive",
       }),
     });
+    expect(
+      parseFindingInteraction("issue_comment", "feedback-fixed", {
+        action: "created",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        issue: { number: 816, pull_request: {} },
+        sender: { login: "robbie" },
+        comment: {
+          id: 100,
+          body: `/ai-review confirm-fixed f_${"a".repeat(24)} verified retry`,
+          author_association: "OWNER",
+          user: { login: "robbie" },
+        },
+      }),
+    ).toEqual({
+      kind: "accepted",
+      event: expect.objectContaining({
+        interactionType: "disposition",
+        disposition: "confirmed-fixed",
+        findingId: `f_${"a".repeat(24)}`,
+        reason: "verified retry",
+      }),
+    });
   });
 
   it("rejects feedback from untrusted actors", () => {

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -2,6 +2,7 @@ import { createHmac } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   parseFindingInteraction,
+  parsePullRequestFinalization,
   parseReviewEvent,
   verifyGitHubSignature,
 } from "../src/webhook";
@@ -207,6 +208,52 @@ describe("parseReviewEvent", () => {
         }),
       ).toEqual({ kind: "ignored", reason: "unsupported-event" });
     }
+  });
+});
+
+describe("parsePullRequestFinalization", () => {
+  it("captures merged and unmerged PR closure without scheduling review", () => {
+    for (const merged of [true, false]) {
+      expect(
+        parsePullRequestFinalization("pull_request", `closed-${merged}`, {
+          action: "closed",
+          repository: { full_name: "Robbie-Palmer/personal-site" },
+          pull_request: {
+            number: 816,
+            merged,
+            closed_at: "2026-08-15T12:00:00Z",
+            head: { sha: "abc123" },
+          },
+        }),
+      ).toEqual({
+        kind: "accepted",
+        event: {
+          deliveryId: `closed-${merged}`,
+          eventName: "pull_request",
+          action: "closed",
+          repository: "Robbie-Palmer/personal-site",
+          pullRequestNumber: 816,
+          headSha: "abc123",
+          finalState: merged ? "merged" : "closed",
+          occurredAt: "2026-08-15T12:00:00Z",
+        },
+      });
+    }
+  });
+
+  it("rejects malformed closure evidence and ignores other events", () => {
+    expect(
+      parsePullRequestFinalization("pull_request", "delivery", {
+        action: "closed",
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        pull_request: { number: 816, head: { sha: "abc123" } },
+      }),
+    ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
+    expect(
+      parsePullRequestFinalization("pull_request", "delivery", {
+        action: "synchronize",
+      }),
+    ).toEqual({ kind: "ignored", reason: "unsupported-event" });
   });
 });
 

--- a/ai-review/tests/webhook.test.ts
+++ b/ai-review/tests/webhook.test.ts
@@ -42,8 +42,9 @@ describe("parseReviewEvent", () => {
     expect(
       parseReviewEvent("pull_request", "delivery-1", {
         action: "synchronize",
+        number: 816,
         repository: { full_name: "Robbie-Palmer/personal-site" },
-        pull_request: { number: 816, head: { sha: "abc123" } },
+        pull_request: { head: { sha: "abc123" } },
       }),
     ).toEqual({
       kind: "accepted",
@@ -97,8 +98,9 @@ describe("parseReviewEvent", () => {
       expect(
         parseReviewEvent("pull_request", "delivery-missing-sha", {
           action: "synchronize",
+          number: 816,
           repository: { full_name: "Robbie-Palmer/personal-site" },
-          pull_request: { number: 816, head: { sha } },
+          pull_request: { head: { sha } },
         }),
       ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
     }
@@ -217,9 +219,9 @@ describe("parsePullRequestFinalization", () => {
       expect(
         parsePullRequestFinalization("pull_request", `closed-${merged}`, {
           action: "closed",
+          number: 816,
           repository: { full_name: "Robbie-Palmer/personal-site" },
           pull_request: {
-            number: 816,
             merged,
             closed_at: "2026-08-15T12:00:00Z",
             head: { sha: "abc123" },
@@ -245,8 +247,21 @@ describe("parsePullRequestFinalization", () => {
     expect(
       parsePullRequestFinalization("pull_request", "delivery", {
         action: "closed",
+        number: 816,
         repository: { full_name: "Robbie-Palmer/personal-site" },
-        pull_request: { number: 816, head: { sha: "abc123" } },
+        pull_request: { head: { sha: "abc123" } },
+      }),
+    ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
+    expect(
+      parsePullRequestFinalization("pull_request", "delivery", {
+        action: "closed",
+        number: 816,
+        repository: { full_name: "Robbie-Palmer/personal-site" },
+        pull_request: {
+          merged: true,
+          closed_at: "not-a-timestamp",
+          head: { sha: "abc123" },
+        },
       }),
     ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
     expect(
@@ -363,8 +378,9 @@ describe("parseFindingInteraction", () => {
     expect(
       parseReviewEvent("pull_request", "x".repeat(256), {
         action: "opened",
+        number: 816,
         repository: { full_name: "Robbie-Palmer/personal-site" },
-        pull_request: { number: 816, head: { sha: "abc123" } },
+        pull_request: { head: { sha: "abc123" } },
       }),
     ).toEqual({ kind: "invalid", reason: "Malformed webhook payload" });
     expect(

--- a/ai-review/tests/workflow.test.ts
+++ b/ai-review/tests/workflow.test.ts
@@ -293,6 +293,7 @@ describe("ReviewWorkflow orchestration", () => {
       payload,
       event.instanceId,
       skippedPrepared,
+      { result: { finding_resolutions: [] }, cost: 0 },
       { hunks: [], candidates: {}, publishedFindings: [] },
       expect.objectContaining({ runCostUsd: 0 }),
     );

--- a/ui/content/projects/agentic-code-review/index.mdx
+++ b/ui/content/projects/agentic-code-review/index.mdx
@@ -226,8 +226,9 @@ described by
 * publish or update native GitHub review findings without duplicating resolved
   threads;
 * report model coverage failures and the resulting confidence explicitly; and
-* record versioned run, finding, model, outcome, latency, token, and cost data
-  for later evaluation.
+* record versioned run, finding, model, outcome, latency, token, and cost data,
+  attributing later-head fixes, explicit dispositions, superseded code, and
+  no-response closures for evaluation.
 
 # Architecture Lineage
 


### PR DESCRIPTION
## Summary

- turn explicit finding dispositions into immutable, versioned evaluation outcomes
- attribute findings resolved on later reviewed heads as confirmed fixes with linked run, hunk, and resolution evidence
- finalize remaining findings when a pull request closes as superseded or no observable response, recording final-head coverage
- persist retry-safe outcome revisions in R2 and document the evaluation contract

## Validation

- `mise //ai-review:check`
- `mise //ai-review:deploy:dry-run`
- Markdown and MDX lint through pre-commit
- staged gitleaks scan
- `git diff --check`

## QA

No interactive preview QA is required. The runtime change is isolated to the standalone AI review Worker; the site change is a copy-only update to the Agentic Code Review project page. Workerd integration tests cover explicit dispositions, later-head fixes, closure finalization, idempotency, and R2 persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outcome tracking for acknowledgements, rejections, confirmed fixes, superseded findings and no-response closures.
  * Added controlled replay of findings across later commits, with evidence-based fixed, present or uncertain classifications.
  * Pull-request closure events now finalise unresolved findings and record whether affected code remains.
  * Outcomes are versioned, deduplicated and safely persisted for reliable reporting.
* **Documentation**
  * Expanded reporting to include evaluation attribution, later-head fixes, dispositions, closure outcomes, model usage, latency, tokens and cost.
* **Bug Fixes**
  * Improved handling of duplicate, malformed and unsupported pull-request closure events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->