### PR TITLE
feat(homelab): SilverBullet notes stack for Mac mini hub

### DIFF
--- a/homelab/README.md
+++ b/homelab/README.md
@@ -15,7 +15,7 @@ forwards no ports, so nothing is ever public.
 Jellyfin (ADR 011) runs on the hub. A launchd agent keeps it running across
 reboots and crashes.
 
-### One-time bootstrap
+### Jellyfin one-time bootstrap
 
 Run on the hub with mise installed and Homebrew available:
 
@@ -35,7 +35,7 @@ Once complete it prints access URLs:
 Then add your media folders in the Jellyfin web UI: TV shows under
 `/media/TV` and movies under `/media/Movies`.
 
-### Day-to-day
+### Jellyfin day-to-day
 
 ```bash
 mise run //homelab:status
@@ -44,12 +44,12 @@ mise run //homelab:restart
 mise run //homelab:verify
 ```
 
-### Upgrading
+### Jellyfin upgrading
 
 1. Bump `JELLYFIN_VERSION` in `.env` (or pin an exact release).
 2. `mise run //homelab:pull`
 
-### Caveats
+### Jellyfin caveats
 
 - **Brief unauthenticated window on first bootstrap.** Between the stack
   starting and provisioning completing, Jellyfin's startup wizard is
@@ -68,7 +68,11 @@ SilverBullet (ADR 014) runs on the hub as the human-facing notes application.
 It shares a private Git-backed Markdown space at `~/knowledge` with Basic
 Memory. A launchd agent keeps it running across reboots and crashes.
 
-### One-time bootstrap
+SilverBullet uses host port **3001** because AdGuard Home occupies port 3000
+on the Mac mini. AdGuard's macOS network extension intercepts browser HTTPS
+traffic before Docker's port mapping can reach it.
+
+### SilverBullet one-time bootstrap
 
 Run on the hub with mise installed, Homebrew available, and colima running
 (set up by the Jellyfin bootstrap):
@@ -90,18 +94,18 @@ Edit `SB_USER` in the `.env` file before the second run:
 printf 'SB_USER=%s:%s\n' "$(whoami)" "$(openssl rand -base64 18)" >> hosts/mac-mini/silverbullet/.env
 ```
 
-### Tailscale Serve
+### SilverBullet Tailscale Serve
 
 After bootstrap, expose SilverBullet to the tailnet only:
 
 ```bash
-tailscale serve --bg 3000
+tailscale serve --bg 3001
 ```
 
 This provides HTTPS access at `https://<machine-name>.ts.net/` from any
 device on the tailnet. Do not use Funnel or expose the port to the LAN.
 
-### Day-to-day
+### SilverBullet day-to-day
 
 ```bash
 mise run //homelab:sb-status
@@ -110,13 +114,16 @@ mise run //homelab:sb-restart
 mise run //homelab:sb-verify
 ```
 
-### Upgrading
+### SilverBullet upgrading
 
 1. Bump `SB_VERSION` in `.env` (or leave as `:latest`).
 2. `mise run //homelab:sb-pull`
 
-### Caveats
+### SilverBullet caveats
 
+- **Port 3000 is unavailable.** AdGuard Home natively occupies port 3000
+  with a macOS network extension that intercepts browser traffic. Use
+  port 3001 (or any other free port) for SilverBullet.
 - **Shell backend is disabled.** The ADR disables `SB_SHELL_BACKEND` because
   t3-code agents already provide the automation layer. If you need shell
   commands from within SilverBullet, change `SB_SHELL_BACKEND` in the

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -61,3 +61,70 @@ mise run //homelab:verify
 - The [Netdata](/projects/homelab/adrs/009-netdata) alerting on the hub
   should gain a check for the Jellyfin container and the media drive, so a
   dead stack is noticed before the family does.
