### PR TITLE
feat(homelab): Jellyfin media server stack for Mac mini hub

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -15,6 +15,7 @@ config_roots = [
     "ai-review",
     "workers/recipe-api",
     "workers/recipe-ingest",
+    "homelab",
 ]
 
 [settings]

--- a/homelab/.gitignore
+++ b/homelab/.gitignore
@@ -1,0 +1,5 @@
+# Per-host local configuration; never commit real values
+hosts/mac-mini/jellyfin/.env
+
+# Runtime state that exists only on the hub (Jellyfin config, metadata, cache)
+hosts/mac-mini/jellyfin/data/

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -1,24 +1,10 @@
 # Home Lab (code-as-config)
 
 This directory declares the home lab's machines as code, following the layout
-planned in [ADR 010](/projects/homelab/adrs/010-nixos-gpu-worker): every host
-gets a `homelab/hosts/<host>/` directory, and each service on that host is a
-subdirectory of it. The goal is the same one that motivates the whole lab —
-the same config in produces the same system out, every change is reviewable
-and rollbackable, and nothing is hand-edited on a box that then forgets it.
-
-```text
-homelab/
-├── mise.toml                 # tasks: bootstrap, up, down, status, logs, pull, verify
-├── hosts/
-│   ├── mac-mini/             # the home hub
-│   │   └── jellyfin/         # Jellyfin media server (ADR 011)
-│   │       ├── docker-compose.yml
-│   │       ├── .env.example  # copy to .env and set MEDIA_DIR (gitignored)
-│   │       ├── launchd/      # homelab.jellyfin.plist template
-│   │       └── scripts/      # bootstrap.sh, keep-running.sh
-│   └── asus-desktop/         # future: NixOS flake for the GPU worker (ADR 010)
-```
+planned in [ADR 010](/projects/homelab/adrs/010-nixos-gpu-worker). The goal is
+the same one that motivates the whole lab — the same config in produces the
+same system out, every change is reviewable and rollbackable, and nothing is
+hand-edited on a box that then forgets it.
 
 All services are reachable only over the home LAN and the
 [Tailscale](/projects/homelab/adrs/000-tailscale) tailnet — the router
@@ -26,67 +12,52 @@ forwards no ports, so nothing is ever public.
 
 ## Jellyfin on the Mac mini
 
-Jellyfin (ADR 011) runs on the hub. The stack is declared in
-`hosts/mac-mini/jellyfin/`; a launchd agent keeps it running across reboots
-and crashes.
+Jellyfin (ADR 011) runs on the hub. A launchd agent keeps it running across
+reboots and crashes.
 
 ### One-time bootstrap
 
 Run on the hub with mise installed and Homebrew available:
 
 ```bash
-cp hosts/mac-mini/jellyfin/.env.example hosts/mac-mini/jellyfin/.env
-# edit .env: set MEDIA_DIR to your library on the 10TB HDD
 mise run //homelab:bootstrap
 ```
 
-`bootstrap` installs dependencies, starts the runtime, installs the
-launchd agent, and brings up the stack. It then prints the access URLs:
+The bootstrap will prompt you to create a `.env` file from the example
+template and set `MEDIA_DIR` to your library on the 10TB HDD, then re-run.
+
+Once complete it prints access URLs:
 
 - **Local**: `http://localhost:8096`
 - **LAN** (Fire TV Stick): `http://<hub-lan-ip>:8096`
 - **Tailnet** (phone / laptop): `http://<hub-tailscale-ip>:8096`
 
 Then add your media folders in the Jellyfin web UI: TV shows under
-`/media/TV` and movies under `/media/Movies` (the library is mounted
-read-only as `/media`).
+`/media/TV` and movies under `/media/Movies`.
 
 ### Day-to-day
 
 ```bash
-mise run //homelab:status    # show the state of the stack
-mise run //homelab:logs      # follow Jellyfin logs
-mise run //homelab:restart   # restart Jellyfin
-mise run //homelab:verify    # check the health endpoint
+mise run //homelab:status
+mise run //homelab:logs
+mise run //homelab:restart
+mise run //homelab:verify
 ```
 
 ### Upgrading
 
-Jellyfin image tags are pinned in `.env` (`JELLYFIN_VERSION`, default `10.11`
-for patch updates of the current stable minor). To upgrade:
-
 1. Bump `JELLYFIN_VERSION` in `.env` (or pin an exact release).
-2. `mise run //homelab:pull` — pulls the new image and recreates the
-   container, keeping the existing config in `data/config/`.
+2. `mise run //homelab:pull`
 
 ### Caveats
 
-- **Brief unauthenticated window on first bootstrap.** Between
-  `docker compose up` and `provision.sh` completing, Jellyfin's startup
-  wizard is accessible on the port. The router forwards no ports and the
-  tailnet is the lab's trust boundary, so this is only a risk if an
-  untrusted peer is on the LAN during the few seconds bootstrap runs.
-- **colima mounts only `$HOME` by default.** The bootstrap mounts `/Volumes`
-  read-only so the media drive is visible to containers. If the VM is
-  recreated without those flags, Jellyfin will see an empty `/media`. If the
-  drive isn't visible, recreate the VM: `colima delete` then re-run
-  `mise run //homelab:bootstrap`.
+- **Brief unauthenticated window on first bootstrap.** Between the stack
+  starting and provisioning completing, Jellyfin's startup wizard is
+  accessible on the port. The router forwards no ports and the tailnet is
+  the lab's trust boundary, so this is only a risk if an untrusted peer is
+  on the LAN during the few seconds bootstrap runs.
 - **The drive must be mounted before bootstrap.** If the HDD isn't
   connected or auto-mounted at login, the mount point won't exist.
-- **Config lives in `data/config/`** (gitignored) next to the compose file,
-  so Jellyfin's metadata and settings are plain files on the hub's disk that
-  a backup job can copy. Move it by setting `JELLYFIN_CONFIG_DIR` if the
-  library metadata grows large.
 - The [Netdata](/projects/homelab/adrs/009-netdata) alerting on the hub
   should gain a check for the Jellyfin container and the media drive, so a
   dead stack is noticed before the family does.

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -24,7 +24,7 @@ mise run //homelab:bootstrap
 ```
 
 The bootstrap will prompt you to create a `.env` file from the example
-template and set `MEDIA_DIR` to your library on the 10TB HDD, then re-run.
+template and set `MEDIA_DIR` to your media library, then re-run.
 
 Once complete it prints access URLs:
 
@@ -56,7 +56,7 @@ mise run //homelab:verify
   accessible on the port. The router forwards no ports and the tailnet is
   the lab's trust boundary, so this is only a risk if an untrusted peer is
   on the LAN during the few seconds bootstrap runs.
-- **The drive must be mounted before bootstrap.** If the HDD isn't
+- **The drive must be mounted before bootstrap.** If the volume isn't
   connected or auto-mounted at login, the mount point won't exist.
 - The [Netdata](/projects/homelab/adrs/009-netdata) alerting on the hub
   should gain a check for the Jellyfin container and the media drive, so a

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -28,7 +28,9 @@ forwards no ports, so nothing is ever public.
 
 Jellyfin (ADR 011) runs on the hub in Docker Compose, managed by colima. The
 stack is declared in `hosts/mac-mini/jellyfin/`; a launchd agent keeps colima
-and the stack running across reboots and crashes.
+and the stack running across reboots and crashes. Colima replaces Docker
+Desktop (it provides the Linux VM with the Docker daemon), but you still
+need the `docker` CLI and `docker-compose` plugin to interact with it.
 
 ### One-time bootstrap
 

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -26,11 +26,9 @@ forwards no ports, so nothing is ever public.
 
 ## Jellyfin on the Mac mini
 
-Jellyfin (ADR 011) runs on the hub in Docker Compose, managed by colima. The
-stack is declared in `hosts/mac-mini/jellyfin/`; a launchd agent keeps colima
-and the stack running across reboots and crashes. Colima replaces Docker
-Desktop (it provides the Linux VM with the Docker daemon), but you still
-need the `docker` CLI and `docker-compose` plugin to interact with it.
+Jellyfin (ADR 011) runs on the hub. The stack is declared in
+`hosts/mac-mini/jellyfin/`; a launchd agent keeps it running across reboots
+and crashes.
 
 ### One-time bootstrap
 
@@ -42,10 +40,8 @@ cp hosts/mac-mini/jellyfin/.env.example hosts/mac-mini/jellyfin/.env
 mise run //homelab:bootstrap
 ```
 
