### PR TITLE
ci: verify pnpm updates before automerge

### DIFF
--- a/.github/workflows/pnpm-compatibility.yml
+++ b/.github/workflows/pnpm-compatibility.yml
@@ -1,0 +1,33 @@
+name: pnpm compatibility
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          experimental: true
+
+      - name: Verify pnpm pins
+        shell: bash
+        run: |
+          package_version="$(node --print "require('./package.json').packageManager.replace(/^pnpm@/, '')")"
+          mise_version="$(mise x -- pnpm --version)"
+
+          if [[ "$package_version" != "$mise_version" ]]; then
+            echo "::error::pnpm versions differ: package.json=$package_version, mise=$mise_version"
+            exit 1
+          fi
+
+      - name: Verify frozen workspace install
+        run: mise x -- pnpm install --frozen-lockfile

--- a/.github/workflows/pnpm-compatibility.yml
+++ b/.github/workflows/pnpm-compatibility.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -42,3 +43,19 @@ jobs:
 
       - name: Verify frozen workspace install
         run: mise x -- pnpm install --frozen-lockfile
+
+      - name: Verify workspace checks
+        run: |
+          mise run //ai-review:check
+          mise run //packages/observability:check
+          mise run //packages/recipe-db:check
+          mise run //packages/recipe-parsing:check
+          mise run //ml-pipelines/recipe-parsing:test
+          mise run //ui:check
+          mise run //workers/recipe-api:check
+          mise run //workers/recipe-ingest:check
+
+      - name: Verify production build
+        run: mise run //ui:build
+        env:
+          NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH: placeholder

--- a/.github/workflows/pnpm-compatibility.yml
+++ b/.github/workflows/pnpm-compatibility.yml
@@ -18,6 +18,17 @@ jobs:
         with:
           experimental: true
 
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "dir=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.dir }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-store-${{ runner.os }}-
+
       - name: Verify pnpm pins
         shell: bash
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -146,16 +146,18 @@
       "groupName": "pnpm"
     },
     {
-      "description": "pnpm is dev tooling in practice, so auto-merge it on the devDependencies terms",
+      "description": "Auto-merge pnpm updates after the pinned binary passes the workspace compatibility check",
       "matchPackageNames": [
         "pnpm",
         "pnpm/pnpm"
       ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "major"
       ],
       "minimumReleaseAge": "3 days",
+      "dependencyDashboardApproval": false,
       "automerge": true
     },
     {


### PR DESCRIPTION
## Summary

- add a stable pnpm compatibility check to every pull request
- verify the packageManager pin matches the pnpm binary installed by mise
- require a frozen workspace install before pnpm updates can merge
- allow Renovate to automerge pnpm major updates after the three-day release-age delay

## Validation

- `mise run //:lint:yaml -- .github/workflows/pnpm-compatibility.yml`
- `mise run //:lint:actions`
- `mise x -- pnpm install --frozen-lockfile`
- Renovate config validator

## Follow-up

After this workflow lands on `main`, add `pnpm compatibility / check` to the main ruleset. Adding it before the workflow exists on the default branch could block existing PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated validation to confirm the configured pnpm version matches the project tooling.
  - Added checks to ensure clean, frozen dependency installations succeed for pull requests.

- **Maintenance**
  - Updated automated dependency updates to support minor, patch, and major releases after a three-day release period.
  - Dependency updates are now validated through workspace compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->