### PR TITLE
fix(recipes): scope PostHog alerts to production logs

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -13,6 +13,12 @@ locals {
     RECIPE_API_PREVIEW_ORIGIN_TEMPLATE = var.recipe_api_preview_origin_template
     CF_PAGES_HOST                      = var.cf_pages_host
   }
+  pages_production_environment_variables = merge(local.pages_environment_variables, {
+    DEPLOYMENT_ENV = "production"
+  })
+  pages_preview_environment_variables = merge(local.pages_environment_variables, {
+    DEPLOYMENT_ENV = "preview"
+  })
   pages_secrets = {
     GITHUB_TOKEN = var.github_token
   }
@@ -47,14 +53,14 @@ resource "cloudflare_pages_project" "personal_site" {
 
   deployment_configs {
     production {
-      environment_variables = local.pages_environment_variables
+      environment_variables = local.pages_production_environment_variables
       secrets               = local.pages_secrets
       compatibility_date    = "2026-05-28"
       compatibility_flags   = ["nodejs_compat"]
     }
 
     preview {
-      environment_variables = local.pages_environment_variables
+      environment_variables = local.pages_preview_environment_variables
       secrets               = local.pages_secrets
       compatibility_date    = "2026-05-28"
       compatibility_flags   = ["nodejs_compat"]

--- a/infra/posthog_alerts.tf
+++ b/infra/posthog_alerts.tf
@@ -12,6 +12,18 @@
 locals {
   posthog_log_alert_collection_path = "/api/projects/${var.posthog_project_id}/logs/alerts/"
   posthog_log_alert_item_path       = "${local.posthog_log_alert_collection_path}{id}/"
+  posthog_production_filter_group = {
+    type = "AND"
+    values = [{
+      type = "AND"
+      values = [{
+        key      = "deployment.environment.name"
+        type     = "log_resource_attribute"
+        operator = "exact"
+        value    = "production"
+      }]
+    }]
+  }
 
   posthog_log_alerts = {
     recipe_api_sustained_errors = {
@@ -47,6 +59,7 @@ locals {
       filters = {
         severityLevels = ["error", "fatal"]
         serviceNames   = alert.service_names
+        filterGroup    = local.posthog_production_filter_group
       }
       threshold_count     = alert.threshold_count
       threshold_operator  = "above"

--- a/ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx
+++ b/ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx
@@ -130,7 +130,9 @@ the workspace is initially more conspicuous than deploying a small Worker.
 Keep the three production alert definitions in Terraform and treat PostHog as the source of truth
 for operational alert state.
 
-* Alert on error and fatal logs for `recipe-api`, `recipe-ingest`, and `recipe-pages`.
+* Alert on error and fatal logs for `recipe-api`, `recipe-ingest`, and `recipe-pages` only when the
+  `deployment.environment.name` resource attribute is `production`. Preview deployments use the
+  same service names and must not notify the production channel.
 * Preserve the different sensitivity of interactive API, background ingestion, and quiet Pages
   workloads rather than applying one global threshold.
 * Simulate material threshold changes against at least seven days of production history.


### PR DESCRIPTION
## Summary

- Label production and preview Pages telemetry with distinct `DEPLOYMENT_ENV` values.
- Restrict the three recipe log alerts to resources where `deployment.environment.name` is `production`.
- Record the production-only rule in the alerting ADR.

## Incident

The `Recipe Pages errors` alert fired on nine `GET /api/notifications` 503 responses between 20:40:47 and 20:42:07 BST. PR 1053 had deleted and recreated its preview Neon branch during that window. The preview API correctly labelled its logs as `preview`, but Pages telemetry defaulted to `production`, so the production alert included the preview outage.

## Validation

- `mise //infra:format:check`
- `mise //infra:lint`
- `mise //infra:lint:tflint`
- `mise //infra:plan` (`0 add, 4 change, 0 destroy`)
- `mise //:lint:mdx:check -- ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx`
- `mise //:lint:typos -- ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx infra/main.tf infra/posthog_alerts.tf`

## QA

No browser QA required. Confirm the Terraform plan only updates the Pages deployment environment variables and the three PostHog alert filters in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Production and preview deployments now use distinct environment settings.
  - Monitoring alerts now target production services only, excluding preview deployments.

- **Documentation**
  - Updated alerting documentation to clarify that production notifications exclude preview environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->