-`bootstrap.sh` installs colima, docker, and docker-compose via Homebrew,
-starts colima with `/Volumes` mounted read-only (vz + virtiofs), installs the
-`homelab.jellyfin` LaunchAgent, and brings up the stack. It then prints the
-access URLs:
+`bootstrap` installs dependencies, starts the runtime, installs the
+launchd agent, and brings up the stack. It then prints the access URLs:
 
 - **Local**: `http://localhost:8096`
 - **LAN** (Fire TV Stick): `http://<hub-lan-ip>:8096`
@@ -58,10 +54,10 @@ read-only as `/media`).
 ### Day-to-day
 
 ```bash
-mise run //homelab:status    # docker compose ps
+mise run //homelab:status    # show the state of the stack
 mise run //homelab:logs      # follow Jellyfin logs
-mise run //homelab:restart   # restart the container
-mise run //homelab:verify    # hit the health endpoint
+mise run //homelab:restart   # restart Jellyfin
+mise run //homelab:verify    # check the health endpoint
 ```
 
 ### Upgrading
@@ -81,13 +77,11 @@ for patch updates of the current stable minor). To upgrade:
   tailnet is the lab's trust boundary, so this is only a risk if an
   untrusted peer is on the LAN during the few seconds bootstrap runs.
 - **colima mounts only `$HOME` by default.** The bootstrap mounts `/Volumes`
-  read-only so the media drive is visible to containers. If you start colima
-  manually without those flags, Jellyfin will see an empty `/media`. If the
-  drive isn't visible, recreate colima: `colima delete` then re-run
+  read-only so the media drive is visible to containers. If the VM is
+  recreated without those flags, Jellyfin will see an empty `/media`. If the
+  drive isn't visible, recreate the VM: `colima delete` then re-run
   `mise run //homelab:bootstrap`.
-- **Drive names with spaces break colima mounts.** Name the media volume
-  without spaces (e.g. `HOME-LAB-10TB`), or the mount fails at colima start.
-- **The drive must be mounted before colima starts.** If the HDD isn't
+- **The drive must be mounted before bootstrap.** If the HDD isn't
   connected or auto-mounted at login, the mount point won't exist.
 - **Config lives in `data/config/`** (gitignored) next to the compose file,
   so Jellyfin's metadata and settings are plain files on the hub's disk that

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -73,6 +73,11 @@ for patch updates of the current stable minor). To upgrade:
 
 ### Caveats
 
+- **Brief unauthenticated window on first bootstrap.** Between
+  `docker compose up` and `provision.sh` completing, Jellyfin's startup
+  wizard is accessible on the port. The router forwards no ports and the
+  tailnet is the lab's trust boundary, so this is only a risk if an
+  untrusted peer is on the LAN during the few seconds bootstrap runs.
 - **colima mounts only `$HOME` by default.** The bootstrap mounts `/Volumes`
   read-only so the media drive is visible to containers. If you start colima
   manually without those flags, Jellyfin will see an empty `/media`. If the

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -1,0 +1,91 @@
+# Home Lab (code-as-config)
+
+This directory declares the home lab's machines as code, following the layout
+planned in [ADR 010](/projects/homelab/adrs/010-nixos-gpu-worker): every host
+gets a `homelab/hosts/<host>/` directory, and each service on that host is a
+subdirectory of it. The goal is the same one that motivates the whole lab —
+the same config in produces the same system out, every change is reviewable
+and rollbackable, and nothing is hand-edited on a box that then forgets it.
+
+```text
+homelab/
+├── mise.toml                 # tasks: bootstrap, up, down, status, logs, pull, verify
+├── hosts/
+│   ├── mac-mini/             # the home hub
+│   │   └── jellyfin/         # Jellyfin media server (ADR 011)
+│   │       ├── docker-compose.yml
+│   │       ├── .env.example  # copy to .env and set MEDIA_DIR (gitignored)
+│   │       ├── launchd/      # homelab.jellyfin.plist template
+│   │       └── scripts/      # bootstrap.sh, keep-running.sh
+│   └── asus-desktop/         # future: NixOS flake for the GPU worker (ADR 010)
+```
+
+All services are reachable only over the home LAN and the
+[Tailscale](/projects/homelab/adrs/000-tailscale) tailnet — the router
+forwards no ports, so nothing is ever public.
+
+## Jellyfin on the Mac mini
+
+Jellyfin (ADR 011) runs on the hub in Docker Compose, managed by colima. The
+stack is declared in `hosts/mac-mini/jellyfin/`; a launchd agent keeps colima
+and the stack running across reboots and crashes.
+
+### One-time bootstrap
+
+Run on the hub with mise installed and Homebrew available:
+
+```bash
+cp hosts/mac-mini/jellyfin/.env.example hosts/mac-mini/jellyfin/.env
+# edit .env: set MEDIA_DIR to your library on the 10TB HDD
+mise run //homelab:bootstrap
+```
+
+`bootstrap.sh` installs colima, docker, and docker-compose via Homebrew,
+starts colima with `/Volumes` mounted read-only (vz + virtiofs), installs the
+`homelab.jellyfin` LaunchAgent, and brings up the stack. It then prints the
+access URLs:
+
+- **Local**: `http://localhost:8096`
+- **LAN** (Fire TV Stick): `http://<hub-lan-ip>:8096`
+- **Tailnet** (phone / laptop): `http://<hub-tailscale-ip>:8096`
+
+Then add your media folders in the Jellyfin web UI: TV shows under
+`/media/TV` and movies under `/media/Movies` (the library is mounted
+read-only as `/media`).
+
+### Day-to-day
+
+```bash
+mise run //homelab:status    # docker compose ps
+mise run //homelab:logs      # follow Jellyfin logs
+mise run //homelab:restart   # restart the container
+mise run //homelab:verify    # hit the health endpoint
+```
+
+### Upgrading
+
+Jellyfin image tags are pinned in `.env` (`JELLYFIN_VERSION`, default `10.11`
+for patch updates of the current stable minor). To upgrade:
+
+1. Bump `JELLYFIN_VERSION` in `.env` (or pin an exact release).
+2. `mise run //homelab:pull` — pulls the new image and recreates the
+   container, keeping the existing config in `data/config/`.
+
+### Caveats
+
+- **colima mounts only `$HOME` by default.** The bootstrap mounts `/Volumes`
+  read-only so the media drive is visible to containers. If you start colima
+  manually without those flags, Jellyfin will see an empty `/media`. If the
+  drive isn't visible, recreate colima: `colima delete` then re-run
+  `mise run //homelab:bootstrap`.
+- **Drive names with spaces break colima mounts.** Name the media volume
+  without spaces (e.g. `HOME-LAB-10TB`), or the mount fails at colima start.
+- **The drive must be mounted before colima starts.** If the HDD isn't
+  connected or auto-mounted at login, the mount point won't exist.
+- **Config lives in `data/config/`** (gitignored) next to the compose file,
+  so Jellyfin's metadata and settings are plain files on the hub's disk that
+  a backup job can copy. Move it by setting `JELLYFIN_CONFIG_DIR` if the
+  library metadata grows large.
+- The [Netdata](/projects/homelab/adrs/009-netdata) alerting on the hub
+  should gain a check for the Jellyfin container and the media drive, so a
+  dead stack is noticed before the family does.

--- a/homelab/hosts/mac-mini/jellyfin/.env.example
+++ b/homelab/hosts/mac-mini/jellyfin/.env.example
@@ -6,9 +6,7 @@ JELLYFIN_VERSION=10.11
 # tailnet; the router forwards no ports, so it is never public.
 JELLYFIN_PORT=8096
 
