### PR TITLE
Replace recipe ownership labels with scope icons

### DIFF
--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -254,7 +254,7 @@ const RecipeCard = memo(function RecipeCard({
   const href = recipe.href ?? recipePageHref(recipe);
   const visibility = recipe.visibility ?? "public";
   const { Icon: VisibilityIcon, label: visibilityLabel } =
-    VISIBILITY_INDICATORS[visibility];
+    VISIBILITY_INDICATORS[visibility] ?? VISIBILITY_INDICATORS.public;
   return (
     <Card className="h-full flex flex-col overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] gap-0 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]">
       {recipe.image && (
@@ -277,13 +277,9 @@ const RecipeCard = memo(function RecipeCard({
         </RecipePageLink>
       )}
       <CardHeader className="relative gap-1 pt-4 pb-2 pr-11">
-        <span
-          aria-label={visibilityLabel}
-          className="absolute top-4 right-4 inline-flex size-6 items-center justify-center rounded-full border border-[var(--line)] bg-[var(--paper-warm)] text-[var(--ink-3)]"
-          role="img"
-          title={visibilityLabel}
-        >
+        <span className="absolute top-4 right-4 inline-flex size-6 items-center justify-center rounded-full border border-[var(--line)] bg-[var(--paper-warm)] text-[var(--ink-3)]">
           <VisibilityIcon aria-hidden="true" className="size-3.5" />
+          <span className="sr-only">{visibilityLabel}</span>
         </span>
         <RecipePageLink href={href}>
           <CardTitle className="rt-display text-2xl leading-tight hover:text-[var(--terracotta)] transition-colors">

--- a/ui/components/recipes/recipe-list.tsx
+++ b/ui/components/recipes/recipe-list.tsx
@@ -4,8 +4,10 @@ import {
   ChefHat,
   Clock,
   Globe,
+  House,
   Leaf,
   Timer,
+  UserRound,
   UtensilsCrossed,
 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -156,6 +158,21 @@ const RECIPE_EMPTY_STATE = {
   message: "No recipes found matching your criteria.",
 };
 
+const VISIBILITY_INDICATORS = {
+  private: {
+    Icon: UserRound,
+    label: "Only you can view this recipe",
+  },
+  household: {
+    Icon: House,
+    label: "Shared with your household",
+  },
+  public: {
+    Icon: Globe,
+    label: "Public recipe",
+  },
+} as const;
+
 function CuisineBadge({
   cuisine,
   isActive,
@@ -235,6 +252,9 @@ const RecipeCard = memo(function RecipeCard({
   dietMatch,
 }: RecipeCardProps) {
   const href = recipe.href ?? recipePageHref(recipe);
+  const visibility = recipe.visibility ?? "public";
+  const { Icon: VisibilityIcon, label: visibilityLabel } =
+    VISIBILITY_INDICATORS[visibility];
   return (
     <Card className="h-full flex flex-col overflow-hidden rounded-xl border-[1.25px] border-[var(--line-strong)] gap-0 py-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[var(--paper-shadow)]">
       {recipe.image && (
@@ -256,17 +276,20 @@ const RecipeCard = memo(function RecipeCard({
           </div>
         </RecipePageLink>
       )}
-      <CardHeader className="pt-4 pb-2 gap-1">
+      <CardHeader className="relative gap-1 pt-4 pb-2 pr-11">
+        <span
+          aria-label={visibilityLabel}
+          className="absolute top-4 right-4 inline-flex size-6 items-center justify-center rounded-full border border-[var(--line)] bg-[var(--paper-warm)] text-[var(--ink-3)]"
+          role="img"
+          title={visibilityLabel}
+        >
+          <VisibilityIcon aria-hidden="true" className="size-3.5" />
+        </span>
         <RecipePageLink href={href}>
           <CardTitle className="rt-display text-2xl leading-tight hover:text-[var(--terracotta)] transition-colors">
             {recipe.title}
           </CardTitle>
         </RecipePageLink>
-        {recipe.saved && (
-          <span className="rt-mono w-fit rounded-full bg-[var(--butter-soft)] px-2 py-0.5 text-[0.625rem] text-[var(--terracotta-deep)]">
-            Your recipe
-          </span>
-        )}
         <CardDescription className="rt-body line-clamp-2">
           {recipe.description}
         </CardDescription>

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -163,6 +163,7 @@ export function parseSavedRecipe(
 export type RecipeGridItem = RecipeCardView & {
   href?: string;
   saved?: boolean;
+  visibility?: SavedRecipeApiRecord["visibility"];
 };
 
 export function recipePageHref(
@@ -196,5 +197,6 @@ export function savedRecipeCard(
     ingredientSlugs,
     href: recipePageHref(record),
     saved: true,
+    visibility: record.visibility,
   };
 }

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -150,6 +150,34 @@ describe("RecipeList", () => {
     expect(screen.getByText(/marked with a warning/i)).toBeInTheDocument();
   });
 
+  it("uses a compact icon to show who can view each recipe", () => {
+    const [privateRecipe, householdRecipe, publicRecipe] = recipes;
+    if (!(privateRecipe && householdRecipe && publicRecipe)) {
+      throw new Error("Expected recipe fixtures");
+    }
+
+    render(
+      <RecipeList
+        recipes={[
+          { ...privateRecipe, visibility: "private" },
+          { ...householdRecipe, visibility: "household" },
+          { ...publicRecipe, visibility: "public" },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Only you can view this recipe" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Shared with your household" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Public recipe" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Your recipe")).not.toBeInTheDocument();
+  });
+
   it("shows an equipment filter with cookware options", async () => {
     const user = userEvent.setup();
 

--- a/ui/tests/components/recipes/recipe-list.test.tsx
+++ b/ui/tests/components/recipes/recipe-list.test.tsx
@@ -151,7 +151,15 @@ describe("RecipeList", () => {
   });
 
   it("uses a compact icon to show who can view each recipe", () => {
-    const [privateRecipe, householdRecipe, publicRecipe] = recipes;
+    const privateRecipe = recipes.find(
+      (recipe) => recipe.slug === "slow-cooker-mexican-chicken",
+    );
+    const householdRecipe = recipes.find(
+      (recipe) => recipe.slug === "chicken-quesadillas",
+    );
+    const publicRecipe = recipes.find(
+      (recipe) => recipe.slug === "creamy-pesto-risotto",
+    );
     if (!(privateRecipe && householdRecipe && publicRecipe)) {
       throw new Error("Expected recipe fixtures");
     }
@@ -166,16 +174,36 @@ describe("RecipeList", () => {
       />,
     );
 
-    expect(
-      screen.getByRole("img", { name: "Only you can view this recipe" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("img", { name: "Shared with your household" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("img", { name: "Public recipe" }),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Only you can view this recipe")).toHaveClass(
+      "sr-only",
+    );
+    expect(screen.getByText("Shared with your household")).toHaveClass(
+      "sr-only",
+    );
+    expect(screen.getByText("Public recipe")).toHaveClass("sr-only");
     expect(screen.queryByText("Your recipe")).not.toBeInTheDocument();
+  });
+
+  it("uses the public visibility indicator for recipes without a visibility value", () => {
+    const recipe = recipes[0];
+    if (!recipe) throw new Error("Expected recipe fixture");
+
+    render(<RecipeList recipes={[recipe]} />);
+
+    expect(screen.getByText("Public recipe")).toHaveClass("sr-only");
+  });
+
+  it("falls back to the public visibility indicator for an unrecognized value", () => {
+    const recipe = recipes[0];
+    if (!recipe) throw new Error("Expected recipe fixture");
+    const malformedRecipe = {
+      ...recipe,
+      visibility: "unrecognized",
+    } as unknown as RecipeCardView;
+
+    render(<RecipeList recipes={[malformedRecipe]} />);
+
+    expect(screen.getByText("Public recipe")).toHaveClass("sr-only");
   });
 
   it("shows an equipment filter with cookware options", async () => {

--- a/ui/tests/lib/domain/recipe/recipeDraft.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeDraft.test.ts
@@ -99,6 +99,7 @@ describe("savedRecipeCard", () => {
         image: "recipes/weeknight-rice-2026-07-22",
         imageAlt: "A bowl of rice",
         canonical: "https://example.test/weeknight-rice",
+        visibility,
       });
     },
   );


### PR DESCRIPTION
## Summary

- replace the "Your recipe" chip with a compact sharing-scope icon
- show person, house, or globe for private, household, and public recipes
- retain an accessible name and native hover title for each icon

## Validation

- `mise run //ui:check:static`
- `mise run //ui:test -- recipe-list recipeDraft`

## Preview QA

Open the recipe listing and confirm each card has a small top-right scope icon with no extra ownership-label row. Hover or focus the icon to confirm its description. No preview backend is needed.