### PR TITLE
feat(recipes): extend delegated agent access to cooking history

### DIFF
--- a/ui/components/recipes/settings/agent-approval-view.tsx
+++ b/ui/components/recipes/settings/agent-approval-view.tsx
@@ -62,13 +62,19 @@ export function AgentApprovalView() {
 
     void getAgent(intent.agentId, controller.signal)
       .then(async (loadedAgent) => {
-        const loadedHost = await getAgentHost(
-          loadedAgent.hostId,
-          controller.signal,
-        );
         if (controller.signal.aborted) return;
         setAgent(loadedAgent);
-        setHost(loadedHost);
+        try {
+          const loadedHost = await getAgentHost(
+            loadedAgent.hostId,
+            controller.signal,
+          );
+          if (!controller.signal.aborted) setHost(loadedHost);
+        } catch (cause) {
+          if (cause instanceof DOMException && cause.name === "AbortError")
+            return;
+          if (!controller.signal.aborted) setHost(null);
+        }
       })
       .catch((cause: unknown) => {
         if (cause instanceof DOMException && cause.name === "AbortError")

--- a/ui/components/recipes/settings/agent-approval-view.tsx
+++ b/ui/components/recipes/settings/agent-approval-view.tsx
@@ -4,47 +4,19 @@ import { Bot, Check, LoaderCircle, Lock, X } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import {
+  type AgentDetail,
+  type AgentHost,
+  decideAgentApproval,
+  getAgent,
+  getAgentHost,
+} from "@/lib/api/agents";
 import { authClient } from "@/lib/auth-client";
-
-type CapabilityGrant = {
-  capability: string;
-  description?: string;
-  status: string;
-};
-
-type AgentRequest = {
-  agent_id: string;
-  name: string;
-  status: string;
-  host_id: string;
-  agent_capability_grants: CapabilityGrant[];
-};
 
 type ApprovalIntent = {
   agentId: string;
   code: string;
 };
-
-function isAgentRequest(value: unknown): value is AgentRequest {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as Partial<AgentRequest>;
-  return (
-    typeof candidate.agent_id === "string" &&
-    typeof candidate.name === "string" &&
-    typeof candidate.status === "string" &&
-    typeof candidate.host_id === "string" &&
-    Array.isArray(candidate.agent_capability_grants) &&
-    candidate.agent_capability_grants.every(
-      (grant) =>
-        grant !== null &&
-        typeof grant === "object" &&
-        typeof grant.capability === "string" &&
-        typeof grant.status === "string" &&
-        (grant.description === undefined ||
-          typeof grant.description === "string"),
-    )
-  );
-}
 
 function readApprovalIntent(): ApprovalIntent | null {
   const params = new URLSearchParams(globalThis.location.search);
@@ -56,18 +28,21 @@ function readApprovalIntent(): ApprovalIntent | null {
   return { agentId, code };
 }
 
-async function responseError(response: Response): Promise<string> {
-  const body = (await response.json().catch(() => null)) as {
-    message?: string;
-    error?: string;
-  } | null;
-  return body?.message ?? body?.error ?? "The request could not be completed.";
+function dateLabel(value: string | null): string {
+  if (!value) return "No expiry supplied";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown expiry";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 
 export function AgentApprovalView() {
   const { data: session, isPending: sessionPending } = authClient.useSession();
   const [intent, setIntent] = useState<ApprovalIntent | null | undefined>();
-  const [agent, setAgent] = useState<AgentRequest | null>(null);
+  const [agent, setAgent] = useState<AgentDetail | null>(null);
+  const [host, setHost] = useState<AgentHost | null>(null);
   const [loading, setLoading] = useState(false);
   const [pendingAction, setPendingAction] = useState<"approve" | "deny" | null>(
     null,
@@ -85,17 +60,15 @@ export function AgentApprovalView() {
     setLoading(true);
     setError(null);
 
-    void fetch(
-      `/api/auth/agent/get?agent_id=${encodeURIComponent(intent.agentId)}`,
-      { credentials: "include", signal: controller.signal },
-    )
-      .then(async (response) => {
-        if (!response.ok) throw new Error(await responseError(response));
-        const body: unknown = await response.json();
-        if (!isAgentRequest(body)) {
-          throw new Error("The agent request response was invalid.");
-        }
-        setAgent(body);
+    void getAgent(intent.agentId, controller.signal)
+      .then(async (loadedAgent) => {
+        const loadedHost = await getAgentHost(
+          loadedAgent.hostId,
+          controller.signal,
+        );
+        if (controller.signal.aborted) return;
+        setAgent(loadedAgent);
+        setHost(loadedHost);
       })
       .catch((cause: unknown) => {
         if (cause instanceof DOMException && cause.name === "AbortError")
@@ -106,7 +79,9 @@ export function AgentApprovalView() {
             : "The agent request could not be loaded.",
         );
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
 
     return () => controller.abort();
   }, [intent, session]);
@@ -116,17 +91,11 @@ export function AgentApprovalView() {
     setPendingAction(action);
     setError(null);
     try {
-      const response = await fetch("/api/auth/agent/approve-capability", {
-        method: "POST",
-        credentials: "include",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          agent_id: intent.agentId,
-          user_code: intent.code,
-          action,
-        }),
+      await decideAgentApproval({
+        agentId: intent.agentId,
+        code: intent.code,
+        action,
       });
-      if (!response.ok) throw new Error(await responseError(response));
       setResult(action === "approve" ? "approved" : "denied");
     } catch (cause) {
       setError(
@@ -207,7 +176,7 @@ export function AgentApprovalView() {
         <div className="mt-5 rounded-xl border border-[var(--line-strong)] bg-[var(--paper-warm)] p-4">
           <p className="rt-mono text-[var(--ink-3)]">Requested access</p>
           <ul className="mt-3 space-y-3">
-            {agent.agent_capability_grants
+            {agent.capabilityGrants
               .filter((grant) => grant.status === "pending")
               .map((grant) => (
                 <li key={grant.capability}>
@@ -222,9 +191,20 @@ export function AgentApprovalView() {
                 </li>
               ))}
           </ul>
-          <p className="rt-mono mt-4 text-xs text-[var(--ink-3)]">
-            Host {agent.host_id}
-          </p>
+          <dl className="rt-mono mt-4 space-y-1 text-xs text-[var(--ink-3)]">
+            <div className="flex gap-1">
+              <dt>Host</dt>
+              <dd>{host?.name ?? agent.hostId}</dd>
+            </div>
+            <div className="flex gap-1">
+              <dt>Account</dt>
+              <dd>{session.user.email}</dd>
+            </div>
+            <div className="flex gap-1">
+              <dt>Access expires</dt>
+              <dd>{dateLabel(agent.expiresAt)}</dd>
+            </div>
+          </dl>
         </div>
       )}
 

--- a/ui/components/recipes/settings/agent-approval-view.tsx
+++ b/ui/components/recipes/settings/agent-approval-view.tsx
@@ -60,10 +60,12 @@ export function AgentApprovalView() {
     setLoading(true);
     setError(null);
 
-    void getAgent(intent.agentId, controller.signal)
-      .then(async (loadedAgent) => {
+    void (async () => {
+      try {
+        const loadedAgent = await getAgent(intent.agentId, controller.signal);
         if (controller.signal.aborted) return;
         setAgent(loadedAgent);
+        setLoading(false);
         try {
           const loadedHost = await getAgentHost(
             loadedAgent.hostId,
@@ -75,8 +77,7 @@ export function AgentApprovalView() {
             return;
           if (!controller.signal.aborted) setHost(null);
         }
-      })
-      .catch((cause: unknown) => {
+      } catch (cause) {
         if (cause instanceof DOMException && cause.name === "AbortError")
           return;
         setError(
@@ -84,10 +85,9 @@ export function AgentApprovalView() {
             ? cause.message
             : "The agent request could not be loaded.",
         );
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
-      });
+        setLoading(false);
+      }
+    })();
 
     return () => controller.abort();
   }, [intent, session]);

--- a/ui/components/recipes/settings/agents-panel.tsx
+++ b/ui/components/recipes/settings/agents-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Bot, Clock, LoaderCircle, ShieldX } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { type AgentSummary, listAgents, revokeAgent } from "@/lib/api/agents";
 import { PanelHead } from "./panel-head";
@@ -33,6 +33,7 @@ export function AgentsPanel() {
   const [agents, setAgents] = useState<AgentSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
+  const loadControllerRef = useRef<AbortController | null>(null);
 
   async function load(signal?: AbortSignal) {
     setError(null);
@@ -49,8 +50,12 @@ export function AgentsPanel() {
   // biome-ignore lint/correctness/useExhaustiveDependencies: load the user's agents once when this panel mounts
   useEffect(() => {
     const controller = new AbortController();
+    loadControllerRef.current = controller;
     void load(controller.signal);
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      loadControllerRef.current = null;
+    };
   }, []);
 
   async function revoke(agent: AgentSummary) {
@@ -63,7 +68,14 @@ export function AgentsPanel() {
     setError(null);
     try {
       await revokeAgent(agent.id);
-      await load();
+      setAgents(
+        (current) =>
+          current?.map((item) =>
+            item.id === agent.id ? { ...item, status: "revoked" } : item,
+          ) ?? null,
+      );
+      const signal = loadControllerRef.current?.signal;
+      if (signal) await load(signal);
     } catch (cause) {
       setError(
         cause instanceof Error

--- a/ui/components/recipes/settings/agents-panel.tsx
+++ b/ui/components/recipes/settings/agents-panel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { Bot, Clock, LoaderCircle, ShieldX } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { type AgentSummary, listAgents, revokeAgent } from "@/lib/api/agents";
+import { PanelHead } from "./panel-head";
+
+function dateLabel(value: string | null): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function statusLabel(status: AgentSummary["status"]): string {
+  if (status === "active") return "Active";
+  if (status === "pending") return "Waiting for approval";
+  if (status === "expired") return "Expired";
+  if (status === "revoked") return "Revoked";
+  if (status === "rejected") return "Denied";
+  return "Claimed";
+}
+
+function canRevoke(agent: AgentSummary): boolean {
+  return agent.status === "active" || agent.status === "pending";
+}
+
+export function AgentsPanel() {
+  const [agents, setAgents] = useState<AgentSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  async function load(signal?: AbortSignal) {
+    setError(null);
+    try {
+      setAgents(await listAgents(signal));
+    } catch (cause) {
+      if (cause instanceof DOMException && cause.name === "AbortError") return;
+      setError(
+        cause instanceof Error ? cause.message : "Agents could not be loaded.",
+      );
+    }
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: load the user's agents once when this panel mounts
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, []);
+
+  async function revoke(agent: AgentSummary) {
+    if (
+      !window.confirm(`Revoke ${agent.name}? Its access will stop immediately.`)
+    ) {
+      return;
+    }
+    setRevokingId(agent.id);
+    setError(null);
+    try {
+      await revokeAgent(agent.id);
+      await load();
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "Agent access could not be revoked.",
+      );
+    } finally {
+      setRevokingId(null);
+    }
+  }
+
+  return (
+    <div>
+      <PanelHead
+        kicker="AGENTS"
+        title="Who can read your cooking data."
+        sub="Each agent has its own access grant. Revoking one agent leaves your other agents and signed-in devices alone."
+      />
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-xl border border-[var(--berry)]/40 bg-[var(--card)] p-4 text-[var(--berry)]"
+        >
+          <p className="rt-body">{error}</p>
+          {agents === null && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => void load()}
+            >
+              Try again
+            </Button>
+          )}
+        </div>
+      )}
+
+      {agents === null && !error && (
+        <output
+          aria-label="Loading agents"
+          className="flex items-center gap-2 py-4 text-[var(--ink-3)]"
+        >
+          <LoaderCircle className="size-4 animate-spin" />
+          <span className="rt-mono">Checking agent access…</span>
+        </output>
+      )}
+
+      {agents?.length === 0 && (
+        <div className="rounded-xl border border-dashed border-[var(--line-strong)] bg-[var(--card)] p-6 text-center">
+          <Bot className="mx-auto size-6 text-[var(--terracotta)]" />
+          <p className="rt-display mt-3 text-3xl">No agents connected.</p>
+          <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
+            Agent access appears here after you approve a request.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {agents?.map((agent) => {
+          const grants = agent.capabilityGrants.filter(
+            (grant) => grant.status === "active" || grant.status === "pending",
+          );
+          return (
+            <article
+              key={agent.id}
+              className="rounded-xl border border-[var(--line-strong)] bg-[var(--card)] p-4 shadow-[var(--paper-shadow)]"
+            >
+              <div className="flex items-start gap-3">
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-[var(--paper-warm)] text-[var(--terracotta-deep)]">
+                  <Bot className="size-5" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <h3 className="rt-display text-2xl">{agent.name}</h3>
+                    <span className="rt-mono text-[var(--ink-3)]">
+                      {statusLabel(agent.status)}
+                    </span>
+                  </div>
+                  <p className="rt-body mt-0.5 text-sm text-[var(--ink-2)]">
+                    Hosted by {agent.hostName}
+                  </p>
+
+                  {grants.length > 0 && (
+                    <ul
+                      aria-label={`${agent.name} capabilities`}
+                      className="mt-3 flex flex-wrap gap-2"
+                    >
+                      {grants.map((grant) => (
+                        <li
+                          key={`${grant.capability}:${grant.status}`}
+                          className="rt-mono rounded-full border border-[var(--line)] bg-[var(--paper-warm)] px-2.5 py-1 text-xs text-[var(--ink-2)]"
+                        >
+                          {grant.capability}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+
+                  <dl className="rt-mono mt-3 grid gap-1 text-xs text-[var(--ink-3)] sm:grid-cols-2">
+                    <div className="flex items-center gap-1.5">
+                      <Clock className="size-3" />
+                      <dt>Last used</dt>
+                      <dd>{dateLabel(agent.lastUsedAt)}</dd>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <Clock className="size-3" />
+                      <dt>Expires</dt>
+                      <dd>{dateLabel(agent.expiresAt)}</dd>
+                    </div>
+                  </dl>
+                </div>
+              </div>
+
+              {canRevoke(agent) && (
+                <div className="mt-4 border-t border-dashed border-[var(--line)] pt-3 text-right">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-[var(--terracotta-deep)]"
+                    disabled={revokingId !== null}
+                    onClick={() => void revoke(agent)}
+                  >
+                    {revokingId === agent.id ? (
+                      <LoaderCircle className="animate-spin" />
+                    ) : (
+                      <ShieldX />
+                    )}
+                    Revoke access
+                  </Button>
+                </div>
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/components/recipes/settings/agents-panel.tsx
+++ b/ui/components/recipes/settings/agents-panel.tsx
@@ -117,8 +117,13 @@ export function AgentsPanel() {
         <div className="rounded-xl border border-dashed border-[var(--line-strong)] bg-[var(--card)] p-6 text-center">
           <Bot className="mx-auto size-6 text-[var(--terracotta)]" />
           <p className="rt-display mt-3 text-3xl">No agents connected.</p>
-          <p className="rt-body mt-1 text-sm text-[var(--ink-3)]">
-            Agent access appears here after you approve a request.
+          <p className="rt-body mx-auto mt-2 max-w-lg text-sm text-[var(--ink-2)]">
+            Agents can help find recipes and make sense of your cooking history.
+            Access is read-only for now, so an agent cannot change anything.
+          </p>
+          <p className="rt-body mx-auto mt-3 max-w-lg text-sm text-[var(--ink-3)]">
+            Start the connection from an Agent Auth-compatible app. You will get
+            an approval request here showing exactly what it wants to read.
           </p>
         </div>
       )}

--- a/ui/components/recipes/settings/settings-view.tsx
+++ b/ui/components/recipes/settings/settings-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Bot,
   Home,
   KeyRound,
   Leaf,
@@ -15,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/generic/styles";
 import { AccountPanel } from "./account-panel";
+import { AgentsPanel } from "./agents-panel";
 import { DietPanel } from "./diet-panel";
 import { HouseholdPanel } from "./household-panel";
 import { SecurityPanel } from "./security-panel";
@@ -25,6 +27,7 @@ const SECTIONS = [
   { id: "units", label: "Units & measurements", icon: Scale },
   { id: "household", label: "Household", icon: Home },
   { id: "diet", label: "Your diet", icon: Leaf },
+  { id: "agents", label: "Agents", icon: Bot },
   { id: "signin", label: "Sign-in & security", icon: KeyRound },
 ] as const;
 type SectionId = (typeof SECTIONS)[number]["id"];
@@ -121,6 +124,7 @@ export function SettingsView() {
             <HouseholdPanel currentUser={session.user} />
           )}
           {section === "diet" && <DietPanel />}
+          {section === "agents" && <AgentsPanel />}
           {section === "signin" && (
             <SecurityPanel currentSessionToken={session.session.token} />
           )}

--- a/ui/lib/api/agents.ts
+++ b/ui/lib/api/agents.ts
@@ -8,11 +8,18 @@ export type AgentStatus =
   | "rejected"
   | "claimed";
 
+export type AgentCapabilityGrantStatus =
+  | "active"
+  | "pending"
+  | "denied"
+  | "revoked"
+  | "consumed";
+
 export type AgentCapabilityGrant = {
   capability: string;
   description?: string;
   expiresAt?: string;
-  status: string;
+  status: AgentCapabilityGrantStatus;
 };
 
 export type AgentSummary = {
@@ -46,11 +53,22 @@ function nullableString(value: unknown): string | null | undefined {
   return value === null || typeof value === "string" ? value : undefined;
 }
 
+const AGENT_CAPABILITY_GRANT_STATUSES = new Set<AgentCapabilityGrantStatus>([
+  "active",
+  "pending",
+  "denied",
+  "revoked",
+  "consumed",
+]);
+
 function capabilityGrant(value: unknown): AgentCapabilityGrant | undefined {
   if (
     !isRecord(value) ||
     typeof value.capability !== "string" ||
-    typeof value.status !== "string"
+    typeof value.status !== "string" ||
+    !AGENT_CAPABILITY_GRANT_STATUSES.has(
+      value.status as AgentCapabilityGrantStatus,
+    )
   ) {
     return undefined;
   }
@@ -69,7 +87,7 @@ function capabilityGrant(value: unknown): AgentCapabilityGrant | undefined {
   }
   return {
     capability: value.capability,
-    status: value.status,
+    status: value.status as AgentCapabilityGrantStatus,
     ...(typeof value.description === "string"
       ? { description: value.description }
       : {}),
@@ -155,10 +173,10 @@ export async function listAgents(
     throw new Error("The agent list response was invalid.");
   }
   const agents = body.agents.map(parseAgentSummary);
-  if (agents.some((agent) => !agent)) {
+  if (!agents.every((agent): agent is AgentSummary => agent !== undefined)) {
     throw new Error("The agent list response was invalid.");
   }
-  return agents as AgentSummary[];
+  return agents;
 }
 
 export async function getAgent(

--- a/ui/lib/api/agents.ts
+++ b/ui/lib/api/agents.ts
@@ -46,40 +46,41 @@ function nullableString(value: unknown): string | null | undefined {
   return value === null || typeof value === "string" ? value : undefined;
 }
 
+function capabilityGrant(value: unknown): AgentCapabilityGrant | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.capability !== "string" ||
+    typeof value.status !== "string"
+  ) {
+    return undefined;
+  }
+  const expiresAt =
+    value.expires_at === undefined
+      ? undefined
+      : nullableString(value.expires_at);
+  if (value.expires_at !== undefined && expiresAt === undefined) {
+    return undefined;
+  }
+  if (
+    value.description !== undefined &&
+    typeof value.description !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    capability: value.capability,
+    status: value.status,
+    ...(typeof value.description === "string"
+      ? { description: value.description }
+      : {}),
+    ...(typeof expiresAt === "string" ? { expiresAt } : {}),
+  };
+}
+
 function capabilityGrants(value: unknown): AgentCapabilityGrant[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const grants: AgentCapabilityGrant[] = [];
-  for (const item of value) {
-    if (
-      !isRecord(item) ||
-      typeof item.capability !== "string" ||
-      typeof item.status !== "string"
-    ) {
-      return undefined;
-    }
-    const expiresAt =
-      item.expires_at === undefined
-        ? undefined
-        : nullableString(item.expires_at);
-    if (item.expires_at !== undefined && expiresAt === undefined) {
-      return undefined;
-    }
-    if (
-      item.description !== undefined &&
-      typeof item.description !== "string"
-    ) {
-      return undefined;
-    }
-    grants.push({
-      capability: item.capability,
-      status: item.status,
-      ...(typeof item.description === "string"
-        ? { description: item.description }
-        : {}),
-      ...(typeof expiresAt === "string" ? { expiresAt } : {}),
-    });
-  }
-  return grants;
+  const grants = value.map(capabilityGrant);
+  return grants.every((grant) => grant !== undefined) ? grants : undefined;
 }
 
 const AGENT_STATUSES = new Set<AgentStatus>([

--- a/ui/lib/api/agents.ts
+++ b/ui/lib/api/agents.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { apiRequest } from "@/lib/api/http";
 
 export type AgentStatus =
@@ -49,8 +50,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function nullableString(value: unknown): string | null | undefined {
-  return value === null || typeof value === "string" ? value : undefined;
+const agentDateTime = z.iso.datetime({ offset: true });
+
+function nullableDateTime(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  const parsed = agentDateTime.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
 }
 
 const AGENT_CAPABILITY_GRANT_STATUSES = new Set<AgentCapabilityGrantStatus>([
@@ -75,7 +80,7 @@ function capabilityGrant(value: unknown): AgentCapabilityGrant | undefined {
   const expiresAt =
     value.expires_at === undefined
       ? undefined
-      : nullableString(value.expires_at);
+      : nullableDateTime(value.expires_at);
   if (value.expires_at !== undefined && expiresAt === undefined) {
     return undefined;
   }
@@ -117,8 +122,9 @@ function agentBase(value: unknown): AgentBase | undefined {
   const status = value.status;
   const mode = value.mode;
   const grants = capabilityGrants(value.agent_capability_grants);
-  const lastUsedAt = nullableString(value.last_used_at);
-  const expiresAt = nullableString(value.expires_at);
+  const createdAt = agentDateTime.safeParse(value.created_at);
+  const lastUsedAt = nullableDateTime(value.last_used_at);
+  const expiresAt = nullableDateTime(value.expires_at);
   if (
     typeof value.agent_id !== "string" ||
     typeof value.name !== "string" ||
@@ -127,7 +133,7 @@ function agentBase(value: unknown): AgentBase | undefined {
     (mode !== "delegated" && mode !== "autonomous") ||
     typeof value.host_id !== "string" ||
     !grants ||
-    typeof value.created_at !== "string" ||
+    !createdAt.success ||
     lastUsedAt === undefined ||
     expiresAt === undefined
   ) {
@@ -140,7 +146,7 @@ function agentBase(value: unknown): AgentBase | undefined {
     mode,
     hostId: value.host_id,
     capabilityGrants: grants,
-    createdAt: value.created_at,
+    createdAt: createdAt.data,
     lastUsedAt,
     expiresAt,
   };
@@ -157,7 +163,7 @@ function parseAgentSummary(value: unknown): AgentSummary | undefined {
 function parseAgentDetail(value: unknown): AgentDetail | undefined {
   const base = agentBase(value);
   if (!base || !isRecord(value)) return undefined;
-  const activatedAt = nullableString(value.activated_at);
+  const activatedAt = nullableDateTime(value.activated_at);
   if (activatedAt === undefined) return undefined;
   return { ...base, activatedAt };
 }

--- a/ui/lib/api/agents.ts
+++ b/ui/lib/api/agents.ts
@@ -237,7 +237,7 @@ export async function decideAgentApproval(input: {
   code: string;
   action: "approve" | "deny";
 }): Promise<void> {
-  await apiRequest("/api/auth/agent/approve-capability", {
+  const body = await apiRequest<unknown>("/api/auth/agent/approve-capability", {
     method: "POST",
     json: {
       agent_id: input.agentId,
@@ -246,4 +246,12 @@ export async function decideAgentApproval(input: {
     },
     fallbackMessage: "The approval decision could not be saved.",
   });
+  const expectedStatus = input.action === "approve" ? "approved" : "denied";
+  if (
+    !isRecord(body) ||
+    body.status !== expectedStatus ||
+    (body.agentId !== undefined && body.agentId !== input.agentId)
+  ) {
+    throw new Error("The approval decision response was invalid.");
+  }
 }

--- a/ui/lib/api/agents.ts
+++ b/ui/lib/api/agents.ts
@@ -1,0 +1,224 @@
+import { apiRequest } from "@/lib/api/http";
+
+export type AgentStatus =
+  | "active"
+  | "pending"
+  | "expired"
+  | "revoked"
+  | "rejected"
+  | "claimed";
+
+export type AgentCapabilityGrant = {
+  capability: string;
+  description?: string;
+  expiresAt?: string;
+  status: string;
+};
+
+export type AgentSummary = {
+  id: string;
+  name: string;
+  status: AgentStatus;
+  mode: "delegated" | "autonomous";
+  hostId: string;
+  hostName: string;
+  capabilityGrants: AgentCapabilityGrant[];
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+};
+
+export type AgentDetail = Omit<AgentSummary, "hostName"> & {
+  activatedAt: string | null;
+};
+
+export type AgentHost = {
+  id: string;
+  name: string;
+  status: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nullableString(value: unknown): string | null | undefined {
+  return value === null || typeof value === "string" ? value : undefined;
+}
+
+function capabilityGrants(value: unknown): AgentCapabilityGrant[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const grants: AgentCapabilityGrant[] = [];
+  for (const item of value) {
+    if (
+      !isRecord(item) ||
+      typeof item.capability !== "string" ||
+      typeof item.status !== "string"
+    ) {
+      return undefined;
+    }
+    const expiresAt =
+      item.expires_at === undefined
+        ? undefined
+        : nullableString(item.expires_at);
+    if (item.expires_at !== undefined && expiresAt === undefined) {
+      return undefined;
+    }
+    if (
+      item.description !== undefined &&
+      typeof item.description !== "string"
+    ) {
+      return undefined;
+    }
+    grants.push({
+      capability: item.capability,
+      status: item.status,
+      ...(typeof item.description === "string"
+        ? { description: item.description }
+        : {}),
+      ...(typeof expiresAt === "string" ? { expiresAt } : {}),
+    });
+  }
+  return grants;
+}
+
+const AGENT_STATUSES = new Set<AgentStatus>([
+  "active",
+  "pending",
+  "expired",
+  "revoked",
+  "rejected",
+  "claimed",
+]);
+
+type AgentBase = Omit<AgentSummary, "hostName">;
+
+function agentBase(value: unknown): AgentBase | undefined {
+  if (!isRecord(value)) return undefined;
+  const status = value.status;
+  const mode = value.mode;
+  const grants = capabilityGrants(value.agent_capability_grants);
+  const lastUsedAt = nullableString(value.last_used_at);
+  const expiresAt = nullableString(value.expires_at);
+  if (
+    typeof value.agent_id !== "string" ||
+    typeof value.name !== "string" ||
+    typeof status !== "string" ||
+    !AGENT_STATUSES.has(status as AgentStatus) ||
+    (mode !== "delegated" && mode !== "autonomous") ||
+    typeof value.host_id !== "string" ||
+    !grants ||
+    typeof value.created_at !== "string" ||
+    lastUsedAt === undefined ||
+    expiresAt === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    id: value.agent_id,
+    name: value.name,
+    status: status as AgentStatus,
+    mode,
+    hostId: value.host_id,
+    capabilityGrants: grants,
+    createdAt: value.created_at,
+    lastUsedAt,
+    expiresAt,
+  };
+}
+
+function parseAgentSummary(value: unknown): AgentSummary | undefined {
+  const base = agentBase(value);
+  if (!base || !isRecord(value) || typeof value.host_name !== "string") {
+    return undefined;
+  }
+  return { ...base, hostName: value.host_name };
+}
+
+function parseAgentDetail(value: unknown): AgentDetail | undefined {
+  const base = agentBase(value);
+  if (!base || !isRecord(value)) return undefined;
+  const activatedAt = nullableString(value.activated_at);
+  if (activatedAt === undefined) return undefined;
+  return { ...base, activatedAt };
+}
+
+export async function listAgents(
+  signal?: AbortSignal,
+): Promise<AgentSummary[]> {
+  const body = await apiRequest<unknown>("/api/auth/agent/list?limit=200", {
+    signal,
+    fallbackMessage: "Agents could not be loaded.",
+  });
+  if (!isRecord(body) || !Array.isArray(body.agents)) {
+    throw new Error("The agent list response was invalid.");
+  }
+  const agents = body.agents.map(parseAgentSummary);
+  if (agents.some((agent) => !agent)) {
+    throw new Error("The agent list response was invalid.");
+  }
+  return agents as AgentSummary[];
+}
+
+export async function getAgent(
+  agentId: string,
+  signal?: AbortSignal,
+): Promise<AgentDetail> {
+  const body = await apiRequest<unknown>(
+    `/api/auth/agent/get?agent_id=${encodeURIComponent(agentId)}`,
+    { signal, fallbackMessage: "The agent request could not be loaded." },
+  );
+  const agent = parseAgentDetail(body);
+  if (!agent) throw new Error("The agent request response was invalid.");
+  return agent;
+}
+
+export async function getAgentHost(
+  hostId: string,
+  signal?: AbortSignal,
+): Promise<AgentHost> {
+  const body = await apiRequest<unknown>(
+    `/api/auth/host/get?host_id=${encodeURIComponent(hostId)}`,
+    { signal, fallbackMessage: "The agent host could not be loaded." },
+  );
+  if (
+    !isRecord(body) ||
+    typeof body.id !== "string" ||
+    typeof body.name !== "string" ||
+    typeof body.status !== "string"
+  ) {
+    throw new Error("The agent host response was invalid.");
+  }
+  return { id: body.id, name: body.name, status: body.status };
+}
+
+export async function revokeAgent(agentId: string): Promise<void> {
+  const body = await apiRequest<unknown>("/api/auth/agent/revoke", {
+    method: "POST",
+    json: { agent_id: agentId },
+    fallbackMessage: "Agent access could not be revoked.",
+  });
+  if (
+    !isRecord(body) ||
+    body.agent_id !== agentId ||
+    body.status !== "revoked"
+  ) {
+    throw new Error("The agent revocation response was invalid.");
+  }
+}
+
+export async function decideAgentApproval(input: {
+  agentId: string;
+  code: string;
+  action: "approve" | "deny";
+}): Promise<void> {
+  await apiRequest("/api/auth/agent/approve-capability", {
+    method: "POST",
+    json: {
+      agent_id: input.agentId,
+      user_code: input.code,
+      action: input.action,
+    },
+    fallbackMessage: "The approval decision could not be saved.",
+  });
+}

--- a/ui/tests/components/recipes/agent-approval-view.test.tsx
+++ b/ui/tests/components/recipes/agent-approval-view.test.tsx
@@ -104,6 +104,43 @@ describe("AgentApprovalView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("allows approval when optional host metadata cannot be loaded", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({
+          agent_id: "agent-1",
+          name: "Meal planner",
+          status: "pending",
+          mode: "delegated",
+          host_id: "host-1",
+          created_at: "2026-08-22T09:00:00.000Z",
+          activated_at: null,
+          last_used_at: null,
+          expires_at: "2026-09-21T09:00:00.000Z",
+          agent_capability_grants: [
+            { capability: "recipes.search", status: "pending" },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(new Response("Unavailable", { status: 503 }))
+      .mockResolvedValueOnce(Response.json({ status: "approved" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentApprovalView />);
+
+    expect(await screen.findByText("Allow Meal planner?")).toBeInTheDocument();
+    expect(screen.getByText("host-1")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Approve access" }),
+    );
+
+    expect(
+      await screen.findByText("Agent access approved."),
+    ).toBeInTheDocument();
+  });
+
   it("shows an error when the agent response is malformed", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({})));
 

--- a/ui/tests/components/recipes/agent-approval-view.test.tsx
+++ b/ui/tests/components/recipes/agent-approval-view.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const authMock = vi.hoisted(() => ({
   session: {
     data: {
-      user: { id: "user-1", name: "Cook" },
+      user: { id: "user-1", name: "Cook", email: "cook@example.test" },
       session: { token: "session-1" },
     } as unknown,
     isPending: false,
@@ -40,10 +40,22 @@ describe("AgentApprovalView", () => {
           agent_id: "agent-1",
           name: "Meal planner",
           status: "pending",
+          mode: "delegated",
           host_id: "host-1",
+          created_at: "2026-08-22T09:00:00.000Z",
+          activated_at: null,
+          last_used_at: null,
+          expires_at: "2026-09-21T09:00:00.000Z",
           agent_capability_grants: [
             { capability: "recipes.search", status: "pending" },
           ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          id: "host-1",
+          name: "Kitchen helper host",
+          status: "active",
         }),
       )
       .mockResolvedValueOnce(Response.json({ status: "approved" }));
@@ -53,17 +65,20 @@ describe("AgentApprovalView", () => {
 
     expect(await screen.findByText("Allow Meal planner?")).toBeInTheDocument();
     expect(screen.getByText("recipes.search")).toBeInTheDocument();
+    expect(screen.getByText("Kitchen helper host")).toBeInTheDocument();
+    expect(screen.getByText("cook@example.test")).toBeInTheDocument();
     expect(window.location.search).toBe("");
 
     await userEvent.click(
       screen.getByRole("button", { name: "Approve access" }),
     );
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/auth/agent/approve-capability",
       expect.objectContaining({
         method: "POST",
+        credentials: "same-origin",
         body: JSON.stringify({
           agent_id: "agent-1",
           user_code: "ABCD-1234",

--- a/ui/tests/components/recipes/agent-approval-view.test.tsx
+++ b/ui/tests/components/recipes/agent-approval-view.test.tsx
@@ -141,6 +141,52 @@ describe("AgentApprovalView", () => {
     ).toBeInTheDocument();
   });
 
+  it("allows approval while optional host metadata is still loading", async () => {
+    let resolveHost: (response: Response) => void = () => {};
+    const hostResponse = new Promise<Response>((resolve) => {
+      resolveHost = resolve;
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({
+          agent_id: "agent-1",
+          name: "Meal planner",
+          status: "pending",
+          mode: "delegated",
+          host_id: "host-1",
+          created_at: "2026-08-22T09:00:00.000Z",
+          activated_at: null,
+          last_used_at: null,
+          expires_at: "2026-09-21T09:00:00.000Z",
+          agent_capability_grants: [
+            { capability: "recipes.search", status: "pending" },
+          ],
+        }),
+      )
+      .mockImplementationOnce(() => hostResponse)
+      .mockResolvedValueOnce(Response.json({ status: "approved" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentApprovalView />);
+
+    expect(await screen.findByText("Allow Meal planner?")).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Approve access" }),
+    );
+    expect(
+      await screen.findByText("Agent access approved."),
+    ).toBeInTheDocument();
+
+    resolveHost(
+      Response.json({
+        id: "host-1",
+        name: "Kitchen helper host",
+        status: "active",
+      }),
+    );
+  });
+
   it("shows an error when the agent response is malformed", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({})));
 

--- a/ui/tests/components/recipes/settings/agents-panel.test.tsx
+++ b/ui/tests/components/recipes/settings/agents-panel.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listAgents: vi.fn(),
+  revokeAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/api/agents", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/agents")>()),
+  listAgents: mocks.listAgents,
+  revokeAgent: mocks.revokeAgent,
+}));
+
+import { AgentsPanel } from "@/components/recipes/settings/agents-panel";
+
+const activeAgent = {
+  id: "agent-1",
+  name: "Meal planner",
+  status: "active" as const,
+  mode: "delegated" as const,
+  hostId: "host-1",
+  hostName: "Kitchen helper host",
+  capabilityGrants: [
+    { capability: "recipes.read", status: "active" },
+    { capability: "cook_log.read", status: "active" },
+  ],
+  createdAt: "2026-08-22T09:00:00.000Z",
+  lastUsedAt: "2026-08-22T10:00:00.000Z",
+  expiresAt: "2026-09-21T09:00:00.000Z",
+};
+
+describe("AgentsPanel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listAgents.mockResolvedValue([activeAgent]);
+    mocks.revokeAgent.mockResolvedValue(undefined);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+  });
+
+  it("shows host, capabilities, status, use, and expiry", async () => {
+    render(<AgentsPanel />);
+
+    expect(await screen.findByText("Meal planner")).toBeInTheDocument();
+    expect(
+      screen.getByText("Hosted by Kitchen helper host"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("recipes.read")).toBeInTheDocument();
+    expect(screen.getByText("cook_log.read")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Last used")).toBeInTheDocument();
+    expect(screen.getByText("Expires")).toBeInTheDocument();
+  });
+
+  it("revokes one agent and reloads the list", async () => {
+    const user = userEvent.setup();
+    mocks.listAgents
+      .mockResolvedValueOnce([activeAgent])
+      .mockResolvedValueOnce([{ ...activeAgent, status: "revoked" }]);
+    render(<AgentsPanel />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Revoke access" }),
+    );
+
+    expect(window.confirm).toHaveBeenCalledWith(
+      "Revoke Meal planner? Its access will stop immediately.",
+    );
+    expect(mocks.revokeAgent).toHaveBeenCalledWith("agent-1");
+    await waitFor(() => expect(mocks.listAgents).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("Revoked")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Revoke access" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the existing list visible when revocation fails", async () => {
+    const user = userEvent.setup();
+    mocks.revokeAgent.mockRejectedValue(new Error("Revocation unavailable"));
+    render(<AgentsPanel />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Revoke access" }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Revocation unavailable",
+    );
+    expect(screen.getByText("Meal planner")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/components/recipes/settings/agents-panel.test.tsx
+++ b/ui/tests/components/recipes/settings/agents-panel.test.tsx
@@ -86,6 +86,7 @@ describe("AgentsPanel", () => {
     );
     expect(mocks.revokeAgent).toHaveBeenCalledWith("agent-1");
     await waitFor(() => expect(mocks.listAgents).toHaveBeenCalledTimes(2));
+    expect(mocks.listAgents).toHaveBeenLastCalledWith(expect.any(AbortSignal));
     expect(await screen.findByText("Revoked")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Revoke access" }),
@@ -105,5 +106,22 @@ describe("AgentsPanel", () => {
       "Revocation unavailable",
     );
     expect(screen.getByText("Meal planner")).toBeInTheDocument();
+  });
+
+  it("keeps a successful revocation visible when refresh fails", async () => {
+    const user = userEvent.setup();
+    mocks.listAgents
+      .mockResolvedValueOnce([activeAgent])
+      .mockRejectedValueOnce(new Error("Agent list refresh failed"));
+    render(<AgentsPanel />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Revoke access" }),
+    );
+
+    expect(await screen.findByText("Revoked")).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Agent list refresh failed",
+    );
   });
 });

--- a/ui/tests/components/recipes/settings/agents-panel.test.tsx
+++ b/ui/tests/components/recipes/settings/agents-panel.test.tsx
@@ -57,6 +57,19 @@ describe("AgentsPanel", () => {
     expect(screen.getByText("Expires")).toBeInTheDocument();
   });
 
+  it("explains what agents can do and how to connect one", async () => {
+    mocks.listAgents.mockResolvedValueOnce([]);
+    render(<AgentsPanel />);
+
+    expect(await screen.findByText("No agents connected.")).toBeInTheDocument();
+    expect(screen.getByText(/Access is read-only for now/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Start the connection from an Agent Auth-compatible app/,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("revokes one agent and reloads the list", async () => {
     const user = userEvent.setup();
     mocks.listAgents

--- a/ui/tests/components/recipes/settings/settings-view.test.tsx
+++ b/ui/tests/components/recipes/settings/settings-view.test.tsx
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   getHouseholdMembers: vi.fn(),
   getHouseholdInvitations: vi.fn(),
   getIncomingHouseholdInvitations: vi.fn(),
+  listAgents: vi.fn(),
+  revokeAgent: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -42,6 +44,12 @@ vi.mock("@/lib/api/households", async (importOriginal) => ({
   getHouseholdMembers: mocks.getHouseholdMembers,
   getHouseholdInvitations: mocks.getHouseholdInvitations,
   getIncomingHouseholdInvitations: mocks.getIncomingHouseholdInvitations,
+}));
+
+vi.mock("@/lib/api/agents", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/api/agents")>()),
+  listAgents: mocks.listAgents,
+  revokeAgent: mocks.revokeAgent,
 }));
 
 function renderSettingsView() {
@@ -91,6 +99,8 @@ describe("SettingsView", () => {
     mocks.getHouseholdMembers.mockResolvedValue([]);
     mocks.getHouseholdInvitations.mockResolvedValue([]);
     mocks.getIncomingHouseholdInvitations.mockResolvedValue([]);
+    mocks.listAgents.mockResolvedValue([]);
+    mocks.revokeAgent.mockResolvedValue(undefined);
     mocks.createHousehold.mockResolvedValue({});
   });
 
@@ -151,6 +161,18 @@ describe("SettingsView", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /github/i })).toBeInTheDocument();
     expect(screen.getByText("this device")).toBeInTheDocument();
+  });
+
+  it("opens agent access management from settings", async () => {
+    const user = userEvent.setup();
+    renderSettingsView();
+
+    await user.click(screen.getByRole("button", { name: "Agents" }));
+
+    expect(
+      await screen.findByText("Who can read your cooking data."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No agents connected.")).toBeInTheDocument();
   });
 
   it("saves a custom units ladder from the units settings panel", async () => {

--- a/ui/tests/lib/api/agents.test.ts
+++ b/ui/tests/lib/api/agents.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { listAgents, revokeAgent } from "@/lib/api/agents";
+import { decideAgentApproval, listAgents, revokeAgent } from "@/lib/api/agents";
 
 const fetchMock = vi.fn<typeof fetch>();
 
@@ -133,5 +133,19 @@ describe("agent access API", () => {
         body: JSON.stringify({ agent_id: "agent-1" }),
       }),
     );
+  });
+
+  it("rejects a mismatched approval response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ status: "approved", agentId: "agent-2" }),
+    );
+
+    await expect(
+      decideAgentApproval({
+        agentId: "agent-1",
+        code: "ABCD-1234",
+        action: "approve",
+      }),
+    ).rejects.toThrow("The approval decision response was invalid.");
   });
 });

--- a/ui/tests/lib/api/agents.test.ts
+++ b/ui/tests/lib/api/agents.test.ts
@@ -90,6 +90,35 @@ describe("agent access API", () => {
     );
   });
 
+  it.each(["created_at", "last_used_at", "expires_at"])(
+    "rejects invalid %s timestamps",
+    async (field) => {
+      fetchMock.mockResolvedValueOnce(
+        Response.json({
+          agents: [
+            {
+              agent_id: "agent-1",
+              name: "Meal planner",
+              status: "active",
+              mode: "delegated",
+              host_id: "host-1",
+              host_name: "Kitchen helper host",
+              agent_capability_grants: [],
+              created_at: "2026-08-22T09:00:00.000Z",
+              last_used_at: null,
+              expires_at: "2026-09-21T09:00:00.000Z",
+              [field]: "not-a-datetime",
+            },
+          ],
+        }),
+      );
+
+      await expect(listAgents()).rejects.toThrow(
+        "The agent list response was invalid.",
+      );
+    },
+  );
+
   it("revokes exactly the selected agent", async () => {
     fetchMock.mockResolvedValueOnce(
       Response.json({ agent_id: "agent-1", status: "revoked" }),

--- a/ui/tests/lib/api/agents.test.ts
+++ b/ui/tests/lib/api/agents.test.ts
@@ -63,6 +63,33 @@ describe("agent access API", () => {
     );
   });
 
+  it("rejects unknown capability grant statuses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({
+        agents: [
+          {
+            agent_id: "agent-1",
+            name: "Meal planner",
+            status: "active",
+            mode: "delegated",
+            host_id: "host-1",
+            host_name: "Kitchen helper host",
+            agent_capability_grants: [
+              { capability: "recipes.read", status: "unknown" },
+            ],
+            created_at: "2026-08-22T09:00:00.000Z",
+            last_used_at: null,
+            expires_at: "2026-09-21T09:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    await expect(listAgents()).rejects.toThrow(
+      "The agent list response was invalid.",
+    );
+  });
+
   it("revokes exactly the selected agent", async () => {
     fetchMock.mockResolvedValueOnce(
       Response.json({ agent_id: "agent-1", status: "revoked" }),

--- a/ui/tests/lib/api/agents.test.ts
+++ b/ui/tests/lib/api/agents.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listAgents, revokeAgent } from "@/lib/api/agents";
+
+const fetchMock = vi.fn<typeof fetch>();
+
+describe("agent access API", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("parses the current user's agents", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({
+        agents: [
+          {
+            agent_id: "agent-1",
+            name: "Meal planner",
+            status: "active",
+            mode: "delegated",
+            host_id: "host-1",
+            host_name: "Kitchen helper host",
+            agent_capability_grants: [
+              {
+                capability: "recipes.read",
+                description: "Read recipes",
+                status: "active",
+                expires_at: "2026-09-21T09:00:00.000Z",
+              },
+            ],
+            created_at: "2026-08-22T09:00:00.000Z",
+            last_used_at: "2026-08-22T10:00:00.000Z",
+            expires_at: "2026-09-21T09:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    await expect(listAgents()).resolves.toEqual([
+      expect.objectContaining({
+        id: "agent-1",
+        hostName: "Kitchen helper host",
+        capabilityGrants: [
+          expect.objectContaining({ capability: "recipes.read" }),
+        ],
+      }),
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/agent/list?limit=200",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+  });
+
+  it("rejects malformed agent rows", async () => {
+    fetchMock.mockResolvedValueOnce(Response.json({ agents: [{}] }));
+
+    await expect(listAgents()).rejects.toThrow(
+      "The agent list response was invalid.",
+    );
+  });
+
+  it("revokes exactly the selected agent", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({ agent_id: "agent-1", status: "revoked" }),
+    );
+
+    await expect(revokeAgent("agent-1")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/agent/revoke",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        body: JSON.stringify({ agent_id: "agent-1" }),
+      }),
+    );
+  });
+});

--- a/workers/recipe-api/scripts/smoke-preview-agent-auth.ts
+++ b/workers/recipe-api/scripts/smoke-preview-agent-auth.ts
@@ -213,12 +213,48 @@ if (!signIn.ok) {
 }
 const cookie = sessionCookie(signIn);
 
+const cookingSessionId = crypto.randomUUID();
+const cookingSession = {
+  sessionId: cookingSessionId,
+  recipeSlug: "preview-private-weeknight-pasta",
+  recipeTitle: "Preview Weeknight Pasta",
+  servings: 2,
+};
+await expectJson(
+  "/api/profile/cooking-sessions",
+  {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: siteURL,
+    },
+    body: JSON.stringify({ ...cookingSession, event: "started" }),
+  },
+  201,
+);
+await expectJson("/api/profile/cooking-sessions", {
+  method: "POST",
+  headers: {
+    cookie,
+    "content-type": "application/json",
+    origin: siteURL,
+  },
+  body: JSON.stringify({ ...cookingSession, event: "completed" }),
+});
+
 const hostKeys = await generateKeyPair("EdDSA");
 const agentKeys = await generateKeyPair("EdDSA");
 const hostKid = `preview-host-${crypto.randomUUID()}`;
 const agentKid = `preview-agent-${crypto.randomUUID()}`;
 const hostPublicKey = await publicJWK(hostKeys.publicKey, hostKid);
 const agentPublicKey = await publicJWK(agentKeys.publicKey, agentKid);
+const requestedCapabilities = [
+  "recipes.search",
+  "recipes.read",
+  "cook_log.read",
+  "cooking_insights.read",
+];
 
 const host = await expectJson<{ hostId: string; status: string }>(
   "/api/auth/host/create",
@@ -260,8 +296,8 @@ const registration = await expectJson<Registration>(
     },
     body: JSON.stringify({
       name: "ADR 061 preview smoke agent",
-      capabilities: ["recipes.search", "recipes.read"],
-      reason: "Verify delegated recipe reads on PR preview",
+      capabilities: requestedCapabilities,
+      reason: "Verify delegated recipe and cooking-history reads on PR preview",
       mode: "delegated",
       preferred_method: "device_authorization",
     }),
@@ -351,7 +387,7 @@ while (Date.now() < deadline) {
 if (status?.status !== "active") {
   throw new Error("Timed out waiting for agent approval");
 }
-for (const capability of ["recipes.search", "recipes.read"]) {
+for (const capability of requestedCapabilities) {
   if (
     !status.agent_capability_grants.some(
       (grant) =>
@@ -429,5 +465,102 @@ if (
 ) {
   throw new Error("Recipe read did not return the delegated user's private recipe");
 }
+
+const cookLogToken = await agentJWT(
+  agentKeys.privateKey,
+  agentKid,
+  registration.agent_id,
+  registration.host_id,
+  discovery.issuer,
+  "cook_log.read",
+);
+const cookLogResponse = await execute(
+  discovery.endpoints.execute,
+  cookLogToken,
+  "cook_log.read",
+  { limit: 50 },
+);
+if (!cookLogResponse.ok) {
+  throw new Error(`Cook log read failed: ${await cookLogResponse.text()}`);
+}
+const cookLog = (await cookLogResponse.json()) as {
+  data: { items: Array<{ id: string; recipeSlug: string }> };
+};
+if (
+  !cookLog.data.items.some(
+    (item) =>
+      item.id === cookingSessionId &&
+      item.recipeSlug === "preview-private-weeknight-pasta",
+  )
+) {
+  throw new Error("Cook log read did not return the delegated user's session");
+}
+
+const insightsToken = await agentJWT(
+  agentKeys.privateKey,
+  agentKid,
+  registration.agent_id,
+  registration.host_id,
+  discovery.issuer,
+  "cooking_insights.read",
+);
+const insightsResponse = await execute(
+  discovery.endpoints.execute,
+  insightsToken,
+  "cooking_insights.read",
+  {},
+);
+if (!insightsResponse.ok) {
+  throw new Error(`Cooking insights read failed: ${await insightsResponse.text()}`);
+}
+const insights = (await insightsResponse.json()) as {
+  data: {
+    cookModeStarts: number;
+    mealsCooked: number;
+    recent: Array<{ id: string }>;
+  };
+};
+if (
+  insights.data.cookModeStarts < 1 ||
+  insights.data.mealsCooked < 1 ||
+  !insights.data.recent.some((item) => item.id === cookingSessionId)
+) {
+  throw new Error("Cooking insights did not include the preview cooking session");
+}
+
+await expectJson<{ agent_id: string; status: string }>(
+  "/api/auth/agent/revoke",
+  {
+    method: "POST",
+    headers: {
+      cookie,
+      "content-type": "application/json",
+      origin: siteURL,
+    },
+    body: JSON.stringify({ agent_id: registration.agent_id }),
+  },
+);
+const revokedToken = await agentJWT(
+  agentKeys.privateKey,
+  agentKid,
+  registration.agent_id,
+  registration.host_id,
+  discovery.issuer,
+  "recipes.read",
+);
+const revokedExecution = await execute(
+  discovery.endpoints.execute,
+  revokedToken,
+  "recipes.read",
+  { slug: "preview-private-weeknight-pasta" },
+);
+if (revokedExecution.status !== 401) {
+  throw new Error(
+    `Revoked agent execution returned ${revokedExecution.status}, expected 401`,
+  );
+}
+await expectJson("/api/profile/cooking-insights", {
+  headers: { cookie },
+});
 
 console.log("Delegated agent-auth preview smoke test passed.");

--- a/workers/recipe-api/scripts/smoke-preview-agent-auth.ts
+++ b/workers/recipe-api/scripts/smoke-preview-agent-auth.ts
@@ -528,7 +528,7 @@ if (
   throw new Error("Cooking insights did not include the preview cooking session");
 }
 
-await expectJson<{ agent_id: string; status: string }>(
+const revoked = await expectJson<{ agent_id: string; status: string }>(
   "/api/auth/agent/revoke",
   {
     method: "POST",
@@ -540,6 +540,12 @@ await expectJson<{ agent_id: string; status: string }>(
     body: JSON.stringify({ agent_id: registration.agent_id }),
   },
 );
+if (
+  revoked.agent_id !== registration.agent_id ||
+  revoked.status !== "revoked"
+) {
+  throw new Error("Agent revocation returned an unexpected response");
+}
 const revokedToken = await agentJWT(
   agentKeys.privateKey,
   agentKid,
@@ -554,9 +560,9 @@ const revokedExecution = await execute(
   "recipes.read",
   { slug: "preview-private-weeknight-pasta" },
 );
-if (revokedExecution.status !== 401) {
+if (revokedExecution.status !== 403) {
   throw new Error(
-    `Revoked agent execution returned ${revokedExecution.status}, expected 401`,
+    `Revoked agent execution returned ${revokedExecution.status}, expected 403`,
   );
 }
 await expectJson("/api/profile/cooking-insights", {

--- a/workers/recipe-api/src/agent-auth.ts
+++ b/workers/recipe-api/src/agent-auth.ts
@@ -4,6 +4,7 @@ import {
   type AgentSession,
   type Capability,
 } from "@better-auth/agent-auth";
+import { APIError } from "better-auth";
 import { and, desc, eq, ilike, inArray, or, type SQL } from "drizzle-orm";
 import type { Db } from "recipe-db";
 import * as schema from "recipe-db/schema";
@@ -115,10 +116,12 @@ function cookingLogQuery(input: z.infer<typeof cookLogReadInput>) {
   }
 
   if (from > to) {
-    throw new Error("from must not be after to");
+    throw new APIError("BAD_REQUEST", { message: "from must not be after to" });
   }
   if (to.getTime() - from.getTime() > MAX_COOK_LOG_RANGE_MS) {
-    throw new Error("Cook log range must not exceed 90 days");
+    throw new APIError("BAD_REQUEST", {
+      message: "Cook log range must not exceed 90 days",
+    });
   }
 
   return { from, to, limit: input.limit, cursor };

--- a/workers/recipe-api/src/agent-auth.ts
+++ b/workers/recipe-api/src/agent-auth.ts
@@ -109,6 +109,39 @@ const cookLogReadInput = z
 
 const noArgumentsInput = z.object({}).strict();
 
+function cookingLogQuery(input: z.infer<typeof cookLogReadInput>) {
+  const cursor = decodeCookingLogCursor(input.cursor);
+  let to = input.to ? new Date(input.to) : new Date();
+  let from = input.from
+    ? new Date(input.from)
+    : new Date(to.getTime() - MAX_COOK_LOG_RANGE_MS);
+
+  if (cursor) {
+    const cursorFrom = new Date(cursor.from);
+    const cursorTo = new Date(cursor.to);
+    const conflictsWithFrom =
+      input.from !== undefined &&
+      new Date(input.from).getTime() !== cursorFrom.getTime();
+    const conflictsWithTo =
+      input.to !== undefined &&
+      new Date(input.to).getTime() !== cursorTo.getTime();
+    if (conflictsWithFrom || conflictsWithTo) {
+      throw new Error("Cursor does not match the requested date range");
+    }
+    from = cursorFrom;
+    to = cursorTo;
+  }
+
+  if (from > to) {
+    throw new Error("from must not be after to");
+  }
+  if (to.getTime() - from.getTime() > MAX_COOK_LOG_RANGE_MS) {
+    throw new Error("Cook log range must not exceed 90 days");
+  }
+
+  return { from, to, limit: input.limit, cursor };
+}
+
 const recipeSummarySchema = {
   type: "object",
   additionalProperties: false,
@@ -397,36 +430,7 @@ export async function executeRecipeAgentCapability(
 
   if (capability === "cook_log.read") {
     const input = cookLogReadInput.parse(args ?? {});
-    const cursor = decodeCookingLogCursor(input.cursor);
-    const to = cursor
-      ? new Date(cursor.to)
-      : input.to
-        ? new Date(input.to)
-        : new Date();
-    const from = cursor
-      ? new Date(cursor.from)
-      : input.from
-        ? new Date(input.from)
-        : new Date(to.getTime() - MAX_COOK_LOG_RANGE_MS);
-    if (
-      cursor &&
-      ((input.from && new Date(input.from).getTime() !== from.getTime()) ||
-        (input.to && new Date(input.to).getTime() !== to.getTime()))
-    ) {
-      throw new Error("Cursor does not match the requested date range");
-    }
-    if (from > to) {
-      throw new Error("from must not be after to");
-    }
-    if (to.getTime() - from.getTime() > MAX_COOK_LOG_RANGE_MS) {
-      throw new Error("Cook log range must not exceed 90 days");
-    }
-    return cookingLogResponse(db, userId, {
-      from,
-      to,
-      limit: input.limit,
-      cursor,
-    });
+    return cookingLogResponse(db, userId, cookingLogQuery(input));
   }
 
   if (capability === "cooking_insights.read") {

--- a/workers/recipe-api/src/agent-auth.ts
+++ b/workers/recipe-api/src/agent-auth.ts
@@ -76,8 +76,8 @@ const recipeReadInput = z
 
 const cookLogReadInput = z
   .object({
-    from: z.string().datetime({ offset: true }).optional(),
-    to: z.string().datetime({ offset: true }).optional(),
+    from: z.iso.datetime({ offset: true }).optional(),
+    to: z.iso.datetime({ offset: true }).optional(),
     limit: z.number().int().min(1).max(50).default(20),
     cursor: z
       .string()

--- a/workers/recipe-api/src/agent-auth.ts
+++ b/workers/recipe-api/src/agent-auth.ts
@@ -87,25 +87,7 @@ const cookLogReadInput = z
       })
       .optional(),
   })
-  .strict()
-  .superRefine((input, context) => {
-    if (!input.from || !input.to) return;
-    const from = Date.parse(input.from);
-    const to = Date.parse(input.to);
-    if (from > to) {
-      context.addIssue({
-        code: "custom",
-        path: ["from"],
-        message: "from must not be after to",
-      });
-    } else if (to - from > MAX_COOK_LOG_RANGE_MS) {
-      context.addIssue({
-        code: "custom",
-        path: ["from"],
-        message: "Cook log range must not exceed 90 days",
-      });
-    }
-  });
+  .strict();
 
 const noArgumentsInput = z.object({}).strict();
 

--- a/workers/recipe-api/src/agent-auth.ts
+++ b/workers/recipe-api/src/agent-auth.ts
@@ -397,10 +397,24 @@ export async function executeRecipeAgentCapability(
 
   if (capability === "cook_log.read") {
     const input = cookLogReadInput.parse(args ?? {});
-    const to = input.to ? new Date(input.to) : new Date();
-    const from = input.from
-      ? new Date(input.from)
-      : new Date(to.getTime() - MAX_COOK_LOG_RANGE_MS);
+    const cursor = decodeCookingLogCursor(input.cursor);
+    const to = cursor
+      ? new Date(cursor.to)
+      : input.to
+        ? new Date(input.to)
+        : new Date();
+    const from = cursor
+      ? new Date(cursor.from)
+      : input.from
+        ? new Date(input.from)
+        : new Date(to.getTime() - MAX_COOK_LOG_RANGE_MS);
+    if (
+      cursor &&
+      ((input.from && new Date(input.from).getTime() !== from.getTime()) ||
+        (input.to && new Date(input.to).getTime() !== to.getTime()))
+    ) {
+      throw new Error("Cursor does not match the requested date range");
+    }
     if (from > to) {
       throw new Error("from must not be after to");
     }
@@ -411,7 +425,7 @@ export async function executeRecipeAgentCapability(
       from,
       to,
       limit: input.limit,
-      cursor: decodeCookingLogCursor(input.cursor),
+      cursor,
     });
   }
 

--- a/workers/recipe-api/src/agent-auth.ts
+++ b/workers/recipe-api/src/agent-auth.ts
@@ -8,9 +8,15 @@ import { and, desc, eq, ilike, inArray, or, type SQL } from "drizzle-orm";
 import type { Db } from "recipe-db";
 import * as schema from "recipe-db/schema";
 import { z } from "zod";
+import {
+  cookingInsightsResponse,
+  cookingLogResponse,
+  decodeCookingLogCursor,
+} from "./cooking-reads";
 
 const READ_GRANT_TTL_SECONDS = 30 * 24 * 60 * 60;
 const MAX_AGENT_LIFETIME_SECONDS = 30 * 24 * 60 * 60;
+const MAX_COOK_LOG_RANGE_MS = 90 * 24 * 60 * 60 * 1_000;
 const AGENT_AUTH_PROVIDER_NAME = "Robbie's Recipes";
 const AGENT_AUTH_PROVIDER_DESCRIPTION =
   "Delegated access to recipes and personal cooking data.";
@@ -68,6 +74,41 @@ const recipeReadInput = z
   })
   .strict();
 
+const cookLogReadInput = z
+  .object({
+    from: z.string().datetime({ offset: true }).optional(),
+    to: z.string().datetime({ offset: true }).optional(),
+    limit: z.number().int().min(1).max(50).default(20),
+    cursor: z
+      .string()
+      .max(500)
+      .refine((value) => decodeCookingLogCursor(value) !== undefined, {
+        message: "Cursor is invalid",
+      })
+      .optional(),
+  })
+  .strict()
+  .superRefine((input, context) => {
+    if (!input.from || !input.to) return;
+    const from = Date.parse(input.from);
+    const to = Date.parse(input.to);
+    if (from > to) {
+      context.addIssue({
+        code: "custom",
+        path: ["from"],
+        message: "from must not be after to",
+      });
+    } else if (to - from > MAX_COOK_LOG_RANGE_MS) {
+      context.addIssue({
+        code: "custom",
+        path: ["from"],
+        message: "Cook log range must not exceed 90 days",
+      });
+    }
+  });
+
+const noArgumentsInput = z.object({}).strict();
+
 const recipeSummarySchema = {
   type: "object",
   additionalProperties: false,
@@ -91,7 +132,26 @@ const recipeSummarySchema = {
   },
 } as const;
 
-export const RECIPE_AGENT_CAPABILITIES = [
+const completedCookingSessionSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "id",
+    "recipeSlug",
+    "recipeTitle",
+    "servings",
+    "completedAt",
+  ],
+  properties: {
+    id: { type: "string", format: "uuid" },
+    recipeSlug: { type: "string" },
+    recipeTitle: { type: "string" },
+    servings: { type: "integer", minimum: 1 },
+    completedAt: { type: "string", format: "date-time" },
+  },
+} as const;
+
+export const RECIPE_SITE_AGENT_CAPABILITIES = [
   {
     name: "recipes.search",
     description:
@@ -152,6 +212,82 @@ export const RECIPE_AGENT_CAPABILITIES = [
             },
             { type: "null" },
           ],
+        },
+      },
+    },
+  },
+  {
+    name: "cook_log.read",
+    description:
+      "Read the delegated user's completed cooking sessions within a bounded date range.",
+    approvalStrength: "session",
+    grantTTL: READ_GRANT_TTL_SECONDS,
+    input: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        from: { type: "string", format: "date-time" },
+        to: { type: "string", format: "date-time" },
+        limit: { type: "integer", minimum: 1, maximum: 50, default: 20 },
+        cursor: { type: "string", maxLength: 500 },
+      },
+    },
+    output: {
+      type: "object",
+      additionalProperties: false,
+      required: ["items", "nextCursor"],
+      properties: {
+        items: {
+          type: "array",
+          maxItems: 50,
+          items: completedCookingSessionSchema,
+        },
+        nextCursor: { type: ["string", "null"] },
+      },
+    },
+  },
+  {
+    name: "cooking_insights.read",
+    description:
+      "Read server-computed cooking totals and the delegated user's recent completed sessions.",
+    approvalStrength: "session",
+    grantTTL: READ_GRANT_TTL_SECONDS,
+    input: {
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    },
+    output: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "cookModeStarts",
+        "mealsCooked",
+        "distinctRecipesCooked",
+        "recent",
+      ],
+      properties: {
+        cookModeStarts: { type: "integer", minimum: 0 },
+        mealsCooked: { type: "integer", minimum: 0 },
+        distinctRecipesCooked: { type: "integer", minimum: 0 },
+        recent: {
+          type: "array",
+          maxItems: 20,
+          items: {
+            ...completedCookingSessionSchema,
+            required: [
+              ...completedCookingSessionSchema.required,
+              "startedAt",
+            ],
+            properties: {
+              ...completedCookingSessionSchema.properties,
+              startedAt: { type: "string", format: "date-time" },
+              completedAt: {
+                type: ["string", "null"],
+                format: "date-time",
+              },
+            },
+          },
         },
       },
     },
@@ -219,9 +355,9 @@ export async function executeRecipeAgentCapability(
   agentSession: AgentSession,
 ) {
   const userId = agentSession.user.id;
-  const visibility = await readableRecipeFilter(db, userId);
 
   if (capability === "recipes.search") {
+    const visibility = await readableRecipeFilter(db, userId);
     const input = recipeSearchInput.parse(args ?? {});
     const pattern = escapedLikePattern(input.query);
     const recipes = await db
@@ -244,6 +380,7 @@ export async function executeRecipeAgentCapability(
   }
 
   if (capability === "recipes.read") {
+    const visibility = await readableRecipeFilter(db, userId);
     const input = recipeReadInput.parse(args ?? {});
     const [recipe] = await db
       .select()
@@ -258,7 +395,32 @@ export async function executeRecipeAgentCapability(
     };
   }
 
-  throw new Error(`Unsupported recipe capability: ${capability}`);
+  if (capability === "cook_log.read") {
+    const input = cookLogReadInput.parse(args ?? {});
+    const to = input.to ? new Date(input.to) : new Date();
+    const from = input.from
+      ? new Date(input.from)
+      : new Date(to.getTime() - MAX_COOK_LOG_RANGE_MS);
+    if (from > to) {
+      throw new Error("from must not be after to");
+    }
+    if (to.getTime() - from.getTime() > MAX_COOK_LOG_RANGE_MS) {
+      throw new Error("Cook log range must not exceed 90 days");
+    }
+    return cookingLogResponse(db, userId, {
+      from,
+      to,
+      limit: input.limit,
+      cursor: decodeCookingLogCursor(input.cursor),
+    });
+  }
+
+  if (capability === "cooking_insights.read") {
+    noArgumentsInput.parse(args ?? {});
+    return cookingInsightsResponse(db, userId);
+  }
+
+  throw new Error(`Unsupported agent capability: ${capability}`);
 }
 
 async function writeAgentAuthAuditEvent(db: Db, event: AgentAuthEvent) {
@@ -293,10 +455,12 @@ export function createRecipeAgentAuthPlugin(db: Db) {
     modes: [...AGENT_AUTH_MODES],
     approvalMethods: [...AGENT_AUTH_APPROVAL_METHODS],
     deviceAuthorizationPage: "/recipes/settings/agents/approve",
-    capabilities: RECIPE_AGENT_CAPABILITIES,
+    capabilities: RECIPE_SITE_AGENT_CAPABILITIES,
     validateCapabilities: (capabilities) =>
       capabilities.every((name) =>
-        RECIPE_AGENT_CAPABILITIES.some((capability) => capability.name === name),
+        RECIPE_SITE_AGENT_CAPABILITIES.some(
+          (capability) => capability.name === name,
+        ),
       ),
     allowDynamicHostRegistration: false,
     defaultHostCapabilities: [],

--- a/workers/recipe-api/src/cooking-reads.ts
+++ b/workers/recipe-api/src/cooking-reads.ts
@@ -28,8 +28,8 @@ export type CookingLogQuery = Readonly<{
 
 const cookingLogCursorSchema = z
   .object({
-    completedAt: z.string().datetime({ offset: true }),
-    id: z.string().uuid(),
+    completedAt: z.iso.datetime({ offset: true }),
+    id: z.uuid(),
   })
   .strict();
 

--- a/workers/recipe-api/src/cooking-reads.ts
+++ b/workers/recipe-api/src/cooking-reads.ts
@@ -17,6 +17,8 @@ import { z } from "zod";
 export type CookingLogCursor = Readonly<{
   completedAt: string;
   id: string;
+  from: string;
+  to: string;
 }>;
 
 export type CookingLogQuery = Readonly<{
@@ -30,6 +32,8 @@ const cookingLogCursorSchema = z
   .object({
     completedAt: z.iso.datetime({ offset: true }),
     id: z.uuid(),
+    from: z.iso.datetime({ offset: true }),
+    to: z.iso.datetime({ offset: true }),
   })
   .strict();
 
@@ -163,6 +167,8 @@ export async function cookingLogResponse(
         ? encodeCookingLogCursor({
             completedAt: last.completedAt.toISOString(),
             id: last.id,
+            from: query.from.toISOString(),
+            to: query.to.toISOString(),
           })
         : null,
   };

--- a/workers/recipe-api/src/cooking-reads.ts
+++ b/workers/recipe-api/src/cooking-reads.ts
@@ -1,0 +1,169 @@
+import {
+  and,
+  count,
+  countDistinct,
+  desc,
+  eq,
+  gte,
+  isNotNull,
+  lt,
+  lte,
+  or,
+} from "drizzle-orm";
+import type { Db } from "recipe-db";
+import * as schema from "recipe-db/schema";
+import { z } from "zod";
+
+export type CookingLogCursor = Readonly<{
+  completedAt: string;
+  id: string;
+}>;
+
+export type CookingLogQuery = Readonly<{
+  from: Date;
+  to: Date;
+  limit: number;
+  cursor?: CookingLogCursor;
+}>;
+
+const cookingLogCursorSchema = z
+  .object({
+    completedAt: z.string().datetime({ offset: true }),
+    id: z.string().uuid(),
+  })
+  .strict();
+
+export function encodeCookingLogCursor(cursor: CookingLogCursor): string {
+  let encoded = btoa(JSON.stringify(cursor))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_");
+  while (encoded.endsWith("=")) encoded = encoded.slice(0, -1);
+  return encoded;
+}
+
+export function decodeCookingLogCursor(
+  value: string | undefined,
+): CookingLogCursor | undefined {
+  if (!value) return undefined;
+  try {
+    let base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    while (base64.length % 4 !== 0) base64 += "=";
+    const parsed = cookingLogCursorSchema.safeParse(JSON.parse(atob(base64)));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function cookingInsightsResponse(db: Db, userId: string) {
+  const [summaries, recent] = await Promise.all([
+    db
+      .select({
+        cookModeStarts: count(),
+        mealsCooked: count(schema.cookingSession.completedAt),
+      })
+      .from(schema.cookingSession)
+      .where(eq(schema.cookingSession.userId, userId)),
+    db
+      .select({
+        id: schema.cookingSession.id,
+        recipeSlug: schema.cookingSession.recipeSlug,
+        recipeTitle: schema.cookingSession.recipeTitle,
+        servings: schema.cookingSession.servings,
+        startedAt: schema.cookingSession.startedAt,
+        completedAt: schema.cookingSession.completedAt,
+      })
+      .from(schema.cookingSession)
+      .where(
+        and(
+          eq(schema.cookingSession.userId, userId),
+          isNotNull(schema.cookingSession.completedAt),
+        ),
+      )
+      .orderBy(desc(schema.cookingSession.completedAt))
+      .limit(20),
+  ]);
+  const summary = summaries[0];
+
+  // count(column) excludes NULL; distinct recipes need their own completed-only
+  // query because the slug itself is present on incomplete starts too.
+  const [completedDistinct] = await db
+    .select({
+      count: countDistinct(schema.cookingSession.recipeSlug),
+    })
+    .from(schema.cookingSession)
+    .where(
+      and(
+        eq(schema.cookingSession.userId, userId),
+        isNotNull(schema.cookingSession.completedAt),
+      ),
+    );
+
+  return {
+    cookModeStarts: summary?.cookModeStarts ?? 0,
+    mealsCooked: summary?.mealsCooked ?? 0,
+    distinctRecipesCooked: completedDistinct?.count ?? 0,
+    recent,
+  };
+}
+
+export async function cookingLogResponse(
+  db: Db,
+  userId: string,
+  query: CookingLogQuery,
+) {
+  const cursorDate = query.cursor
+    ? new Date(query.cursor.completedAt)
+    : undefined;
+  const cursorFilter =
+    query.cursor && cursorDate
+      ? or(
+          lt(schema.cookingSession.completedAt, cursorDate),
+          and(
+            eq(schema.cookingSession.completedAt, cursorDate),
+            lt(schema.cookingSession.id, query.cursor.id),
+          ),
+        )
+      : undefined;
+
+  const rows = await db
+    .select({
+      id: schema.cookingSession.id,
+      recipeSlug: schema.cookingSession.recipeSlug,
+      recipeTitle: schema.cookingSession.recipeTitle,
+      servings: schema.cookingSession.servings,
+      completedAt: schema.cookingSession.completedAt,
+    })
+    .from(schema.cookingSession)
+    .where(
+      and(
+        eq(schema.cookingSession.userId, userId),
+        isNotNull(schema.cookingSession.completedAt),
+        gte(schema.cookingSession.completedAt, query.from),
+        lte(schema.cookingSession.completedAt, query.to),
+        cursorFilter,
+      ),
+    )
+    .orderBy(
+      desc(schema.cookingSession.completedAt),
+      desc(schema.cookingSession.id),
+    )
+    .limit(query.limit + 1);
+
+  const items = rows.slice(0, query.limit).map((row) => ({
+    ...row,
+    completedAt: row.completedAt as Date,
+  }));
+  const last = items.at(-1);
+
+  return {
+    items,
+    nextCursor:
+      rows.length > query.limit && last
+        ? encodeCookingLogCursor({
+            completedAt: last.completedAt.toISOString(),
+            id: last.id,
+          })
+        : null,
+  };
+}

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -15,14 +15,12 @@ import {
 import {
   and,
   count,
-  countDistinct,
   desc,
   eq,
   exists,
   gt,
   gte,
   inArray,
-  isNotNull,
   isNull,
   lt,
   notInArray,
@@ -44,6 +42,7 @@ import { parseSchemaOrgRecipeHtml } from "recipe-parsing/schema-org";
 import { recipeAgentConfiguration } from "./agent-auth";
 import { createAuth } from "./auth";
 import { verifyCloudflareAccess } from "./cloudflare-access";
+import { cookingInsightsResponse } from "./cooking-reads";
 import { hasPostgresErrorCode } from "./db/errors";
 import {
   decodeFeedCursor,
@@ -833,58 +832,6 @@ async function recipeBoxResponse(db: Db, userId: string) {
     recipeSlugs,
     // Remove after the Postgres-backed UI has been deployed everywhere.
     staticRecipeSlugs: recipeSlugs,
-  };
-}
-
-async function cookingInsightsResponse(db: Db, userId: string) {
-  const [summaries, recent] = await Promise.all([
-    db
-      .select({
-        cookModeStarts: count(),
-        mealsCooked: count(schema.cookingSession.completedAt),
-      })
-      .from(schema.cookingSession)
-      .where(eq(schema.cookingSession.userId, userId)),
-    db
-      .select({
-        id: schema.cookingSession.id,
-        recipeSlug: schema.cookingSession.recipeSlug,
-        recipeTitle: schema.cookingSession.recipeTitle,
-        servings: schema.cookingSession.servings,
-        startedAt: schema.cookingSession.startedAt,
-        completedAt: schema.cookingSession.completedAt,
-      })
-      .from(schema.cookingSession)
-      .where(
-        and(
-          eq(schema.cookingSession.userId, userId),
-          isNotNull(schema.cookingSession.completedAt),
-        ),
-      )
-      .orderBy(desc(schema.cookingSession.completedAt))
-      .limit(20),
-  ]);
-  const summary = summaries[0];
-
-  // count(column) excludes NULL; distinct recipes need their own completed-only
-  // query because the slug itself is present on incomplete starts too.
-  const [completedDistinct] = await db
-    .select({
-      count: countDistinct(schema.cookingSession.recipeSlug),
-    })
-    .from(schema.cookingSession)
-    .where(
-      and(
-        eq(schema.cookingSession.userId, userId),
-        isNotNull(schema.cookingSession.completedAt),
-      ),
-    );
-
-  return {
-    cookModeStarts: summary?.cookModeStarts ?? 0,
-    mealsCooked: summary?.mealsCooked ?? 0,
-    distinctRecipesCooked: completedDistinct?.count ?? 0,
-    recent,
   };
 }
 

--- a/workers/recipe-api/tests/agent-auth.test.ts
+++ b/workers/recipe-api/tests/agent-auth.test.ts
@@ -395,6 +395,59 @@ describe("recipe Agent Auth capabilities", () => {
     ).rejects.toThrow();
   });
 
+  it("keeps the original cooking-log date window across pages", async () => {
+    const firstPage = await executeRecipeAgentCapability(
+      queryDb([
+        {
+          id: "00000000-0000-4000-8000-000000000062",
+          recipeSlug: "tomato-soup",
+          recipeTitle: "Tomato Soup",
+          servings: 2,
+          completedAt: new Date("2026-08-20T18:30:00.000Z"),
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000061",
+          recipeSlug: "lentil-soup",
+          recipeTitle: "Lentil Soup",
+          servings: 4,
+          completedAt: new Date("2026-08-19T18:30:00.000Z"),
+        },
+      ]),
+      "cook_log.read",
+      {
+        from: "2026-08-01T00:00:00.000Z",
+        to: "2026-08-22T00:00:00.000Z",
+        limit: 1,
+      },
+      agentSession(),
+    );
+    if (!("nextCursor" in firstPage)) {
+      throw new Error("Expected a cooking-log response");
+    }
+    const nextCursor = firstPage.nextCursor;
+    expect(nextCursor).toBeTypeOf("string");
+
+    const secondPage = await executeRecipeAgentCapability(
+      queryDb([]),
+      "cook_log.read",
+      { cursor: nextCursor },
+      agentSession(),
+    );
+
+    expect(secondPage).toEqual({ items: [], nextCursor: null });
+    await expect(
+      executeRecipeAgentCapability(
+        queryDb([]),
+        "cook_log.read",
+        {
+          cursor: nextCursor,
+          from: "2026-08-02T00:00:00.000Z",
+        },
+        agentSession(),
+      ),
+    ).rejects.toThrow("Cursor does not match the requested date range");
+  });
+
   it("returns server-computed cooking insights for the delegated user", async () => {
     const completedAt = new Date("2026-08-20T18:30:00.000Z");
     const result = await executeRecipeAgentCapability(

--- a/workers/recipe-api/tests/agent-auth.test.ts
+++ b/workers/recipe-api/tests/agent-auth.test.ts
@@ -384,7 +384,10 @@ describe("recipe Agent Auth capabilities", () => {
         },
         agentSession(),
       ),
-    ).rejects.toThrow("Cook log range must not exceed 90 days");
+    ).rejects.toMatchObject({
+      status: "BAD_REQUEST",
+      message: "Cook log range must not exceed 90 days",
+    });
     await expect(
       executeRecipeAgentCapability(
         queryDb([]),

--- a/workers/recipe-api/tests/agent-auth.test.ts
+++ b/workers/recipe-api/tests/agent-auth.test.ts
@@ -6,7 +6,7 @@ import {
   createRecipeAgentAuthPlugin,
   escapedLikePattern,
   executeRecipeAgentCapability,
-  RECIPE_AGENT_CAPABILITIES,
+  RECIPE_SITE_AGENT_CAPABILITIES,
 } from "../src/agent-auth";
 import { createAuth } from "../src/auth";
 
@@ -203,12 +203,17 @@ describe("recipe Agent Auth capabilities", () => {
     expect(state.writes[0]?.expiresAt.getTime()).toBeGreaterThan(Date.now());
   });
 
-  it("exposes only the first delegated read slice", () => {
+  it("exposes recipe and committed cooking-history reads", () => {
     expect(
-      RECIPE_AGENT_CAPABILITIES.map((capability) => capability.name),
-    ).toEqual(["recipes.search", "recipes.read"]);
+      RECIPE_SITE_AGENT_CAPABILITIES.map((capability) => capability.name),
+    ).toEqual([
+      "recipes.search",
+      "recipes.read",
+      "cook_log.read",
+      "cooking_insights.read",
+    ]);
     expect(
-      RECIPE_AGENT_CAPABILITIES.every(
+      RECIPE_SITE_AGENT_CAPABILITIES.every(
         (capability) =>
           capability.approvalStrength === "session" &&
           capability.grantTTL === 30 * 24 * 60 * 60,
@@ -217,7 +222,7 @@ describe("recipe Agent Auth capabilities", () => {
   });
 
   it("bounds recipe search input and result size", () => {
-    const search = RECIPE_AGENT_CAPABILITIES.find(
+    const search = RECIPE_SITE_AGENT_CAPABILITIES.find(
       (capability) => capability.name === "recipes.search",
     );
 
@@ -231,6 +236,25 @@ describe("recipe Agent Auth capabilities", () => {
     });
     expect(search?.output).toMatchObject({
       properties: { items: { maxItems: 25 } },
+    });
+  });
+
+  it("bounds cooking log dates, cursors, and result size", () => {
+    const cookLog = RECIPE_SITE_AGENT_CAPABILITIES.find(
+      (capability) => capability.name === "cook_log.read",
+    );
+
+    expect(cookLog?.input).toMatchObject({
+      additionalProperties: false,
+      properties: {
+        from: { format: "date-time" },
+        to: { format: "date-time" },
+        limit: { minimum: 1, maximum: 50, default: 20 },
+        cursor: { maxLength: 500 },
+      },
+    });
+    expect(cookLog?.output).toMatchObject({
+      properties: { items: { maxItems: 50 } },
     });
   });
 
@@ -280,9 +304,11 @@ describe("recipe Agent Auth capabilities", () => {
       agentSession(),
     );
 
-    expect(result.items).toMatchObject([
-      { slug: "household-stew", visibility: "household", owned: false },
-    ]);
+    expect(result).toMatchObject({
+      items: [
+        { slug: "household-stew", visibility: "household", owned: false },
+      ],
+    });
   });
 
   it("reads one visible recipe with its Cooklang body", async () => {
@@ -312,6 +338,93 @@ describe("recipe Agent Auth capabilities", () => {
     ).resolves.toEqual({ recipe: null });
   });
 
+  it("reads only bounded completed cooking-log rows for the delegated user", async () => {
+    const completedAt = new Date("2026-08-20T18:30:00.000Z");
+    const result = await executeRecipeAgentCapability(
+      queryDb([
+        {
+          id: "00000000-0000-4000-8000-000000000062",
+          recipeSlug: "tomato-soup",
+          recipeTitle: "Tomato Soup",
+          servings: 2,
+          completedAt,
+        },
+      ]),
+      "cook_log.read",
+      {
+        from: "2026-08-01T00:00:00.000Z",
+        to: "2026-08-22T00:00:00.000Z",
+        limit: 10,
+      },
+      agentSession(),
+    );
+
+    expect(result).toEqual({
+      items: [
+        {
+          id: "00000000-0000-4000-8000-000000000062",
+          recipeSlug: "tomato-soup",
+          recipeTitle: "Tomato Soup",
+          servings: 2,
+          completedAt,
+        },
+      ],
+      nextCursor: null,
+    });
+  });
+
+  it("rejects unbounded or malformed cooking-log requests", async () => {
+    await expect(
+      executeRecipeAgentCapability(
+        queryDb([]),
+        "cook_log.read",
+        {
+          from: "2026-01-01T00:00:00.000Z",
+          to: "2026-08-22T00:00:00.000Z",
+        },
+        agentSession(),
+      ),
+    ).rejects.toThrow("Cook log range must not exceed 90 days");
+    await expect(
+      executeRecipeAgentCapability(
+        queryDb([]),
+        "cook_log.read",
+        { cursor: "not-a-cursor" },
+        agentSession(),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("returns server-computed cooking insights for the delegated user", async () => {
+    const completedAt = new Date("2026-08-20T18:30:00.000Z");
+    const result = await executeRecipeAgentCapability(
+      queryDb(
+        [{ cookModeStarts: 4, mealsCooked: 3 }],
+        [
+          {
+            id: "00000000-0000-4000-8000-000000000063",
+            recipeSlug: "tomato-soup",
+            recipeTitle: "Tomato Soup",
+            servings: 2,
+            startedAt: new Date("2026-08-20T18:00:00.000Z"),
+            completedAt,
+          },
+        ],
+        [{ count: 2 }],
+      ),
+      "cooking_insights.read",
+      {},
+      agentSession(),
+    );
+
+    expect(result).toMatchObject({
+      cookModeStarts: 4,
+      mealsCooked: 3,
+      distinctRecipesCooked: 2,
+      recent: [{ recipeSlug: "tomato-soup", completedAt }],
+    });
+  });
+
   it("rejects malformed and unsupported capability requests", async () => {
     await expect(
       executeRecipeAgentCapability(
@@ -328,7 +441,7 @@ describe("recipe Agent Auth capabilities", () => {
         {},
         agentSession(),
       ),
-    ).rejects.toThrow("Unsupported recipe capability: recipes.delete");
+    ).rejects.toThrow("Unsupported agent capability: recipes.delete");
   });
 
   it("validates, executes, and audits through the Agent Auth callbacks", async () => {

--- a/workers/recipe-api/tests/cooking-reads.test.ts
+++ b/workers/recipe-api/tests/cooking-reads.test.ts
@@ -9,6 +9,8 @@ describe("cooking-log cursors", () => {
     const cursor = {
       completedAt: "2026-08-20T18:30:00.000Z",
       id: "00000000-0000-4000-8000-000000000062",
+      from: "2026-08-01T00:00:00.000Z",
+      to: "2026-08-22T00:00:00.000Z",
     };
 
     expect(decodeCookingLogCursor(encodeCookingLogCursor(cursor))).toEqual(

--- a/workers/recipe-api/tests/cooking-reads.test.ts
+++ b/workers/recipe-api/tests/cooking-reads.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeCookingLogCursor,
+  encodeCookingLogCursor,
+} from "../src/cooking-reads";
+
+describe("cooking-log cursors", () => {
+  it("round-trips a stable completed-at and ID cursor", () => {
+    const cursor = {
+      completedAt: "2026-08-20T18:30:00.000Z",
+      id: "00000000-0000-4000-8000-000000000062",
+    };
+
+    expect(decodeCookingLogCursor(encodeCookingLogCursor(cursor))).toEqual(
+      cursor,
+    );
+  });
+
+  it.each([undefined, "", "not-base64", btoa("{}")])(
+    "rejects malformed cursor %s",
+    (cursor) => {
+      expect(decodeCookingLogCursor(cursor)).toBeUndefined();
+    },
+  );
+});

--- a/workers/recipe-api/tests/integration/database.test.ts
+++ b/workers/recipe-api/tests/integration/database.test.ts
@@ -10,6 +10,10 @@ import {
   vi,
 } from "vitest";
 import { createAuth } from "../../src/auth";
+import {
+  cookingLogResponse,
+  decodeCookingLogCursor,
+} from "../../src/cooking-reads";
 import { app, type Bindings } from "../../src/index";
 
 const databaseURL = process.env.DATABASE_URL;
@@ -511,6 +515,72 @@ describe("recipe API PostgreSQL integration", () => {
         .from(schema.cookingSession)
         .where(eq(schema.cookingSession.userId, cook.id)),
     ).toHaveLength(0);
+  });
+
+  it("scopes and paginates delegated cooking-log reads", async () => {
+    const cook = await createUser("History Cook", "history-cook@example.test");
+    const otherCook = await createUser(
+      "Other History Cook",
+      "other-history-cook@example.test",
+    );
+    await db.insert(schema.cookingSession).values([
+      {
+        id: "2f64837b-3f3e-4c18-ae39-35df6808dc61",
+        userId: cook.id,
+        recipeSlug: "older-soup",
+        recipeTitle: "Older Soup",
+        servings: 2,
+        startedAt: new Date("2026-08-19T17:00:00.000Z"),
+        completedAt: new Date("2026-08-19T18:00:00.000Z"),
+      },
+      {
+        id: "2f64837b-3f3e-4c18-ae39-35df6808dc62",
+        userId: cook.id,
+        recipeSlug: "newer-stew",
+        recipeTitle: "Newer Stew",
+        servings: 4,
+        startedAt: new Date("2026-08-20T17:00:00.000Z"),
+        completedAt: new Date("2026-08-20T18:00:00.000Z"),
+      },
+      {
+        id: "2f64837b-3f3e-4c18-ae39-35df6808dc63",
+        userId: otherCook.id,
+        recipeSlug: "private-pasta",
+        recipeTitle: "Private Pasta",
+        servings: 8,
+        startedAt: new Date("2026-08-21T17:00:00.000Z"),
+        completedAt: new Date("2026-08-21T18:00:00.000Z"),
+      },
+    ]);
+
+    const range = {
+      from: new Date("2026-08-01T00:00:00.000Z"),
+      to: new Date("2026-08-31T23:59:59.999Z"),
+      limit: 1,
+    };
+    const firstPage = await cookingLogResponse(db, cook.id, range);
+
+    expect(firstPage.items).toMatchObject([
+      {
+        id: "2f64837b-3f3e-4c18-ae39-35df6808dc62",
+        recipeSlug: "newer-stew",
+      },
+    ]);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const secondPage = await cookingLogResponse(db, cook.id, {
+      ...range,
+      cursor: decodeCookingLogCursor(firstPage.nextCursor ?? undefined),
+    });
+    expect(secondPage).toMatchObject({
+      items: [
+        {
+          id: "2f64837b-3f3e-4c18-ae39-35df6808dc61",
+          recipeSlug: "older-soup",
+        },
+      ],
+      nextCursor: null,
+    });
   });
 
   it("persists household membership and preserves notification snapshots", async () => {


### PR DESCRIPTION
## Summary

- add bounded, cursor-paginated `cook_log.read` and server-computed `cooking_insights.read` capabilities for the delegated user
- add host/account/expiry context to approval plus a recipe-settings panel for inspecting and independently revoking agents
- extend database isolation tests and the protected-preview smoke flow through cooking-history reads, revocation, and unaffected browser access

Pantry access is deliberately excluded. SC-449 moves the remaining browser-owned multiplayer pantry state into Postgres before SC-450 adds `pantry.read`.

## Verification

- `mise run //workers/recipe-api:check`
- `mise run //workers/recipe-api:test:integration`
- `mise run //ui:check`
- protected PR preview: registration, notification approval context, four delegated reads, replay rejection, independent revocation, revoked-call denial, lifecycle listing, and unaffected browser-session access
- SonarCloud quality gate: passed with zero open issues

## Tracking

- [SC-447](https://app.shortcut.com/personal-294/story/447)
- ADR 061 follow-ups: SC-449 through SC-457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Agents section in Settings to view active access grants, capabilities, hosts, usage and expiry dates.
  - Added controls to revoke agent access and approve or deny requested capabilities.
  - Agents can now access completed cooking logs and cooking insights with date-range and pagination support.
  - Added cooking insights covering completed meals, recipe variety and recent cooking activity.

- **Bug Fixes**
  - Improved loading, error and empty states for agent management.
  - Added clearer access-expiry fallbacks and more reliable approval handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->