-# Media library on the hub's external 10TB HDD. The colima VM mounts
-# /Volumes read-only (see bootstrap.sh), so any drive path works as long as
-# the volume name contains no spaces. Jellyfin sees this as /media.
+# Media library path. Any mounted volume works; Jellyfin sees this as /media.
 MEDIA_DIR=/Volumes/EXAMPLE-DRIVE/Media
 
 # Timezone used for scheduled tasks (e.g. America/Los_Angeles).

--- a/homelab/hosts/mac-mini/jellyfin/.env.example
+++ b/homelab/hosts/mac-mini/jellyfin/.env.example
@@ -1,0 +1,15 @@
+# Jellyfin image tag. Track the current stable minor (10.11) for patch
+# updates, or pin an exact release such as 10.11.7 for full reproducibility.
+JELLYFIN_VERSION=10.11
+
+# Host port for the Jellyfin web UI. Reachable on the home LAN and the
+# tailnet; the router forwards no ports, so it is never public.
+JELLYFIN_PORT=8096
+
+# Media library on the hub's external 10TB HDD. The colima VM mounts
+# /Volumes read-only (see bootstrap.sh), so any drive path works as long as
+# the volume name contains no spaces. Jellyfin sees this as /media.
+MEDIA_DIR=/Volumes/EXAMPLE-DRIVE/Media
+
+# Timezone used for scheduled tasks (e.g. America/Los_Angeles).
+TZ=UTC

--- a/homelab/hosts/mac-mini/jellyfin/docker-compose.yml
+++ b/homelab/hosts/mac-mini/jellyfin/docker-compose.yml
@@ -1,0 +1,20 @@
+name: jellyfin
+
+services:
+  jellyfin:
+    image: jellyfin/jellyfin:${JELLYFIN_VERSION:-10.11}
+    container_name: jellyfin
+    restart: unless-stopped
+    ports:
+      - "${JELLYFIN_PORT:-8096}:8096"
+    environment:
+      TZ: "${TZ:-UTC}"
+    volumes:
+      - "${JELLYFIN_CONFIG_DIR:-./data/config}:/config"
+      - "${MEDIA_DIR:?set MEDIA_DIR in the jellyfin .env file}:/media:ro"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8096/health"]
+      interval: 1m
+      timeout: 5s
+      retries: 3
+      start_period: 60s

--- a/homelab/hosts/mac-mini/jellyfin/launchd/homelab.jellyfin.plist
+++ b/homelab/hosts/mac-mini/jellyfin/launchd/homelab.jellyfin.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>homelab.jellyfin</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__HOMELAB_ROOT__/hosts/mac-mini/jellyfin/scripts/keep-running.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/homelab.jellyfin.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/homelab.jellyfin.err.log</string>
+</dict>
+</plist>

--- a/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# One-time bootstrap for the Jellyfin stack on the macOS hub (Mac mini):
-#   1. Install colima, docker, and docker-compose via Homebrew.
-#   2. Create the .env file from the example template (requires MEDIA_DIR).
-#   3. Start colima with the media drive mounted (vz + virtiofs, /Volumes read-only).
-#   4. Install and start the homelab.jellyfin LaunchAgent (keep-running.sh).
-#   5. Bring up the compose stack and print access URLs.
+# One-time bootstrap for the Jellyfin stack on the Mac mini hub.
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
@@ -36,8 +31,6 @@ if ! command -v colima >/dev/null 2>&1; then
   echo "Installing colima via Homebrew"
   brew install colima
 fi
-# docker and docker-compose may be missing even when colima is present (e.g.
-# installed independently or after Docker Desktop was removed).
 for tool in docker docker-compose; do
   if ! command -v "$tool" >/dev/null 2>&1; then
     echo "Installing $tool via Homebrew"
@@ -48,9 +41,8 @@ require_command colima
 require_command docker
 require_command docker-compose
 
-# Docker Desktop leaves a credsStore pointing at its own helper (absent from
-# this script's PATH). With colima we only pull public images, so a credential
-# helper is unnecessary and its stale reference breaks every pull.
+# Remove a stale credential helper that breaks image pulls when the original
+# tool is no longer installed.
 if [[ -f "${HOME}/.docker/config.json" ]] && command -v jq >/dev/null 2>&1; then
   stale_store="$(jq -r '.credsStore // empty' "${HOME}/.docker/config.json" 2>/dev/null)"
   if [[ -n "$stale_store" ]] && ! command -v "docker-credential-${stale_store}" >/dev/null 2>&1; then
@@ -100,18 +92,13 @@ if [[ ! -d "$MEDIA_DIR" ]]; then
 fi
 mkdir -p "$MEDIA_DIR/TV" "$MEDIA_DIR/Movies"
 
-# 3. colima ----------------------------------------------------------------
+# 3. VM setup --------------------------------------------------------------
 if colima status >/dev/null 2>&1; then
   echo "colima is already running; keeping its current configuration."
   echo "If the media drive is not visible to containers, recreate it with:"
   echo "  colima delete && mise run //homelab:bootstrap"
 else
-  # The hub has 8GB of RAM and also runs Docker Desktop, so colima gets a
-  # modest allocation; raise it via COLIMA_CPU / COLIMA_MEMORY if needed.
-  # $HOME is shared read-write (repo config dir lives there); /Volumes is
-  # shared read-only so containers can see the 10TB HDD. Note: passing
-  # --mount replaces colima's default mounts, so $HOME must be listed too.
-  echo "Starting colima (vz + virtiofs, \$HOME rw + /Volumes ro)"
+  echo "Starting colima"
   colima start \
     --vm-type vz \
     --mount-type virtiofs \
@@ -147,7 +134,7 @@ DOCKER_CONTEXT=colima docker compose \
   --project-directory "$JELLYFIN_DIR" \
   up -d
 
-# 6. Configure Jellyfin (wizard + libraries) --------------------------------
+# 6. Configure Jellyfin ----------------------------------------------------
 echo "Waiting for Jellyfin to accept connections..."
 healthy=false
 for _ in $(seq 1 20); do

--- a/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
@@ -58,7 +58,7 @@ fi
 if [[ ! -f "$ENV_FILE" ]]; then
   cp "${JELLYFIN_DIR}/.env.example" "$ENV_FILE"
   echo "Created $ENV_FILE from the example template."
-  echo "Set MEDIA_DIR to your media library on the 10TB HDD, then re-run."
+  echo "Set MEDIA_DIR to your media library, then re-run."
   exit 1
 fi
 
@@ -87,7 +87,7 @@ if [[ -z "$MEDIA_DIR" ]]; then
 fi
 if [[ ! -d "$MEDIA_DIR" ]]; then
   echo "MEDIA_DIR does not exist on this machine: $MEDIA_DIR" >&2
-  echo "Is the 10TB HDD connected and mounted?" >&2
+  echo "Is the media volume connected and mounted?" >&2
   exit 1
 fi
 mkdir -p "$MEDIA_DIR/TV" "$MEDIA_DIR/Movies"

--- a/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
@@ -55,9 +55,10 @@ if [[ -f "${HOME}/.docker/config.json" ]] && command -v jq >/dev/null 2>&1; then
   stale_store="$(jq -r '.credsStore // empty' "${HOME}/.docker/config.json" 2>/dev/null)"
   if [[ -n "$stale_store" ]] && ! command -v "docker-credential-${stale_store}" >/dev/null 2>&1; then
     echo "Removing stale credsStore \"${stale_store}\" from ~/.docker/config.json"
-    jq 'del(.credsStore)' "${HOME}/.docker/config.json" \
-      > "${HOME}/.docker/config.json.tmp" \
-      && mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
+    tmpfile="$(mktemp "${HOME}/.docker/config.json.XXXXXX")"
+    trap 'rm -f "$tmpfile"' EXIT
+    jq 'del(.credsStore)' "${HOME}/.docker/config.json" > "$tmpfile" \
+      && mv "$tmpfile" "${HOME}/.docker/config.json"
   fi
 fi
 
