### PR TITLE
Route Mac mini egress through always-on Hotspot Shield VPN

### DIFF
--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -6,6 +6,7 @@ status: "in_progress"
 tech_stack:
   - "Tailscale"
   - "AdGuard Home"
+  - "Hotspot Shield"
   - "t3-code"
   - "Claude Code"
   - "Codex"
@@ -114,6 +115,7 @@ NET1["Netdata"]
 T3["t3-code + agents"]
 JEL["Jellyfin"]
 end
+HSS["Hotspot Shield VPN, always-on"]
 subgraph pi["Raspberry Pi"]
 ADG2["AdGuard Home, fallback DNS"]
 NET2["Netdata to hub"]
@@ -131,6 +133,8 @@ end
 Router --> ADG1
 Router --> ADG2
 ADG2 --> ADG1
+hub -->|"all egress"| HSS
+HSS -->|"encrypted tunnel"| Internet
 DailyPhone -->|"photo upload"| Ente["Ente cloud"]
 Ente -->|"download backup"| ENT
 ENT --> HDD[("10TB HDD")]
@@ -173,6 +177,15 @@ owns the photo backup pipeline, the lab's two most important jobs.
   requests over my home network. AdGuard is also reachable over the tailnet,
   so the phone keeps blocking trackers and ads on cellular or any other
   network. A router-level setup cannot provide that coverage.
+* **Always-on VPN egress.** The mini runs
+  [Hotspot Shield](https://www.hotspotshield.com) as an always-on client, so
+  every outbound connection leaves through its tunnel and the ISP sees one
+  encrypted stream instead of individual destinations. This forced one config
+  change elsewhere: Hotspot Shield kills TLS connections to known
+  encrypted-DNS endpoints, so AdGuard's DNS-over-HTTPS upstream stopped
+  resolving under the tunnel. The upstreams are now plain UDP Quad9
+  (9.9.9.9), which passes through untouched. LAN devices keep their filtering
+  either way; only the mini's own traffic is tunnelled.
 * **Monitoring.** It runs [Netdata](/projects/homelab/adrs/009-netdata),
   connected to my Slack workspace via a Slack app, to alarm on anything
   going wrong.
@@ -298,6 +311,17 @@ internet "stops working."
 hardware. The Pi keeps working during Mac mini reboots and vice versa. The
 proposed View 20 watchdog will use mobile data to report a failure of both
 resolvers.
+
+## The VPN tunnel dies quietly after a reboot
+
+Hotspot Shield ships as an App Store app, and its tunnel only comes back
+after a user session starts. An unattended restart (power cut, forced update)
+puts the mini back online with traffic egressing from the home IP until
+someone logs in.
+
+**Mitigation.** Netdata watches the mini's public IP and alerts Slack when it
+falls outside the VPN exit range. Until that alert exists, treat the tunnel as
+down after any unattended reboot.
 
 ## Photo backup silently failing
 

--- a/ui/content/technologies.ts
+++ b/ui/content/technologies.ts
@@ -968,6 +968,14 @@ export const technologies: TechnologyContent[] = [
     type: "tool",
   },
   {
+    name: "Hotspot Shield",
+    added: "2026-08-22",
+    description:
+      "VPN client and service that encrypts internet traffic and routes it through remote servers, masking the user's IP address",
+    website: "https://www.hotspotshield.com",
+    type: "tool",
+  },
+  {
     name: "t3-code",
     added: "2026-08-02",
     description:


### PR DESCRIPTION
**Summary**

- Home lab topology diagram now shows Hotspot Shield as the always-on egress hop in front of the Mac mini (`hub --> HSS --> Internet`)
- New node bullet documents what the tunnel hides from the ISP and why AdGuard's upstream moved from DNS-over-HTTPS to plain UDP Quad9 (the VPN resets TLS to known encrypted-DNS endpoints)
- New risk entry covers the quiet tunnel loss after an unattended reboot, with a Netdata public-IP alert as mitigation
- Adds Hotspot Shield to `tech_stack` and `content/technologies.ts` (the repo validates every referenced technology exists)

**Validation**

- Mermaid chart parse test (`mermaid-charts.test.ts`), repository reference validation, typecheck, Biome lint, and project/content tests all pass
- Live-verified on the actual hub: tunnel up, AdGuard filtering intact, MagicDNS and Tailscale healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the homelab project overview to include Hotspot Shield in the technology stack and network topology.
  * Documented always-on VPN egress for the Mac mini and the updated DNS routing.
  * Added a risk note covering VPN recovery after unattended reboots, with monitoring and Slack alerts.
* **New Features**
  * Added Hotspot Shield to the technology catalogue with its description, website and classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->