### PR TITLE
fix(homelab): probe silverbullet healthcheck over IPv4 loopback

### DIFF
--- a/homelab/hosts/mac-mini/silverbullet/docker-compose.yml
+++ b/homelab/hosts/mac-mini/silverbullet/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     cap_drop:
       - ALL
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3000/"]
       interval: 1m
       timeout: 5s
       retries: 3


### PR DESCRIPTION
The compose healthcheck probed `http://localhost:3000/`. Inside the container busybox wget resolves localhost to `::1` first and never falls back to IPv4, while SilverBullet binds `0.0.0.0:3000` only. Every probe got connection refused, so the container sat at `unhealthy` permanently even though it served fine on the host.

Side effect: the media automation watchdog restarts any container that stays unhealthy for three consecutive cycles, so SilverBullet was bounced every ~5.5 minutes around the clock.

Probe `127.0.0.1` directly instead.

Applied to the live stack already (compose recreate): health flips to `healthy`, stays there across probe intervals, login and space listing verified end to end.