@@ -72,14 +73,15 @@ fi
 # Generate admin credentials on first bootstrap so provision.sh can complete
 # the Jellyfin setup without the interactive web wizard.
 if ! grep -qE '^JELLYFIN_ADMIN_USER=' "$ENV_FILE"; then
-  JELLYFIN_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+  JELLYFIN_ADMIN_PASSWORD="$(openssl rand -base64 32)"
   printf 'JELLYFIN_ADMIN_USER=admin\nJELLYFIN_ADMIN_PASSWORD=%s\n' "$JELLYFIN_ADMIN_PASSWORD" >> "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
   echo "Generated Jellyfin admin credentials; saved to $ENV_FILE (gitignored)."
 fi
 
 env_value() {
   local key="$1"
-  grep -E "^${key}=" "$ENV_FILE" | tail -1 | cut -d= -f2- \
+  grep -F "${key}=" "$ENV_FILE" | tail -1 | cut -d= -f2- \
     | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
 }
 
@@ -120,14 +122,24 @@ else
 fi
 
 # 4. LaunchAgent -----------------------------------------------------------
+# Escape sed metacharacters in replacement strings to prevent injection.
+sed_escape() { printf '%s' "$1" | sed 's/[&/\]/\\&/g'; }
+HOMELAB_ROOT_ESC="$(sed_escape "$HOMELAB_ROOT")"
+HOME_ESC="$(sed_escape "$HOME")"
 sed \
-  -e "s|__HOMELAB_ROOT__|${HOMELAB_ROOT}|g" \
-  -e "s|__HOME__|${HOME}|g" \
+  -e "s|__HOMELAB_ROOT__|${HOMELAB_ROOT_ESC}|g" \
+  -e "s|__HOME__|${HOME_ESC}|g" \
   "${JELLYFIN_DIR}/launchd/${LAUNCHD_AGENT}.plist" > "$LAUNCHD_TARGET"
 
 launchctl bootout "gui/$(id -u)" "$LAUNCHD_TARGET" 2>/dev/null || true
-launchctl bootstrap "gui/$(id -u)" "$LAUNCHD_TARGET"
-launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_AGENT}"
+if ! launchctl bootstrap "gui/$(id -u)" "$LAUNCHD_TARGET"; then
+  echo "Failed to install LaunchAgent ${LAUNCHD_AGENT}" >&2
+  exit 1
+fi
+if ! launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_AGENT}"; then
+  echo "Failed to start LaunchAgent ${LAUNCHD_AGENT}" >&2
+  exit 1
+fi
 echo "Installed and started LaunchAgent ${LAUNCHD_AGENT}"
 
 # 5. Bring up the stack ----------------------------------------------------
@@ -137,12 +149,18 @@ DOCKER_CONTEXT=colima docker compose \
 
 # 6. Configure Jellyfin (wizard + libraries) --------------------------------
 echo "Waiting for Jellyfin to accept connections..."
+healthy=false
 for _ in $(seq 1 20); do
   if curl -fsS "http://localhost:${JELLYFIN_PORT}/health" >/dev/null 2>&1; then
+    healthy=true
     break
   fi
   sleep 3
 done
+if [[ "$healthy" != "true" ]]; then
+  echo "Jellyfin did not become healthy within 60 seconds" >&2
+  exit 1
+fi
 bash "${JELLYFIN_DIR}/scripts/provision.sh"
 
 # 7. Report access ----------------------------------------------------------

--- a/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time bootstrap for the Jellyfin stack on the macOS hub (Mac mini):
+#   1. Install colima, docker, and docker-compose via Homebrew.
+#   2. Create the .env file from the example template (requires MEDIA_DIR).
+#   3. Start colima with the media drive mounted (vz + virtiofs, /Volumes read-only).
+#   4. Install and start the homelab.jellyfin LaunchAgent (keep-running.sh).
+#   5. Bring up the compose stack and print access URLs.
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+HOMELAB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+JELLYFIN_DIR="${HOMELAB_ROOT}/hosts/mac-mini/jellyfin"
+ENV_FILE="${JELLYFIN_DIR}/.env"
+LAUNCHD_AGENT="homelab.jellyfin"
+LAUNCHD_TARGET="${HOME}/Library/LaunchAgents/${LAUNCHD_AGENT}.plist"
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "Missing required command: $name" >&2
+    exit 1
+  fi
+}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "bootstrap.sh must run on the macOS hub (Mac mini)." >&2
+  exit 1
+fi
+
+require_command brew
+
+# 1. Container runtime -----------------------------------------------------
+if ! command -v colima >/dev/null 2>&1; then
+  echo "Installing colima, docker, and docker-compose via Homebrew"
+  brew install colima docker docker-compose
+fi
+require_command colima
+require_command docker
+require_command docker-compose
+
+# Docker Desktop leaves a credsStore pointing at its own helper (absent from
+# this script's PATH). With colima we only pull public images, so a credential
+# helper is unnecessary and its stale reference breaks every pull.
+if [[ -f "${HOME}/.docker/config.json" ]] && command -v jq >/dev/null 2>&1; then
+  stale_store="$(jq -r '.credsStore // empty' "${HOME}/.docker/config.json" 2>/dev/null)"
+  if [[ -n "$stale_store" ]] && ! command -v "docker-credential-${stale_store}" >/dev/null 2>&1; then
+    echo "Removing stale credsStore \"${stale_store}\" from ~/.docker/config.json"
+    jq 'del(.credsStore)' "${HOME}/.docker/config.json" \
+      > "${HOME}/.docker/config.json.tmp" \
+      && mv "${HOME}/.docker/config.json.tmp" "${HOME}/.docker/config.json"
+  fi
+fi
+
+# 2. Environment -----------------------------------------------------------
+if [[ ! -f "$ENV_FILE" ]]; then
+  cp "${JELLYFIN_DIR}/.env.example" "$ENV_FILE"
+  echo "Created $ENV_FILE from the example template."
+  echo "Set MEDIA_DIR to your media library on the 10TB HDD, then re-run."
+  exit 1
+fi
+
+# Generate admin credentials on first bootstrap so provision.sh can complete
+# the Jellyfin setup without the interactive web wizard.
+if ! grep -qE '^JELLYFIN_ADMIN_USER=' "$ENV_FILE"; then
+  JELLYFIN_ADMIN_PASSWORD="$(openssl rand -hex 16)"
+  printf 'JELLYFIN_ADMIN_USER=admin\nJELLYFIN_ADMIN_PASSWORD=%s\n' "$JELLYFIN_ADMIN_PASSWORD" >> "$ENV_FILE"
+  echo "Generated Jellyfin admin credentials; saved to $ENV_FILE (gitignored)."
+fi
+
+env_value() {
+  local key="$1"
+  grep -E "^${key}=" "$ENV_FILE" | tail -1 | cut -d= -f2- \
+    | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
+}
+
+MEDIA_DIR="$(env_value MEDIA_DIR)"
+JELLYFIN_PORT="$(env_value JELLYFIN_PORT)"
+JELLYFIN_PORT="${JELLYFIN_PORT:-8096}"
+
+if [[ -z "$MEDIA_DIR" ]]; then
+  echo "MEDIA_DIR is not set in $ENV_FILE" >&2
+  exit 1
+fi
+if [[ ! -d "$MEDIA_DIR" ]]; then
+  echo "MEDIA_DIR does not exist on this machine: $MEDIA_DIR" >&2
+  echo "Is the 10TB HDD connected and mounted?" >&2
+  exit 1
+fi
+mkdir -p "$MEDIA_DIR/TV" "$MEDIA_DIR/Movies"
+
+# 3. colima ----------------------------------------------------------------
+if colima status >/dev/null 2>&1; then
+  echo "colima is already running; keeping its current configuration."
+  echo "If the media drive is not visible to containers, recreate it with:"
+  echo "  colima delete && mise run //homelab:bootstrap"
+else
+  # The hub has 8GB of RAM and also runs Docker Desktop, so colima gets a
+  # modest allocation; raise it via COLIMA_CPU / COLIMA_MEMORY if needed.
+  # $HOME is shared read-write (repo config dir lives there); /Volumes is
+  # shared read-only so containers can see the 10TB HDD. Note: passing
+  # --mount replaces colima's default mounts, so $HOME must be listed too.
+  echo "Starting colima (vz + virtiofs, \$HOME rw + /Volumes ro)"
+  colima start \
+    --vm-type vz \
+    --mount-type virtiofs \
+    --cpu "${COLIMA_CPU:-4}" \
+    --memory "${COLIMA_MEMORY:-4}" \
+    --mount "${HOME}:w" \
+    --mount /Volumes
+fi
+
+# 4. LaunchAgent -----------------------------------------------------------
+sed \
+  -e "s|__HOMELAB_ROOT__|${HOMELAB_ROOT}|g" \
+  -e "s|__HOME__|${HOME}|g" \
+  "${JELLYFIN_DIR}/launchd/${LAUNCHD_AGENT}.plist" > "$LAUNCHD_TARGET"
+
+launchctl bootout "gui/$(id -u)" "$LAUNCHD_TARGET" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$LAUNCHD_TARGET"
+launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_AGENT}"
+echo "Installed and started LaunchAgent ${LAUNCHD_AGENT}"
+
+# 5. Bring up the stack ----------------------------------------------------
+DOCKER_CONTEXT=colima docker compose \
+  --project-directory "$JELLYFIN_DIR" \
+  up -d
+
+# 6. Configure Jellyfin (wizard + libraries) --------------------------------
+echo "Waiting for Jellyfin to accept connections..."
+for _ in $(seq 1 20); do
+  if curl -fsS "http://localhost:${JELLYFIN_PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 3
+done
+bash "${JELLYFIN_DIR}/scripts/provision.sh"
+
+# 7. Report access ----------------------------------------------------------
+echo ""
+echo "Jellyfin is up. Access the web UI at:"
+echo "  local:   http://localhost:${JELLYFIN_PORT}"
+LAN_IF="$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')"
+LAN_IP="$(ipconfig getifaddr "$LAN_IF" 2>/dev/null || true)"
+if [[ -n "$LAN_IP" ]]; then
+  echo "  LAN:     http://${LAN_IP}:${JELLYFIN_PORT}  (Fire TV Stick)"
+fi
+TAILSCALE_IP="$(tailscale ip -4 2>/dev/null | head -n1 || true)"
+if [[ -n "$TAILSCALE_IP" ]]; then
+  echo "  tailnet: http://${TAILSCALE_IP}:${JELLYFIN_PORT}  (phone / laptop)"
+fi
+echo ""
+echo "Add your media folders in the Jellyfin web UI: TV under /media/TV,"
+echo "movies under /media/Movies. The library is mounted read-only."

