### PR TITLE
Add media stack health gauges and Slack alerting

### DIFF
--- a/homelab/README.md
+++ b/homelab/README.md
@@ -147,8 +147,16 @@ mise run //homelab:media-provision   # re-run wiring; safe to repeat
   agent refuse to start the containers until the hub's default route runs
   through a VPN tunnel interface, so torrent traffic never touches the
   residential line during the boot race ([ADR 020](/projects/homelab/adrs/020-vpn-gated-stack)).
-- The [Netdata](/projects/homelab/adrs/009-netdata) alerting should cover
-  these containers as well.
+- **Health gauges and alerts.** The keep-running agent probes every service
+  endpoint each cycle (plus the VPN tunnel itself) and pushes 0/1 gauges into
+  Netdata's local StatsD listener; it also restarts any container Docker marks
+  unhealthy for three consecutive cycles, since a hung process never exits and
+  Docker's own restart policy never fires for one.
+  [`netdata/health.d/media_automation.conf`](hosts/mac-mini/netdata/health.d/media_automation.conf)
+  turns those gauges into Slack alerts through the existing Netdata
+  notification pipeline. Install it with:
+  `cp hosts/mac-mini/netdata/health.d/media_automation.conf /opt/homebrew/etc/netdata/health.d/`
+  and restart netdata.
 
 ## SilverBullet on the Mac mini
 
@@ -228,8 +236,11 @@ mise run //homelab:sb-verify
 - **SilverBullet listens on localhost only.** The Docker compose file binds
   `127.0.0.1`. Remote access goes through Tailscale Serve, not direct
   port exposure.
-- The [Netdata](/projects/homelab/adrs/009-netdata) alerting should also
-  check the SilverBullet container health.
+- **SilverBullet health is watched too.** The media-automation keep-running
+  agent reports the SilverBullet container's Docker health as a Netdata gauge,
+  and the shared
+  [`media_automation.conf`](hosts/mac-mini/netdata/health.d/media_automation.conf)
+  alarm file raises a Slack alert if it stays unhealthy or exits.
 
 ## Basic Memory on the Mac mini
 

--- a/homelab/README.md
+++ b/homelab/README.md
@@ -58,9 +58,10 @@ mise run //homelab:verify
   on the LAN during the few seconds bootstrap runs.
 - **The drive must be mounted before bootstrap.** If the volume isn't
   connected or auto-mounted at login, the mount point won't exist.
-- The [Netdata](/projects/homelab/adrs/009-netdata) alerting on the hub
-  should gain a check for the Jellyfin container and the media drive, so a
-  dead stack is noticed before the family does.
+- The [Netdata](/projects/homelab/adrs/009-netdata) alerting on the hub now
+  covers the Jellyfin container (see the media automation section below);
+  the media drive itself is the remaining gap, so a dead disk is only
+  noticed when playback fails.
 
 ## Media automation on the Mac mini
 

--- a/homelab/hosts/mac-mini/media-automation/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/media-automation/scripts/keep-running.sh
@@ -10,13 +10,52 @@ set -uo pipefail
 # The stack is only brought up while the hub's default route runs through a
 # VPN tunnel interface (utun*); see ADR 020. Until a tunnel appears, the VM
 # still starts but the containers are held back, cycle by cycle.
+#
+# Every cycle also reports health gauges to Netdata's local StatsD listener
+# (see health.d/media_automation.conf): one per service endpoint, one for the
+# VPN tunnel itself, and one for each container's Docker health status. A
+# container that stays unhealthy for UNHEALTHY_RESTART_THRESHOLD consecutive
+# cycles is restarted here — a hung process never exits, so Docker's own
+# restart policy never fires for it.
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export DOCKER_CONTEXT="colima"
 
 MEDIA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHECK_INTERVAL_SECONDS="${CHECK_INTERVAL_SECONDS:-60}"
+UNHEALTHY_RESTART_THRESHOLD="${UNHEALTHY_RESTART_THRESHOLD:-3}"
 LOG_TS="+%F %T"
