### PR TITLE
feat(recipes): inherit diet exclusions through group hierarchy

### DIFF
--- a/packages/recipe-db/src/schema.ts
+++ b/packages/recipe-db/src/schema.ts
@@ -656,6 +656,11 @@ export const ingredientGroupMember = pgTable(
   ],
 );
 
+export const ingredientGroupRelationTypeEnum = pgEnum(
+  "ingredient_group_relation_type",
+  ["classification", "composition"],
+);
+
 export const ingredientGroupHierarchy = pgTable(
   "ingredient_group_hierarchy",
   {
@@ -665,6 +670,7 @@ export const ingredientGroupHierarchy = pgTable(
     broaderGroupKey: text()
       .notNull()
       .references(() => ingredientGroup.key, { onDelete: "cascade" }),
+    relationType: ingredientGroupRelationTypeEnum().notNull(),
     createdAt: timestamp({ withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/ui/lib/api/diet.ts
+++ b/ui/lib/api/diet.ts
@@ -22,7 +22,7 @@ type DietLabelOption = {
 };
 
 export type DietGroupOption = DietLabelOption & {
-  /** Direct classification edges only; do not infer transitive diet exclusions. */
+  /** Direct classification parents. Ingredient slugs include narrower groups. */
   broaderGroupKeys: string[];
   ingredientSlugs: string[];
 };

--- a/ui/tests/components/recipes/diet-provider.test.tsx
+++ b/ui/tests/components/recipes/diet-provider.test.tsx
@@ -106,4 +106,44 @@ describe("DietProvider", () => {
 
     expect(await screen.findByText("Diet ready")).toBeInTheDocument();
   });
+
+  it("matches narrower ingredients returned under an excluded parent group", async () => {
+    apiMocks.getDietProfile.mockResolvedValue({
+      presetDietKeys: [],
+      excludedIngredientSlugs: [],
+      excludedGroupKeys: ["poultry"],
+      recipeMatchMode: "hide",
+    });
+    apiMocks.getDietOptions.mockResolvedValue({
+      presets: [],
+      groups: [
+        {
+          key: "poultry",
+          label: "Poultry",
+          sub: "Chicken, turkey, and related ingredients",
+          broaderGroupKeys: [],
+          ingredientSlugs: ["chicken-breast"],
+        },
+      ],
+      ingredients: [{ slug: "chicken-breast", name: "Chicken breast" }],
+    });
+
+    function ChickenRecipeMatch() {
+      const { matchRecipe } = useDiet();
+      const match = matchRecipe({
+        ingredients: [{ slug: "chicken-breast", name: "Chicken breast" }],
+      });
+      return <p>{match.matches ? "Allowed" : "Chicken recipe excluded"}</p>;
+    }
+
+    render(
+      <DietProvider>
+        <ChickenRecipeMatch />
+      </DietProvider>,
+    );
+
+    expect(
+      await screen.findByText("Chicken recipe excluded"),
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/tests/components/recipes/settings/diet-panel.test.tsx
+++ b/ui/tests/components/recipes/settings/diet-panel.test.tsx
@@ -46,13 +46,15 @@ describe("DietPanel", () => {
           key: "meat",
           label: "Meat",
           sub: "Meat ingredients",
+          broaderGroupKeys: [],
           ingredientSlugs: ["bacon"],
         },
         {
-          key: "chilli",
-          label: "Chilli",
-          sub: "Chilli ingredients",
-          ingredientSlugs: ["chilli"],
+          key: "poultry",
+          label: "Poultry",
+          sub: "Chicken, turkey, and related ingredients",
+          broaderGroupKeys: [],
+          ingredientSlugs: ["chicken-breast"],
         },
       ],
       ingredients: [{ slug: "bacon", name: "Bacon", category: "protein" }],
@@ -69,20 +71,20 @@ describe("DietPanel", () => {
     render(<DietPanel />);
 
     const meat = await screen.findByRole("button", { name: /Meat/ });
-    const chilli = screen.getByRole("button", { name: /Chilli/ });
+    const poultry = screen.getByRole("button", { name: /Poultry/ });
 
     expect(meat).toHaveAttribute("aria-pressed", "true");
     expect(meat).toBeDisabled();
     expect(meat).toHaveTextContent("covered by preset");
-    expect(chilli).toHaveAttribute("aria-pressed", "false");
-    expect(chilli).not.toBeDisabled();
+    expect(poultry).toHaveAttribute("aria-pressed", "false");
+    expect(poultry).not.toBeDisabled();
   });
 
-  it("updates the shared diet cache after a successful save", async () => {
+  it("saves poultry as a custom group exclusion", async () => {
     const { queryClient } = render(<DietPanel />);
-    const chilli = await screen.findByRole("button", { name: /Chilli/ });
+    const poultry = await screen.findByRole("button", { name: /Poultry/ });
 
-    fireEvent.click(chilli);
+    fireEvent.click(poultry);
     fireEvent.click(screen.getByRole("button", { name: "Save diet profile" }));
 
     expect(await screen.findByText("saved")).toBeInTheDocument();
@@ -90,7 +92,7 @@ describe("DietPanel", () => {
       queryClient.getQueryData(recipeQueryKeys.dietProfile("diet-user")),
     ).toEqual(
       expect.objectContaining({
-        excludedGroupKeys: ["chilli"],
+        excludedGroupKeys: ["poultry"],
       }),
     );
   });

--- a/workers/recipe-api/drizzle/0011_type_ingredient_group_relationships.sql
+++ b/workers/recipe-api/drizzle/0011_type_ingredient_group_relationships.sql
@@ -3,6 +3,14 @@ ALTER TABLE "ingredient_group_hierarchy" ADD COLUMN "relation_type" "ingredient_
 UPDATE "ingredient_group_hierarchy"
 SET "relation_type" = 'classification';--> statement-breakpoint
 ALTER TABLE "ingredient_group_hierarchy" ALTER COLUMN "relation_type" SET NOT NULL;--> statement-breakpoint
+DELETE FROM "ingredient_group_member"
+WHERE "group_key" = 'poultry'
+	AND "ingredient_slug" IN (
+		'chicken-breast',
+		'chicken-thigh',
+		'chicken-stock',
+		'chicken-stock-pot'
+	);--> statement-breakpoint
 CREATE OR REPLACE FUNCTION "reject_ingredient_group_hierarchy_cycle"()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/workers/recipe-api/drizzle/0011_type_ingredient_group_relationships.sql
+++ b/workers/recipe-api/drizzle/0011_type_ingredient_group_relationships.sql
@@ -1,0 +1,40 @@
+CREATE TYPE "public"."ingredient_group_relation_type" AS ENUM('classification', 'composition');--> statement-breakpoint
+ALTER TABLE "ingredient_group_hierarchy" ADD COLUMN "relation_type" "ingredient_group_relation_type";--> statement-breakpoint
+UPDATE "ingredient_group_hierarchy"
+SET "relation_type" = 'classification';--> statement-breakpoint
+ALTER TABLE "ingredient_group_hierarchy" ALTER COLUMN "relation_type" SET NOT NULL;--> statement-breakpoint
+CREATE OR REPLACE FUNCTION "reject_ingredient_group_hierarchy_cycle"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	IF NEW."relation_type" <> 'classification' THEN
+		RETURN NEW;
+	END IF;
+
+	PERFORM pg_advisory_xact_lock(hashtext('ingredient_group_hierarchy'));
+	IF EXISTS (
+		WITH RECURSIVE "broader_groups" AS (
+			SELECT NEW."broader_group_key" AS "group_key"
+			UNION
+			SELECT "hierarchy"."broader_group_key"
+			FROM "ingredient_group_hierarchy" AS "hierarchy"
+			INNER JOIN "broader_groups"
+				ON "hierarchy"."narrower_group_key" = "broader_groups"."group_key"
+			WHERE "hierarchy"."relation_type" = 'classification'
+				AND NOT (
+					TG_OP = 'UPDATE'
+					AND "hierarchy"."narrower_group_key" = OLD."narrower_group_key"
+					AND "hierarchy"."broader_group_key" = OLD."broader_group_key"
+				)
+		)
+		SELECT 1
+		FROM "broader_groups"
+		WHERE "group_key" = NEW."narrower_group_key"
+	) THEN
+		RAISE EXCEPTION 'ingredient group classification cannot contain cycles'
+			USING ERRCODE = '23514';
+	END IF;
+	RETURN NEW;
+END;
+$$;

--- a/workers/recipe-api/drizzle/0011_type_ingredient_group_relationships.sql
+++ b/workers/recipe-api/drizzle/0011_type_ingredient_group_relationships.sql
@@ -1,8 +1,6 @@
 CREATE TYPE "public"."ingredient_group_relation_type" AS ENUM('classification', 'composition');--> statement-breakpoint
-ALTER TABLE "ingredient_group_hierarchy" ADD COLUMN "relation_type" "ingredient_group_relation_type";--> statement-breakpoint
-UPDATE "ingredient_group_hierarchy"
-SET "relation_type" = 'classification';--> statement-breakpoint
-ALTER TABLE "ingredient_group_hierarchy" ALTER COLUMN "relation_type" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "ingredient_group_hierarchy" ADD COLUMN "relation_type" "ingredient_group_relation_type" DEFAULT 'classification' NOT NULL;--> statement-breakpoint
+ALTER TABLE "ingredient_group_hierarchy" ALTER COLUMN "relation_type" DROP DEFAULT;--> statement-breakpoint
 DELETE FROM "ingredient_group_member"
 WHERE "group_key" = 'poultry'
 	AND "ingredient_slug" IN (
@@ -10,6 +8,13 @@ WHERE "group_key" = 'poultry'
 		'chicken-thigh',
 		'chicken-stock',
 		'chicken-stock-pot'
+	)
+	AND EXISTS (
+		SELECT 1
+		FROM "ingredient_group_hierarchy"
+		WHERE "narrower_group_key" = 'chicken'
+			AND "broader_group_key" = 'poultry'
+			AND "relation_type" = 'classification'
 	);--> statement-breakpoint
 CREATE OR REPLACE FUNCTION "reject_ingredient_group_hierarchy_cycle"()
 RETURNS trigger

--- a/workers/recipe-api/drizzle/meta/0011_snapshot.json
+++ b/workers/recipe-api/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,4491 @@
+{
+  "id": "60f94ea3-3e32-4016-8eeb-5e65c9405c04",
+  "prevId": "045d5580-f8b4-4c8b-87a0-3c64312f2d0c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'delegated'"
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks_url": {
+          "name": "jwks_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_user_id_idx": {
+          "name": "agent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_host_id_idx": {
+          "name": "agent_host_id_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_status_idx": {
+          "name": "agent_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_kid_idx": {
+          "name": "agent_kid_idx",
+          "columns": [
+            {
+              "expression": "kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_user_id_user_id_fk": {
+          "name": "agent_user_id_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_host_id_agent_host_id_fk": {
+          "name": "agent_host_id_agent_host_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "agent_host",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_auth_audit_event": {
+      "name": "agent_auth_audit_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_auth_audit_event_user_time_idx": {
+          "name": "agent_auth_audit_event_user_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_auth_audit_event_agent_time_idx": {
+          "name": "agent_auth_audit_event_agent_time_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_auth_audit_event_host_time_idx": {
+          "name": "agent_auth_audit_event_host_time_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_capability_grant": {
+      "name": "agent_capability_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "denied_by": {
+          "name": "denied_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "constraints": {
+          "name": "constraints",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_capability_grant_agent_id_idx": {
+          "name": "agent_capability_grant_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_capability_grant_capability_idx": {
+          "name": "agent_capability_grant_capability_idx",
+          "columns": [
+            {
+              "expression": "capability",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_capability_grant_granted_by_idx": {
+          "name": "agent_capability_grant_granted_by_idx",
+          "columns": [
+            {
+              "expression": "granted_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_capability_grant_status_idx": {
+          "name": "agent_capability_grant_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_capability_grant_agent_id_agent_id_fk": {
+          "name": "agent_capability_grant_agent_id_agent_id_fk",
+          "tableFrom": "agent_capability_grant",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_capability_grant_denied_by_user_id_fk": {
+          "name": "agent_capability_grant_denied_by_user_id_fk",
+          "tableFrom": "agent_capability_grant",
+          "tableTo": "user",
+          "columnsFrom": [
+            "denied_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_capability_grant_granted_by_user_id_fk": {
+          "name": "agent_capability_grant_granted_by_user_id_fk",
+          "tableFrom": "agent_capability_grant",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_host": {
+      "name": "agent_host",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_capabilities": {
+          "name": "default_capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kid": {
+          "name": "kid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks_url": {
+          "name": "jwks_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_token_hash": {
+          "name": "enrollment_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrollment_token_expires_at": {
+          "name": "enrollment_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_host_user_id_idx": {
+          "name": "agent_host_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_host_kid_idx": {
+          "name": "agent_host_kid_idx",
+          "columns": [
+            {
+              "expression": "kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_host_enrollment_token_hash_idx": {
+          "name": "agent_host_enrollment_token_hash_idx",
+          "columns": [
+            {
+              "expression": "enrollment_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_host_status_idx": {
+          "name": "agent_host_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_host_user_id_user_id_fk": {
+          "name": "agent_host_user_id_user_id_fk",
+          "tableFrom": "agent_host",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_rate_limit": {
+      "name": "app_rate_limit",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.approval_request": {
+      "name": "approval_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "user_code_hash": {
+          "name": "user_code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_hint": {
+          "name": "login_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "binding_message": {
+          "name": "binding_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_notification_token": {
+          "name": "client_notification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_notification_endpoint": {
+          "name": "client_notification_endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_mode": {
+          "name": "delivery_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "approval_request_agent_id_idx": {
+          "name": "approval_request_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_request_host_id_idx": {
+          "name": "approval_request_host_id_idx",
+          "columns": [
+            {
+              "expression": "host_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_request_user_id_idx": {
+          "name": "approval_request_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "approval_request_status_idx": {
+          "name": "approval_request_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "approval_request_agent_id_agent_id_fk": {
+          "name": "approval_request_agent_id_agent_id_fk",
+          "tableFrom": "approval_request",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_request_host_id_agent_host_id_fk": {
+          "name": "approval_request_host_id_agent_host_id_fk",
+          "tableFrom": "approval_request",
+          "tableTo": "agent_host",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "approval_request_user_id_user_id_fk": {
+          "name": "approval_request_user_id_user_id_fk",
+          "tableFrom": "approval_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_secondary_storage": {
+      "name": "auth_secondary_storage",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_secondary_storage_expires_at_idx": {
+          "name": "auth_secondary_storage_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cooking_session": {
+      "name": "cooking_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_slug": {
+          "name": "recipe_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_title": {
+          "name": "recipe_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "servings": {
+          "name": "servings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cooking_session_user_started_idx": {
+          "name": "cooking_session_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cooking_session_user_completed_idx": {
+          "name": "cooking_session_user_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cooking_session_user_recipe_completed_idx": {
+          "name": "cooking_session_user_recipe_completed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipe_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cooking_session_user_id_user_id_fk": {
+          "name": "cooking_session_user_id_user_id_fk",
+          "tableFrom": "cooking_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset": {
+      "name": "diet_preset",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset_excluded_group": {
+      "name": "diet_preset_excluded_group",
+      "schema": "",
+      "columns": {
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_preset_excluded_group_group_key_idx": {
+          "name": "diet_preset_excluded_group_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diet_preset_excluded_group_preset_key_diet_preset_key_fk": {
+          "name": "diet_preset_excluded_group_preset_key_diet_preset_key_fk",
+          "tableFrom": "diet_preset_excluded_group",
+          "tableTo": "diet_preset",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diet_preset_excluded_group_group_key_ingredient_group_key_fk": {
+          "name": "diet_preset_excluded_group_group_key_ingredient_group_key_fk",
+          "tableFrom": "diet_preset_excluded_group",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "diet_preset_excluded_group_pk": {
+          "name": "diet_preset_excluded_group_pk",
+          "columns": [
+            "preset_key",
+            "group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diet_preset_excluded_ingredient": {
+      "name": "diet_preset_excluded_ingredient",
+      "schema": "",
+      "columns": {
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "diet_preset_excluded_ingredient_slug_idx": {
+          "name": "diet_preset_excluded_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "diet_preset_excluded_ingredient_preset_key_diet_preset_key_fk": {
+          "name": "diet_preset_excluded_ingredient_preset_key_diet_preset_key_fk",
+          "tableFrom": "diet_preset_excluded_ingredient",
+          "tableTo": "diet_preset",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "diet_preset_excluded_ingredient_ingredient_slug_ingredient_slug_fk": {
+          "name": "diet_preset_excluded_ingredient_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "diet_preset_excluded_ingredient",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "diet_preset_excluded_ingredient_pk": {
+          "name": "diet_preset_excluded_ingredient_pk",
+          "columns": [
+            "preset_key",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient": {
+      "name": "ingredient",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_group": {
+      "name": "ingredient_group",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_group_hierarchy": {
+      "name": "ingredient_group_hierarchy",
+      "schema": "",
+      "columns": {
+        "narrower_group_key": {
+          "name": "narrower_group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "broader_group_key": {
+          "name": "broader_group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relation_type": {
+          "name": "relation_type",
+          "type": "ingredient_group_relation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingredient_group_hierarchy_broader_group_key_idx": {
+          "name": "ingredient_group_hierarchy_broader_group_key_idx",
+          "columns": [
+            {
+              "expression": "broader_group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredient_group_hierarchy_narrower_group_key_ingredient_group_key_fk": {
+          "name": "ingredient_group_hierarchy_narrower_group_key_ingredient_group_key_fk",
+          "tableFrom": "ingredient_group_hierarchy",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "narrower_group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingredient_group_hierarchy_broader_group_key_ingredient_group_key_fk": {
+          "name": "ingredient_group_hierarchy_broader_group_key_ingredient_group_key_fk",
+          "tableFrom": "ingredient_group_hierarchy",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "broader_group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ingredient_group_hierarchy_pk": {
+          "name": "ingredient_group_hierarchy_pk",
+          "columns": [
+            "narrower_group_key",
+            "broader_group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ingredient_group_hierarchy_not_self_check": {
+          "name": "ingredient_group_hierarchy_not_self_check",
+          "value": "\"ingredient_group_hierarchy\".\"narrower_group_key\" <> \"ingredient_group_hierarchy\".\"broader_group_key\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingredient_group_member": {
+      "name": "ingredient_group_member",
+      "schema": "",
+      "columns": {
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ingredient_group_member_ingredient_slug_idx": {
+          "name": "ingredient_group_member_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredient_group_member_group_key_ingredient_group_key_fk": {
+          "name": "ingredient_group_member_group_key_ingredient_group_key_fk",
+          "tableFrom": "ingredient_group_member",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ingredient_group_member_ingredient_slug_ingredient_slug_fk": {
+          "name": "ingredient_group_member_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "ingredient_group_member",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "ingredient_group_member_pk": {
+          "name": "ingredient_group_member_pk",
+          "columns": [
+            "group_key",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitation_organization_id_idx": {
+          "name": "invitation_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_status_idx": {
+          "name": "invitation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_id_idx": {
+          "name": "member_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_id_idx": {
+          "name": "member_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_user_unique": {
+          "name": "member_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_agent_approval_event": {
+      "name": "notification_agent_approval_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approval_request_id": {
+          "name": "approval_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id_snapshot": {
+          "name": "agent_id_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name_snapshot": {
+          "name": "agent_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capabilities_snapshot": {
+          "name": "capabilities_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at_snapshot": {
+          "name": "expires_at_snapshot",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approval_code_ciphertext": {
+          "name": "approval_code_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_agent_approval_request_uidx": {
+          "name": "notification_agent_approval_request_uidx",
+          "columns": [
+            {
+              "expression": "approval_request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_agent_approval_event_event_id_notification_event_id_fk": {
+          "name": "notification_agent_approval_event_event_id_notification_event_id_fk",
+          "tableFrom": "notification_agent_approval_event",
+          "tableTo": "notification_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_agent_approval_event_approval_request_id_approval_request_id_fk": {
+          "name": "notification_agent_approval_event_approval_request_id_approval_request_id_fk",
+          "tableFrom": "notification_agent_approval_event",
+          "tableTo": "approval_request",
+          "columnsFrom": [
+            "approval_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_user_id": {
+          "name": "recipient_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_delivery_event_recipient_uidx": {
+          "name": "notification_delivery_event_recipient_uidx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_delivery_recipient_read_at_idx": {
+          "name": "notification_delivery_recipient_read_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_event_id_notification_event_id_fk": {
+          "name": "notification_delivery_event_id_notification_event_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "notification_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_recipient_user_id_user_id_fk": {
+          "name": "notification_delivery_recipient_user_id_user_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_event": {
+      "name": "notification_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name_snapshot": {
+          "name": "actor_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_event_kind_idx": {
+          "name": "notification_event_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_event_actor_user_id_user_id_fk": {
+          "name": "notification_event_actor_user_id_user_id_fk",
+          "tableFrom": "notification_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_household_event": {
+      "name": "notification_household_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_name_snapshot": {
+          "name": "household_name_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_household_event_household_idx": {
+          "name": "notification_household_event_household_idx",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_household_event_event_id_notification_event_id_fk": {
+          "name": "notification_household_event_event_id_notification_event_id_fk",
+          "tableFrom": "notification_household_event",
+          "tableTo": "notification_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_household_event_household_id_organization_id_fk": {
+          "name": "notification_household_event_household_id_organization_id_fk",
+          "tableFrom": "notification_household_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_household_invitation_event": {
+      "name": "notification_household_invitation_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_household_invitation_event_invitation_idx": {
+          "name": "notification_household_invitation_event_invitation_idx",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_household_invitation_event_event_id_notification_household_event_event_id_fk": {
+          "name": "notification_household_invitation_event_event_id_notification_household_event_event_id_fk",
+          "tableFrom": "notification_household_invitation_event",
+          "tableTo": "notification_household_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "event_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_household_invitation_event_invitation_id_invitation_id_fk": {
+          "name": "notification_household_invitation_event_invitation_id_invitation_id_fk",
+          "tableFrom": "notification_household_invitation_event",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipe_recommendation_event": {
+      "name": "notification_recipe_recommendation_event",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipe_slug_snapshot": {
+          "name": "recipe_slug_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_title_snapshot": {
+          "name": "recipe_title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "notification_recipe_recommendation_recipe_idx": {
+          "name": "notification_recipe_recommendation_recipe_idx",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipe_recommendation_event_event_id_notification_event_id_fk": {
+          "name": "notification_recipe_recommendation_event_event_id_notification_event_id_fk",
+          "tableFrom": "notification_recipe_recommendation_event",
+          "tableTo": "notification_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_recipe_recommendation_event_recipe_id_recipe_id_fk": {
+          "name": "notification_recipe_recommendation_event_recipe_id_recipe_id_fk",
+          "tableFrom": "notification_recipe_recommendation_event",
+          "tableTo": "recipe",
+          "columnsFrom": [
+            "recipe_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pantry_aggregate": {
+      "name": "pantry_aggregate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_aggregate_user_uidx": {
+          "name": "pantry_aggregate_user_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pantry_aggregate_household_uidx": {
+          "name": "pantry_aggregate_household_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pantry_aggregate_user_id_user_id_fk": {
+          "name": "pantry_aggregate_user_id_user_id_fk",
+          "tableFrom": "pantry_aggregate",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_aggregate_organization_id_organization_id_fk": {
+          "name": "pantry_aggregate_organization_id_organization_id_fk",
+          "tableFrom": "pantry_aggregate",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pantry_aggregate_owner_check": {
+          "name": "pantry_aggregate_owner_check",
+          "value": "num_nonnulls(\"pantry_aggregate\".\"user_id\", \"pantry_aggregate\".\"organization_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pantry_item": {
+      "name": "pantry_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "pantry_location",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "1"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_item_user_ingredient_uidx": {
+          "name": "pantry_item_user_ingredient_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pantry_item_household_ingredient_uidx": {
+          "name": "pantry_item_household_ingredient_uidx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pantry_item_ingredient_slug_idx": {
+          "name": "pantry_item_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pantry_item_user_id_user_id_fk": {
+          "name": "pantry_item_user_id_user_id_fk",
+          "tableFrom": "pantry_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_item_organization_id_organization_id_fk": {
+          "name": "pantry_item_organization_id_organization_id_fk",
+          "tableFrom": "pantry_item",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pantry_item_ingredient_slug_ingredient_slug_fk": {
+          "name": "pantry_item_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "pantry_item",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pantry_item_owner_check": {
+          "name": "pantry_item_owner_check",
+          "value": "num_nonnulls(\"pantry_item\".\"user_id\", \"pantry_item\".\"organization_id\") = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.pantry_operation": {
+      "name": "pantry_operation",
+      "schema": "",
+      "columns": {
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command_fingerprint": {
+          "name": "command_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pantry_operation_created_at_idx": {
+          "name": "pantry_operation_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pantry_operation_aggregate_id_pantry_aggregate_id_fk": {
+          "name": "pantry_operation_aggregate_id_pantry_aggregate_id_fk",
+          "tableFrom": "pantry_operation",
+          "tableTo": "pantry_aggregate",
+          "columnsFrom": [
+            "aggregate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pantry_operation_aggregate_id_operation_id_pk": {
+          "name": "pantry_operation_aggregate_id_operation_id_pk",
+          "columns": [
+            "aggregate_id",
+            "operation_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe": {
+      "name": "recipe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_user_id_idx": {
+          "name": "recipe_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_public_feed_idx": {
+          "name": "recipe_public_feed_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_household_feed_idx": {
+          "name": "recipe_household_feed_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_user_id_user_id_fk": {
+          "name": "recipe_user_id_user_id_fk",
+          "tableFrom": "recipe",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_slug_unique": {
+          "name": "recipe_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_artifact": {
+      "name": "recipe_import_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_import_artifact_job_id_idx": {
+          "name": "recipe_import_artifact_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_artifact_job_stage_kind_unique": {
+          "name": "recipe_import_artifact_job_stage_kind_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_artifact_job_id_recipe_import_job_id_fk": {
+          "name": "recipe_import_artifact_job_id_recipe_import_job_id_fk",
+          "tableFrom": "recipe_import_artifact",
+          "tableTo": "recipe_import_job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_attempt": {
+      "name": "recipe_import_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retryable": {
+          "name": "retryable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recipe_import_attempt_job_id_idx": {
+          "name": "recipe_import_attempt_job_id_idx",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_attempt_job_stage_attempt_unique": {
+          "name": "recipe_import_attempt_job_stage_attempt_unique",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stage",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attempt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_attempt_job_id_recipe_import_job_id_fk": {
+          "name": "recipe_import_attempt_job_id_recipe_import_job_id_fk",
+          "tableFrom": "recipe_import_attempt",
+          "tableTo": "recipe_import_job",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recipe_import_job": {
+      "name": "recipe_import_job",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "recipe_import_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "recipe_import_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_label": {
+          "name": "progress_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_count": {
+          "name": "image_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recipe_import_job_user_id_idx": {
+          "name": "recipe_import_job_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_job_user_status_idx": {
+          "name": "recipe_import_job_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recipe_import_job_user_created_idx": {
+          "name": "recipe_import_job_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_import_job_user_id_user_id_fk": {
+          "name": "recipe_import_job_user_id_user_id_fk",
+          "tableFrom": "recipe_import_job",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_excluded_group": {
+      "name": "user_diet_excluded_group",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_key": {
+          "name": "group_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_excluded_group_group_key_idx": {
+          "name": "user_diet_excluded_group_group_key_idx",
+          "columns": [
+            {
+              "expression": "group_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_diet_excluded_group_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_excluded_group_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_excluded_group",
+          "tableTo": "user_diet_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_diet_excluded_group_group_key_ingredient_group_key_fk": {
+          "name": "user_diet_excluded_group_group_key_ingredient_group_key_fk",
+          "tableFrom": "user_diet_excluded_group",
+          "tableTo": "ingredient_group",
+          "columnsFrom": [
+            "group_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_excluded_group_pk": {
+          "name": "user_diet_excluded_group_pk",
+          "columns": [
+            "user_id",
+            "group_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_excluded_ingredient": {
+      "name": "user_diet_excluded_ingredient",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_slug": {
+          "name": "ingredient_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_excluded_ingredient_slug_idx": {
+          "name": "user_diet_excluded_ingredient_slug_idx",
+          "columns": [
+            {
+              "expression": "ingredient_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_diet_excluded_ingredient_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_excluded_ingredient_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_excluded_ingredient",
+          "tableTo": "user_diet_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_diet_excluded_ingredient_ingredient_slug_ingredient_slug_fk": {
+          "name": "user_diet_excluded_ingredient_ingredient_slug_ingredient_slug_fk",
+          "tableFrom": "user_diet_excluded_ingredient",
+          "tableTo": "ingredient",
+          "columnsFrom": [
+            "ingredient_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_excluded_ingredient_pk": {
+          "name": "user_diet_excluded_ingredient_pk",
+          "columns": [
+            "user_id",
+            "ingredient_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_preset": {
+      "name": "user_diet_preset",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preset_key": {
+          "name": "preset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_diet_preset_preset_key_idx": {
+          "name": "user_diet_preset_preset_key_idx",
+          "columns": [
+            {
+              "expression": "preset_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_diet_preset_user_id_user_diet_profile_user_id_fk": {
+          "name": "user_diet_preset_user_id_user_diet_profile_user_id_fk",
+          "tableFrom": "user_diet_preset",
+          "tableTo": "user_diet_profile",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_diet_preset_preset_key_diet_preset_key_fk": {
+          "name": "user_diet_preset_preset_key_diet_preset_key_fk",
+          "tableFrom": "user_diet_preset",
+          "tableTo": "diet_preset",
+          "columnsFrom": [
+            "preset_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_diet_preset_pk": {
+          "name": "user_diet_preset_pk",
+          "columns": [
+            "user_id",
+            "preset_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_diet_profile": {
+      "name": "user_diet_profile",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_match_mode": {
+          "name": "recipe_match_mode",
+          "type": "diet_recipe_match_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hide'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_diet_profile_user_id_user_id_fk": {
+          "name": "user_diet_profile_user_id_user_id_fk",
+          "tableFrom": "user_diet_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_email": {
+      "name": "user_email",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_user_id_idx": {
+          "name": "user_email_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_email_user_id_user_id_fk": {
+          "name": "user_email_user_id_user_id_fk",
+          "tableFrom": "user_email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_follow": {
+      "name": "user_follow",
+      "schema": "",
+      "columns": {
+        "follower_user_id": {
+          "name": "follower_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followed_user_id": {
+          "name": "followed_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follow_followed_user_id_idx": {
+          "name": "user_follow_followed_user_id_idx",
+          "columns": [
+            {
+              "expression": "followed_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follow_follower_user_id_user_id_fk": {
+          "name": "user_follow_follower_user_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "follower_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follow_followed_user_id_user_id_fk": {
+          "name": "user_follow_followed_user_id_user_id_fk",
+          "tableFrom": "user_follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "followed_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_follow_pk": {
+          "name": "user_follow_pk",
+          "columns": [
+            "follower_user_id",
+            "followed_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_follow_not_self": {
+          "name": "user_follow_not_self",
+          "value": "\"user_follow\".\"follower_user_id\" <> \"user_follow\".\"followed_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_box": {
+      "name": "user_recipe_box",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_recipe_box_user_id_user_id_fk": {
+          "name": "user_recipe_box_user_id_user_id_fk",
+          "tableFrom": "user_recipe_box",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_recipe_box_item": {
+      "name": "user_recipe_box_item",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipe_slug": {
+          "name": "recipe_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_recipe_box_item_user_id_user_id_fk": {
+          "name": "user_recipe_box_item_user_id_user_id_fk",
+          "tableFrom": "user_recipe_box_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_recipe_box_item_user_id_recipe_slug_pk": {
+          "name": "user_recipe_box_item_user_id_recipe_slug_pk",
+          "columns": [
+            "user_id",
+            "recipe_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.diet_recipe_match_mode": {
+      "name": "diet_recipe_match_mode",
+      "schema": "public",
+      "values": [
+        "hide",
+        "warn"
+      ]
+    },
+    "public.ingredient_group_relation_type": {
+      "name": "ingredient_group_relation_type",
+      "schema": "public",
+      "values": [
+        "classification",
+        "composition"
+      ]
+    },
+    "public.pantry_location": {
+      "name": "pantry_location",
+      "schema": "public",
+      "values": [
+        "fridge",
+        "cupboards",
+        "fresh"
+      ]
+    },
+    "public.recipe_import_stage": {
+      "name": "recipe_import_stage",
+      "schema": "public",
+      "values": [
+        "extract",
+        "normalize",
+        "canonicalize",
+        "finalize"
+      ]
+    },
+    "public.recipe_import_status": {
+      "name": "recipe_import_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "household"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/workers/recipe-api/drizzle/meta/_journal.json
+++ b/workers/recipe-api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1787443563268,
       "tag": "0010_add_ingredient_group_hierarchy",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1787476142372,
+      "tag": "0011_type_ingredient_group_relationships",
+      "breakpoints": true
     }
   ]
 }

--- a/workers/recipe-api/scripts/smoke-preview-profiles.ts
+++ b/workers/recipe-api/scripts/smoke-preview-profiles.ts
@@ -253,6 +253,23 @@ if (
 ) {
   throw new Error("Chicken ingredient-group hierarchy did not match");
 }
+const poultryGroup = dietOptions.groups.find(
+  (group) => group.key === "poultry",
+);
+if (!poultryGroup) {
+  throw new Error("Poultry ingredient group was missing");
+}
+if (
+  ![
+    "chicken-breast",
+    "chicken-thigh",
+    "chicken-stock",
+    "chicken-stock-pot",
+    "turkey-mince",
+  ].every((slug) => poultryGroup.ingredientSlugs.includes(slug))
+) {
+  throw new Error("Poultry did not inherit the chicken group ingredients");
+}
 const stockGroup = dietOptions.groups.find((group) => group.key === "stock");
 if (!stockGroup) {
   throw new Error("Stock ingredient group was missing");

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -2295,6 +2295,66 @@ async function findDietProfile(
   };
 }
 
+type IngredientGroupRelation = {
+  narrowerGroupKey: string;
+  broaderGroupKey: string;
+  relationType: (typeof schema.ingredientGroupRelationTypeEnum.enumValues)[number];
+};
+
+function expandedIngredientSlugsByGroup(
+  groupKeys: readonly string[],
+  groupMembers: readonly { groupKey: string; ingredientSlug: string }[],
+  groupRelations: readonly IngredientGroupRelation[],
+): Map<string, string[]> {
+  const directIngredientSlugsByGroup = new Map<string, Set<string>>();
+  for (const row of groupMembers) {
+    const ingredientSlugs =
+      directIngredientSlugsByGroup.get(row.groupKey) ?? new Set<string>();
+    ingredientSlugs.add(row.ingredientSlug);
+    directIngredientSlugsByGroup.set(row.groupKey, ingredientSlugs);
+  }
+
+  const narrowerGroupKeysByGroup = new Map<string, Set<string>>();
+  for (const relation of groupRelations) {
+    if (relation.relationType !== "classification") continue;
+
+    const narrowerGroupKeys =
+      narrowerGroupKeysByGroup.get(relation.broaderGroupKey) ??
+      new Set<string>();
+    narrowerGroupKeys.add(relation.narrowerGroupKey);
+    narrowerGroupKeysByGroup.set(relation.broaderGroupKey, narrowerGroupKeys);
+  }
+
+  const expanded = new Map<string, string[]>();
+  for (const groupKey of groupKeys) {
+    const ingredientSlugs = new Set<string>();
+    const visitedGroupKeys = new Set<string>();
+    const pendingGroupKeys = [groupKey];
+
+    while (pendingGroupKeys.length > 0) {
+      const currentGroupKey = pendingGroupKeys.pop();
+      if (!currentGroupKey || visitedGroupKeys.has(currentGroupKey)) continue;
+      visitedGroupKeys.add(currentGroupKey);
+
+      for (const ingredientSlug of
+        directIngredientSlugsByGroup.get(currentGroupKey) ?? []) {
+        ingredientSlugs.add(ingredientSlug);
+      }
+      for (const narrowerGroupKey of
+        narrowerGroupKeysByGroup.get(currentGroupKey) ?? []) {
+        pendingGroupKeys.push(narrowerGroupKey);
+      }
+    }
+
+    expanded.set(
+      groupKey,
+      [...ingredientSlugs].sort((a, b) => a.localeCompare(b)),
+    );
+  }
+
+  return expanded;
+}
+
 async function listDietOptions(db: Db) {
   const [
     ingredients,
@@ -2329,6 +2389,7 @@ async function listDietOptions(db: Db) {
         .select({
           narrowerGroupKey: schema.ingredientGroupHierarchy.narrowerGroupKey,
           broaderGroupKey: schema.ingredientGroupHierarchy.broaderGroupKey,
+          relationType: schema.ingredientGroupHierarchy.relationType,
         })
         .from(schema.ingredientGroupHierarchy),
       db
@@ -2366,15 +2427,16 @@ async function listDietOptions(db: Db) {
     ingredientSlugsByPreset.set(row.presetKey, ingredientSlugs);
   }
 
-  const ingredientSlugsByGroup = new Map<string, string[]>();
-  for (const row of groupMembers) {
-    const ingredientSlugs = ingredientSlugsByGroup.get(row.groupKey) ?? [];
-    ingredientSlugs.push(row.ingredientSlug);
-    ingredientSlugsByGroup.set(row.groupKey, ingredientSlugs);
-  }
+  const ingredientSlugsByGroup = expandedIngredientSlugsByGroup(
+    groups.map((group) => group.key),
+    groupMembers,
+    groupHierarchy,
+  );
 
   const broaderGroupKeysByGroup = new Map<string, string[]>();
   for (const row of groupHierarchy) {
+    if (row.relationType !== "classification") continue;
+
     const broaderGroupKeys =
       broaderGroupKeysByGroup.get(row.narrowerGroupKey) ?? [];
     broaderGroupKeys.push(row.broaderGroupKey);

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -2301,58 +2301,86 @@ type IngredientGroupRelation = {
   relationType: (typeof schema.ingredientGroupRelationTypeEnum.enumValues)[number];
 };
 
+function addToSetMap(
+  map: Map<string, Set<string>>,
+  key: string,
+  value: string,
+) {
+  const values = map.get(key) ?? new Set<string>();
+  values.add(value);
+  map.set(key, values);
+}
+
+function directIngredientSlugsByGroup(
+  groupMembers: readonly { groupKey: string; ingredientSlug: string }[],
+) {
+  const directIngredientSlugs = new Map<string, Set<string>>();
+  for (const row of groupMembers) {
+    addToSetMap(directIngredientSlugs, row.groupKey, row.ingredientSlug);
+  }
+  return directIngredientSlugs;
+}
+
+function narrowerClassificationKeysByGroup(
+  groupRelations: readonly IngredientGroupRelation[],
+) {
+  const narrowerGroupKeys = new Map<string, Set<string>>();
+  for (const relation of groupRelations) {
+    if (relation.relationType !== "classification") continue;
+    addToSetMap(
+      narrowerGroupKeys,
+      relation.broaderGroupKey,
+      relation.narrowerGroupKey,
+    );
+  }
+  return narrowerGroupKeys;
+}
+
+function expandedIngredientSlugsForGroup(
+  groupKey: string,
+  directIngredientSlugs: ReadonlyMap<string, ReadonlySet<string>>,
+  narrowerGroupKeys: ReadonlyMap<string, ReadonlySet<string>>,
+): string[] {
+  const ingredientSlugs = new Set<string>();
+  const visitedGroupKeys = new Set<string>();
+  const pendingGroupKeys = [groupKey];
+
+  while (pendingGroupKeys.length > 0) {
+    const currentGroupKey = pendingGroupKeys.pop();
+    if (!currentGroupKey || visitedGroupKeys.has(currentGroupKey)) continue;
+    visitedGroupKeys.add(currentGroupKey);
+
+    for (const ingredientSlug of
+      directIngredientSlugs.get(currentGroupKey) ?? []) {
+      ingredientSlugs.add(ingredientSlug);
+    }
+    for (const narrowerGroupKey of narrowerGroupKeys.get(currentGroupKey) ??
+      []) {
+      pendingGroupKeys.push(narrowerGroupKey);
+    }
+  }
+
+  return [...ingredientSlugs].sort((a, b) => a.localeCompare(b));
+}
+
 function expandedIngredientSlugsByGroup(
   groupKeys: readonly string[],
   groupMembers: readonly { groupKey: string; ingredientSlug: string }[],
   groupRelations: readonly IngredientGroupRelation[],
 ): Map<string, string[]> {
-  const directIngredientSlugsByGroup = new Map<string, Set<string>>();
-  for (const row of groupMembers) {
-    const ingredientSlugs =
-      directIngredientSlugsByGroup.get(row.groupKey) ?? new Set<string>();
-    ingredientSlugs.add(row.ingredientSlug);
-    directIngredientSlugsByGroup.set(row.groupKey, ingredientSlugs);
-  }
-
-  const narrowerGroupKeysByGroup = new Map<string, Set<string>>();
-  for (const relation of groupRelations) {
-    if (relation.relationType !== "classification") continue;
-
-    const narrowerGroupKeys =
-      narrowerGroupKeysByGroup.get(relation.broaderGroupKey) ??
-      new Set<string>();
-    narrowerGroupKeys.add(relation.narrowerGroupKey);
-    narrowerGroupKeysByGroup.set(relation.broaderGroupKey, narrowerGroupKeys);
-  }
-
-  const expanded = new Map<string, string[]>();
-  for (const groupKey of groupKeys) {
-    const ingredientSlugs = new Set<string>();
-    const visitedGroupKeys = new Set<string>();
-    const pendingGroupKeys = [groupKey];
-
-    while (pendingGroupKeys.length > 0) {
-      const currentGroupKey = pendingGroupKeys.pop();
-      if (!currentGroupKey || visitedGroupKeys.has(currentGroupKey)) continue;
-      visitedGroupKeys.add(currentGroupKey);
-
-      for (const ingredientSlug of
-        directIngredientSlugsByGroup.get(currentGroupKey) ?? []) {
-        ingredientSlugs.add(ingredientSlug);
-      }
-      for (const narrowerGroupKey of
-        narrowerGroupKeysByGroup.get(currentGroupKey) ?? []) {
-        pendingGroupKeys.push(narrowerGroupKey);
-      }
-    }
-
-    expanded.set(
+  const directIngredientSlugs = directIngredientSlugsByGroup(groupMembers);
+  const narrowerGroupKeys =
+    narrowerClassificationKeysByGroup(groupRelations);
+  return new Map(
+    groupKeys.map((groupKey) => [
       groupKey,
-      [...ingredientSlugs].sort((a, b) => a.localeCompare(b)),
-    );
-  }
-
-  return expanded;
+      expandedIngredientSlugsForGroup(
+        groupKey,
+        directIngredientSlugs,
+        narrowerGroupKeys,
+      ),
+    ]),
+  );
 }
 
 async function listDietOptions(db: Db) {

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -191,6 +191,7 @@ const dbMock = vi.hoisted(() => {
     ingredientGroupHierarchy: [] as {
       narrowerGroupKey: string;
       broaderGroupKey: string;
+      relationType: "classification" | "composition";
     }[],
     dietPresetExcludedGroups: [] as { presetKey: string; groupKey: string }[],
     dietPresetExcludedIngredients: [] as {
@@ -1651,6 +1652,7 @@ const dbMock = vi.hoisted(() => {
       return state.ingredientGroupHierarchy.map((row) => [
         row.narrowerGroupKey,
         row.broaderGroupKey,
+        row.relationType,
       ]);
     }
 
@@ -2055,6 +2057,7 @@ function seedDietCatalog() {
   dbMock.state.ingredientGroupHierarchy.push({
     narrowerGroupKey: "chicken",
     broaderGroupKey: "poultry",
+    relationType: "classification",
   });
 }
 
@@ -3707,6 +3710,102 @@ describe("profile diet preferences", () => {
         { slug: "milk", name: "milk", category: "dairy" },
       ],
     });
+  });
+
+  it("inherits ingredients through classifications and ignores composition", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+    seedDietCatalog();
+    dbMock.state.ingredientGroups.push(
+      {
+        key: "animal-product",
+        label: "Animal product",
+        description: null,
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+      {
+        key: "meat",
+        label: "Meat",
+        description: null,
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+      {
+        key: "prepared-food",
+        label: "Prepared food",
+        description: null,
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+    );
+    dbMock.state.ingredients.push(
+      {
+        slug: "chicken-breast",
+        name: "chicken breast",
+        category: "protein",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+      {
+        slug: "vegetable-stock",
+        name: "vegetable stock",
+        category: "stock",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+    );
+    dbMock.state.ingredientGroupMembers.push(
+      { groupKey: "chicken", ingredientSlug: "chicken-breast" },
+      { groupKey: "prepared-food", ingredientSlug: "vegetable-stock" },
+    );
+    dbMock.state.ingredientGroupHierarchy.push(
+      {
+        narrowerGroupKey: "poultry",
+        broaderGroupKey: "animal-product",
+        relationType: "classification",
+      },
+      {
+        narrowerGroupKey: "chicken",
+        broaderGroupKey: "meat",
+        relationType: "classification",
+      },
+      {
+        narrowerGroupKey: "meat",
+        broaderGroupKey: "animal-product",
+        relationType: "classification",
+      },
+      {
+        narrowerGroupKey: "prepared-food",
+        broaderGroupKey: "animal-product",
+        relationType: "composition",
+      },
+    );
+
+    const res = await app.request("/api/profile/diet/options", {}, env);
+    const body = (await res.json()) as {
+      groups: Array<{
+        key: string;
+        broaderGroupKeys: string[];
+        ingredientSlugs: string[];
+      }>;
+    };
+
+    expect(res.status).toBe(200);
+    expect(
+      body.groups.find((group) => group.key === "poultry")?.ingredientSlugs,
+    ).toEqual(["chicken-breast"]);
+    expect(
+      body.groups.find((group) => group.key === "animal-product")
+        ?.ingredientSlugs,
+    ).toEqual(["chicken-breast"]);
+    expect(
+      body.groups.find((group) => group.key === "prepared-food")
+        ?.broaderGroupKeys,
+    ).toEqual([]);
   });
 
   it("creates and updates the signed-in user's diet profile", async () => {

--- a/workers/recipe-api/tests/integration/database.test.ts
+++ b/workers/recipe-api/tests/integration/database.test.ts
@@ -152,7 +152,7 @@ beforeAll(async () => {
     where slug in ('almond-milk', 'cajun-powder', 'cajun-seasoning', 'salted-butter')
     order by slug
   `;
-  expect(migrationCount?.count).toBe(11);
+  expect(migrationCount?.count).toBe(12);
   expect(tableCount?.count).toBe(43);
   expect(catalogRows).toEqual([
     { category: "dairy", slug: "almond-milk" },
@@ -935,7 +935,11 @@ describe("recipe API PostgreSQL integration", () => {
   it("allows edge replacement and rejects cycles in the group hierarchy", async () => {
     try {
       const reversed = await client<
-        { broaderGroupKey: string; narrowerGroupKey: string }[]
+        {
+          broaderGroupKey: string;
+          narrowerGroupKey: string;
+          relationType: string;
+        }[]
       >`
         update ingredient_group_hierarchy
         set
@@ -946,17 +950,23 @@ describe("recipe API PostgreSQL integration", () => {
           and broader_group_key = 'poultry'
         returning
           narrower_group_key as "narrowerGroupKey",
-          broader_group_key as "broaderGroupKey"
+          broader_group_key as "broaderGroupKey",
+          relation_type as "relationType"
       `;
       expect(reversed).toEqual([
-        { narrowerGroupKey: "poultry", broaderGroupKey: "chicken" },
+        {
+          narrowerGroupKey: "poultry",
+          broaderGroupKey: "chicken",
+          relationType: "classification",
+        },
       ]);
       await expect(
         client`
           insert into ingredient_group_hierarchy (
             narrower_group_key,
-            broader_group_key
-          ) values ('chicken', 'poultry')
+            broader_group_key,
+            relation_type
+          ) values ('chicken', 'poultry', 'classification')
         `,
       ).rejects.toMatchObject({ code: "23514" });
     } finally {
@@ -977,14 +987,16 @@ describe("recipe API PostgreSQL integration", () => {
       client`
         insert into ingredient_group_hierarchy (
           narrower_group_key,
-          broader_group_key
-        ) values ('dairy', 'gluten')
+          broader_group_key,
+          relation_type
+        ) values ('dairy', 'gluten', 'classification')
       `,
       client`
         insert into ingredient_group_hierarchy (
           narrower_group_key,
-          broader_group_key
-        ) values ('gluten', 'dairy')
+          broader_group_key,
+          relation_type
+        ) values ('gluten', 'dairy', 'classification')
       `,
     ]);
 
@@ -1009,6 +1021,53 @@ describe("recipe API PostgreSQL integration", () => {
         where
           (narrower_group_key = 'dairy' and broader_group_key = 'gluten')
           or (narrower_group_key = 'gluten' and broader_group_key = 'dairy')
+      `;
+    }
+  });
+
+  it("does not inherit diet ingredients across composition relationships", async () => {
+    const cook = await createUser("Relation Cook", "relation-cook@example.test");
+
+    try {
+      await client`
+        insert into ingredient_group_hierarchy (
+          narrower_group_key,
+          broader_group_key,
+          relation_type
+        ) values
+          ('stock', 'poultry', 'composition'),
+          ('stock', 'meat', 'composition')
+      `;
+
+      const response = await authenticatedRequest(
+        cook,
+        "/api/profile/diet/options",
+      );
+      expect(response.status).toBe(200);
+      const options = (await response.json()) as {
+        groups: Array<{
+          broaderGroupKeys: string[];
+          ingredientSlugs: string[];
+          key: string;
+        }>;
+      };
+
+      expect(
+        options.groups.find((group) => group.key === "stock")
+          ?.broaderGroupKeys,
+      ).toEqual([]);
+      expect(
+        options.groups.find((group) => group.key === "poultry")
+          ?.ingredientSlugs,
+      ).not.toContain("vegetable-stock");
+      expect(
+        options.groups.find((group) => group.key === "meat")?.ingredientSlugs,
+      ).not.toContain("vegetable-stock");
+    } finally {
+      await client`
+        delete from ingredient_group_hierarchy
+        where narrower_group_key = 'stock'
+          and broader_group_key in ('poultry', 'meat')
       `;
     }
   });


### PR DESCRIPTION
## Summary

- type ingredient-group links as classification or composition
- expand each diet group through all narrower classification groups on the API server
- ignore composition links during inherited diet filtering
- remove duplicate direct Chicken memberships from Poultry so the catalog uses the hierarchy
- cover multiple parents, arbitrary depth, duplicate paths, composition regressions, the frontend Poultry selection flow, and deployed preview inheritance

## Validation

- `mise run //workers/recipe-api:check`
- `mise run //workers/recipe-api:test:integration`
- `mise run //packages/recipe-db:typecheck`
- `mise run //ui:test -- tests/components/recipes/settings/diet-panel.test.tsx tests/components/recipes/diet-provider.test.tsx`
- `mise run //ui:typecheck`
- `mise run //ui:lint`
- `mise run //:lint:typos`

## Preview QA

- verify the authenticated Diet settings page can save Poultry as a custom group exclusion
- verify the deployed profile smoke test receives Chicken ingredients through Poultry
- verify composition-only links do not add ingredient exclusions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diet options now include ingredients inherited through classification groups, including multi-level group relationships.
  * Composition relationships are kept separate and do not affect diet group inheritance.
  * Added safeguards to prevent invalid circular group classifications.

* **Bug Fixes**
  * Improved exclusion handling so excluding a parent group also excludes ingredients in its narrower child groups.
  * Updated poultry group data to include chicken and turkey ingredients correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->