### PR TITLE
Split home lab topology into focused diagrams

### DIFF
--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -403,17 +403,17 @@ They will not become DNS servers, general compute nodes, or permanent cameras.
 The lab is being built incrementally, starting from the highest-value
 workloads and layering on the rest:
 
-| Phase | Workload                                                      | Status      |
-| ----- | ------------------------------------------------------------- | ----------- |
-| 1     | Photo backup (Ente → 10TB HDD)                                | Live        |
-| 2     | Agentic development hub (t3-code + agents)                    | Live        |
-| 3     | DNS privacy (AdGuard Home, primary + failover)                | Live        |
-| 4     | CUPS printing on the Pi (avoiding printer e-waste)            | Live        |
-| 5     | NixOS GPU worker for batch CV jobs, with DVC-managed datasets | Proposed    |
-| 6     | Jellyfin media server for the Fire TV Stick                   | In progress |
-| 7     | Physical Android and iOS device lab                           | Proposed    |
-| 8     | Cellular watchdog on the View 20                              | Proposed    |
-| 9     | Second compute node (idle 4080 laptop)                        | Idea        |
+| Phase | Workload                                                      | Status   |
+| ----- | ------------------------------------------------------------- | -------- |
+| 1     | Photo backup (Ente → 10TB HDD)                                | Live     |
+| 2     | Agentic development hub (t3-code + agents)                    | Live     |
+| 3     | DNS privacy (AdGuard Home, primary + failover)                | Live     |
+| 4     | CUPS printing on the Pi (avoiding printer e-waste)            | Live     |
+| 5     | NixOS GPU worker for batch CV jobs, with DVC-managed datasets | Proposed |
+| 6     | Jellyfin media server for the Fire TV Stick                   | Live     |
+| 7     | Physical Android and iOS device lab                           | Proposed |
+| 8     | Cellular watchdog on the View 20                              | Proposed |
+| 9     | Second compute node (idle 4080 laptop)                        | Idea     |
 
 # What this is not
 
@@ -514,9 +514,8 @@ narrowly scoped alert credential.
 
 ## Media server scope creep
 
-Jellyfin is the most consumer-facing thing on the roadmap and the easiest to
+Jellyfin is the lab's most consumer-facing service and the easiest one to
 over-invest in.
 
-**Mitigation.** It's explicitly a Phase 6 "nice to have." It only gets built
-after the higher-priority workloads are solid, and it stays behind the
-tailnet with a simple client story.
+**Mitigation.** Keep it as one container behind the tailnet, serving the Fire
+TV Stick. Add complexity only to fix a playback or operational problem.

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -112,19 +112,19 @@ pulls photos from Ente, works with code and agent providers, and sends
 operational alerts to Slack.
 
 <Mermaid