+STATSD_HOST="${STATSD_HOST:-127.0.0.1}"
+STATSD_PORT="${STATSD_PORT:-8125}"
+
+# Consecutive unhealthy cycles per container. Two parallel indexed arrays
+# instead of an associative array: launchd runs this under /bin/bash, and
+# macOS's bash 3.2 predates declare -A.
+UNHEALTHY_NAMES=()
+UNHEALTHY_COUNTS=()
+
+unhealthy_count() {
+  local i
+  for ((i = 0; i < ${#UNHEALTHY_NAMES[@]}; i++)); do
+    if [[ "${UNHEALTHY_NAMES[$i]}" == "$1" ]]; then
+      echo "${UNHEALTHY_COUNTS[$i]}"
+      return
+    fi
+  done
+  echo 0
+}
+
+unhealthy_set() {
+  local i
+  for ((i = 0; i < ${#UNHEALTHY_NAMES[@]}; i++)); do
+    if [[ "${UNHEALTHY_NAMES[$i]}" == "$1" ]]; then
+      UNHEALTHY_COUNTS[$i]="$2"
+      return
+    fi
+  done
+  UNHEALTHY_NAMES+=("$1")
+  UNHEALTHY_COUNTS+=("$2")
+}
 
 colima_running() {
   if colima status >/dev/null 2>&1; then
@@ -34,7 +73,82 @@ vpn_tunnel_active() {
   return 1
 }
 
+# Any HTTP response at all means the process is alive and serving; the
+# status code is irrelevant (qBittorrent returns 401 without a session).
+service_up() {
+  local url="$1" code=""
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null)" || return 1
+  [[ "$code" =~ ^[0-9]+$ ]]
+}
+
+# Netdata's StatsD gauges decay to zero within seconds of the last packet, so
+# each reading is resent every GAUGE_RESEND_SECONDS to keep charts warm
+# between probes.
+GAUGE_RESEND_SECONDS="${GAUGE_RESEND_SECONDS:-10}"
+declare -a LAST_GAUGES=()
+
+gauge() {
+  # Netdata's StatsD listener takes "<name>:<value>|g" per the StatsD
+  # protocol; a comma instead of a colon parses as a DogStatsD tag and the
+  # value never registers.
+  printf '%s:%s|g\n' "$1" "$2" > "/dev/udp/${STATSD_HOST}/${STATSD_PORT}"
+}
+
+resend_gauges() {
+  local line
+  for line in ${LAST_GAUGES[@]+"${LAST_GAUGES[@]}"}; do
+    printf '%s\n' "$line" > "/dev/udp/${STATSD_HOST}/${STATSD_PORT}"
+  done
+}
+
+report_gauges() {
+  local fresh=()
+  fresh+=("media_tunnel_up:$(vpn_tunnel_active && echo 1 || echo 0)|g")
+  fresh+=("media_jellyfin_up:$(service_up http://localhost:8096/health && echo 1 || echo 0)|g")
+  fresh+=("media_sonarr_up:$(service_up http://localhost:8989/ping && echo 1 || echo 0)|g")
+  fresh+=("media_radarr_up:$(service_up http://localhost:7878/ping && echo 1 || echo 0)|g")
+  fresh+=("media_prowlarr_up:$(service_up http://localhost:9696/ping && echo 1 || echo 0)|g")
+  fresh+=("media_qbittorrent_up:$(service_up http://localhost:8080/api/v2/app/version && echo 1 || echo 0)|g")
+  LAST_GAUGES=("${fresh[@]}")
+}
+
+# Restarts containers that Docker marks unhealthy for too many consecutive
+# cycles, and appends every tracked container's health as a gauge line.
+watch_container_health() {
+  local name health
+  while IFS=$'\t' read -r name health; do
+    name="${name#/}"
+    [[ -n "$name" ]] || continue
+    if [[ "$health" == "unhealthy" ]]; then
+      cycles="$(unhealthy_count "$name")"
+      cycles=$((cycles + 1))
+      unhealthy_set "$name" "$cycles"
+      if (( cycles >= UNHEALTHY_RESTART_THRESHOLD )); then
+        echo "$(date "$LOG_TS") $name unhealthy $cycles cycles; restarting" >&2
+        docker restart "$name" >/dev/null 2>&1 \
+          && unhealthy_set "$name" 0 \
+          || echo "$(date "$LOG_TS") $name restart failed; retrying next cycle" >&2
+      fi
+    else
+      unhealthy_set "$name" 0
+    fi
+    # Containers without a health check count as healthy: "unhealthy" means
+    # Docker's probe failed, and that is the only state worth alerting on.
+    if [[ "$health" == "healthy" || "$health" == "running" ]]; then
+      LAST_GAUGES+=("media_${name//-/_}_container_healthy:1|g")
+    else
+      LAST_GAUGES+=("media_${name//-/_}_container_healthy:0|g")
+    fi
+  done < <(docker ps -q 2>/dev/null \
+    | xargs -n 25 docker inspect \
+      --format '{{.Name}}{{"\t"}}{{if .State.Health}}{{.State.Health.Status}}{{else if .State.Running}}running{{else}}stopped{{end}}' 2>/dev/null)
+}
+
 while true; do
+  report_gauges
+  watch_container_health
+  resend_gauges
+
   if ! colima_running; then
     echo "$(date "$LOG_TS") colima is not running; starting it" >&2
     colima start \
@@ -56,5 +170,15 @@ while true; do
     echo "$(date "$LOG_TS") no VPN tunnel on the default route; holding the stack (ADR 020)" >&2
   fi
 
-  sleep "$CHECK_INTERVAL_SECONDS"
+  remaining="$CHECK_INTERVAL_SECONDS"
+  while (( remaining > 0 )); do
+    if (( remaining < GAUGE_RESEND_SECONDS )); then
+      sleep "$remaining"
+      remaining=0
+    else
+      sleep "$GAUGE_RESEND_SECONDS"
+      (( remaining -= GAUGE_RESEND_SECONDS ))
+    fi
+    resend_gauges
+  done
 done

--- a/homelab/hosts/mac-mini/media-automation/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/media-automation/scripts/keep-running.sh
@@ -35,26 +35,26 @@ UNHEALTHY_NAMES=()
 UNHEALTHY_COUNTS=()
 
 unhealthy_count() {
-  local i
+  local i name="$1"
   for ((i = 0; i < ${#UNHEALTHY_NAMES[@]}; i++)); do
-    if [[ "${UNHEALTHY_NAMES[$i]}" == "$1" ]]; then
+    if [[ "${UNHEALTHY_NAMES[$i]}" == "$name" ]]; then
       echo "${UNHEALTHY_COUNTS[$i]}"
-      return
+      return 0
     fi
   done
   echo 0
 }
 
 unhealthy_set() {
-  local i
+  local i name="$1" count="$2"
   for ((i = 0; i < ${#UNHEALTHY_NAMES[@]}; i++)); do
-    if [[ "${UNHEALTHY_NAMES[$i]}" == "$1" ]]; then
-      UNHEALTHY_COUNTS[$i]="$2"
-      return
+    if [[ "${UNHEALTHY_NAMES[$i]}" == "$name" ]]; then
+      UNHEALTHY_COUNTS[$i]="$count"
+      return 0
     fi
   done
-  UNHEALTHY_NAMES+=("$1")
-  UNHEALTHY_COUNTS+=("$2")
+  UNHEALTHY_NAMES+=("$name")
+  UNHEALTHY_COUNTS+=("$count")
 }
 
 colima_running() {
@@ -88,10 +88,12 @@ GAUGE_RESEND_SECONDS="${GAUGE_RESEND_SECONDS:-10}"
 declare -a LAST_GAUGES=()
 
 gauge() {
+  local name="$1" value="$2"
   # Netdata's StatsD listener takes "<name>:<value>|g" per the StatsD
   # protocol; a comma instead of a colon parses as a DogStatsD tag and the
   # value never registers.
-  printf '%s:%s|g\n' "$1" "$2" > "/dev/udp/${STATSD_HOST}/${STATSD_PORT}"
+  printf '%s:%s|g\n' "$name" "$value" > "/dev/udp/${STATSD_HOST}/${STATSD_PORT}"
+  return 0
 }
 
 resend_gauges() {
@@ -99,6 +101,7 @@ resend_gauges() {
   for line in ${LAST_GAUGES[@]+"${LAST_GAUGES[@]}"}; do
     printf '%s\n' "$line" > "/dev/udp/${STATSD_HOST}/${STATSD_PORT}"
   done
+  return 0
 }
 
 report_gauges() {
@@ -110,6 +113,7 @@ report_gauges() {
   fresh+=("media_prowlarr_up:$(service_up http://localhost:9696/ping && echo 1 || echo 0)|g")
   fresh+=("media_qbittorrent_up:$(service_up http://localhost:8080/api/v2/app/version && echo 1 || echo 0)|g")
   LAST_GAUGES=("${fresh[@]}")
+  return 0
 }
 
 # Restarts containers that Docker marks unhealthy for too many consecutive
@@ -142,6 +146,7 @@ watch_container_health() {
   done < <(docker ps -q 2>/dev/null \
     | xargs -n 25 docker inspect \
       --format '{{.Name}}{{"\t"}}{{if .State.Health}}{{.State.Health.Status}}{{else if .State.Running}}running{{else}}stopped{{end}}' 2>/dev/null)
+  return 0
 }
 
 while true; do

--- a/homelab/hosts/mac-mini/media-automation/scripts/keep-running.sh
+++ b/homelab/hosts/mac-mini/media-automation/scripts/keep-running.sh
@@ -28,6 +28,12 @@ LOG_TS="+%F %T"
 STATSD_HOST="${STATSD_HOST:-127.0.0.1}"
 STATSD_PORT="${STATSD_PORT:-8125}"
 
+# The qBittorrent probe must match the host port compose publishes. Read the
+# same variable the compose file interpolates, without sourcing the .env's
+# secrets into this process.
+QBITTORRENT_PORT="$(sed -n 's/^QBITTORRENT_PORT=//p' "$MEDIA_DIR/.env" 2>/dev/null | tr -d '\"'"'"' \r')"
+QBITTORRENT_PORT="${QBITTORRENT_PORT:-8080}"
+
 # Consecutive unhealthy cycles per container. Two parallel indexed arrays
 # instead of an associative array: launchd runs this under /bin/bash, and
 # macOS's bash 3.2 predates declare -A.
@@ -111,7 +117,7 @@ report_gauges() {
   fresh+=("media_sonarr_up:$(service_up http://localhost:8989/ping && echo 1 || echo 0)|g")
   fresh+=("media_radarr_up:$(service_up http://localhost:7878/ping && echo 1 || echo 0)|g")
   fresh+=("media_prowlarr_up:$(service_up http://localhost:9696/ping && echo 1 || echo 0)|g")
-  fresh+=("media_qbittorrent_up:$(service_up http://localhost:8080/api/v2/app/version && echo 1 || echo 0)|g")
+  fresh+=("media_qbittorrent_up:$(service_up "http://localhost:${QBITTORRENT_PORT}/api/v2/app/version" && echo 1 || echo 0)|g")
   LAST_GAUGES=("${fresh[@]}")
   return 0
 }
@@ -119,7 +125,7 @@ report_gauges() {
 # Restarts containers that Docker marks unhealthy for too many consecutive
 # cycles, and appends every tracked container's health as a gauge line.
 watch_container_health() {
-  local name health
+  local name health cycles
   while IFS=$'\t' read -r name health; do
     name="${name#/}"
     [[ -n "$name" ]] || continue

--- a/homelab/hosts/mac-mini/netdata/health.d/media_automation.conf
+++ b/homelab/hosts/mac-mini/netdata/health.d/media_automation.conf
@@ -1,0 +1,84 @@
+# Media automation health alarms (ADR 016/020/021 companion).
+#
+# keep-running.sh pushes one StatsD gauge per service into the local Netdata
+# listener every cycle: media_<name>_up for HTTP liveness and
+# media_<container>_container_healthy for Docker health status. These rules
+# raise a warning on any zero reading and clear it automatically once the
+# gauge returns to 1; notifications ride the existing Slack integration in
+# health_alarm_notify.conf.
+#
+# Install: cp health.d/media_automation.conf /opt/homebrew/etc/netdata/health.d/
+# then `launchctl kickstart -k gui/$(id -u)/homebrew.mxcl.netdata` (or restart
+# netdata) to reload.
+
+ template: media_jellyfin_down
+       on: statsd_media.jellyfin_up_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 2m
+    info: Jellyfin is not answering HTTP health checks on localhost:8096
+     to: sysadmin
+
+ template: media_sonarr_down
+       on: statsd_media.sonarr_up_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 2m
+    info: Sonarr is not answering pings on localhost:8989
+     to: sysadmin
+
+ template: media_radarr_down
+       on: statsd_media.radarr_up_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 2m
+    info: Radarr is not answering pings on localhost:7878
+     to: sysadmin
+
+ template: media_prowlarr_down
+       on: statsd_media.prowlarr_up_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 2m
+    info: Prowlarr is not answering pings on localhost:9696
+     to: sysadmin
+
+ template: media_qbittorrent_down
+       on: statsd_media.qbittorrent_up_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 2m
+    info: qBittorrent is not answering on localhost:8080
+     to: sysadmin
+
+ template: media_vpn_tunnel_down
+       on: statsd_media.tunnel_up_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 5m
+    info: The hub's default route no longer runs through a VPN tunnel interface
+     to: sysadmin
+
+ template: media_jellyfin_container_unhealthy
+       on: statsd_media.jellyfin_container_healthy_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 4m
+    info: The Jellyfin container's Docker health check is failing or it has exited
+     to: sysadmin
+
+ template: media_silverbullet_container_unhealthy
+       on: statsd_media.silverbullet_container_healthy_gauge
+     calc: $gauge
+   every: 30s
+    warn: $this == 0
+   delay: down 5m
+    info: The SilverBullet container's Docker health check is failing or it has exited
+     to: sysadmin

--- a/ui/content/projects/homelab/index.mdx
+++ b/ui/content/projects/homelab/index.mdx
@@ -101,7 +101,7 @@ kit would solve a software problem with more hardware.
   an upgrade can never silently break the GPU and every change is reviewable
   and rollbackable.
 * As the lab owner, I want Netdata to tell Slack when something is
-  overheating or down, so I find out about problems before they matter.
+  overheating, down, or hung, so I find out about problems before they matter.
 * As a web developer, I want agents to test changes on real Android 10, newer
   Android, and iOS 15 hardware, so mobile regressions are caught before
   a pull request merges.
@@ -399,7 +399,10 @@ owns the photo backup pipeline, the lab's two most important jobs.
   either way; only the mini's own traffic is tunnelled.
 * **Monitoring.** It runs [Netdata](/projects/homelab/adrs/009-netdata),
   connected to my Slack workspace via a Slack app, to alarm on anything
-  going wrong.
+  going wrong. The media stack feeds it per-service health gauges through
+  its StatsD listener, and the supervisor that keeps that stack alive
+  restarts containers Docker marks unhealthy — the hung-process case a
+  restart policy can never catch.
 * **Media.** It runs [Jellyfin](/projects/homelab/adrs/011-jellyfin) to serve
   TV shows and movies to my Fire TV Stick, in Docker Compose under colima
   with its config declared in `homelab/hosts/mac-mini/jellyfin/` in this


### PR DESCRIPTION
## What

Closes the monitoring gap that last night's Jellyfin incident exposed: the
container sat `Up (unhealthy)` for over an hour while nothing watched it —
a hung process never exits, so Docker's restart policy never fires and
nothing alerted.

## Changes

- **`keep-running.sh`** (existing 60s supervisor loop):
  - Probes every service each cycle (Jellyfin `/health`, arrs' `/ping`,
    qBittorrent version endpoint — any HTTP answer means alive) plus a VPN
    tunnel default-route check, and pushes 0/1 gauges into Netdata's local
    StatsD listener over `/dev/udp`.
  - Gauges are resent every 10 s between probes because Netdata's StatsD
    gauges decay to zero within seconds of the last packet.
  - Restarts any container Docker marks `unhealthy` for three consecutive
    cycles (verified live: it caught and restarted an unhealthy SilverBullet
    within minutes of deploy).
  - Stays compatible with macOS's system bash 3.2, which launchd uses —
    no associative arrays.
- **`netdata/health.d/media_automation.conf`** (new, committed for
  reproducibility): eight alarms on those gauges riding the existing
  Netdata→Slack pipeline. `delay: down` hysteresis suppresses transient
  blips; only sustained outages page. Install line documented in README.
- **Docs**: README caveats replace two "alerting should cover this"
  placeholders with what now exists; homelab page monitoring bullet and
  user story updated.

## Verification

- All eight gauges report real values; all alarms CLEAR on a healthy stack.
- Live-fire: stopped Jellyfin — container alarm went WARNING immediately,
  the supervisor brought it back within one cycle, and the service alarm's
  2-minute hysteresis correctly suppressed the transient.
- Slack delivery proven end-to-end via `alarm-notify.sh test sysadmin`
  (`sent slack notification to '#homelab-alerts'` on both transitions).
- One debugging note baked into comments: StatsD takes `name:value|g` —
  a comma parses as a DogStatsD tag and the value silently never registers.

## Notes for reviewers

- SilverBullet was found genuinely unhealthy right after rollout (the new
  alarm caught it); investigating separately.
- Pre-existing `lint:yaml`/`lint:markdown` failures on main are unrelated
  (infra mkdocs tags, vendored trash-guides files); MDX check identical
  before/after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health monitoring for media automation services, VPN connectivity, and SilverBullet.
  * Added Netdata dashboards and alerts for unavailable or unhealthy services.
  * Added automatic container recovery after repeated unhealthy checks.
  * Health readings are refreshed regularly to improve monitoring reliability.

* **Documentation**
  * Updated homelab documentation and project content to describe service health reporting, alerts, and recovery of hung processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->