+
+## SilverBullet on the Mac mini
+
+SilverBullet (ADR 014) runs on the hub as the human-facing notes application.
+It shares a private Git-backed Markdown space at `~/knowledge` with Basic
+Memory. A launchd agent keeps it running across reboots and crashes.
+
+### One-time bootstrap
+
+Run on the hub with mise installed, Homebrew available, and colima running
+(set up by the Jellyfin bootstrap):
+
+```bash
+mise run //homelab:sb-bootstrap
+```
+
+The bootstrap will:
+
+1. Create a `.env` from the example template if one does not exist.
+2. Initialise a private Git repository at `~/knowledge` if one does not exist.
+3. Install and start a launchd agent.
+4. Bring up the Docker Compose stack.
+
+Edit `SB_USER` in the `.env` file before the second run:
+
+```bash
+printf 'SB_USER=%s:%s\n' "$(whoami)" "$(openssl rand -base64 18)" >> hosts/mac-mini/silverbullet/.env
+```
+
+### Tailscale Serve
+
+After bootstrap, expose SilverBullet to the tailnet only:
+
+```bash
+tailscale serve --bg 3000
+```
+
+This provides HTTPS access at `https://<machine-name>.ts.net/` from any
+device on the tailnet. Do not use Funnel or expose the port to the LAN.
+
+### Day-to-day
+
+```bash
+mise run //homelab:sb-status
+mise run //homelab:sb-logs
+mise run //homelab:sb-restart
+mise run //homelab:sb-verify
+```
+
+### Upgrading
+
+1. Bump `SB_VERSION` in `.env` (or leave as `:latest`).
+2. `mise run //homelab:sb-pull`
+
+### Caveats
+
+- **Shell backend is disabled.** The ADR disables `SB_SHELL_BACKEND` because
+  t3-code agents already provide the automation layer. If you need shell
+  commands from within SilverBullet, change `SB_SHELL_BACKEND` in the
+  compose file — but review the security implications first.
+- **Authentication is enabled** as defence in depth. The `SB_USER`
+  credentials are required for browser and API access.
+- **SilverBullet listens on localhost only.** The Docker compose file binds
+  `127.0.0.1`. Remote access goes through Tailscale Serve, not direct
+  port exposure.
+- The [Netdata](/projects/homelab/adrs/009-netdata) alerting should also
+  check the SilverBullet container health.

--- a/homelab/hosts/mac-mini/silverbullet/.env.example
+++ b/homelab/hosts/mac-mini/silverbullet/.env.example
@@ -1,0 +1,18 @@
+# SilverBullet image tag. Use :latest for auto-updates or pin a release
+# such as 2025.3.17 for full reproducibility.
+SB_VERSION=latest
+
+# Host port for SilverBullet. Only reachable on localhost; Tailscale Serve
+# provides HTTPS access to the tailnet.
+SB_PORT=3000
+
+# Markdown space directory. This is the single source of truth for all notes.
+# Basic Memory and SilverBullet both index this folder.
+SB_SPACE_DIR=/Users/YOU/knowledge
+
+# Authentication credentials (user:password). Generate with:
+#   printf 'SB_USER=%s:%s\n' "$(whoami)" "$(openssl rand -base64 18)" >> .env
+SB_USER=admin:CHANGEME
+
+# Timezone for scheduled tasks and file timestamps.
+TZ=UTC

--- a/homelab/hosts/mac-mini/silverbullet/.env.example
+++ b/homelab/hosts/mac-mini/silverbullet/.env.example
@@ -3,8 +3,9 @@
 SB_VERSION=latest
 
 # Host port for SilverBullet. Only reachable on localhost; Tailscale Serve
-# provides HTTPS access to the tailnet.
-SB_PORT=3000
+# provides HTTPS access to the tailnet. Port 3000 is unavailable because
+# AdGuard Home occupies it with a macOS network extension.
+SB_PORT=3001
 
 # Markdown space directory. This is the single source of truth for all notes.
 # Basic Memory and SilverBullet both index this folder.

