### PR TITLE
chore(deps): bump awscli to 2.36.31 and enable automerge

### DIFF
--- a/backups/mise.toml
+++ b/backups/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 age = "1.3.1"
-awscli = "2.36.24"
+awscli = "2.36.31"
 jq = "1.8.2"
 
 [tasks.backup]

--- a/renovate.json
+++ b/renovate.json
@@ -88,12 +88,11 @@
       "automerge": true
     },
     {
-      "description": "Review the Neon backup toolchain by hand - the backup job runs against real data and no CI job proves these beforehand",
+      "description": "Review age and jq by hand - the backup job runs against real data and no CI job proves these beforehand",
       "matchManagers": [
         "mise"
       ],
       "matchDepNames": [
-        "awscli",
         "age",
         "jq"
       ],


### PR DESCRIPTION
Bumps awscli from 2.36.24 to the latest 2.36.31 and removes it from the manual-review renovate override so future patch bumps auto-merge via the existing mise rule.

Closes #1070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AWS command-line tooling to a newer version.
  * Refined maintenance review settings for selected command-line tools.
  * No changes to application functionality or user-facing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->