-  chart={`flowchart LR
+  chart={`flowchart TB
 Owner["Lab owner"]
-Household["Household devices"]
-Lab["Home lab<br/>Private services, storage and compute"]
-Cloud["Ente cloud<br/>Photo library"]
-Code["GitHub and AI providers<br/>Code and agent APIs"]
-Alerts["Slack<br/>Operational alerts"]
+Household["Household"]
+Lab["Home lab"]
+Cloud["Ente"]
+Code["GitHub and<br/>AI providers"]
+Alerts["Slack"]
 
-Owner -->|"develops, administers and streams"| Lab
-Household -->|"uses DNS and printing"| Lab
-Cloud -->|"supplies photo backup"| Lab
-Lab -->|"reads and writes repositories<br/>calls agent APIs"| Code
-Lab -->|"sends alerts"| Alerts
+Owner -->|"Manages"| Lab
+Household -->|"DNS and printing"| Lab
+Cloud -->|"Photos"| Lab
+Lab -->|"Code and agents"| Code
+Lab -->|"Alerts"| Alerts
 
 classDef person fill:#7c3aed,color:#fff,stroke:#6d28d9
 classDef system fill:#2563eb,color:#fff,stroke:#1d4ed8
@@ -178,11 +178,10 @@ class Storage data
 `}
 />
 
-## Deployment
+## Live deployment
 
 The Mac mini owns the main workloads and the Raspberry Pi keeps DNS and
-monitoring alive during hub maintenance. The GPU worker and phone lab are
-proposed additions.
+monitoring alive during hub maintenance.
 
 <Mermaid
   chart={`flowchart LR
@@ -190,54 +189,55 @@ Router["Home router"]
 Slack["Slack"]
 Printer["Canon MX3100"]
 FireTV["Fire TV Stick"]
-
-subgraph mini["Mac mini, always on"]
-PrimaryDNS["AdGuard Home<br/>Primary DNS"]
-Dev["t3-code and agents"]
-Backup["Ente sync"]
-Media["Jellyfin"]
-HubMonitor["Netdata parent"]
 Drive[("10TB HDD")]
-end
 
-subgraph pi["Raspberry Pi, always on"]
-FallbackDNS["AdGuard Home<br/>Fallback DNS"]
-Print["CUPS"]
-PiMonitor["Netdata child"]
-end
+Mini["Mac mini<br/>Primary DNS<br/>t3-code and agents<br/>Ente sync<br/>Jellyfin<br/>Netdata parent"]
+Pi["Raspberry Pi<br/>Fallback DNS<br/>CUPS<br/>Netdata child"]
 
-subgraph worker["Asus desktop, proposed"]
-GPU["NixOS and GTX 1060<br/>Batch CV jobs"]
+Router -->|"Primary DNS"| Mini
+Router -->|"Fallback DNS"| Pi
+Pi -->|"Metrics and DNS config"| Mini
+Mini --> Drive
+Mini --> FireTV
+Mini --> Slack
+Pi --> Printer
+
+classDef live fill:#0f766e,color:#fff,stroke:#115e59
+classDef data fill:#4338ca,color:#fff,stroke:#3730a3
+class Mini,Pi live
+class Drive data
+`}
+/>
+
+## Proposed deployment
+
+The Mac mini will wake the Asus desktop for GPU jobs and run browser tests on
+the phone lab. The View 20 will check the live hosts over cellular so it can
+still report a home power or internet failure.
+
+<Mermaid
+  chart={`flowchart TB
+Mini["Mac mini<br/>Home hub"]
+Pi["Raspberry Pi<br/>Fallback host"]
+Worker["Asus desktop<br/>NixOS and GTX 1060"]
 Cache[("1TB DVC cache")]
-end
-
-subgraph devices["Phone device lab, proposed"]
-Phones["Android and iOS<br/>Browser QA"]
+Phones["Phone lab<br/>Android and iOS QA"]
 Watchdog["View 20<br/>Cellular watchdog"]
-end
+Slack["Slack"]
 
-Router --> PrimaryDNS
-Router --> FallbackDNS
-FallbackDNS -->|"syncs configuration"| PrimaryDNS
-Backup --> Drive
-Media --> Drive
-Media --> FireTV
-Print --> Printer
-PiMonitor --> HubMonitor
-HubMonitor --> Slack
-Dev -.->|"wakes and submits jobs"| GPU
-GPU --> Cache
-Dev -.->|"runs preview tests"| Phones
-Watchdog -.->|"checks both hosts"| mini
-Watchdog -.->|"checks both hosts"| pi
-Watchdog -.->|"alerts over mobile data"| Slack
+Mini -->|"GPU jobs"| Worker
+Worker --> Cache
+Mini -->|"Browser tests"| Phones
+Watchdog -->|"Checks"| Mini
+Watchdog -->|"Checks"| Pi
+Watchdog -->|"Alerts"| Slack
 
 classDef live fill:#0f766e,color:#fff,stroke:#115e59
 classDef proposed fill:#fef3c7,color:#78350f,stroke:#d97706,stroke-dasharray:5 5
 classDef data fill:#4338ca,color:#fff,stroke:#3730a3
-class PrimaryDNS,Dev,Backup,Media,HubMonitor,FallbackDNS,Print,PiMonitor live
-class GPU,Cache,Phones,Watchdog proposed
-class Drive data
+class Mini,Pi live
+class Worker,Phones,Watchdog proposed
+class Cache data
 `}
 />
 

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -178,10 +178,12 @@ class Storage data
 `}
 />
 
