### PR TITLE
Fix preview rotation secret sync

### DIFF
--- a/scripts/sync-doppler-github-envs.sh
+++ b/scripts/sync-doppler-github-envs.sh
@@ -32,9 +32,21 @@ load_config_entries() {
   fi
 
   secrets_json=$(doppler secrets --project "$doppler_project" --config "$doppler_config" --json)
-  jq -c --arg source "$doppler_project/$doppler_config" '
+  jq -c \
+    --arg source "$doppler_project/$doppler_config" \
+    --arg config "$doppler_config" '
     to_entries
-    | map(select(.key | startswith("DOPPLER_") | not))
+    | map(select(
+        (.key | startswith("DOPPLER_") | not)
+        or (
+          $config == "ops_preview_agent_access"
+          and (
+            .key == "DOPPLER_AGENT_CONFIG"
+            or .key == "DOPPLER_PROJECT"
+            or .key == "DOPPLER_SERVICE_TOKEN"
+          )
+        )
+      ))
     | map({
         name: .key,
         value: .value.computed,


### PR DESCRIPTION
## Summary
- preserve the three rotation-specific `DOPPLER_*` entries when syncing `ops_preview_agent_access`
- continue filtering Doppler metadata from every other config
- prevent a later sync from deleting the rotation workflow's scoped Doppler credential and target variables

## Validation
- `bash -n scripts/sync-doppler-github-envs.sh`
- live `preview-agent-access` sync retained both secrets and all three variables
- fixture check confirmed non-rotation configs still exclude Doppler metadata
- staged gitleaks scan passed
- on-demand rotation workflow passed before this follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved required Doppler configuration values when loading preview agent access settings.
  * Continued excluding unrelated Doppler-prefixed entries from synchronised environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->