### PR TITLE
[codex] Fix shopping list extras in flat view

### DIFF
--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -380,13 +380,15 @@ export function ShoppingList({
   const flatLines = useMemo(() => [...aggregated].sort(byName), [aggregated]);
   const flatItems = useMemo(() => {
     const items = [
-      ...flatLines.map((line) => ({
-        kind: "ingredient" as const,
-        id: line.ingredient,
-        name: formatShoppingName(line),
-        checked: checkedSet.has(line.ingredient),
-        line,
-      })),
+      ...flatLines
+        .filter((line) => !stock[line.ingredient])
+        .map((line) => ({
+          kind: "ingredient" as const,
+          id: line.ingredient,
+          name: formatShoppingName(line),
+          checked: checkedSet.has(line.ingredient),
+          line,
+        })),
       ...state.extras.map((extra) => ({
         kind: "extra" as const,
         id: extra.id,
@@ -400,7 +402,7 @@ export function ShoppingList({
       ...items.filter((item) => !item.checked),
       ...items.filter((item) => item.checked),
     ];
-  }, [flatLines, checkedSet, state.extras]);
+  }, [flatLines, checkedSet, state.extras, stock]);
 
   const haveLines = useMemo(
     () => aggregated.filter((line) => stock[line.ingredient]).sort(byName),

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -264,37 +264,7 @@ function ExtrasSection({
       {showItems && extras.length > 0 && (
         <div className="mt-1">
           {ordered.map((extra) => (
-            <div
-              key={extra.id}
-              className="flex items-center gap-2.5 py-1.5 border-b border-dashed border-[var(--line)] last:border-0"
-            >
-              <button
-                type="button"
-                aria-pressed={extra.checked}
-                onClick={() => onToggle(extra.id, extra.checked)}
-                className="flex items-center gap-2.5 flex-1 text-left"
-              >
-                <ShoppingCheckbox checked={extra.checked} />
-                <span
-                  className={[
-                    "rt-body leading-snug",
-                    extra.checked
-                      ? "line-through text-[var(--ink-3)]"
-                      : "text-[var(--ink)]",
-                  ].join(" ")}
-                >
-                  {extra.text}
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => removeExtra(extra.id)}
-                aria-label={`Remove ${extra.text}`}
-                className="text-[var(--ink-4)] hover:text-[var(--berry)] transition-colors"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            </div>
+            <ExtraItemRow key={extra.id} extra={extra} onToggle={onToggle} />
           ))}
         </div>
       )}

--- a/ui/components/recipes/shopping/shopping-list.tsx
+++ b/ui/components/recipes/shopping/shopping-list.tsx
@@ -11,7 +11,7 @@ import {
   X,
 } from "lucide-react";
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { ShoppingCheckbox } from "@/components/recipes/shopping/shopping-checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -240,14 +240,18 @@ function SectionHeading({
 function ExtrasSection({
   extras,
   onToggle,
+  showItems = true,
 }: Readonly<{
   extras: { id: string; text: string; checked: boolean }[];
   onToggle: (id: string, checked: boolean) => void;
+  showItems?: boolean;
 }>) {
   const [text, setText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
   const submit = () => {
     addExtra(text);
     setText("");
+    inputRef.current?.focus();
   };
   // Ticked extras sink to the bottom too, matching the ingredient rows.
   const ordered = [
@@ -256,8 +260,8 @@ function ExtrasSection({
   ];
   return (
     <div className="mt-6">
-      <SectionHeading title="extras" />
-      {extras.length > 0 && (
+      {showItems && <SectionHeading title="extras" />}
+      {showItems && extras.length > 0 && (
         <div className="mt-1">
           {ordered.map((extra) => (
             <div
@@ -302,6 +306,7 @@ function ExtrasSection({
         className="mt-3 flex gap-2 max-w-sm"
       >
         <Input
+          ref={inputRef}
           value={text}
           onChange={(e) => setText(e.target.value)}
           placeholder="Add an extra (milk, bread…)"
@@ -316,6 +321,45 @@ function ExtrasSection({
           <Plus className="h-4 w-4" /> Add
         </button>
       </form>
+    </div>
+  );
+}
+
+function ExtraItemRow({
+  extra,
+  onToggle,
+}: Readonly<{
+  extra: { id: string; text: string; checked: boolean };
+  onToggle: (id: string, checked: boolean) => void;
+}>) {
+  return (
+    <div className="flex items-center gap-2.5 py-1.5 border-b border-dashed border-[var(--line)] last:border-0">
+      <button
+        type="button"
+        aria-pressed={extra.checked}
+        onClick={() => onToggle(extra.id, extra.checked)}
+        className="flex items-center gap-2.5 flex-1 text-left"
+      >
+        <ShoppingCheckbox checked={extra.checked} />
+        <span
+          className={[
+            "rt-body leading-snug",
+            extra.checked
+              ? "line-through text-[var(--ink-3)]"
+              : "text-[var(--ink)]",
+          ].join(" ")}
+        >
+          {extra.text}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => removeExtra(extra.id)}
+        aria-label={`Remove ${extra.text}`}
+        className="text-[var(--ink-4)] hover:text-[var(--berry)] transition-colors"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
     </div>
   );
 }
@@ -364,6 +408,29 @@ export function ShoppingList({
     );
 
   const flatLines = useMemo(() => [...aggregated].sort(byName), [aggregated]);
+  const flatItems = useMemo(() => {
+    const items = [
+      ...flatLines.map((line) => ({
+        kind: "ingredient" as const,
+        id: line.ingredient,
+        name: formatShoppingName(line),
+        checked: checkedSet.has(line.ingredient),
+        line,
+      })),
+      ...state.extras.map((extra) => ({
+        kind: "extra" as const,
+        id: extra.id,
+        name: extra.text,
+        checked: extra.checked,
+        extra,
+      })),
+    ].sort((a, b) => a.name.localeCompare(b.name));
+
+    return [
+      ...items.filter((item) => !item.checked),
+      ...items.filter((item) => item.checked),
+    ];
+  }, [flatLines, checkedSet, state.extras]);
 
   const haveLines = useMemo(
     () => aggregated.filter((line) => stock[line.ingredient]).sort(byName),
@@ -537,18 +604,26 @@ export function ShoppingList({
             <div className="rt-mono text-[var(--ink-3)] mb-1">
               Just ingredients · A–Z
             </div>
-            {groupLines(flatLines).map((line) => (
-              <ItemRow
-                key={line.ingredient}
-                line={line}
-                system={system}
-                checked={checkedSet.has(line.ingredient)}
-                kitchenLocation={locationOf(line)}
-                onToggle={handleIngredientToggle}
-                showRecipes
-                onRemoveFromStock={stockActions.removeFromStock}
-              />
-            ))}
+            {flatItems.map((item) =>
+              item.kind === "ingredient" ? (
+                <ItemRow
+                  key={item.id}
+                  line={item.line}
+                  system={system}
+                  checked={item.checked}
+                  kitchenLocation={locationOf(item.line)}
+                  onToggle={handleIngredientToggle}
+                  showRecipes
+                  onRemoveFromStock={stockActions.removeFromStock}
+                />
+              ) : (
+                <ExtraItemRow
+                  key={item.id}
+                  extra={item.extra}
+                  onToggle={handleExtraToggle}
+                />
+              ),
+            )}
           </div>
         )}
 
@@ -637,7 +712,11 @@ export function ShoppingList({
         </div>
       )}
 
-      <ExtrasSection extras={state.extras} onToggle={handleExtraToggle} />
+      <ExtrasSection
+        extras={state.extras}
+        onToggle={handleExtraToggle}
+        showItems={view !== "flat"}
+      />
     </div>
   );
 }

--- a/ui/tests/components/recipes/shopping/shopping-list.test.tsx
+++ b/ui/tests/components/recipes/shopping/shopping-list.test.tsx
@@ -5,6 +5,7 @@ import { ShoppingList } from "@/components/recipes/shopping/shopping-list";
 import type { ShoppingRecipe } from "@/lib/api/shopping";
 import {
   __resetShoppingListForTests,
+  addExtra,
   addRecipe,
   toggleChecked,
 } from "@/lib/shopping/shoppingListStore";
@@ -222,5 +223,52 @@ describe("ShoppingList pantry state", () => {
       "full shopping list without kitchen filtering",
     );
     expect(screen.getByText("garlic")).toBeInTheDocument();
+  });
+});
+
+describe("ShoppingList extras", () => {
+  beforeEach(() => {
+    pantryState.error = null;
+    pantryState.isPending = false;
+    localStorage.clear();
+    __resetShoppingListForTests();
+    addRecipe("garlic-pasta");
+    addExtra("bread");
+  });
+
+  afterEach(() => {
+    __resetShoppingListForTests();
+  });
+
+  it("mixes extras into the ingredient-only list", async () => {
+    const user = userEvent.setup();
+    render(<ShoppingList recipes={recipes} />);
+
+    await user.click(screen.getByText("just ingredients"));
+
+    expect(
+      screen.queryByRole("heading", { name: /extras/i }),
+    ).not.toBeInTheDocument();
+    const rows = screen.getAllByRole("button", { pressed: false });
+    expect(rows.map((row) => row.textContent)).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/bread/i),
+        expect.stringMatching(/garlic/i),
+      ]),
+    );
+  });
+
+  it("keeps the extra input focused after adding an item", async () => {
+    const user = userEvent.setup();
+    render(<ShoppingList recipes={recipes} />);
+
+    const input = screen.getByRole("textbox", { name: "Add an extra item" });
+    await user.clear(input);
+    await user.type(input, "milk");
+    await user.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue("");
+    expect(screen.getByText("milk")).toBeInTheDocument();
   });
 });

--- a/ui/tests/components/recipes/shopping/shopping-list.test.tsx
+++ b/ui/tests/components/recipes/shopping/shopping-list.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 const pantryState = vi.hoisted(() => ({
   error: null as Error | null,
   isPending: false,
+  stock: {} as Record<string, "fridge" | "cupboards" | "fresh">,
 }));
 
 vi.mock("@/lib/analytics/recipe-product", () => ({
@@ -32,7 +33,7 @@ vi.mock("@/hooks/use-kitchen-stock", () => ({
     removeFromStock: vi.fn(),
   }),
   useKitchenStockQuery: () => ({
-    data: { scope: { type: "personal" }, stock: {} },
+    data: { scope: { type: "personal" }, stock: pantryState.stock },
     error: pantryState.error,
     isPending: pantryState.isPending,
   }),
@@ -69,6 +70,7 @@ describe("ShoppingList value analytics", () => {
   beforeEach(() => {
     pantryState.error = null;
     pantryState.isPending = false;
+    pantryState.stock = {};
     localStorage.clear();
     __resetShoppingListForTests();
     addRecipe("garlic-pasta");
@@ -156,6 +158,7 @@ describe("ShoppingList aisle view section completion", () => {
   beforeEach(() => {
     pantryState.error = null;
     pantryState.isPending = false;
+    pantryState.stock = {};
     localStorage.clear();
     __resetShoppingListForTests();
     addRecipe("veg-and-chicken");
@@ -191,6 +194,7 @@ describe("ShoppingList pantry state", () => {
   beforeEach(() => {
     pantryState.error = null;
     pantryState.isPending = false;
+    pantryState.stock = {};
     localStorage.clear();
     __resetShoppingListForTests();
     addRecipe("garlic-pasta");
@@ -230,6 +234,7 @@ describe("ShoppingList extras", () => {
   beforeEach(() => {
     pantryState.error = null;
     pantryState.isPending = false;
+    pantryState.stock = {};
     localStorage.clear();
     __resetShoppingListForTests();
     addRecipe("garlic-pasta");
@@ -249,13 +254,42 @@ describe("ShoppingList extras", () => {
     expect(
       screen.queryByRole("heading", { name: /extras/i }),
     ).not.toBeInTheDocument();
-    const rows = screen.getAllByRole("button", { pressed: false });
-    expect(rows.map((row) => row.textContent)).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/bread/i),
-        expect.stringMatching(/garlic/i),
-      ]),
-    );
+    const uncheckedRows = screen.getAllByRole("button", { pressed: false });
+    expect(uncheckedRows.map((row) => row.textContent)).toEqual([
+      expect.stringMatching(/bread/i),
+      expect.stringMatching(/garlic/i),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "bread" }));
+
+    expect(
+      screen
+        .getAllByRole("button", { pressed: false })
+        .map((row) => row.textContent),
+    ).toEqual([expect.stringMatching(/garlic/i)]);
+    expect(
+      screen
+        .getAllByRole("button", { pressed: true })
+        .map((row) => row.textContent),
+    ).toEqual([expect.stringMatching(/bread/i)]);
+  });
+
+  it("keeps kitchen-stocked ingredients out of the flat list", async () => {
+    pantryState.stock = { garlic: "fridge" };
+    const user = userEvent.setup();
+    render(<ShoppingList recipes={recipes} />);
+
+    await user.click(screen.getByText("just ingredients"));
+
+    expect(
+      screen
+        .getAllByRole("button", { pressed: false })
+        .map((row) => row.textContent),
+    ).toEqual([expect.stringMatching(/bread/i)]);
+    expect(
+      screen.getByRole("heading", { name: /already have/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("garlic")).toBeInTheDocument();
   });
 
   it("keeps the extra input focused after adding an item", async () => {


### PR DESCRIPTION
## What changed

- Merge manual extras into the A-Z "just ingredients" list.
- Keep extras separate in aisle and recipe views, where they cannot belong to a group.
- Return focus to the extra-item field after submission.

## Why

The flat list is meant to be one ingredient list. Extras previously stayed in a separate section even there, which split the shopping flow.

## Validation

- `mise run //ui:test -- shopping-list.test.tsx`
- `mise run //ui:typecheck`
- `mise exec -- pnpm --dir ui exec biome check components/recipes/shopping/shopping-list.tsx tests/components/recipes/shopping/shopping-list.test.tsx`

The full UI lint task has existing diagnostics in unrelated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Flat shopping-list view now combines ingredients and extra items in alphabetical order, with checked items shown last.
  - Extra items can be added while keeping the input ready for another entry.
  - Extra items are displayed consistently across shopping-list views.
  - Kitchen-stocked ingredients are shown in the pantry section and excluded from the flat list.

- **Bug Fixes**
  - Improved visibility and organisation of extra items in the shopping list.
  - Adding an extra item now clears the input while retaining focus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->