-## Live deployment
+## Deployment
 
-The Mac mini owns the main workloads and the Raspberry Pi keeps DNS and
-monitoring alive during hub maintenance.
+### Device context
+
+The Mac mini is the home hub. The Raspberry Pi keeps DNS available during hub
+maintenance and owns the printer connection.
 
 <Mermaid
   chart={`flowchart LR
@@ -192,12 +194,12 @@ Printer["Canon MX3100"]
 FireTV["Fire TV Stick"]
 Drive[("10TB HDD")]
 
-Mini["Mac mini<br/>Primary DNS<br/>Hotspot Shield VPN<br/>t3-code and agents<br/>Ente sync<br/>Jellyfin<br/>Netdata parent"]
-Pi["Raspberry Pi<br/>Fallback DNS<br/>CUPS<br/>Netdata child"]
+Mini["Mac mini<br/>Home hub"]
+Pi["Raspberry Pi<br/>Fallback host"]
 
 Router -->|"Primary DNS"| Mini
 Router -->|"Fallback DNS"| Pi
-Pi -->|"Metrics and DNS config"| Mini
+Pi -->|"Metrics"| Mini
 Mini --> Drive
 Mini --> FireTV
 Mini --> Slack
@@ -211,7 +213,62 @@ class Drive data
 `}
 />
 
-## Proposed deployment
+### Mac mini containers
+
+The Mac mini hosts the lab's main services. Hotspot Shield routes its outbound
+traffic through an encrypted tunnel.
+
+<Mermaid
+  chart={`flowchart TB
+subgraph mini["Mac mini"]
+DNS["AdGuard Home<br/>Primary DNS"]
+VPN["Hotspot Shield<br/>All outbound traffic"]
+Dev["t3-code<br/>Coding agents"]
+Backup["Ente sync<br/>Photo backup"]
+Media["Jellyfin<br/>Media server"]
+Monitor["Netdata<br/>Parent node"]
+Storage[("10TB HDD")]
+end
+
+Ente["Ente cloud"] --> Backup
+Backup --> Storage
+Media --> Storage
+Media --> FireTV["Fire TV Stick"]
+Dev --> Code["GitHub and<br/>AI providers"]
+Monitor --> Slack["Slack"]
+VPN --> Internet["Internet"]
+
+classDef service fill:#0f766e,color:#fff,stroke:#115e59
+classDef data fill:#4338ca,color:#fff,stroke:#3730a3
+class DNS,VPN,Dev,Backup,Media,Monitor service
+class Storage data
+`}
+/>
+
+### Raspberry Pi containers
+
+The Pi runs the fallback DNS resolver, sends metrics to the Mac mini, and
+connects the old Canon printer to the network.
+
+<Mermaid
+  chart={`flowchart LR
+subgraph pi["Raspberry Pi"]
+DNS["AdGuard Home<br/>Fallback DNS"]
+Monitor["Netdata<br/>Child node"]
+Print["CUPS<br/>Print server"]
+end
+
+
+DNS -->|"Syncs config"| Primary["Primary DNS<br/>Mac mini"]
+Monitor -->|"Sends metrics"| Hub["Netdata parent<br/>Mac mini"]
+Print --> Printer["Canon MX3100"]
+
+classDef service fill:#0f766e,color:#fff,stroke:#115e59
+class DNS,Monitor,Print service
+`}
+/>
+
+### Proposed devices
 
 The Mac mini will wake the Asus desktop and 4080 laptop for GPU jobs, and run
 browser tests on the phone lab. The View 20 will check the live hosts over

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -137,25 +137,20 @@ class Cloud,Code,Alerts external
 
 ## Containers
 
-Tailscale is the private entry point for interactive services. Backup and media
-services share local storage, while Netdata reports failures outside the lab.
+### Interactive services
+
+Tailscale is the private entry point for DNS, development, media, and printing.
 
 <Mermaid