--- a/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
@@ -144,11 +144,11 @@ echo "  local:   http://localhost:${JELLYFIN_PORT}"
 LAN_IF="$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')"
 LAN_IP="$(ipconfig getifaddr "$LAN_IF" 2>/dev/null || true)"
 if [[ -n "$LAN_IP" ]]; then
-  echo "  LAN:     http://${LAN_IP}:${JELLYFIN_PORT}  (Fire TV Stick)"
+  echo "  LAN:     http://${LAN_IP}:${JELLYFIN_PORT}  (Fire TV Stick)" # NOSONAR S5332: informational echo, not a network request
 fi
 TAILSCALE_IP="$(tailscale ip -4 2>/dev/null | head -n1 || true)"
 if [[ -n "$TAILSCALE_IP" ]]; then
-  echo "  tailnet: http://${TAILSCALE_IP}:${JELLYFIN_PORT}  (phone / laptop)"
+  echo "  tailnet: http://${TAILSCALE_IP}:${JELLYFIN_PORT}  (phone / laptop)" # NOSONAR S5332: informational echo, not a network request
 fi
 echo ""
 echo "Add your media folders in the Jellyfin web UI: TV under /media/TV,"

--- a/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/bootstrap.sh
@@ -33,9 +33,17 @@ require_command brew
 
 # 1. Container runtime -----------------------------------------------------
 if ! command -v colima >/dev/null 2>&1; then
-  echo "Installing colima, docker, and docker-compose via Homebrew"
-  brew install colima docker docker-compose
+  echo "Installing colima via Homebrew"
+  brew install colima
 fi
+# docker and docker-compose may be missing even when colima is present (e.g.
+# installed independently or after Docker Desktop was removed).
+for tool in docker docker-compose; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Installing $tool via Homebrew"
+    brew install "$tool"
+  fi
+done
 require_command colima
 require_command docker
 require_command docker-compose

--- a/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# Keeps the Jellyfin stack running under launchd (homelab.jellyfin).
-# Re-checks every 60 seconds, starting colima and the compose stack if either
-# has stopped, so the stack self-heals across hub reboots and colima crashes.
-# Runs forever; launchd's KeepAlive restarts it if it ever exits.
+# Keeps the Jellyfin stack running under launchd. Re-checks every 60 seconds,
+# starting the VM and the compose stack if either has stopped, so the stack
+# self-heals across hub reboots and crashes. Runs forever; launchd's KeepAlive
+# restarts it if it ever exits.
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export DOCKER_CONTEXT="colima"
@@ -20,8 +20,6 @@ colima_running() {
 while true; do
   if ! colima_running; then
     echo "$(date '+%F %T') colima is not running; starting it" >&2
-    # Same mount layout as bootstrap.sh: $HOME rw + /Volumes ro. If the VM
-    # already exists these flags are ignored and its saved config is reused.
     colima start \
       --vm-type vz \
       --mount-type virtiofs \

--- a/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
@@ -25,8 +25,8 @@ while true; do
     colima start \
       --vm-type vz \
       --mount-type virtiofs \
-      --cpu 4 \
-      --memory 4 \
+      --cpu "${COLIMA_CPU:-4}" \
+      --memory "${COLIMA_MEMORY:-4}" \
       --mount "${HOME}:w" \
       --mount /Volumes >/dev/null 2>&1 \
       || echo "$(date '+%F %T') colima start failed; retrying next cycle" >&2

--- a/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Keeps the Jellyfin stack running under launchd (homelab.jellyfin).
+# Re-checks every 60 seconds, starting colima and the compose stack if either
+# has stopped, so the stack self-heals across hub reboots and colima crashes.
+# Runs forever; launchd's KeepAlive restarts it if it ever exits.
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export DOCKER_CONTEXT="colima"
+
+JELLYFIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_INTERVAL_SECONDS="${CHECK_INTERVAL_SECONDS:-60}"
+
+colima_running() {
+  colima status >/dev/null 2>&1
+}
+
+while true; do
+  if ! colima_running; then
+    echo "$(date '+%F %T') colima is not running; starting it" >&2
+    # Same mount layout as bootstrap.sh: $HOME rw + /Volumes ro. If the VM
+    # already exists these flags are ignored and its saved config is reused.
+    colima start \
+      --vm-type vz \
+      --mount-type virtiofs \
+      --cpu 4 \
+      --memory 4 \
+      --mount "${HOME}:w" \
+      --mount /Volumes >/dev/null 2>&1 \
+      || echo "$(date '+%F %T') colima start failed; retrying next cycle" >&2
+  fi
+
+  if colima_running; then
+    docker compose \
+      --project-directory "$JELLYFIN_DIR" \
+      up -d >/dev/null 2>&1 \
+      || echo "$(date '+%F %T') docker compose up failed; retrying next cycle" >&2
+  fi
+
+  sleep "$CHECK_INTERVAL_SECONDS"
+done

--- a/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/keep-running.sh
@@ -14,6 +14,7 @@ CHECK_INTERVAL_SECONDS="${CHECK_INTERVAL_SECONDS:-60}"
 
 colima_running() {
   colima status >/dev/null 2>&1
+  return $?
 }
 
 while true; do

--- a/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Idempotently completes the Jellyfin first-run wizard and creates the media
-# libraries (TV Shows -> /media/TV, Movies -> /media/Movies) via the API, so
-# no manual web onboarding is needed. Admin credentials come from the .env
-# file (JELLYFIN_ADMIN_USER / JELLYFIN_ADMIN_PASSWORD).
+# Completes the Jellyfin first-run wizard and creates media libraries via the
+# API, so no manual web onboarding is needed.
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 

--- a/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
@@ -34,17 +34,18 @@ if [[ -z "$ADMIN_USER" || -z "$ADMIN_PASS" ]]; then
 fi
 
 AUTH_HEADER='MediaBrowser Client="provision", Device="mac-mini", DeviceId="provision-cli", Version="1.0"'
+CONTENT_TYPE='Content-Type: application/json'
 
 # 1. Complete the startup wizard if it is still pending ---------------------
 status="$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BASE_URL/Startup/Configuration")"
 if [[ "$status" == "200" ]]; then
   echo "Completing Jellyfin first-run wizard"
   curl -s --max-time 10 -X POST "$BASE_URL/Startup/Configuration" \
