### PR TITLE
Keep salted and unsalted butter separate when shopping

### DIFF
--- a/packages/recipe-parsing/src/data/canonical-ingredients.json
+++ b/packages/recipe-parsing/src/data/canonical-ingredients.json
@@ -577,6 +577,10 @@
       "category": "spice"
     },
     {
+      "slug": "salted-butter",
+      "category": "dairy"
+    },
+    {
       "slug": "sea-salt",
       "category": "spice"
     },

--- a/packages/recipe-parsing/tests/normalization/ingredient-normalization.test.ts
+++ b/packages/recipe-parsing/tests/normalization/ingredient-normalization.test.ts
@@ -52,6 +52,19 @@ describe("canonicalizeIngredientSlug", () => {
     expect(decision.canonicalSlug).toBe("garlic-powder");
   });
 
+  it.each(["butter", "salted-butter", "unsalted-butter"])(
+    "keeps the purchasing identity for %s",
+    (rawSlug) => {
+      const decision = canonicalizeIngredientSlug({
+        rawSlug,
+        ontology: new Set(["butter", "salted-butter", "unsalted-butter"]),
+      });
+
+      expect(decision.canonicalSlug).toBe(rawSlug);
+      expect(decision.method).toBe("exact");
+    },
+  );
+
   it.each([
     {
       rawSlug: "slices-of-bacon",

--- a/ui/content/recipes/ingredients.ts
+++ b/ui/content/recipes/ingredients.ts
@@ -44,6 +44,7 @@ export const ingredients = [
 
   // Dairy
   { name: "butter", category: "dairy" },
+  { name: "salted butter", category: "dairy" },
   { name: "unsalted butter", category: "dairy" },
   { name: "double cream", category: "dairy" },
   { name: "single cream", category: "dairy" },

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -154,6 +154,24 @@ function isIngredientOnlyStep(step: Step): boolean {
   return hasIngredient;
 }
 
+function addDeclaredIngredientSlugs(
+  step: Step,
+  ingredients: Ingredient[],
+  declaredSlugs: Set<IngredientSlug>,
+): void {
+  for (const item of step.items) {
+    if (item.type !== "ingredient") continue;
+    const ingredient = ingredients[item.index];
+    if (!ingredient) continue;
+    declaredSlugs.add(resolvedIngredientSlug(ingredient));
+    // Cooklang references a declaration by its registered name, even when
+    // the declaration uses a purchasing-specific display alias. Keep both
+    // identities so a later `@butter{}` does not become an extra generic
+    // item after `@butter|unsalted butter{}` was already declared.
+    declaredSlugs.add(normalizeIngredientSlugForOutput(ingredient.name));
+  }
+}
+
 function findDeclaredIngredientSlugs(
   sections: ParsedCooklangRecipe["sections"],
   ingredients: Ingredient[],
@@ -164,17 +182,7 @@ function findDeclaredIngredientSlugs(
       if (content.type !== "step" || !isIngredientOnlyStep(content.value)) {
         continue;
       }
-      for (const item of content.value.items) {
-        if (item.type !== "ingredient") continue;
-        const ingredient = ingredients[item.index];
-        if (!ingredient) continue;
-        declaredSlugs.add(resolvedIngredientSlug(ingredient));
-        // Cooklang references a declaration by its registered name, even when
-        // the declaration uses a purchasing-specific display alias. Keep both
-        // identities so a later `@butter{}` does not become an extra generic
-        // item after `@butter|unsalted butter{}` was already declared.
-        declaredSlugs.add(normalizeIngredientSlugForOutput(ingredient.name));
-      }
+      addDeclaredIngredientSlugs(content.value, ingredients, declaredSlugs);
     }
   }
   return declaredSlugs;

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -22,6 +22,7 @@ import {
   mergeIngredientIntoGroup,
   normalizeIngredientSlugForOutput,
 } from "@/lib/domain/recipe/ingredient";
+import { resolveDisplayedIngredientSlug } from "@/lib/domain/recipe/ingredientIdentity";
 import type {
   IngredientGroup,
   RecipeContent,
@@ -57,6 +58,13 @@ type ResolvedIngredient = {
   amount: number | undefined;
   unit: Unit | undefined;
 };
+
+function resolvedIngredientSlug(ingredient: Ingredient): IngredientSlug {
+  return resolveDisplayedIngredientSlug(
+    ingredient.name,
+    ingredient_display_name(ingredient),
+  );
+}
 
 export type UnitRecovery = {
   /** Result of parser.parse(body) — no scale — so we can read the unit the
@@ -158,10 +166,7 @@ function findDeclaredIngredientSlugs(
       }
       for (const item of content.value.items) {
         if (item.type !== "ingredient") continue;
-        const ingredient = ingredients[item.index]!;
-        declaredSlugs.add(
-          normalizeIngredientSlugForOutput(ingredient.name) as IngredientSlug,
-        );
+        declaredSlugs.add(resolvedIngredientSlug(ingredients[item.index]!));
       }
     }
   }
@@ -262,10 +267,11 @@ function buildIngredientGroupItem(
   resolved: ResolvedIngredient,
   annotations: IngredientAnnotations,
 ): RecipeIngredient {
-  const ingSlug = normalizeIngredientSlugForOutput(
+  const registeredSlug = normalizeIngredientSlugForOutput(
     ingredient.name,
   ) as IngredientSlug;
-  const ann = annotations[ingSlug];
+  const ingSlug = resolvedIngredientSlug(ingredient);
+  const ann = annotations[ingSlug] ?? annotations[registeredSlug];
 
   return {
     ingredient: ingSlug,
@@ -289,9 +295,7 @@ function collectStepIngredients(
     if (item.type !== "ingredient") continue;
 
     const ingredient = ingredients[item.index]!;
-    const ingredientSlug = normalizeIngredientSlugForOutput(
-      ingredient.name,
-    ) as IngredientSlug;
+    const ingredientSlug = resolvedIngredientSlug(ingredient);
     if (!isDeclaration && declaredSlugs.has(ingredientSlug)) continue;
     mergeIngredientIntoGroup(
       currentGroup,
@@ -375,7 +379,9 @@ export function buildScaledRecipeParts(
   const groups: GroupAccumulator[] = [currentGroup];
   const namedGroups = new Map<string, GroupAccumulator>();
   const instructions: string[] = [];
-  const ingredientNames = ingredients.map((ingredient) => ingredient.name);
+  const ingredientNames = ingredients.map((ingredient) =>
+    resolvedIngredientSlug(ingredient).replaceAll("-", " "),
+  );
   const ingredientDisplayValues = ingredients.map(formatIngredientDisplay);
   const ingredientAmounts = resolvedIngredients.map((r) => r.amount ?? null);
   const ingredientUnits = resolvedIngredients.map((r) => r.unit ?? null);

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -173,9 +173,7 @@ function findDeclaredIngredientSlugs(
         // the declaration uses a purchasing-specific display alias. Keep both
         // identities so a later `@butter{}` does not become an extra generic
         // item after `@butter|unsalted butter{}` was already declared.
-        declaredSlugs.add(
-          normalizeIngredientSlugForOutput(ingredient.name) as IngredientSlug,
-        );
+        declaredSlugs.add(normalizeIngredientSlugForOutput(ingredient.name));
       }
     }
   }
@@ -276,9 +274,9 @@ function buildIngredientGroupItem(
   resolved: ResolvedIngredient,
   annotations: IngredientAnnotations,
 ): RecipeIngredient {
-  const registeredSlug = normalizeIngredientSlugForOutput(
+  const registeredSlug: IngredientSlug = normalizeIngredientSlugForOutput(
     ingredient.name,
-  ) as IngredientSlug;
+  );
   const ingSlug = resolvedIngredientSlug(ingredient);
   const ann = annotations[ingSlug] ?? annotations[registeredSlug];
 

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -166,7 +166,16 @@ function findDeclaredIngredientSlugs(
       }
       for (const item of content.value.items) {
         if (item.type !== "ingredient") continue;
-        declaredSlugs.add(resolvedIngredientSlug(ingredients[item.index]!));
+        const ingredient = ingredients[item.index];
+        if (!ingredient) continue;
+        declaredSlugs.add(resolvedIngredientSlug(ingredient));
+        // Cooklang references a declaration by its registered name, even when
+        // the declaration uses a purchasing-specific display alias. Keep both
+        // identities so a later `@butter{}` does not become an extra generic
+        // item after `@butter|unsalted butter{}` was already declared.
+        declaredSlugs.add(
+          normalizeIngredientSlugForOutput(ingredient.name) as IngredientSlug,
+        );
       }
     }
   }

--- a/ui/lib/domain/recipe/cooklangTransform.ts
+++ b/ui/lib/domain/recipe/cooklangTransform.ts
@@ -309,12 +309,14 @@ function collectStepIngredients(
   for (const item of step.items) {
     if (item.type !== "ingredient") continue;
 
-    const ingredient = ingredients[item.index]!;
+    const ingredient = ingredients[item.index];
+    const resolvedIngredient = resolved[item.index];
+    if (!ingredient || !resolvedIngredient) continue;
     const ingredientSlug = resolvedIngredientSlug(ingredient);
     if (!isDeclaration && declaredSlugs.has(ingredientSlug)) continue;
     mergeIngredientIntoGroup(
       currentGroup,
-      buildIngredientGroupItem(ingredient, resolved[item.index]!, annotations),
+      buildIngredientGroupItem(ingredient, resolvedIngredient, annotations),
     );
   }
 }

--- a/ui/lib/domain/recipe/ingredientIdentity.ts
+++ b/ui/lib/domain/recipe/ingredientIdentity.ts
@@ -1,0 +1,33 @@
+import { ingredients as definedIngredients } from "@/content/recipes/ingredients";
+import {
+  type IngredientSlug,
+  normalizeIngredientSlugForOutput,
+  resolveIngredientSlug,
+} from "@/lib/domain/recipe/ingredient";
+
+const knownIngredientSlugs = new Set<IngredientSlug>(
+  definedIngredients.map(resolveIngredientSlug),
+);
+
+/**
+ * Use the visible ingredient as the identity when it names another catalog
+ * ingredient exactly. Cooklang aliases normally preserve harmless wording
+ * differences, but `@butter|unsalted butter{}` must not let generic butter in
+ * the pantry satisfy a request for unsalted butter.
+ */
+export function resolveDisplayedIngredientSlug(
+  registeredName: string,
+  displayName?: string,
+): IngredientSlug {
+  const registeredSlug = normalizeIngredientSlugForOutput(
+    registeredName,
+  ) as IngredientSlug;
+  if (!displayName) return registeredSlug;
+
+  const displayedSlug = normalizeIngredientSlugForOutput(
+    displayName,
+  ) as IngredientSlug;
+  return knownIngredientSlugs.has(displayedSlug)
+    ? displayedSlug
+    : registeredSlug;
+}

--- a/ui/lib/domain/recipe/ingredientIdentity.ts
+++ b/ui/lib/domain/recipe/ingredientIdentity.ts
@@ -19,14 +19,11 @@ export function resolveDisplayedIngredientSlug(
   registeredName: string,
   displayName?: string,
 ): IngredientSlug {
-  const registeredSlug = normalizeIngredientSlugForOutput(
-    registeredName,
-  ) as IngredientSlug;
+  const registeredSlug: IngredientSlug =
+    normalizeIngredientSlugForOutput(registeredName);
   if (!displayName) return registeredSlug;
 
-  const displayedSlug = normalizeIngredientSlugForOutput(
-    displayName,
-  ) as IngredientSlug;
+  const displayedSlug = resolveIngredientSlug({ name: displayName });
   return knownIngredientSlugs.has(displayedSlug)
     ? displayedSlug
     : registeredSlug;

--- a/ui/lib/domain/recipe/recipeDraft.ts
+++ b/ui/lib/domain/recipe/recipeDraft.ts
@@ -4,6 +4,7 @@ import {
   SavedRecipePayloadSchema,
 } from "recipe-domain/serialization";
 import { buildRecipeContentFromParsed } from "@/lib/domain/recipe/cooklangTransform";
+import { resolveDisplayedIngredientSlug } from "@/lib/domain/recipe/ingredientIdentity";
 import {
   type RecipeContent,
   RecipeContentSchema,
@@ -101,10 +102,9 @@ function recipeContentToDetail(
 ): RecipeDetailView {
   const ingredientNames = new Map<string, string>();
   content.instructionSdk?.ingredientNames.forEach((name, index) => {
-    ingredientNames.set(
-      normalizeSlug(name),
-      content.instructionSdk?.ingredientDisplayValues[index] ?? name,
-    );
+    const display =
+      content.instructionSdk?.ingredientDisplayValues[index] ?? name;
+    ingredientNames.set(normalizeSlug(name), display);
   });
   const totalTime =
     content.prepTime != null && content.cookTime != null
@@ -129,11 +129,15 @@ function recipeContentToDetail(
     cookware: content.cookware,
     ingredientGroups: content.ingredientGroups.map((group) => ({
       name: group.name,
-      items: group.items.map((item) => ({
-        ...item,
-        name:
-          ingredientNames.get(item.ingredient) ?? displayName(item.ingredient),
-      })),
+      items: group.items.map((item) => {
+        const name =
+          ingredientNames.get(item.ingredient) ?? displayName(item.ingredient);
+        return {
+          ...item,
+          ingredient: resolveDisplayedIngredientSlug(item.ingredient, name),
+          name,
+        };
+      }),
     })),
     instructions: content.instructions,
     instructionSdk: content.instructionSdk,

--- a/ui/tests/components/recipes/shopping/shopping-list.test.tsx
+++ b/ui/tests/components/recipes/shopping/shopping-list.test.tsx
@@ -48,6 +48,8 @@ vi.mock("@/hooks/use-unit-preference", async () => {
   };
 });
 
+type Slug = ShoppingRecipe["ingredients"][number]["ingredient"];
+
 const recipes: ShoppingRecipe[] = [
   {
     slug: "garlic-pasta",
@@ -61,6 +63,39 @@ const recipes: ShoppingRecipe[] = [
         name: "garlic",
         amount: 1,
         unit: "clove",
+      },
+    ],
+  },
+];
+
+const butterRecipes: ShoppingRecipe[] = [
+  {
+    slug: "salted-butter-dish",
+    title: "Salted butter dish",
+    servings: 2,
+    cuisine: [],
+    ingredients: [
+      {
+        ingredient: "salted-butter" as Slug,
+        name: "salted butter",
+        amount: 100,
+        unit: "g",
+        category: "dairy",
+      },
+    ],
+  },
+  {
+    slug: "unsalted-butter-dish",
+    title: "Unsalted butter dish",
+    servings: 2,
+    cuisine: [],
+    ingredients: [
+      {
+        ingredient: "unsalted-butter" as Slug,
+        name: "unsalted butter",
+        amount: 200,
+        unit: "g",
+        category: "dairy",
       },
     ],
   },
@@ -121,8 +156,6 @@ describe("ShoppingList value analytics", () => {
     expect(mocks.captureRecipeValue).toHaveBeenCalledTimes(1);
   });
 });
-
-type Slug = ShoppingRecipe["ingredients"][number]["ingredient"];
 
 const twoAisleRecipes: ShoppingRecipe[] = [
   {
@@ -227,6 +260,24 @@ describe("ShoppingList pantry state", () => {
       "full shopping list without kitchen filtering",
     );
     expect(screen.getByText("garlic")).toBeInTheDocument();
+  });
+
+  it("does not let stocked salted butter hide unsalted butter", () => {
+    __resetShoppingListForTests();
+    addRecipe("salted-butter-dish");
+    addRecipe("unsalted-butter-dish");
+    pantryState.stock = { "salted-butter": "fridge" };
+
+    render(<ShoppingList recipes={butterRecipes} />);
+
+    expect(
+      screen.getByRole("button", { name: /200g unsalted butter/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+    expect(
+      screen.getByRole("button", {
+        name: /remove salted butter from the kitchen/i,
+      }),
+    ).toBeInTheDocument();
   });
 });
 

--- a/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
+++ b/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
@@ -202,6 +202,16 @@ describe("buildScaledRecipeParts", () => {
     ]);
   });
 
+  it("preserves an exact catalog display identity when canonical aliases differ", () => {
+    const parts = buildScaledRecipeParts(
+      parsedAt(`Add @pepper|red pepper{1}.\n`),
+    );
+
+    expect(parts.ingredientGroups[0]?.items).toEqual([
+      { ingredient: "red-pepper", amount: 1 },
+    ]);
+  });
+
   it("keeps purchasing-specific catalog ingredients separate from a generic alias", () => {
     const parts = buildScaledRecipeParts(
       parsedAt(

--- a/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
+++ b/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
@@ -223,6 +223,23 @@ describe("buildScaledRecipeParts", () => {
     ]);
   });
 
+  it("does not add generic butter when an instruction references a specific declaration", () => {
+    const parts = buildScaledRecipeParts(
+      parsedAt(
+        [
+          "@butter|unsalted butter{200%g}",
+          "",
+          "Cream the @butter{} with sugar.",
+        ].join("\n"),
+      ),
+    );
+
+    expect(parts.ingredientGroups[0]?.items).toEqual([
+      { ingredient: "unsalted-butter", amount: 200, unit: "g" },
+    ]);
+    expect(parts.instructions).toEqual(["Cream the butter with sugar."]);
+  });
+
   it("lists cookware by its registered name while steps keep the alias", () => {
     const parts = buildScaledRecipeParts(
       parsedAt(

--- a/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
+++ b/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
@@ -250,6 +250,21 @@ describe("buildScaledRecipeParts", () => {
     expect(parts.instructions).toEqual(["Cream the butter with sugar."]);
   });
 
+  it("does not let a generic declaration suppress a specific later ingredient", () => {
+    const parts = buildScaledRecipeParts(
+      parsedAt(
+        ["@butter{100%g}", "", "Fold in @butter|unsalted butter{50%g}."].join(
+          "\n",
+        ),
+      ),
+    );
+
+    expect(parts.ingredientGroups[0]?.items).toEqual([
+      { ingredient: "butter", amount: 100, unit: "g" },
+      { ingredient: "unsalted-butter", amount: 50, unit: "g" },
+    ]);
+  });
+
   it("lists cookware by its registered name while steps keep the alias", () => {
     const parts = buildScaledRecipeParts(
       parsedAt(

--- a/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
+++ b/ui/tests/lib/domain/recipe/cooklangTransform.test.ts
@@ -202,6 +202,27 @@ describe("buildScaledRecipeParts", () => {
     ]);
   });
 
+  it("keeps purchasing-specific catalog ingredients separate from a generic alias", () => {
+    const parts = buildScaledRecipeParts(
+      parsedAt(
+        [
+          "@butter|salted butter{100%g}",
+          "",
+          "@butter|unsalted butter{200%g}",
+        ].join("\n"),
+      ),
+    );
+
+    expect(parts.ingredientGroups[0]?.items).toEqual([
+      { ingredient: "salted-butter", amount: 100, unit: "g" },
+      { ingredient: "unsalted-butter", amount: 200, unit: "g" },
+    ]);
+    expect(parts.instructionSdk.ingredientNames).toEqual([
+      "salted butter",
+      "unsalted butter",
+    ]);
+  });
+
   it("lists cookware by its registered name while steps keep the alias", () => {
     const parts = buildScaledRecipeParts(
       parsedAt(

--- a/ui/tests/lib/domain/recipe/recipeDraft.test.ts
+++ b/ui/tests/lib/domain/recipe/recipeDraft.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildRecipeDraft,
   normalizeRecipeSource,
+  parseSavedRecipe,
   parseSavedRecipePayload,
   savedRecipeCard,
 } from "@/lib/domain/recipe/recipeDraft";
@@ -106,6 +107,42 @@ describe("savedRecipeCard", () => {
 
   it("parses the source and recipe needed by the editor", () => {
     expect(parseSavedRecipePayload(record("private"))).toEqual(savedPayload);
+  });
+
+  it("repairs a saved specific ingredient whose hidden identity is generic", () => {
+    const legacyPayload = {
+      ...savedPayload,
+      recipe: {
+        ...savedPayload.recipe,
+        ingredientGroups: [
+          {
+            items: [{ ingredient: "butter", amount: 200, unit: "g" }],
+          },
+        ],
+        instructionSdk: {
+          sections: [],
+          ingredientNames: ["butter"],
+          ingredientDisplayValues: ["unsalted butter"],
+          ingredientAmounts: [200],
+          ingredientUnits: ["g"],
+          cookwareDisplayValues: [],
+          inlineQuantityDisplayValues: [],
+          timerDisplayValues: [],
+          timerDurationSeconds: [],
+        },
+      },
+    };
+    const parsed = parseSavedRecipe({
+      ...record("private"),
+      body: JSON.stringify(legacyPayload),
+    });
+
+    expect(parsed?.ingredientGroups[0]?.items).toEqual([
+      expect.objectContaining({
+        ingredient: "unsalted-butter",
+        name: "unsalted butter",
+      }),
+    ]);
   });
 
   it("preserves the canonical source URL in saved recipe views", () => {

--- a/ui/tests/lib/domain/shopping/aggregate.test.ts
+++ b/ui/tests/lib/domain/shopping/aggregate.test.ts
@@ -55,6 +55,22 @@ describe("aggregateShoppingList", () => {
     expect(garlic.recipes.map((r) => r.slug)).toEqual(["a", "b"]);
   });
 
+  it("does not merge salted and unsalted butter", () => {
+    const lines = aggregateShoppingList([
+      select(
+        recipe("savoury", [ing("salted-butter", { amount: 100, unit: "g" })]),
+      ),
+      select(
+        recipe("baking", [ing("unsalted-butter", { amount: 200, unit: "g" })]),
+      ),
+    ]);
+
+    expect(lines.map((line) => line.ingredient)).toEqual([
+      "salted-butter",
+      "unsalted-butter",
+    ]);
+  });
+
   it("sums compatible units by converting to a base unit", () => {
     const lines = aggregateShoppingList([
       select(recipe("a", [ing("pasta", { amount: 300, unit: "g" })])),

--- a/workers/recipe-api/drizzle/0008_add_salted_butter.sql
+++ b/workers/recipe-api/drizzle/0008_add_salted_butter.sql
@@ -1,0 +1,8 @@
+insert into "ingredient" ("slug", "name", "category", "created_at", "updated_at")
+values ('salted-butter', 'salted butter', 'dairy', now(), now())
+on conflict ("slug") do update
+set "name" = excluded."name", "category" = excluded."category", "updated_at" = now();
+--> statement-breakpoint
+insert into "ingredient_group_member" ("group_key", "ingredient_slug", "created_at")
+values ('dairy', 'salted-butter', now())
+on conflict do nothing;

--- a/workers/recipe-api/drizzle/meta/0008_snapshot.json
+++ b/workers/recipe-api/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,3302 @@
+{
+  "id": "44783fca-c615-4d99-9b4f-6dbeb4c265f3",
+  "prevId": "b6bf11e9-de49-4d88-b5cc-9025aad5cd6e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_rate_limit": {
+      "name": "app_rate_limit",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cooking_session": {
+      "name": "cooking_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_slug": {
+          "name": "recipe_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_title": {
+          "name": "recipe_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cooking_session_user_started_idx": {
+          "name": "cooking_session_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cooking_session_user_completed_idx": {
+          "name": "cooking_session_user_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "cooking_session_user_recipe_completed_idx": {
+          "name": "cooking_session_user_recipe_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "cooking_session_user_id_user_id_fk": {
+          "name": "cooking_session_user_id_user_id_fk",
+          "tableFrom": "cooking_session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset": {
+      "name": "diet_preset",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset_excluded_group": {
+      "name": "diet_preset_excluded_group",
+      "schema": "",
+      "columns": {
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_preset_excluded_group_group_key_idx": {
+          "name": "diet_preset_excluded_group_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "diet_preset_excluded_group_preset_key_diet_preset_key_fk": {
+          "name": "diet_preset_excluded_group_preset_key_diet_preset_key_fk",
+          "tableFrom": "diet_preset_excluded_group",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "tableTo": "diet_preset",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "diet_preset_excluded_group_group_key_ingredient_group_key_fk": {
+          "name": "diet_preset_excluded_group_group_key_ingredient_group_key_fk",
+          "tableFrom": "diet_preset_excluded_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "tableTo": "ingredient_group",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "diet_preset_excluded_group_pk": {
+          "name": "diet_preset_excluded_group_pk",
+          "columns": [
+            "preset_key",
+            "group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset_excluded_ingredient": {
+      "name": "diet_preset_excluded_ingredient",
+      "schema": "",
+      "columns": {
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_preset_excluded_ingredient_slug_idx": {
+          "name": "diet_preset_excluded_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "diet_preset_excluded_ingredient_preset_key_diet_preset_key_fk": {
+          "name": "diet_preset_excluded_ingredient_preset_key_diet_preset_key_fk",
+          "tableFrom": "diet_preset_excluded_ingredient",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "tableTo": "diet_preset",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "diet_preset_excluded_ingredient_ingredient_slug_ingredient_slug_fk": {
+          "name": "diet_preset_excluded_ingredient_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "diet_preset_excluded_ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "tableTo": "ingredient",
+          "columnsTo": [
+            "slug"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "diet_preset_excluded_ingredient_pk": {
+          "name": "diet_preset_excluded_ingredient_pk",
+          "columns": [
+            "preset_key",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient": {
+      "name": "ingredient",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_group": {
+      "name": "ingredient_group",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_group_member": {
+      "name": "ingredient_group_member",
+      "schema": "",
+      "columns": {
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingredient_group_member_ingredient_slug_idx": {
+          "name": "ingredient_group_member_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "ingredient_group_member_group_key_ingredient_group_key_fk": {
+          "name": "ingredient_group_member_group_key_ingredient_group_key_fk",
+          "tableFrom": "ingredient_group_member",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "tableTo": "ingredient_group",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "ingredient_group_member_ingredient_slug_ingredient_slug_fk": {
+          "name": "ingredient_group_member_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "ingredient_group_member",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "tableTo": "ingredient",
+          "columnsTo": [
+            "slug"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ingredient_group_member_pk": {
+          "name": "ingredient_group_member_pk",
+          "columns": [
+            "group_key",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "member_user_unique": {
+          "name": "member_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_delivery_event_recipient_uidx": {
+          "name": "notification_delivery_event_recipient_uidx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notification_delivery_recipient_read_at_idx": {
+          "name": "notification_delivery_recipient_read_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_event_id_notification_event_id_fk": {
+          "name": "notification_delivery_event_id_notification_event_id_fk",
+          "tableFrom": "notification_delivery",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "notification_event",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_delivery_recipient_user_id_user_id_fk": {
+          "name": "notification_delivery_recipient_user_id_user_id_fk",
+          "tableFrom": "notification_delivery",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_event": {
+      "name": "notification_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name_snapshot": {
+          "name": "actor_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_event_kind_idx": {
+          "name": "notification_event_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_event_actor_user_id_user_id_fk": {
+          "name": "notification_event_actor_user_id_user_id_fk",
+          "tableFrom": "notification_event",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_household_event": {
+      "name": "notification_household_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_name_snapshot": {
+          "name": "household_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_household_event_household_idx": {
+          "name": "notification_household_event_household_idx",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_household_event_event_id_notification_event_id_fk": {
+          "name": "notification_household_event_event_id_notification_event_id_fk",
+          "tableFrom": "notification_household_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "notification_event",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_household_event_household_id_organization_id_fk": {
+          "name": "notification_household_event_household_id_organization_id_fk",
+          "tableFrom": "notification_household_event",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_household_invitation_event": {
+      "name": "notification_household_invitation_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_household_invitation_event_invitation_idx": {
+          "name": "notification_household_invitation_event_invitation_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_household_invitation_event_event_id_notification_household_event_event_id_fk": {
+          "name": "notification_household_invitation_event_event_id_notification_household_event_event_id_fk",
+          "tableFrom": "notification_household_invitation_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "notification_household_event",
+          "columnsTo": [
+            "event_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_household_invitation_event_invitation_id_invitation_id_fk": {
+          "name": "notification_household_invitation_event_invitation_id_invitation_id_fk",
+          "tableFrom": "notification_household_invitation_event",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "tableTo": "invitation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipe_recommendation_event": {
+      "name": "notification_recipe_recommendation_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_slug_snapshot": {
+          "name": "recipe_slug_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_title_snapshot": {
+          "name": "recipe_title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_recipe_recommendation_recipe_idx": {
+          "name": "notification_recipe_recommendation_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_recipe_recommendation_event_event_id_notification_event_id_fk": {
+          "name": "notification_recipe_recommendation_event_event_id_notification_event_id_fk",
+          "tableFrom": "notification_recipe_recommendation_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "notification_event",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_recipe_recommendation_event_recipe_id_recipe_id_fk": {
+          "name": "notification_recipe_recommendation_event_recipe_id_recipe_id_fk",
+          "tableFrom": "notification_recipe_recommendation_event",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "tableTo": "recipe",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pantry_aggregate": {
+      "name": "pantry_aggregate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_aggregate_user_uidx": {
+          "name": "pantry_aggregate_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pantry_aggregate_household_uidx": {
+          "name": "pantry_aggregate_household_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pantry_aggregate_user_id_user_id_fk": {
+          "name": "pantry_aggregate_user_id_user_id_fk",
+          "tableFrom": "pantry_aggregate",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "pantry_aggregate_organization_id_organization_id_fk": {
+          "name": "pantry_aggregate_organization_id_organization_id_fk",
+          "tableFrom": "pantry_aggregate",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pantry_aggregate_owner_check": {
+          "name": "pantry_aggregate_owner_check",
+          "value": "num_nonnulls(\"pantry_aggregate\".\"user_id\", \"pantry_aggregate\".\"organization_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pantry_item": {
+      "name": "pantry_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "pantry_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "1"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_item_user_ingredient_uidx": {
+          "name": "pantry_item_user_ingredient_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pantry_item_household_ingredient_uidx": {
+          "name": "pantry_item_household_ingredient_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "pantry_item_ingredient_slug_idx": {
+          "name": "pantry_item_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pantry_item_user_id_user_id_fk": {
+          "name": "pantry_item_user_id_user_id_fk",
+          "tableFrom": "pantry_item",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "pantry_item_organization_id_organization_id_fk": {
+          "name": "pantry_item_organization_id_organization_id_fk",
+          "tableFrom": "pantry_item",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "pantry_item_ingredient_slug_ingredient_slug_fk": {
+          "name": "pantry_item_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "pantry_item",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "tableTo": "ingredient",
+          "columnsTo": [
+            "slug"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pantry_item_owner_check": {
+          "name": "pantry_item_owner_check",
+          "value": "num_nonnulls(\"pantry_item\".\"user_id\", \"pantry_item\".\"organization_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pantry_operation": {
+      "name": "pantry_operation",
+      "schema": "",
+      "columns": {
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_fingerprint": {
+          "name": "command_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_operation_created_at_idx": {
+          "name": "pantry_operation_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "pantry_operation_aggregate_id_pantry_aggregate_id_fk": {
+          "name": "pantry_operation_aggregate_id_pantry_aggregate_id_fk",
+          "tableFrom": "pantry_operation",
+          "columnsFrom": [
+            "aggregate_id"
+          ],
+          "tableTo": "pantry_aggregate",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pantry_operation_aggregate_id_operation_id_pk": {
+          "name": "pantry_operation_aggregate_id_operation_id_pk",
+          "columns": [
+            "aggregate_id",
+            "operation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe": {
+      "name": "recipe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_user_id_idx": {
+          "name": "recipe_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recipe_public_feed_idx": {
+          "name": "recipe_public_feed_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recipe_household_feed_idx": {
+          "name": "recipe_household_feed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_user_id_user_id_fk": {
+          "name": "recipe_user_id_user_id_fk",
+          "tableFrom": "recipe",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_slug_unique": {
+          "name": "recipe_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_artifact": {
+      "name": "recipe_import_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_import_artifact_job_id_idx": {
+          "name": "recipe_import_artifact_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recipe_import_artifact_job_stage_kind_unique": {
+          "name": "recipe_import_artifact_job_stage_kind_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_artifact_job_id_recipe_import_job_id_fk": {
+          "name": "recipe_import_artifact_job_id_recipe_import_job_id_fk",
+          "tableFrom": "recipe_import_artifact",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "tableTo": "recipe_import_job",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_attempt": {
+      "name": "recipe_import_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retryable": {
+          "name": "retryable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_import_attempt_job_id_idx": {
+          "name": "recipe_import_attempt_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recipe_import_attempt_job_stage_attempt_unique": {
+          "name": "recipe_import_attempt_job_stage_attempt_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_attempt_job_id_recipe_import_job_id_fk": {
+          "name": "recipe_import_attempt_job_id_recipe_import_job_id_fk",
+          "tableFrom": "recipe_import_attempt",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "tableTo": "recipe_import_job",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_job": {
+      "name": "recipe_import_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_import_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_label": {
+          "name": "progress_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipe_import_job_user_id_idx": {
+          "name": "recipe_import_job_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recipe_import_job_user_status_idx": {
+          "name": "recipe_import_job_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "recipe_import_job_user_created_idx": {
+          "name": "recipe_import_job_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_job_user_id_user_id_fk": {
+          "name": "recipe_import_job_user_id_user_id_fk",
+          "tableFrom": "recipe_import_job",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_excluded_group": {
+      "name": "user_diet_excluded_group",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_excluded_group_group_key_idx": {
+          "name": "user_diet_excluded_group_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_diet_excluded_group_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_excluded_group_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_excluded_group",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user_diet_profile",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_diet_excluded_group_group_key_ingredient_group_key_fk": {
+          "name": "user_diet_excluded_group_group_key_ingredient_group_key_fk",
+          "tableFrom": "user_diet_excluded_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "tableTo": "ingredient_group",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_excluded_group_pk": {
+          "name": "user_diet_excluded_group_pk",
+          "columns": [
+            "user_id",
+            "group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_excluded_ingredient": {
+      "name": "user_diet_excluded_ingredient",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_excluded_ingredient_slug_idx": {
+          "name": "user_diet_excluded_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_diet_excluded_ingredient_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_excluded_ingredient_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_excluded_ingredient",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user_diet_profile",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_diet_excluded_ingredient_ingredient_slug_ingredient_slug_fk": {
+          "name": "user_diet_excluded_ingredient_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "user_diet_excluded_ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "tableTo": "ingredient",
+          "columnsTo": [
+            "slug"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_excluded_ingredient_pk": {
+          "name": "user_diet_excluded_ingredient_pk",
+          "columns": [
+            "user_id",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_preset": {
+      "name": "user_diet_preset",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_preset_preset_key_idx": {
+          "name": "user_diet_preset_preset_key_idx",
+          "columns": [
+            {
+              "expression": "preset_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_diet_preset_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_preset_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_preset",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user_diet_profile",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_diet_preset_preset_key_diet_preset_key_fk": {
+          "name": "user_diet_preset_preset_key_diet_preset_key_fk",
+          "tableFrom": "user_diet_preset",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "tableTo": "diet_preset",
+          "columnsTo": [
+            "key"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_preset_pk": {
+          "name": "user_diet_preset_pk",
+          "columns": [
+            "user_id",
+            "preset_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_profile": {
+      "name": "user_diet_profile",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_match_mode": {
+          "name": "recipe_match_mode",
+          "type": "diet_recipe_match_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hide'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_diet_profile_user_id_user_id_fk": {
+          "name": "user_diet_profile_user_id_user_id_fk",
+          "tableFrom": "user_diet_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email": {
+      "name": "user_email",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_user_id_idx": {
+          "name": "user_email_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_email_user_id_user_id_fk": {
+          "name": "user_email_user_id_user_id_fk",
+          "tableFrom": "user_email",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follow": {
+      "name": "user_follow",
+      "schema": "",
+      "columns": {
+        "follower_user_id": {
+          "name": "follower_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followed_user_id": {
+          "name": "followed_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follow_followed_user_id_idx": {
+          "name": "user_follow_followed_user_id_idx",
+          "columns": [
+            {
+              "expression": "followed_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_follow_follower_user_id_user_id_fk": {
+          "name": "user_follow_follower_user_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "columnsFrom": [
+            "follower_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_follow_followed_user_id_user_id_fk": {
+          "name": "user_follow_followed_user_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "columnsFrom": [
+            "followed_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_follow_pk": {
+          "name": "user_follow_pk",
+          "columns": [
+            "follower_user_id",
+            "followed_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_follow_not_self": {
+          "name": "user_follow_not_self",
+          "value": "\"user_follow\".\"follower_user_id\" <> \"user_follow\".\"followed_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_box": {
+      "name": "user_recipe_box",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_recipe_box_user_id_user_id_fk": {
+          "name": "user_recipe_box_user_id_user_id_fk",
+          "tableFrom": "user_recipe_box",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_box_item": {
+      "name": "user_recipe_box_item",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_slug": {
+          "name": "recipe_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_recipe_box_item_user_id_user_id_fk": {
+          "name": "user_recipe_box_item_user_id_user_id_fk",
+          "tableFrom": "user_recipe_box_item",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_recipe_box_item_user_id_recipe_slug_pk": {
+          "name": "user_recipe_box_item_user_id_recipe_slug_pk",
+          "columns": [
+            "user_id",
+            "recipe_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.diet_recipe_match_mode": {
+      "name": "diet_recipe_match_mode",
+      "schema": "public",
+      "values": [
+        "hide",
+        "warn"
+      ]
+    },
+    "public.pantry_location": {
+      "name": "pantry_location",
+      "schema": "public",
+      "values": [
+        "fridge",
+        "cupboards",
+        "fresh"
+      ]
+    },
+    "public.recipe_import_stage": {
+      "name": "recipe_import_stage",
+      "schema": "public",
+      "values": [
+        "extract",
+        "normalize",
+        "canonicalize",
+        "finalize"
+      ]
+    },
+    "public.recipe_import_status": {
+      "name": "recipe_import_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "household"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/workers/recipe-api/drizzle/meta/_journal.json
+++ b/workers/recipe-api/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1786273611769,
       "tag": "0007_revisioned_pantry_commands",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1787391346391,
+      "tag": "0008_add_salted_butter",
+      "breakpoints": true
     }
   ]
 }

--- a/workers/recipe-api/tests/integration/database.test.ts
+++ b/workers/recipe-api/tests/integration/database.test.ts
@@ -149,14 +149,15 @@ beforeAll(async () => {
   >`
     select slug, category
     from ingredient
-    where slug in ('almond-milk', 'cajun-powder', 'cajun-seasoning')
+    where slug in ('almond-milk', 'cajun-powder', 'cajun-seasoning', 'salted-butter')
     order by slug
   `;
-  expect(migrationCount?.count).toBe(8);
+  expect(migrationCount?.count).toBe(9);
   expect(tableCount?.count).toBe(35);
   expect(catalogRows).toEqual([
     { category: "dairy", slug: "almond-milk" },
     { category: "spice", slug: "cajun-seasoning" },
+    { category: "dairy", slug: "salted-butter" },
   ]);
 });
 


### PR DESCRIPTION
## Summary

- treat visible catalog ingredients as their shopping and pantry identity when a Cooklang alias points at a different product
- keep butter, salted butter, and unsalted butter as separate identities
- repair older saved recipes on read when their visible butter type conflicts with a generic hidden identity
- add salted butter to the parsing and database catalogs

## Validation

- UI unit tests: 889 passed
- recipe parsing tests: 160 passed
- recipe API tests: 222 passed
- recipe ingest tests: 29 passed
- UI, recipe parsing, recipe API, and recipe ingest typechecks passed
- production UI build passed
- Biome lint, formatting checks, typo checks, and migration checks passed

The database integration suite could not start locally because Docker stalled while pulling `postgres:17-alpine`. CI should run it with its normal PostgreSQL service.

## Preview QA

Requires a signed-in backend preview.

1. Add one recipe that needs salted butter and another that needs unsalted butter.
2. Put salted butter in the pantry.
3. Open the shopping list.
4. Confirm salted butter appears under "already have" and unsalted butter remains unticked on the shopping list.
5. Confirm generic butter does not hide either specific variant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added salted butter as a recognised dairy ingredient across recipes, ingredient search and shopping lists.
  * Salted and unsalted butter are now kept as separate ingredients, including when recipes use a generic butter label.
  * Improved ingredient matching while preserving compatibility with existing recipes.

* **Bug Fixes**
  * Corrected legacy recipes and shopping lists so specific butter variants are identified and displayed accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->