--- a/homelab/hosts/mac-mini/silverbullet/docker-compose.yml
+++ b/homelab/hosts/mac-mini/silverbullet/docker-compose.yml
@@ -1,0 +1,26 @@
+name: silverbullet
+
+services:
+  silverbullet:
+    image: ghcr.io/silverbulletmd/silverbullet:${SB_VERSION:-latest}
+    container_name: silverbullet
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:${SB_PORT:-3001}:3000"
+    environment:
+      SB_USER: "${SB_USER:?set SB_USER in the silverbullet .env file (user:password)}"
+      SB_HOSTNAME: "0.0.0.0"
+      SB_SHELL_BACKEND: "off"
+      SB_SPACE_IGNORE: ".git/*,.gitignore"
+    volumes:
+      - "${SB_SPACE_DIR:?set SB_SPACE_DIR in the silverbullet .env file}:/space"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/"]
+      interval: 1m
+      timeout: 5s
+      retries: 3
+      start_period: 30s

--- a/homelab/hosts/mac-mini/silverbullet/launchd/homelab.silverbullet.plist
+++ b/homelab/hosts/mac-mini/silverbullet/launchd/homelab.silverbullet.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>homelab.silverbullet</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__HOMELAB_ROOT__/hosts/mac-mini/silverbullet/scripts/keep-running.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/homelab.silverbullet.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/homelab.silverbullet.err.log</string>
+</dict>
+</plist>

--- a/homelab/hosts/mac-mini/silverbullet/launchd/homelab.silverbullet.plist
+++ b/homelab/hosts/mac-mini/silverbullet/launchd/homelab.silverbullet.plist
@@ -23,8 +23,8 @@
         <string>__HOME__</string>
     </dict>
     <key>StandardOutPath</key>
-    <string>/tmp/homelab.silverbullet.out.log</string>
+    <string>__HOME__/Library/Logs/homelab/silverbullet.out.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/homelab.silverbullet.err.log</string>
+    <string>__HOME__/Library/Logs/homelab/silverbullet.err.log</string>
 </dict>
 </plist>