-    -H "Content-Type: application/json" \
+    -H "$CONTENT_TYPE" \
     -d '{"ServerName":"Mac Mini","UICulture":"en-GB","MetadataCountryCode":"GB","PreferredMetadataLanguage":"en"}' \
     -o /dev/null -w "  startup configuration: %{http_code}\n"
   curl -s --max-time 10 -X POST "$BASE_URL/Startup/User" \
-    -H "Content-Type: application/json" \
+    -H "$CONTENT_TYPE" \
     -d "{\"Name\":\"$ADMIN_USER\",\"Password\":\"$ADMIN_PASS\"}" \
     -o /dev/null -w "  admin user: %{http_code}\n"
   curl -s --max-time 10 -X POST "$BASE_URL/Startup/Complete" \
@@ -55,7 +56,7 @@ fi
 
 # 2. Authenticate as admin ---------------------------------------------------
 TOKEN="$(curl -s --max-time 10 -X POST "$BASE_URL/Users/AuthenticateByName" \
-  -H "Content-Type: application/json" \
+  -H "$CONTENT_TYPE" \
   -H "X-Emby-Authorization: $AUTH_HEADER" \
   -d "{\"Username\":\"$ADMIN_USER\",\"Pw\":\"$ADMIN_PASS\"}" | jq -r .AccessToken)"
 if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
@@ -78,7 +79,7 @@ add_library() {
   echo "  adding $name library ($path)"
   curl -s --max-time 15 -X POST \
     "$BASE_URL/Library/VirtualFolders?name=$name_enc&collectionType=$type_enc&paths=$path_enc&refreshLibrary=true" \
-    -H "Content-Type: application/json" -H "X-Emby-Token: $TOKEN" \
+    -H "$CONTENT_TYPE" -H "X-Emby-Token: $TOKEN" \
     -d '{"libraryOptions":{"enableRealtimeMonitor":true}}' \
     -o /dev/null -w "  $name: %{http_code}\n"
 }

--- a/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Idempotently completes the Jellyfin first-run wizard and creates the media
+# libraries (TV Shows -> /media/TV, Movies -> /media/Movies) via the API, so
+# no manual web onboarding is needed. Admin credentials come from the .env
+# file (JELLYFIN_ADMIN_USER / JELLYFIN_ADMIN_PASSWORD).
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+JELLYFIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${JELLYFIN_DIR}/.env"
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "Missing required command: $name" >&2
+    exit 1
+  fi
+}
+require_command curl
+require_command jq
+
+PORT="$(grep -E '^JELLYFIN_PORT=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2-)"
+PORT="${PORT:-8096}"
+BASE_URL="http://localhost:${PORT}"
+
+ADMIN_USER="$(grep -E '^JELLYFIN_ADMIN_USER=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+ADMIN_PASS="$(grep -E '^JELLYFIN_ADMIN_PASSWORD=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+if [[ -z "$ADMIN_USER" || -z "$ADMIN_PASS" ]]; then
+  echo "JELLYFIN_ADMIN_USER / JELLYFIN_ADMIN_PASSWORD are not set in $ENV_FILE" >&2
+  echo "Run bootstrap.sh (which generates them) or add them manually." >&2
+  exit 1
+fi
+
+AUTH_HEADER='MediaBrowser Client="provision", Device="mac-mini", DeviceId="provision-cli", Version="1.0"'
+
+# 1. Complete the startup wizard if it is still pending ---------------------
+status="$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$BASE_URL/Startup/Configuration")"
+if [[ "$status" == "200" ]]; then
+  echo "Completing Jellyfin first-run wizard"
+  curl -s --max-time 10 -X POST "$BASE_URL/Startup/Configuration" \
+    -H "Content-Type: application/json" \
+    -d '{"ServerName":"Mac Mini","UICulture":"en-GB","MetadataCountryCode":"GB","PreferredMetadataLanguage":"en"}' \
+    -o /dev/null -w "  startup configuration: %{http_code}\n"
+  curl -s --max-time 10 -X POST "$BASE_URL/Startup/User" \
+    -H "Content-Type: application/json" \
+    -d "{\"Name\":\"$ADMIN_USER\",\"Password\":\"$ADMIN_PASS\"}" \
+    -o /dev/null -w "  admin user: %{http_code}\n"
+  curl -s --max-time 10 -X POST "$BASE_URL/Startup/Complete" \
+    -o /dev/null -w "  wizard complete: %{http_code}\n"
+else
+  echo "Startup wizard already complete (Startup/Configuration returned $status); skipping"
+fi
+
+# 2. Authenticate as admin ---------------------------------------------------
+TOKEN="$(curl -s --max-time 10 -X POST "$BASE_URL/Users/AuthenticateByName" \
+  -H "Content-Type: application/json" \
+  -H "X-Emby-Authorization: $AUTH_HEADER" \
+  -d "{\"Username\":\"$ADMIN_USER\",\"Pw\":\"$ADMIN_PASS\"}" | jq -r .AccessToken)"
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo "Authentication failed for user '$ADMIN_USER' - check JELLYFIN_ADMIN_* in $ENV_FILE" >&2
+  exit 1
+fi
+
+# 3. Create the media libraries if they do not exist ------------------------
+add_library() {
+  local name="$1" type="$2" path="$3"
+  if curl -s --max-time 10 "$BASE_URL/Library/VirtualFolders" -H "X-Emby-Token: $TOKEN" \
+      | jq -e --arg n "$name" 'any(.[]; .Name == $n)' >/dev/null 2>&1; then
+    echo "  library '$name' already exists; skipping"
+    return
+  fi
+  local name_enc type_enc path_enc
+  name_enc="$(jq -rn --arg v "$name" '$v|@uri')"
+  type_enc="$(jq -rn --arg v "$type" '$v|@uri')"
+  path_enc="$(jq -rn --arg v "$path" '$v|@uri')"
+  echo "  adding $name library ($path)"
+  curl -s --max-time 15 -X POST \
+    "$BASE_URL/Library/VirtualFolders?name=$name_enc&collectionType=$type_enc&paths=$path_enc&refreshLibrary=true" \
+    -H "Content-Type: application/json" -H "X-Emby-Token: $TOKEN" \
+    -d '{"libraryOptions":{"enableRealtimeMonitor":true}}' \
+    -o /dev/null -w "  $name: %{http_code}\n"
+}
+
+add_library "TV Shows" "tvshows" "/media/TV"
+add_library "Movies" "movies" "/media/Movies"
+
+echo ""
+echo "Jellyfin is configured. Log in at http://localhost:${PORT} with user '$ADMIN_USER'."
+echo "Libraries: TV Shows -> /media/TV, Movies -> /media/Movies (backed by MEDIA_DIR on the host)."

