### PR TITLE
Trace recipe database request stages

### DIFF
--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -436,6 +436,8 @@ export async function withPostHogSpan<T>(
     kind?: SpanKind;
     waitUntil?: WaitUntilContext;
     attributes?: Attributes;
+    // Set false only when an enclosing request or workflow span will flush.
+    flush?: boolean;
   },
   operation: (span: Span) => Promise<T>,
 ): Promise<T> {
@@ -495,10 +497,12 @@ export async function withPostHogSpan<T>(
     return result;
   } finally {
     safelyRecordTelemetry("end span", () => span.end());
-    try {
-      await flushAfter(state, options.waitUntil);
-    } catch (error) {
-      reportTelemetryFailure("flush span telemetry", error);
+    if (options.flush !== false) {
+      try {
+        await flushAfter(state, options.waitUntil);
+      } catch (error) {
+        reportTelemetryFailure("flush span telemetry", error);
+      }
     }
   }
 }

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -436,7 +436,10 @@ export async function withPostHogSpan<T>(
     kind?: SpanKind;
     waitUntil?: WaitUntilContext;
     attributes?: Attributes;
-    // Set false only when an enclosing request or workflow span will flush.
+    /**
+     * Set false only when an enclosing request or workflow span will flush.
+     * @default true
+     */
     flush?: boolean;
   },
   operation: (span: Span) => Promise<T>,

--- a/packages/observability/tests/index.test.ts
+++ b/packages/observability/tests/index.test.ts
@@ -337,6 +337,31 @@ describe("enabled telemetry", () => {
     consoleError.mockRestore();
   });
 
+  it("can defer flushing child spans to their request boundary", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    exported.rejectTraceExporterFlush = true;
+
+    await expect(
+      withPostHogSpan(
+        {
+          env: enabledEnv,
+          serviceName: "test-service",
+          spanName: "request.child",
+          flush: false,
+        },
+        async () => "application result",
+      ),
+    ).resolves.toBe("application result");
+
+    exported.rejectTraceExporterFlush = false;
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining('"stage":"flush traces"'),
+    );
+    consoleError.mockRestore();
+  });
+
   it("fails open if a bundle requests a different service name", async () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -153,6 +153,8 @@ type AppEnv = {
   Variables: Partial<AuthorizationVariables>;
 };
 
+type SpanAttributes = Record<string, boolean | number | string>;
+
 extendZodWithOpenApi(z);
 
 const app = new OpenAPIHono<AppEnv>();
@@ -981,7 +983,9 @@ async function loadOptionalRecipeSession(
 ): Promise<AuthenticatedSession | null> {
   if (!hasLoadableAuthConfiguration(c.env)) return null;
   try {
-    return await loadBetterAuthSession(c, db);
+    return await withRecipeApiSpan(c, "auth.session.lookup", () =>
+      loadBetterAuthSession(c, db),
+    );
   } catch (error) {
     console.error("Recipe session lookup failed", error);
     return null;
@@ -1006,7 +1010,9 @@ async function requireRecipeSession(
   }
 
   try {
-    const session = await loadBetterAuthSession(c, db);
+    const session = await withRecipeApiSpan(c, "auth.session.lookup", () =>
+      loadBetterAuthSession(c, db),
+    );
     if (!session) {
       return {
         success: false,
@@ -1028,6 +1034,35 @@ type WithDbOptions = {
   onError?: (error: unknown) => Response | undefined;
 };
 
+function withRecipeApiSpan<T>(
+  c: Context<AppEnv>,
+  spanName: string,
+  operation: () => Promise<T>,
+  attributes?: SpanAttributes,
+): Promise<T> {
+  let waitUntil:
+    | { waitUntil(promise: Promise<unknown>): void }
+    | undefined;
+  try {
+    waitUntil = c.executionCtx;
+  } catch {
+    // Hono's direct app.request() test helper has no execution context.
+  }
+  return withPostHogSpan(
+    {
+      env: c.env,
+      serviceName: "recipe-api",
+      spanName,
+      traceCarrier: traceCarrierFromHeaders(c.req.raw.headers),
+      waitUntil,
+      attributes,
+      // The outer request span flushes after every route and its children end.
+      flush: false,
+    },
+    operation,
+  );
+}
+
 async function withDatabase(
   c: Context<AppEnv>,
   failureKind: "query" | "mutation" | "lookup",
@@ -1040,16 +1075,31 @@ async function withDatabase(
 
   let client: DbClient | undefined;
   try {
-    const connection = createDb(connectionString);
+    const connection = await withRecipeApiSpan(
+      c,
+      "db.client.create",
+      async () => createDb(connectionString),
+      { "db.system.name": "postgresql" },
+    );
     client = connection.client;
-    return await action(connection.db);
+    return await withRecipeApiSpan(
+      c,
+      "db.operation",
+      () => Promise.resolve(action(connection.db)),
+      { "db.system.name": "postgresql" },
+    );
   } catch (e) {
     const mapped = options?.onError?.(e);
     if (mapped) return mapped;
     console.error(logMessage, e);
     return c.json({ error: `Database ${failureKind} failed` }, 502);
   } finally {
-    await closeDbClient(client);
+    await withRecipeApiSpan(
+      c,
+      "db.client.close",
+      () => closeDbClient(client),
+      { "db.system.name": "postgresql" },
+    );
   }
 }
 
@@ -2977,7 +3027,12 @@ registerRoute("get", "/pantry", async (c) => {
     "GET /pantry query failed",
     async ({ db, session }) => {
       c.header("Cache-Control", "private, no-store");
-      return c.json(await pantryResponse(db, session.user.id));
+      const pantry = await withRecipeApiSpan(c, "pantry.read.query", () =>
+        pantryResponse(db, session.user.id),
+      );
+      return withRecipeApiSpan(c, "http.response.serialize", async () =>
+        c.json(pantry),
+      );
     },
   );
 });
@@ -4161,18 +4216,38 @@ registerRoute("get", "/recipes", async (c) => {
     "query",
     "GET /recipes query failed",
     async (db) => {
-      let visibilityFilter: SQL | undefined;
-      if (scope === "owned") {
-        const session = await requireRecipeSession(c, db);
-        if (!session.success) return session.response;
-        visibilityFilter = eq(schema.recipe.userId, session.session.user.id);
-      } else {
-        const session = await loadOptionalRecipeSession(c, db);
-        visibilityFilter = await readableRecipeFilter(db, session?.user.id);
-      }
-      const page = await listRecipesPage(db, visibilityFilter, cursor, limit.data);
+      const queryResult = await withRecipeApiSpan(
+        c,
+        "recipes.list.query",
+        async () => {
+          let visibilityFilter: SQL | undefined;
+          if (scope === "owned") {
+            const session = await requireRecipeSession(c, db);
+            if (!session.success) return session.response;
+            visibilityFilter = eq(
+              schema.recipe.userId,
+              session.session.user.id,
+            );
+          } else {
+            const session = await loadOptionalRecipeSession(c, db);
+            visibilityFilter = await readableRecipeFilter(db, session?.user.id);
+          }
+          const page = await listRecipesPage(
+            db,
+            visibilityFilter,
+            cursor,
+            limit.data,
+          );
+          return page;
+        },
+        { "app.recipe.scope": scope ?? "readable" },
+      );
+      if (queryResult instanceof Response) return queryResult;
+      const page = queryResult;
       const items = page.recipes.map(recipeResponse);
-      return c.json(paginated ? { items, nextCursor: page.nextCursor } : items);
+      return withRecipeApiSpan(c, "http.response.serialize", async () =>
+        c.json(paginated ? { items, nextCursor: page.nextCursor } : items),
+      );
     },
   );
 });
@@ -4599,27 +4674,41 @@ registerRoute("get", "/recipes/:slug", async (c) => {
     "query",
     "GET /recipes/:slug query failed",
     async (db) => {
-      const session = await loadOptionalRecipeSession(c, db);
-      const recipe = await findRecipeBySlug(db, slug.slug);
-      if (!recipe) return c.notFound();
+      const queryResult = await withRecipeApiSpan(
+        c,
+        "recipes.detail.query",
+        async () => {
+          const session = await loadOptionalRecipeSession(c, db);
+          const recipe = await findRecipeBySlug(db, slug.slug);
+          if (!recipe) return c.notFound();
 
-      if (recipe.visibility !== "public") {
-        if (!session) return c.notFound();
-        const household = {
-          userSharesHouseholdWithOwner: await usersShareHousehold(
-            db,
-            recipe.userId,
-            session.user.id,
-          ),
-        };
-        const decision = authorizeRecipeRead(session.user, recipe, household);
-        if (!decision.allowed) return c.notFound();
-      }
+          if (recipe.visibility !== "public") {
+            if (!session) return c.notFound();
+            const household = {
+              userSharesHouseholdWithOwner: await usersShareHousehold(
+                db,
+                recipe.userId,
+                session.user.id,
+              ),
+            };
+            const decision = authorizeRecipeRead(
+              session.user,
+              recipe,
+              household,
+            );
+            if (!decision.allowed) return c.notFound();
+          }
 
-      return c.json({
-        ...recipeResponse(recipe),
-        owned: session?.user.id === recipe.userId,
-      });
+          return { recipe, session };
+        },
+      );
+      if (queryResult instanceof Response) return queryResult;
+      return withRecipeApiSpan(c, "http.response.serialize", async () =>
+        c.json({
+          ...recipeResponse(queryResult.recipe),
+          owned: queryResult.session?.user.id === queryResult.recipe.userId,
+        }),
+      );
     },
   );
 });


### PR DESCRIPTION
## Summary

- attach child spans to each recipe API request for auth session lookup, database client setup, route database work, and client cleanup
- split recipe-list, recipe-detail, and pantry reads into named query and response-serialization spans
- defer child-span flushing to the enclosing request so added detail does not create one OTLP export per span

## Validation

- `mise //packages/observability:check`
- `mise //workers/recipe-api:check`
- `mise //ui:lint` with existing warnings only

## QA

- load the recipe list, one recipe detail page, and the pantry in the protected preview
- confirm each request still succeeds
- confirm PostHog shows the new child spans under the matching `recipe-api` request trace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable telemetry flushing for traced operations, allowing flushing to be deferred when needed.
  * Expanded tracing coverage across recipe API requests, database activity and response generation.

* **Bug Fixes**
  * Prevented unnecessary flush-error reports when telemetry flushing is intentionally deferred.

* **Compatibility**
  * Recipe API routes continue to return the same responses and maintain existing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->