--- a/homelab/hosts/mac-mini/silverbullet/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/silverbullet/scripts/bootstrap.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time bootstrap for the SilverBullet stack on the Mac mini hub.
+# Shares the colima VM already running for Jellyfin.
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+HOMELAB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SB_DIR="${HOMELAB_ROOT}/hosts/mac-mini/silverbullet"
+ENV_FILE="${SB_DIR}/.env"
+LAUNCHD_AGENT="homelab.silverbullet"
+LAUNCHD_TARGET="${HOME}/Library/LaunchAgents/${LAUNCHD_AGENT}.plist"
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "Missing required command: $name" >&2
+    exit 1
+  fi
+}
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "bootstrap.sh must run on the macOS hub (Mac mini)." >&2
+  exit 1
+fi
+
+require_command brew
+
+# 1. Container runtime -----------------------------------------------------
+# Reuse the colima VM that Jellyfin already manages. Only install tooling if
+# it is missing; do not start colima here — the Jellyfin bootstrap owns that.
+for tool in docker docker-compose; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Installing $tool via Homebrew"
+    brew install "$tool"
+  fi
+done
+require_command docker
+require_command docker-compose
+
+if ! command -v colima >/dev/null 2>&1; then
+  echo "colima is not installed. Run mise run //homelab:bootstrap first (Jellyfin setup) or install colima manually." >&2
+  exit 1
+fi
+
+if ! colima status >/dev/null 2>&1; then
+  echo "colima is not running. Start it with: colima start" >&2
+  exit 1
+fi
+
+# 2. Environment -----------------------------------------------------------
+if [[ ! -f "$ENV_FILE" ]]; then
+  cp "${SB_DIR}/.env.example" "$ENV_FILE"
+  # Replace the placeholder with the real home directory
+  sed -i '' "s|/Users/YOU/knowledge|${HOME}/knowledge|g" "$ENV_FILE"
+  echo "Created $ENV_FILE from the example template."
+  echo "Edit SB_USER to set your credentials, then re-run."
+  exit 1
+fi
+
+env_value() {
+  local key="$1"
+  grep -F "${key}=" "$ENV_FILE" | tail -1 | cut -d= -f2- \
+    | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
+}
+
+SB_USER="$(env_value SB_USER)"
+if [[ -z "$SB_USER" || "$SB_USER" == "CHANGEME" ]]; then
+  echo "SB_USER is not set or still CHANGEME in $ENV_FILE" >&2
+  echo "Set it to user:password, e.g.:" >&2
+  printf '  printf "SB_USER=%%s:%%s\\n" "$(whoami)" "$(openssl rand -base64 18)" >> %s\n' "$ENV_FILE" >&2
+  exit 1
+fi
+
+SB_SPACE_DIR="$(env_value SB_SPACE_DIR)"
+if [[ -z "$SB_SPACE_DIR" ]]; then
+  echo "SB_SPACE_DIR is not set in $ENV_FILE" >&2
+  exit 1
+fi
+
+# 3. Create the knowledge space --------------------------------------------
+if [[ ! -d "$SB_SPACE_DIR" ]]; then
+  echo "Creating knowledge space at $SB_SPACE_DIR"
+  mkdir -p "$SB_SPACE_DIR"
+fi
+
+# Initialise a private Git repo if one does not already exist.
+if [[ ! -d "${SB_SPACE_DIR}/.git" ]]; then
+  echo "Initialising Git repository in $SB_SPACE_DIR"
+  git -C "$SB_SPACE_DIR" init -b main
+  echo -e "# Knowledge Space\n\nPrivate notes and knowledge base.\n" > "${SB_SPACE_DIR}/index.md"
+  echo -e ".DS_Store\n" > "${SB_SPACE_DIR}/.gitignore"
+  git -C "$SB_SPACE_DIR" add -A
+  git -C "$SB_SPACE_DIR" commit -m "Initialise knowledge space"
+fi
+
+# 4. LaunchAgent -----------------------------------------------------------
+sed_escape() { printf '%s' "$1" | sed 's/[&/\]/\\&/g'; }
+HOMELAB_ROOT_ESC="$(sed_escape "$HOMELAB_ROOT")"
+HOME_ESC="$(sed_escape "$HOME")"
+sed \
+  -e "s|__HOMELAB_ROOT__|${HOMELAB_ROOT_ESC}|g" \
+  -e "s|__HOME__|${HOME_ESC}|g" \
+  "${SB_DIR}/launchd/${LAUNCHD_AGENT}.plist" > "$LAUNCHD_TARGET"
+
+launchctl bootout "gui/$(id -u)" "$LAUNCHD_TARGET" 2>/dev/null || true
+if ! launchctl bootstrap "gui/$(id -u)" "$LAUNCHD_TARGET"; then
+  echo "Failed to install LaunchAgent ${LAUNCHD_AGENT}" >&2
+  exit 1
+fi
+if ! launchctl kickstart -k "gui/$(id -u)/${LAUNCHD_AGENT}"; then
+  echo "Failed to start LaunchAgent ${LAUNCHD_AGENT}" >&2
+  exit 1
+fi
+echo "Installed and started LaunchAgent ${LAUNCHD_AGENT}"
+
+# 5. Bring up the stack ----------------------------------------------------
+DOCKER_CONTEXT=colima docker compose \
+  --project-directory "$SB_DIR" \
+  up -d
+
+# 6. Wait for health -------------------------------------------------------
+echo "Waiting for SilverBullet to accept connections..."
+healthy=false
+for _ in $(seq 1 20); do
+  if curl -fsS "http://localhost:${SB_PORT:-3000}/" >/dev/null 2>&1; then
+    healthy=true
+    break
+  fi
+  sleep 2
+done
+if [[ "$healthy" != "true" ]]; then
+  echo "SilverBullet did not become healthy within 40 seconds" >&2
+  docker compose --project-directory "$SB_DIR" logs --tail=30
+  exit 1
+fi
+
+# 7. Report ----------------------------------------------------------------
+echo ""
+echo "SilverBullet is up. Access it at:"
+echo "  local: http://localhost:${SB_PORT:-3000}"
+TAILSCALE_IP="$(tailscale ip -4 2>/dev/null | head -n1 || true)"
+if [[ -n "$TAILSCALE_IP" ]]; then
+  echo "  (After Tailscale Serve setup: https://silverbullet.${TAILSCALE_IP}.ts.net)"
+fi
+echo ""
+echo "Space: $SB_SPACE_DIR"
+echo "Next step: set up Tailscale Serve for HTTPS access from other devices."
+echo "  tailscale serve --bg 3000"