--- a/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
@@ -21,12 +21,18 @@ require_command() {
 require_command curl
 require_command jq
 
-PORT="$(grep -E '^JELLYFIN_PORT=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2-)"
+env_value() {
+  local key="$1"
+  grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- \
+    | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
+}
+
+PORT="$(env_value JELLYFIN_PORT)"
 PORT="${PORT:-8096}"
 BASE_URL="http://localhost:${PORT}"
 
-ADMIN_USER="$(grep -E '^JELLYFIN_ADMIN_USER=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
-ADMIN_PASS="$(grep -E '^JELLYFIN_ADMIN_PASSWORD=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+ADMIN_USER="$(env_value JELLYFIN_ADMIN_USER)"
+ADMIN_PASS="$(env_value JELLYFIN_ADMIN_PASSWORD)"
 if [[ -z "$ADMIN_USER" || -z "$ADMIN_PASS" ]]; then
   echo "JELLYFIN_ADMIN_USER / JELLYFIN_ADMIN_PASSWORD are not set in $ENV_FILE" >&2
   echo "Run bootstrap.sh (which generates them) or add them manually." >&2

--- a/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
+++ b/homelab/hosts/mac-mini/jellyfin/scripts/provision.sh
@@ -23,7 +23,7 @@ require_command jq
 
 env_value() {
   local key="$1"
-  grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- \
+  grep -F "${key}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- \
     | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
 }
 
@@ -50,9 +50,10 @@ if [[ "$status" == "200" ]]; then
     -H "$CONTENT_TYPE" \
     -d '{"ServerName":"Mac Mini","UICulture":"en-GB","MetadataCountryCode":"GB","PreferredMetadataLanguage":"en"}' \
     -o /dev/null -w "  startup configuration: %{http_code}\n"
+  user_json="$(jq -n --arg u "$ADMIN_USER" --arg p "$ADMIN_PASS" '{Name: $u, Password: $p}')"
   curl -s --max-time 10 -X POST "$BASE_URL/Startup/User" \
     -H "$CONTENT_TYPE" \
-    -d "{\"Name\":\"$ADMIN_USER\",\"Password\":\"$ADMIN_PASS\"}" \
+    -d "$user_json" \
     -o /dev/null -w "  admin user: %{http_code}\n"
   curl -s --max-time 10 -X POST "$BASE_URL/Startup/Complete" \
     -o /dev/null -w "  wizard complete: %{http_code}\n"
@@ -61,10 +62,11 @@ else
 fi
 
 # 2. Authenticate as admin ---------------------------------------------------
+auth_json="$(jq -n --arg u "$ADMIN_USER" --arg p "$ADMIN_PASS" '{Username: $u, Pw: $p}')"
 TOKEN="$(curl -s --max-time 10 -X POST "$BASE_URL/Users/AuthenticateByName" \
   -H "$CONTENT_TYPE" \
   -H "X-Emby-Authorization: $AUTH_HEADER" \
-  -d "{\"Username\":\"$ADMIN_USER\",\"Pw\":\"$ADMIN_PASS\"}" | jq -r .AccessToken)"
+  -d "$auth_json" | jq -r .AccessToken)"
 if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
   echo "Authentication failed for user '$ADMIN_USER' - check JELLYFIN_ADMIN_* in $ENV_FILE" >&2
   exit 1

--- a/homelab/mise.toml
+++ b/homelab/mise.toml
@@ -1,13 +1,12 @@
-# Tasks for managing the homelab services declared in this repo. Run them
-# with the //homelab: prefix, e.g. `mise run //homelab:status`. These tasks
-# must be run on the machine that hosts the service (the Mac mini hub).
+# Tasks for managing homelab services. Run with the //homelab: prefix,
+# e.g. `mise run //homelab:status`. Must be run on the hosting machine.
 
 [tasks.bootstrap]
-description = "Install dependencies and deploy the Jellyfin stack on the hub"
+description = "Install dependencies and deploy the Jellyfin stack"
 run = "bash hosts/mac-mini/jellyfin/scripts/bootstrap.sh"
 
 [tasks.provision]
-description = "Complete the Jellyfin wizard and create the media libraries via the API"
+description = "Complete the Jellyfin wizard and create media libraries"
 run = "bash hosts/mac-mini/jellyfin/scripts/provision.sh"
 
 [tasks.status]
@@ -36,10 +35,10 @@ dir = "hosts/mac-mini/jellyfin"
 run = "docker compose logs -f --tail=100"
 
 [tasks.pull]
-description = "Pull the configured image and recreate the container (upgrade)"
+description = "Pull the configured image and recreate the container"
 dir = "hosts/mac-mini/jellyfin"
 run = "docker compose up -d --pull always"
 
 [tasks.verify]
-description = "Check the Jellyfin health endpoint on the hub"
+description = "Check the Jellyfin health endpoint"
 run = 'curl -fsS "http://localhost:${JELLYFIN_PORT:-8096}/health" && echo "Jellyfin is healthy"'

--- a/homelab/mise.toml
+++ b/homelab/mise.toml
@@ -1,0 +1,45 @@
+# Tasks for managing the homelab services declared in this repo. Run them
+# with the //homelab: prefix, e.g. `mise run //homelab:status`. These tasks
+# must be run on the machine that hosts the service (the Mac mini hub).
+
+[tasks.bootstrap]
+description = "Install the container runtime and deploy the Jellyfin stack on the hub"
+run = "bash hosts/mac-mini/jellyfin/scripts/bootstrap.sh"
+
+[tasks.provision]
+description = "Complete the Jellyfin wizard and create the media libraries via the API"
+run = "bash hosts/mac-mini/jellyfin/scripts/provision.sh"
+
+[tasks.status]
+description = "Show the state of the Jellyfin stack"
+dir = "hosts/mac-mini/jellyfin"
+run = "docker compose ps"
+
+[tasks.up]
+description = "Create and start the Jellyfin stack"
+dir = "hosts/mac-mini/jellyfin"
+run = "docker compose up -d"
+
+[tasks.down]
+description = "Stop the Jellyfin stack"
+dir = "hosts/mac-mini/jellyfin"
+run = "docker compose down"
+
+[tasks.restart]
+description = "Restart the Jellyfin container"
+dir = "hosts/mac-mini/jellyfin"
+run = "docker compose restart"
+
+[tasks.logs]
+description = "Follow the Jellyfin logs"
+dir = "hosts/mac-mini/jellyfin"
+run = "docker compose logs -f --tail=100"
+
+[tasks.pull]
+description = "Pull the configured image and recreate the container (upgrade)"
+dir = "hosts/mac-mini/jellyfin"
+run = "docker compose up -d --pull always"
+
+[tasks.verify]
+description = "Check the Jellyfin health endpoint on the hub"
+run = 'curl -fsS "http://localhost:${JELLYFIN_PORT:-8096}/health" && echo "Jellyfin is healthy"'

--- a/homelab/mise.toml
+++ b/homelab/mise.toml
@@ -3,7 +3,7 @@
 # must be run on the machine that hosts the service (the Mac mini hub).
 
 [tasks.bootstrap]
-description = "Install the container runtime and deploy the Jellyfin stack on the hub"
+description = "Install dependencies and deploy the Jellyfin stack on the hub"
 run = "bash hosts/mac-mini/jellyfin/scripts/bootstrap.sh"
 
 [tasks.provision]

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     ],
     "*.{yml,yaml}": [
       "mise run //:lint:yaml"
+    ],
+    "homelab/**/*.{yml,yaml}": [
+      "mise run //:lint:yaml"
     ]
   }
 }

--- a/ui/content/projects/homelab/adrs/011-jellyfin.mdx
+++ b/ui/content/projects/homelab/adrs/011-jellyfin.mdx
@@ -1,8 +1,8 @@
 ---
 title: "ADR 011: Jellyfin media server"
-date: "2026-08-02"
-status: "Proposed"
-tech_stack: ["Jellyfin"]
+date: "2026-08-15"
+status: "Accepted"
+tech_stack: ["Jellyfin", "Docker"]
 ---
 
 # Context
@@ -13,16 +13,20 @@ files. I already pay for Netflix, Disney Plus, Amazon Prime, and Apple TV,
 and still end up rewatching things — the library I've bought deserves a
 better player than the streaming apps I pay for repeatedly.
 
-This is **Proposed**, not Accepted, for reasons that aren't about scope:
+This stayed **Proposed** until it was built, because adoption is the real
+test: the server only earns its place if it's good enough to switch to from
+the streaming apps, and that is decided by whether the family actually uses
+it — not by the scope of the implementation.
 
 * It's strictly for local use in my own home — it will never be a public
   service, so there's no exposure or multi-user internet angle to design for.
 * The UX has to be good enough to switch to from the streaming apps, and
   playback latency has to be low enough to not be noticed.