-  chart={`flowchart LR
+  chart={`flowchart TB
 People["Owner and household devices"]
-Ente["Ente cloud"]
-GitHub["GitHub and AI providers"]
-Slack["Slack"]
 
 subgraph lab["Home lab"]
 Access["Tailscale<br/>Private access network"]
 DNS["AdGuard Home<br/>Filtered DNS"]
 Dev["t3-code and coding agents<br/>Development workspace"]
-Backup["Ente sync<br/>Photo backup job"]
 Media["Jellyfin<br/>Media server"]
 Print["CUPS<br/>Print server"]
-Monitor["Netdata<br/>Monitoring and alerts"]
-Storage[("Local storage<br/>Photos, media and datasets")]
 end
 
 People --> Access
@@ -163,17 +158,35 @@ Access --> DNS
 Access --> Dev
 Access --> Media
 Access --> Print
-Ente -->|"downloads photos"| Backup
-Backup --> Storage
-Media --> Storage
-Dev -->|"repos and model requests"| GitHub
-Monitor -->|"alerts"| Slack
+DNS ~~~ Dev ~~~ Media ~~~ Print
+
+classDef external fill:#475569,color:#fff,stroke:#334155
+classDef service fill:#0f766e,color:#fff,stroke:#115e59
+class People external
+class Access,DNS,Dev,Media,Print service
+`}
+/>
+
+### Data and monitoring services
+
+Ente sync and Jellyfin share local storage. Netdata sends operational alerts
+to Slack, while the development workspace talks to GitHub and the agent APIs.
+
+<Mermaid
+  chart={`flowchart TB
+Ente["Ente cloud"] --> Backup["Ente sync<br/>Photo backup"]
+Backup --> Storage[("Local storage")]
+Storage --> Media["Jellyfin<br/>Media server"]
+Monitor["Netdata<br/>Monitoring"] --> Slack["Slack"]
+Dev["t3-code<br/>Coding agents"] --> Code["GitHub and<br/>AI providers"]
+
+Backup ~~~ Monitor ~~~ Dev
 
 classDef external fill:#475569,color:#fff,stroke:#334155
 classDef service fill:#0f766e,color:#fff,stroke:#115e59
 classDef data fill:#4338ca,color:#fff,stroke:#3730a3
-class People,Ente,GitHub,Slack external
-class Access,DNS,Dev,Backup,Media,Print,Monitor service
+class Ente,Slack,Code external
+class Backup,Media,Monitor,Dev service
 class Storage data
 `}
 />
@@ -186,7 +199,7 @@ The Mac mini is the home hub. The Raspberry Pi keeps DNS available during hub
 maintenance and owns the printer connection.
 
 <Mermaid
-  chart={`flowchart LR
+  chart={`flowchart TB
 Router["Home router"]
 Internet["Internet"]
 Slack["Slack"]
@@ -230,6 +243,7 @@ Monitor["Netdata<br/>Parent node"]
 Storage[("10TB HDD")]
 end
 
+DNS ~~~ VPN ~~~ Dev ~~~ Backup ~~~ Media ~~~ Monitor
 Ente["Ente cloud"] --> Backup
 Backup --> Storage
 Media --> Storage

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -186,12 +186,13 @@ monitoring alive during hub maintenance.
 <Mermaid
   chart={`flowchart LR
 Router["Home router"]
+Internet["Internet"]
 Slack["Slack"]
 Printer["Canon MX3100"]
 FireTV["Fire TV Stick"]
 Drive[("10TB HDD")]
 
-Mini["Mac mini<br/>Primary DNS<br/>t3-code and agents<br/>Ente sync<br/>Jellyfin<br/>Netdata parent"]
+Mini["Mac mini<br/>Primary DNS<br/>Hotspot Shield VPN<br/>t3-code and agents<br/>Ente sync<br/>Jellyfin<br/>Netdata parent"]
 Pi["Raspberry Pi<br/>Fallback DNS<br/>CUPS<br/>Netdata child"]
 
 Router -->|"Primary DNS"| Mini
@@ -200,6 +201,7 @@ Pi -->|"Metrics and DNS config"| Mini
 Mini --> Drive
 Mini --> FireTV
 Mini --> Slack
+Mini -->|"VPN egress"| Internet
 Pi --> Printer
 
 classDef live fill:#0f766e,color:#fff,stroke:#115e59
@@ -211,21 +213,23 @@ class Drive data
 
 ## Proposed deployment
 
-The Mac mini will wake the Asus desktop for GPU jobs and run browser tests on
-the phone lab. The View 20 will check the live hosts over cellular so it can
-still report a home power or internet failure.
+The Mac mini will wake the Asus desktop and 4080 laptop for GPU jobs, and run
+browser tests on the phone lab. The View 20 will check the live hosts over
+cellular so it can still report a home power or internet failure.
 
 <Mermaid
   chart={`flowchart TB
 Mini["Mac mini<br/>Home hub"]
 Pi["Raspberry Pi<br/>Fallback host"]
 Worker["Asus desktop<br/>NixOS and GTX 1060"]
+Laptop["Laptop<br/>RTX 4080 compute"]
 Cache[("1TB DVC cache")]
 Phones["Phone lab<br/>Android and iOS QA"]
 Watchdog["View 20<br/>Cellular watchdog"]
 Slack["Slack"]
 
 Mini -->|"GPU jobs"| Worker
+Mini -->|"GPU jobs"| Laptop
 Worker --> Cache
 Mini -->|"Browser tests"| Phones
 Watchdog -->|"Checks"| Mini
@@ -236,7 +240,7 @@ classDef live fill:#0f766e,color:#fff,stroke:#115e59
 classDef proposed fill:#fef3c7,color:#78350f,stroke:#d97706,stroke-dasharray:5 5
 classDef data fill:#4338ca,color:#fff,stroke:#3730a3
 class Mini,Pi live
-class Worker,Phones,Watchdog proposed
+class Worker,Laptop,Phones,Watchdog proposed
 class Cache data
 `}
 />

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -105,15 +105,11 @@ kit would solve a software problem with more hardware.
 
 # Topology
 
-The diagrams borrow the zoom levels from the
-[C4 model](https://c4model.com/): start with the lab's place in the world,
-then open the box to see its services, then show where those services run.
-They use ordinary Mermaid flowcharts rather than C4-specific notation.
-
 ## System context
 
-This view treats the whole home lab as one system. It shows who uses it and
-the external systems it depends on, without exposing its internal machinery.
+Personal and household devices reach the lab over its private network. The lab
+pulls photos from Ente, works with code and agent providers, and sends
+operational alerts to Slack.
 
 <Mermaid
   chart={`flowchart LR
@@ -141,9 +137,8 @@ class Cloud,Code,Alerts external
 
 ## Containers
 
-Here, "container" means a separately running service or data store, as it
-does in C4. This is the logical service map. The next diagram covers physical
-machines and failover.
+Tailscale is the private entry point for interactive services. Backup and media
+services share local storage, while Netdata reports failures outside the lab.
 
 <Mermaid
   chart={`flowchart LR
@@ -185,8 +180,9 @@ class Storage data
 
 ## Deployment
 
-The deployment view maps those services to hardware. Dashed links and boxes
-marked "proposed" are planned work, not part of the live lab.
+The Mac mini owns the main workloads and the Raspberry Pi keeps DNS and
+monitoring alive during hub maintenance. The GPU worker and phone lab are
+proposed additions.
 
 <Mermaid
   chart={`flowchart LR

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -105,54 +105,143 @@ kit would solve a software problem with more hardware.
 
 # Topology
 
+The diagrams borrow the zoom levels from the
+[C4 model](https://c4model.com/): start with the lab's place in the world,
+then open the box to see its services, then show where those services run.
+They use ordinary Mermaid flowcharts rather than C4-specific notation.
+
+## System context
+
+This view treats the whole home lab as one system. It shows who uses it and
+the external systems it depends on, without exposing its internal machinery.
+
 <Mermaid
   chart={`flowchart LR
-Internet["Internet"] -->|"router DNS"| Router["Home router"]
-subgraph hub["Mac mini, home hub"]
-ADG1["AdGuard Home, primary DNS"]
-ENT["Ente sync"]
-NET1["Netdata"]
-T3["t3-code + agents"]
-JEL["Jellyfin"]
+Owner["Lab owner"]
+Household["Household devices"]
+Lab["Home lab<br/>Private services, storage and compute"]
+Cloud["Ente cloud<br/>Photo library"]
+Code["GitHub and AI providers<br/>Code and agent APIs"]
+Alerts["Slack<br/>Operational alerts"]
+
+Owner -->|"develops, administers and streams"| Lab
+Household -->|"uses DNS and printing"| Lab
+Cloud -->|"supplies photo backup"| Lab
+Lab -->|"reads and writes repositories<br/>calls agent APIs"| Code
+Lab -->|"sends alerts"| Alerts
+
+classDef person fill:#7c3aed,color:#fff,stroke:#6d28d9
+classDef system fill:#2563eb,color:#fff,stroke:#1d4ed8
+classDef external fill:#475569,color:#fff,stroke:#334155
+class Owner,Household person
+class Lab system
+class Cloud,Code,Alerts external
+`}
+/>
+
+## Containers
+
+Here, "container" means a separately running service or data store, as it
+does in C4. This is the logical service map. The next diagram covers physical
+machines and failover.
+
+<Mermaid
+  chart={`flowchart LR
+People["Owner and household devices"]
+Ente["Ente cloud"]
+GitHub["GitHub and AI providers"]
+Slack["Slack"]
+
+subgraph lab["Home lab"]
+Access["Tailscale<br/>Private access network"]
+DNS["AdGuard Home<br/>Filtered DNS"]
+Dev["t3-code and coding agents<br/>Development workspace"]
+Backup["Ente sync<br/>Photo backup job"]
+Media["Jellyfin<br/>Media server"]
+Print["CUPS<br/>Print server"]
+Monitor["Netdata<br/>Monitoring and alerts"]
+Storage[("Local storage<br/>Photos, media and datasets")]
 end
-HSS["Hotspot Shield VPN, always-on"]
-subgraph pi["Raspberry Pi"]
-ADG2["AdGuard Home, fallback DNS"]
-NET2["Netdata to hub"]
-CUP["CUPS"]
+
+People --> Access
+Access --> DNS
+Access --> Dev
+Access --> Media
+Access --> Print
+Ente -->|"downloads photos"| Backup
+Backup --> Storage
+Media --> Storage
+Dev -->|"repos and model requests"| GitHub
+Monitor -->|"alerts"| Slack
+
+classDef external fill:#475569,color:#fff,stroke:#334155
+classDef service fill:#0f766e,color:#fff,stroke:#115e59
+classDef data fill:#4338ca,color:#fff,stroke:#3730a3
+class People,Ente,GitHub,Slack external
+class Access,DNS,Dev,Backup,Media,Print,Monitor service
+class Storage data
+`}
+/>
+
+## Deployment
+
+The deployment view maps those services to hardware. Dashed links and boxes
+marked "proposed" are planned work, not part of the live lab.
+
+<Mermaid
+  chart={`flowchart LR
+Router["Home router"]
+Slack["Slack"]
+Printer["Canon MX3100"]
+FireTV["Fire TV Stick"]
+
+subgraph mini["Mac mini, always on"]
+PrimaryDNS["AdGuard Home<br/>Primary DNS"]
+Dev["t3-code and agents"]
+Backup["Ente sync"]
+Media["Jellyfin"]
+HubMonitor["Netdata parent"]
+Drive[("10TB HDD")]
 end
-subgraph asus["Asus desktop, proposed NixOS worker"]
-GPU["GTX 1060, CV jobs"]
-DVC["DVC dataset cache"]
+
+subgraph pi["Raspberry Pi, always on"]
+FallbackDNS["AdGuard Home<br/>Fallback DNS"]
+Print["CUPS"]
+PiMonitor["Netdata child"]
 end
-subgraph phones["Phone device lab, proposed"]
-MAGIC["Magic5 Pro, newer Android QA"]
-VIEW["View 20, Android 10 QA + watchdog"]
-IOS["iPhone 6s, iOS 15 QA"]
+
+subgraph worker["Asus desktop, proposed"]
+GPU["NixOS and GTX 1060<br/>Batch CV jobs"]
+Cache[("1TB DVC cache")]
 end
-Router --> ADG1
-Router --> ADG2
-ADG2 --> ADG1
-hub -->|"all egress"| HSS
-HSS -->|"encrypted tunnel"| Internet
-DailyPhone -->|"photo upload"| Ente["Ente cloud"]
-Ente -->|"download backup"| ENT
-ENT --> HDD[("10TB HDD")]
-NET1 --> Slack["Slack"]
-NET2 --> Slack
-CUP --> Printer["Canon MX3100 (2011)"]
-JEL --> FireStick["Fire TV Stick"]
-GitHub["GitHub"]
-DailyPhone["Daily phone"]
-DailyPhone -->|"agents"| T3
-T3 -->|"repos / PRs"| GitHub
-hub -->|"WoL (L2 broadcast)"| asus
-T3 -->|"preview tests"| MAGIC
-T3 -->|"preview tests"| VIEW
-T3 -->|"preview tests"| IOS
-VIEW -->|"checks over cellular + Tailscale"| hub
-VIEW -->|"checks over cellular + Tailscale"| pi
-VIEW -->|"alerts over mobile data"| Slack
+
+subgraph devices["Phone device lab, proposed"]
+Phones["Android and iOS<br/>Browser QA"]
+Watchdog["View 20<br/>Cellular watchdog"]
+end
+
+Router --> PrimaryDNS
+Router --> FallbackDNS
+FallbackDNS -->|"syncs configuration"| PrimaryDNS
+Backup --> Drive
+Media --> Drive
+Media --> FireTV
+Print --> Printer
+PiMonitor --> HubMonitor
+HubMonitor --> Slack
+Dev -.->|"wakes and submits jobs"| GPU
+GPU --> Cache
+Dev -.->|"runs preview tests"| Phones
+Watchdog -.->|"checks both hosts"| mini
+Watchdog -.->|"checks both hosts"| pi
+Watchdog -.->|"alerts over mobile data"| Slack
+
+classDef live fill:#0f766e,color:#fff,stroke:#115e59
+classDef proposed fill:#fef3c7,color:#78350f,stroke:#d97706,stroke-dasharray:5 5
+classDef data fill:#4338ca,color:#fff,stroke:#3730a3
+class PrimaryDNS,Dev,Backup,Media,HubMonitor,FallbackDNS,Print,PiMonitor live
+class GPU,Cache,Phones,Watchdog proposed
+class Drive data
 `}
 />
 

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -244,12 +244,13 @@ Storage[("10TB HDD")]
 end
 
 DNS ~~~ VPN ~~~ Dev ~~~ Backup ~~~ Media ~~~ Monitor
-Ente["Ente cloud"] --> Backup
 Backup --> Storage
 Media --> Storage
 Media --> FireTV["Fire TV Stick"]
-Dev --> Code["GitHub and<br/>AI providers"]
-Monitor --> Slack["Slack"]
+DNS -->|"Quad9 DNS"| VPN
+Dev -->|"Code and agent APIs"| VPN
+Backup -->|"Ente sync"| VPN
+Monitor -->|"Slack alerts"| VPN
 VPN --> Internet["Internet"]
 
 classDef service fill:#0f766e,color:#fff,stroke:#115e59


### PR DESCRIPTION
## Summary

- replace the crowded home-lab topology with focused system, service, device, and per-host diagrams
- separate interactive services, background jobs, live hardware, and proposed devices
- include Hotspot Shield and the proposed RTX 4080 worker
- mark Jellyfin live and update its scope-creep mitigation

## Validation

- `mise run //ui:check`
- `mise run //ui:test -- tests/lib/content/mermaid-charts.test.ts`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise run //ui:build`
- pre-commit MDX lint and secret scan

## Preview QA

Checked the production export at desktop and iPhone 12 Pro widths in light and dark modes. All seven Mermaid diagrams render without errors, clipped labels, or horizontal page overflow. The protected Cloudflare preview deployed successfully at `/projects/homelab#topology`.