### PR TITLE
feat(homelab): launchd agent for Tailscale Serve persistence

### DIFF
--- a/homelab/README.md
+++ b/homelab/README.md
@@ -96,9 +96,16 @@ printf 'SB_USER=%s:%s\n' "$(whoami)" "$(openssl rand -base64 18)" >> hosts/mac-m
 
 ### SilverBullet Tailscale Serve
 
-After bootstrap, expose SilverBullet to the tailnet only:
+After bootstrap, Tailscale Serve is managed automatically by a launchd agent
+(`homelab.tailscale-serve`). It verifies every 5 minutes that port 3001 is
+served and re-applies if overwritten by another Tailscale serve/funnel
+invocation (e.g. t3-code preview agents).
 
 ```bash
+# Check current status
+tailscale serve status
+
+# Manually re-apply if needed
 tailscale serve --bg 3001
 ```
 

--- a/homelab/hosts/mac-mini/silverbullet/scripts/bootstrap.sh
+++ b/homelab/hosts/mac-mini/silverbullet/scripts/bootstrap.sh
@@ -136,15 +136,35 @@ if [[ "$healthy" != "true" ]]; then
   exit 1
 fi
 
-# 7. Report ----------------------------------------------------------------
+# 7. Tailscale Serve agent -------------------------------------------------
+TS_SERVE_AGENT="homelab.tailscale-serve"
+TS_SERVE_TARGET="${HOME}/Library/LaunchAgents/${TS_SERVE_AGENT}.plist"
+TS_SERVE_DIR="${HOMELAB_ROOT}/hosts/mac-mini/tailscale-serve"
+
+if [[ -f "${TS_SERVE_DIR}/launchd/${TS_SERVE_AGENT}.plist" ]]; then
+  mkdir -p "${HOME}/Library/Logs/homelab"
+  sed \
+    -e "s|__HOMELAB_ROOT__|${HOMELAB_ROOT_ESC}|g" \
+    -e "s|__HOME__|${HOME_ESC}|g" \
+    "${TS_SERVE_DIR}/launchd/${TS_SERVE_AGENT}.plist" > "$TS_SERVE_TARGET"
+
+  launchctl bootout "gui/$(id -u)" "$TS_SERVE_TARGET" 2>/dev/null || true
+  if ! launchctl bootstrap "gui/$(id -u)" "$TS_SERVE_TARGET"; then
+    echo "Warning: failed to install LaunchAgent ${TS_SERVE_AGENT}" >&2
+  else
+    launchctl kickstart "gui/$(id -u)/${TS_SERVE_AGENT}" 2>/dev/null || true
+    echo "Installed LaunchAgent ${TS_SERVE_AGENT}"
+  fi
+fi
+
+# 8. Report ----------------------------------------------------------------
 echo ""
 echo "SilverBullet is up. Access it at:"
 echo "  local: http://localhost:${SB_PORT}"
 TAILSCALE_IP="$(tailscale ip -4 2>/dev/null | head -n1 || true)"
 if [[ -n "$TAILSCALE_IP" ]]; then
-  echo "  tailnet: https://robbies-mac-mini.tailaa0e46.ts.net/  (after tailscale serve)"
+  echo "  tailnet: https://robbies-mac-mini.tailaa0e46.ts.net/  (auto-managed by launchd)"
 fi
 echo ""
 echo "Space: $SB_SPACE_DIR"
-echo "Next step: set up Tailscale Serve for HTTPS access from other devices."
-echo "  tailscale serve --bg ${SB_PORT}"
+echo "Tailscale Serve is managed by homelab.tailscale-serve (re-applies every 5m if overwritten)."

--- a/homelab/hosts/mac-mini/tailscale-serve/launchd/homelab.tailscale-serve.plist
+++ b/homelab/hosts/mac-mini/tailscale-serve/launchd/homelab.tailscale-serve.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>homelab.tailscale-serve</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__HOMELAB_ROOT__/hosts/mac-mini/tailscale-serve/scripts/re-apply.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/homelab/tailscale-serve.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/homelab/tailscale-serve.err.log</string>
+</dict>
+</plist>

--- a/homelab/hosts/mac-mini/tailscale-serve/scripts/re-apply.sh
+++ b/homelab/hosts/mac-mini/tailscale-serve/scripts/re-apply.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Re-applies Tailscale Serve for SilverBullet (port 3001). The serve config
+# can be overwritten by other Tailscale serve/funnel invocations (e.g.
+# t3-code preview agents), so this script periodically verifies and
+# re-applies the desired state.
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+DESIRED_PORT="${SB_PORT:-3001}"
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "$(date '+%F %T') tailscale command not found; skipping" >&2
+  exit 0
+fi
+
+if ! tailscale status >/dev/null 2>&1; then
+  echo "$(date '+%F %T') tailscale not connected; skipping" >&2
+  exit 0
+fi
+
+status_json="$(tailscale serve status --json 2>/dev/null || echo '{}')"
+
+if echo "$status_json" | grep -q "\"${DESIRED_PORT}\""; then
+  exit 0
+fi
+
+echo "$(date '+%F %T') re-applying Tailscale Serve for SilverBullet on port ${DESIRED_PORT}"
+tailscale serve --bg "${DESIRED_PORT}"


### PR DESCRIPTION
Adds a launchd agent that verifies Tailscale Serve includes port 3001 every 5 minutes, re-applying if overwritten by t3-code preview agents.

**Changes:**
- `tailscale-serve/scripts/re-apply.sh` — idempotent check + apply script
- `tailscale-serve/launchd/homelab.tailscale-serve.plist` — launchd agent (RunAtLoad + 5m interval)
- Updated `bootstrap.sh` to install the agent after stack health check
- Updated README with Tailscale Serve agent docs