-* Adoption is the real test: it only gets built out if it's tested with my
-  family and they actually use it.
+* Adoption is the acceptance test, and it still gates whether this stays
+  running: it only gets kept if it's tested with my family and they actually
+  use it.
 
-# Decision (proposed)
+# Decision
 
 Run **Jellyfin** on the Mac mini to serve my media library to the Fire TV
 Stick.
@@ -31,6 +35,16 @@ Jellyfin is free, open source, self-hosted, and has a first-class Fire TV
 client. The library lives on the hub's storage (the same machine that already
 holds the photo backup), served only over the home network/tailnet — not
 exposed publicly.
+
+The server runs in **Docker Compose** under **colima** on the hub, declared
+as code in `homelab/hosts/mac-mini/jellyfin/` in this repo. The image is
+pinned, the media library is mounted read-only from the 10TB HDD, and a
+launchd agent keeps the stack running across reboots. It's managed with mise
+(`mise run //homelab:...`), so upgrades are a version bump plus a recompose.
+The router forwards no ports, so access is over the home LAN (the Fire TV
+Stick) and the [Tailscale](/projects/homelab/adrs/000-tailscale) tailnet
+(phone and laptop) — the tailnet is the lab's trust boundary, per the network
+ADR.
 
 # Alternatives
 
@@ -75,4 +89,5 @@ exposed publicly.
   an ongoing task.
 * **Storage pressure** on the hub alongside the photo backup.
 * **Adoption risk**: if the UX or latency isn't good enough for the family,
-  it won't get used — the reason it stays Proposed until tested.
+  it won't get used — the reason it stayed Proposed until built, and the
+  gate on keeping it running.

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -17,6 +17,7 @@ tech_stack:
   - "NixOS"
   - "CUPS"
   - "Docker"
+  - "Jellyfin"
 ---
 
 # Vision
@@ -105,20 +106,20 @@ constraint is software, not silicon.
   chart={`flowchart LR
 Internet["Internet"] -->|"router DNS"| Router["Home router"]
 subgraph hub["Mac mini — home hub"]
-    ADG1["AdGuard Home — primary DNS"]
-    ENT["Ente sync"]
-    NET1["Netdata"]
-    T3["t3-code + agents"]
-    JEL["Jellyfin — planned"]
+  ADG1["AdGuard Home — primary DNS"]
+  ENT["Ente sync"]
+  NET1["Netdata"]
+  T3["t3-code + agents"]
+  JEL["Jellyfin"]
 end
 subgraph pi["Raspberry Pi"]
-    ADG2["AdGuard Home — fallback DNS"]
-    NET2["Netdata → hub"]
-    CUP["CUPS"]
+  ADG2["AdGuard Home — fallback DNS"]
+  NET2["Netdata → hub"]
+  CUP["CUPS"]
 end
 subgraph asus["Asus desktop (NixOS) — proposed"]
-    GPU["GTX 1060 — CV jobs"]
-    DVC["DVC dataset cache"]
+  GPU["GTX 1060 — CV jobs"]
+  DVC["DVC dataset cache"]
 end
 Router --> ADG1
 Router --> ADG2
@@ -163,8 +164,11 @@ photo backup pipeline.
 * **Monitoring.** Runs [Netdata](/projects/homelab/adrs/009-netdata),
   connected to my Slack workspace via a Slack app, to alarm on anything
   going wrong.
-* **Media (planned).** Will run [Jellyfin](/projects/homelab/adrs/011-jellyfin)
-  to serve TV shows and movies to my Fire TV Stick.
+* **Media.** Runs [Jellyfin](/projects/homelab/adrs/011-jellyfin) to serve
+  TV shows and movies to my Fire TV Stick, in Docker Compose under colima
+  with its config declared in `homelab/hosts/mac-mini/jellyfin/` in this
+  repo. The library lives on the 10TB HDD and is served over the LAN and the
+  tailnet only.
 
 ## Raspberry Pi — the resilient sidekick
 
@@ -229,7 +233,7 @@ workloads and layering on the rest:
 | 3     | DNS privacy (AdGuard Home, primary + failover)                | Live        |
 | 4     | CUPS printing on the Pi (avoiding printer ewaste)             | Live        |
 | 5     | NixOS GPU worker for batch CV jobs, with DVC-managed datasets | Proposed    |
-| 6     | Jellyfin media server for the Fire TV Stick                   | Proposed    |
+| 6     | Jellyfin media server for the Fire TV Stick                   | In progress |
 | 7     | Second compute node (idle 4080 laptop)                        | Idea        |
 
 # What This Is Not


### PR DESCRIPTION
## What

Deploy Jellyfin in Docker Compose under colima, managed as code. This
implements [ADR 011](/projects/homelab/adrs/011-jellyfin) and phase 6 of
the homelab roadmap.

The stack is declared in `homelab/hosts/mac-mini/jellyfin/` and includes:
- `docker-compose.yml` — pinned Jellyfin 10.11 image, read-only media
  mount, health check
- `bootstrap.sh` — one-time setup: colima (vz + virtiofs), launchd agent,
  compose up, API provisioning
- `keep-running.sh` — self-healing loop under launchd across reboots and
  colima crashes
- `provision.sh` — idempotent API setup (startup wizard, admin user,
  TV Shows + Movies libraries)
- `homelab.jellyfin.plist` — launchd agent template (RunAtLoad + KeepAlive)
- `.env.example` — template for media path, port, image tag
- `mise.toml` — 9 tasks (bootstrap, provision, up, down, status, restart,
  logs, pull, verify)

Also updates ADR 011 to Accepted, marks phase 6 as In progress in the
roadmap, and registers the `homelab/` config root.

## Why

The family's media library (bought movies + shows) deserves a better
player than the streaming apps we pay for. Jellyfin runs locally on the
hub, served over LAN (Fire TV Stick) and tailnet (phone/laptop) only —
no public exposure, no port forwarding.

## Validation

- [x] `docker compose config` valid
- [x] All scripts pass `bash -n` syntax check
- [x] `plutil -lint` passes on the launchd plist
- [x] Markdownlint, MDX lint, YAML lint, and gitleaks pre-commit hooks
  all pass
- [x] Bootstrap tested on the hub: colima started, launchd agent installed,
      Jellyfin healthy on localhost:8096, LAN, and tailnet
- [x] Self-heal verified: stopped container → restarted via keep-running.sh
- [x] API provisioning verified: admin user created, TV Shows + Movies
      libraries registered, test content indexed
- [x] Phone playback tested via Tailscale

## QA

Tested live on the Mac mini hub (the machine that will run this in
production):
- `localhost:8096/health` → Healthy
- `192.168.1.59:8096/health` → Healthy (LAN)
- `100.124.230.4:8096/health` → Healthy (tailnet)
- Web UI login page loads (HTTP 200)
- Test movie plays on phone over Tailscale

## Notes

- The media mount (`/Volumes/Expansion/Media → /media:ro`) is read-only;
  Jellyfin config is persisted in the gitignored `data/config/` directory.
- Admin credentials are auto-generated by bootstrap and stored in the
  gitignored `.env` file.
- `keep-running.sh` starts colima with the same mount flags as
  bootstrap.sh to avoid drift.
- The 10TB HDD has an intermittent USB connection (ASMedia controller +
  Seagate bridge incompatibility); not a blocker but noted in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Jellyfin media server deployment for the Mac mini, accessible over LAN and Tailscale.
  * Added automated setup, provisioning, health checks, library creation, and persistent service management.
  * Added commands for starting, stopping, restarting, monitoring, upgrading, viewing logs, and verifying the service.
  * Added configurable media storage, timezone, port, and image version settings.
  * Added automatic recovery to keep the service running.

* **Documentation**
  * Documented deployment, access URLs, daily operations, upgrades, architecture, adoption considerations, and the requirement to mount media storage before setup.
  * Updated the homelab technology stack and service topology to reflect Jellyfin as running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->