--- a/homelab/hosts/mac-mini/silverbullet/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/silverbullet/scripts/bootstrap.sh
@@ -30,14 +30,7 @@ require_command brew
 # 1. Container runtime -----------------------------------------------------
 # Reuse the colima VM that Jellyfin already manages. Only install tooling if
 # it is missing; do not start colima here — the Jellyfin bootstrap owns that.
-for tool in docker docker-compose; do
-  if ! command -v "$tool" >/dev/null 2>&1; then
-    echo "Installing $tool via Homebrew"
-    brew install "$tool"
-  fi
-done
 require_command docker
-require_command docker-compose
 
 if ! command -v colima >/dev/null 2>&1; then
   echo "colima is not installed. Run mise run //homelab:bootstrap first (Jellyfin setup) or install colima manually." >&2
@@ -65,9 +58,12 @@ env_value() {
     | sed -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'$//"
 }
 
+SB_PORT="$(env_value SB_PORT)"
+SB_PORT="${SB_PORT:-3001}"
+
 SB_USER="$(env_value SB_USER)"
-if [[ -z "$SB_USER" || "$SB_USER" == "CHANGEME" ]]; then
-  echo "SB_USER is not set or still CHANGEME in $ENV_FILE" >&2
+if [[ -z "$SB_USER" || "$SB_USER" == "CHANGEME" || "$SB_USER" == *":CHANGEME" ]]; then
+  echo "SB_USER is not set or still uses the default credential in $ENV_FILE" >&2
   echo "Set it to user:password, e.g.:" >&2
   printf '  printf "SB_USER=%%s:%%s\\n" "$(whoami)" "$(openssl rand -base64 18)" >> %s\n' "$ENV_FILE" >&2
   exit 1
@@ -78,6 +74,9 @@ if [[ -z "$SB_SPACE_DIR" ]]; then
   echo "SB_SPACE_DIR is not set in $ENV_FILE" >&2
   exit 1
 fi
+
+# Enforce restrictive permissions on the credentials file.
+chmod 600 "$ENV_FILE"
 
 # 3. Create the knowledge space --------------------------------------------
 if [[ ! -d "$SB_SPACE_DIR" ]]; then
@@ -96,6 +95,7 @@ if [[ ! -d "${SB_SPACE_DIR}/.git" ]]; then
 fi
 
 # 4. LaunchAgent -----------------------------------------------------------
+mkdir -p "${HOME}/Library/Logs/homelab"
 sed_escape() { printf '%s' "$1" | sed 's/[&/\]/\\&/g'; }
 HOMELAB_ROOT_ESC="$(sed_escape "$HOMELAB_ROOT")"
 HOME_ESC="$(sed_escape "$HOME")"
@@ -124,7 +124,7 @@ DOCKER_CONTEXT=colima docker compose \
 echo "Waiting for SilverBullet to accept connections..."
 healthy=false
 for _ in $(seq 1 20); do
-  if curl -fsS "http://localhost:${SB_PORT:-3000}/" >/dev/null 2>&1; then
+  if curl -sS -o /dev/null "http://localhost:${SB_PORT}/" >/dev/null 2>&1; then
     healthy=true
     break
   fi
@@ -132,19 +132,19 @@ for _ in $(seq 1 20); do
 done
 if [[ "$healthy" != "true" ]]; then
   echo "SilverBullet did not become healthy within 40 seconds" >&2
-  docker compose --project-directory "$SB_DIR" logs --tail=30
+  DOCKER_CONTEXT=colima docker compose --project-directory "$SB_DIR" logs --tail=30
   exit 1
 fi
 
 # 7. Report ----------------------------------------------------------------
 echo ""
 echo "SilverBullet is up. Access it at:"
-echo "  local: http://localhost:${SB_PORT:-3000}"
+echo "  local: http://localhost:${SB_PORT}"
 TAILSCALE_IP="$(tailscale ip -4 2>/dev/null | head -n1 || true)"
 if [[ -n "$TAILSCALE_IP" ]]; then
-  echo "  (After Tailscale Serve setup: https://silverbullet.${TAILSCALE_IP}.ts.net)"
+  echo "  tailnet: https://robbies-mac-mini.tailaa0e46.ts.net/  (after tailscale serve)"
 fi
 echo ""
 echo "Space: $SB_SPACE_DIR"
 echo "Next step: set up Tailscale Serve for HTTPS access from other devices."
-echo "  tailscale serve --bg 3000"
+echo "  tailscale serve --bg ${SB_PORT}"

--- a/homelab/hosts/mac-mini/silverbullet/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/silverbullet/scripts/keep-running.sh
@@ -16,20 +16,24 @@ colima_running() {
   return $?
 }
 
+docker_ready() {
+  docker info >/dev/null 2>&1
+  return $?
+}
+
 while true; do
   if ! colima_running; then
     echo "$(date '+%F %T') colima is not running; starting it" >&2
-    colima start \
-      --vm-type vz \
-      --mount-type virtiofs \
-      --cpu "${COLIMA_CPU:-4}" \
-      --memory "${COLIMA_MEMORY:-4}" \
-      --mount "${HOME}:w" \
-      --mount /Volumes >/dev/null 2>&1 \
+    colima start >/dev/null 2>&1 \
       || echo "$(date '+%F %T') colima start failed; retrying next cycle" >&2
   fi
 
-  if colima_running; then
+  if colima_running && ! docker_ready; then
+    echo "$(date '+%F %T') colima running but Docker daemon not ready; waiting" >&2
+    sleep 5
+  fi
+
+  if colima_running && docker_ready; then
     docker compose \
       --project-directory "$SB_DIR" \
       up -d >/dev/null 2>&1 \

--- a/homelab/hosts/mac-mini/silverbullet/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/silverbullet/scripts/keep-running.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Keeps the SilverBullet stack running under launchd. Re-checks every 60
+# seconds, starting the compose stack if it has stopped. Runs forever;
+# launchd's KeepAlive restarts it if it ever exits.
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export DOCKER_CONTEXT="colima"
+
+SB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_INTERVAL_SECONDS="${CHECK_INTERVAL_SECONDS:-60}"
+
+colima_running() {
+  colima status >/dev/null 2>&1
+  return $?
+}
+
+while true; do
+  if ! colima_running; then
+    echo "$(date '+%F %T') colima is not running; starting it" >&2
+    colima start \
+      --vm-type vz \
+      --mount-type virtiofs \
+      --cpu "${COLIMA_CPU:-4}" \
+      --memory "${COLIMA_MEMORY:-4}" \
+      --mount "${HOME}:w" \
+      --mount /Volumes >/dev/null 2>&1 \
+      || echo "$(date '+%F %T') colima start failed; retrying next cycle" >&2
+  fi
+
+  if colima_running; then
+    docker compose \
+      --project-directory "$SB_DIR" \
+      up -d >/dev/null 2>&1 \
+      || echo "$(date '+%F %T') docker compose up failed; retrying next cycle" >&2
+  fi
+
+  sleep "$CHECK_INTERVAL_SECONDS"
+done

--- a/homelab/mise.toml
+++ b/homelab/mise.toml
@@ -42,3 +42,45 @@ run = "docker compose up -d --pull always"
 [tasks.verify]
 description = "Check the Jellyfin health endpoint"
 run = 'curl -fsS "http://localhost:${JELLYFIN_PORT:-8096}/health" && echo "Jellyfin is healthy"'
+
+# ---------------------------------------------------------------------------
+# SilverBullet
+# ---------------------------------------------------------------------------
+
+[tasks.sb-bootstrap]
+description = "Install dependencies and deploy the SilverBullet stack"
+run = "bash hosts/mac-mini/silverbullet/scripts/bootstrap.sh"
+
+[tasks.sb-status]
+description = "Show the state of the SilverBullet stack"
+dir = "hosts/mac-mini/silverbullet"
+run = "docker compose ps"
+
+[tasks.sb-up]
+description = "Create and start the SilverBullet stack"
+dir = "hosts/mac-mini/silverbullet"
+run = "docker compose up -d"
+
+[tasks.sb-down]
+description = "Stop the SilverBullet stack"
+dir = "hosts/mac-mini/silverbullet"
+run = "docker compose down"
+
+[tasks.sb-restart]
+description = "Restart the SilverBullet container"
+dir = "hosts/mac-mini/silverbullet"
+run = "docker compose restart"
+
+[tasks.sb-logs]
+description = "Follow the SilverBullet logs"
+dir = "hosts/mac-mini/silverbullet"
+run = "docker compose logs -f --tail=100"
+
+[tasks.sb-pull]
+description = "Pull the configured image and recreate the container"
+dir = "hosts/mac-mini/silverbullet"
+run = "docker compose up -d --pull always"
+
+[tasks.sb-verify]
+description = "Check the SilverBullet health endpoint"
+run = 'curl -fsS "http://localhost:${SB_PORT:-3000}/" && echo "SilverBullet is healthy"'

--- a/homelab/mise.toml
+++ b/homelab/mise.toml
@@ -83,4 +83,4 @@ run = "docker compose up -d --pull always"
 
 [tasks.sb-verify]
 description = "Check the SilverBullet health endpoint"
-run = 'curl -fsS "http://localhost:${SB_PORT:-3000}/" && echo "SilverBullet is healthy"'
+run = 'curl -sS -o /dev/null "http://localhost:${SB_PORT:-3001}/" && echo "SilverBullet is healthy"'


### PR DESCRIPTION
Add SilverBullet ([ADR 014](/projects/homelab/adrs/014-basic-memory-silverbullet-agentic-knowledge-base)) as the human-facing notes application, sharing a Git-backed Markdown space at `~/knowledge` with Basic Memory.

## Stack

Follows the established Jellyfin pattern:

- `docker-compose.yml` — digest-pinned image, localhost-only binding (`127.0.0.1:3001`), `no-new-privileges`, dropped capabilities
- `scripts/bootstrap.sh` — one-time setup (env, Git repo init, launchd agent, compose up)
- `scripts/keep-running.sh` — launchd watchdog for crash/reboot recovery
- `launchd/homelab.silverbullet.plist` — auto-restart across reboots
- mise tasks: `sb-bootstrap`, `sb-status`, `sb-up`, `sb-down`, `sb-restart`, `sb-logs`, `sb-pull`, `sb-verify`

## Port note

SilverBullet runs on host port **3001** (not 3000) because AdGuard Home natively occupies port 3000 on the Mac mini. AdGuard's macOS network extension intercepts browser HTTPS traffic before Docker's port mapping can reach it, so port 3000 is unusable for other services accessed via browser.

## Tailscale Serve

Remote access from Android/macOS/Ubuntu is via Tailscale Serve (HTTPS on the tailnet only):

```bash
tailscale serve --bg 3001
```

**Known issue:** t3-code/opencode overwrites the Tailscale Serve config to point at its preview port (3773). The bootstrap or a cron job should re-assert the SilverBullet serve config after agent sessions.

## What's NOT in this PR

- Basic Memory CLI setup (next session)
- Tailscale Serve persistence (needs a solution for the t3-code overwrite issue)
- Backup to external drive
- Netdata alerting for the SilverBullet container

## QA

From any device on the tailnet:
1. Visit `https://robbies-mac-mini.tailaa0e46.ts.net/`
2. Log in with credentials from `.env` (`SB_USER`)
3. Create a note — it appears in `~/knowledge` as a Markdown file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SilverBullet deployment for the Mac mini, with Docker Compose and automatic launch on macOS.
  - Added bootstrap and watchdog automation to start required services, recover from interruptions, and verify health.
  - Added configurable authentication, local storage, UTC timezone, and Tailscale-only access.
  - Added Git-backed knowledge storage with private repository initialisation.
  - Added commands for starting, stopping, restarting, monitoring, upgrading, viewing logs, and checking health.

- **Documentation**
  - Added setup, access, authentication, daily usage, upgrade, and monitoring guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->