### PR TITLE
perf(recipes): bootstrap profile data

### DIFF
--- a/functions/api/profile/bootstrap.ts
+++ b/functions/api/profile/bootstrap.ts
@@ -1,0 +1,10 @@
+import {
+  proxyRecipeApiRequest,
+  type RecipeApiProxyContext,
+} from "../auth/routing";
+
+export const onRequest = (context: RecipeApiProxyContext): Promise<Response> =>
+  proxyRecipeApiRequest(
+    context,
+    "Profile APIs are available on the canonical PR preview URL only",
+  );

--- a/ui/components/recipes/add-recipe-view.tsx
+++ b/ui/components/recipes/add-recipe-view.tsx
@@ -102,7 +102,7 @@ async function invalidateSavedRecipeQueries({
   if (!userId) return;
   const invalidations = [
     queryClient.invalidateQueries({
-      queryKey: recipeQueryKeys.recipeBoxRecipes(userId),
+      queryKey: recipeQueryKeys.bootstrap(userId),
     }),
     queryClient.invalidateQueries({
       queryKey: recipeQueryKeys.savedRecipe(userId, slug),

--- a/ui/components/recipes/kitchen/recipe-kitchen.tsx
+++ b/ui/components/recipes/kitchen/recipe-kitchen.tsx
@@ -14,7 +14,7 @@ export function RecipeKitchen() {
   const recipeBox = useQuery({
     ...recipeBoxRecipesQuery(session?.user.id ?? "pending"),
     enabled: !isPending && Boolean(session),
-    select: ({ recipes }) => buildKitchenCatalog(recipes),
+    select: ({ recipeBox }) => buildKitchenCatalog(recipeBox.recipes),
   });
 
   if (isPending) {

--- a/ui/components/recipes/notifications/notification-bell.tsx
+++ b/ui/components/recipes/notifications/notification-bell.tsx
@@ -1,18 +1,27 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
 import { Bell } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { getNotificationPage } from "@/lib/api/notifications";
 import { authClient } from "@/lib/auth-client";
+import { recipeBootstrapQuery } from "@/lib/query/recipe-queries";
 
 const NOTIFICATION_REFRESH_INTERVAL_MS = 10_000;
 
 export function NotificationBell() {
   const { data: session } = authClient.useSession();
   const sessionUserId = session?.user.id;
+  const bootstrap = useQuery({
+    ...recipeBootstrapQuery(sessionUserId ?? "pending"),
+    enabled: Boolean(sessionUserId),
+  });
   const [unread, setUnread] = useState({ userId: "", count: 0 });
-  const count = unread.userId === sessionUserId ? unread.count : 0;
+  const count =
+    unread.userId === sessionUserId
+      ? unread.count
+      : (bootstrap.data?.unreadNotificationCount ?? 0);
 
   useEffect(() => {
     if (!sessionUserId) return;
@@ -30,7 +39,6 @@ export function NotificationBell() {
       if (document.visibilityState === "visible") refresh();
     };
 
-    refresh();
     const interval = globalThis.setInterval(
       refreshWhenVisible,
       NOTIFICATION_REFRESH_INTERVAL_MS,

--- a/ui/components/recipes/notifications/notifications-view.tsx
+++ b/ui/components/recipes/notifications/notifications-view.tsx
@@ -194,7 +194,7 @@ export function NotificationsView() {
             queryKey: recipeQueryKeys.recipeBox(sessionUserId),
           }),
           queryClient.invalidateQueries({
-            queryKey: recipeQueryKeys.recipeBoxRecipes(sessionUserId),
+            queryKey: recipeQueryKeys.bootstrap(sessionUserId),
           }),
         ]);
       }

--- a/ui/components/recipes/shopping/recipe-shopping.tsx
+++ b/ui/components/recipes/shopping/recipe-shopping.tsx
@@ -14,7 +14,8 @@ export function RecipeShopping() {
   const recipeBox = useQuery({
     ...recipeBoxRecipesQuery(session?.user.id ?? "pending"),
     enabled: !isPending && Boolean(session),
-    select: ({ recipes }) => recipeRecordsToShoppingRecipes(recipes),
+    select: ({ recipeBox }) =>
+      recipeRecordsToShoppingRecipes(recipeBox.recipes),
   });
 
   if (isPending) {

--- a/ui/lib/api/recipe-bootstrap.ts
+++ b/ui/lib/api/recipe-bootstrap.ts
@@ -1,0 +1,65 @@
+import type { DietOptions, DietProfile } from "@/lib/api/diet";
+import { apiRequest } from "@/lib/api/http";
+import type { RecipeBoxProfile } from "@/lib/api/recipe-box";
+import type { SavedRecipeApiRecord } from "@/lib/domain/recipe/recipeDraft";
+
+type RecipeBootstrapResponse = {
+  recipeBox: {
+    ownedRecipes: SavedRecipeApiRecord[];
+    readableRecipes: SavedRecipeApiRecord[];
+    profile: RecipeBoxProfile;
+  };
+  diet: {
+    profile: DietProfile;
+    options: DietOptions;
+  };
+  unreadNotificationCount: number;
+};
+
+export type RecipeBootstrap = {
+  recipeBox: {
+    recipes: SavedRecipeApiRecord[];
+    box: RecipeBoxProfile;
+  };
+  diet: RecipeBootstrapResponse["diet"];
+  unreadNotificationCount: number;
+};
+
+function selectRecipeBoxRecipes(
+  owned: SavedRecipeApiRecord[],
+  readable: SavedRecipeApiRecord[],
+  box: RecipeBoxProfile,
+) {
+  const ownedSlugs = new Set(owned.map((recipe) => recipe.slug));
+  const selectedSlugs = new Set(box.recipeSlugs);
+  const selectedOrStarterRecipes = readable.filter(
+    (recipe) =>
+      !ownedSlugs.has(recipe.slug) &&
+      (!box.completed || selectedSlugs.has(recipe.slug)),
+  );
+  return [...owned, ...selectedOrStarterRecipes];
+}
+
+export async function getRecipeBootstrap(
+  signal?: AbortSignal,
+): Promise<RecipeBootstrap> {
+  const response = await apiRequest<RecipeBootstrapResponse>(
+    "/api/profile/bootstrap",
+    {
+      signal,
+      fallbackMessage: "Recipe profile request failed.",
+    },
+  );
+  return {
+    recipeBox: {
+      recipes: selectRecipeBoxRecipes(
+        response.recipeBox.ownedRecipes,
+        response.recipeBox.readableRecipes,
+        response.recipeBox.profile,
+      ),
+      box: response.recipeBox.profile,
+    },
+    diet: response.diet,
+    unreadNotificationCount: response.unreadNotificationCount,
+  };
+}

--- a/ui/lib/api/saved-recipes.ts
+++ b/ui/lib/api/saved-recipes.ts
@@ -1,6 +1,4 @@
 import { ApiError, apiRequest } from "@/lib/api/http";
-import type { RecipeBoxProfile } from "@/lib/api/recipe-box";
-import { getRecipeBoxProfile } from "@/lib/api/recipe-box";
 import type { SavedRecipeApiRecord } from "@/lib/domain/recipe/recipeDraft";
 
 const PAGE_LIMIT = 100;
@@ -68,22 +66,4 @@ export async function getSavedRecipe(
     }
     throw error;
   }
-}
-
-export async function fetchRecipeBoxRecipes(
-  signal?: AbortSignal,
-): Promise<{ recipes: SavedRecipeApiRecord[]; box: RecipeBoxProfile }> {
-  const [owned, readable, box] = await Promise.all([
-    fetchAllSavedRecipes({ scope: "owned", signal }),
-    fetchAllSavedRecipes({ signal }),
-    getRecipeBoxProfile(signal),
-  ]);
-  const ownedSlugs = new Set(owned.map((recipe) => recipe.slug));
-  const selectedSlugs = new Set(box.recipeSlugs);
-  const selectedOrStarterRecipes = readable.filter(
-    (recipe) =>
-      !ownedSlugs.has(recipe.slug) &&
-      (!box.completed || selectedSlugs.has(recipe.slug)),
-  );
-  return { recipes: [...owned, ...selectedOrStarterRecipes], box };
 }

--- a/ui/lib/query/recipe-mutations.ts
+++ b/ui/lib/query/recipe-mutations.ts
@@ -1,5 +1,6 @@
 import { mutationOptions, type QueryClient } from "@tanstack/react-query";
 import { type DietProfile, saveDietProfile } from "@/lib/api/diet";
+import type { RecipeBootstrap } from "@/lib/api/recipe-bootstrap";
 import { saveRecipeBoxProfile } from "@/lib/api/recipe-box";
 import { recipeQueryKeys } from "@/lib/query/recipe-query-keys";
 
@@ -11,7 +12,13 @@ export const saveDietProfileMutation = (
     mutationKey: [...recipeQueryKeys.diet(userId), "save"],
     mutationFn: (profile: DietProfile) => saveDietProfile(profile),
     onSuccess: (profile) => {
-      queryClient.setQueryData(recipeQueryKeys.dietProfile(userId), profile);
+      queryClient.setQueryData<RecipeBootstrap>(
+        recipeQueryKeys.bootstrap(userId),
+        (current) =>
+          current
+            ? { ...current, diet: { ...current.diet, profile } }
+            : current,
+      );
     },
   });
 
@@ -25,7 +32,7 @@ export const saveRecipeBoxMutation = (
     onSuccess: async (box) => {
       queryClient.setQueryData(recipeQueryKeys.recipeBox(userId), box);
       await queryClient.invalidateQueries({
-        queryKey: recipeQueryKeys.recipeBoxRecipes(userId),
+        queryKey: recipeQueryKeys.bootstrap(userId),
       });
     },
   });

--- a/ui/lib/query/recipe-mutations.ts
+++ b/ui/lib/query/recipe-mutations.ts
@@ -11,7 +11,10 @@ export const saveDietProfileMutation = (
   mutationOptions({
     mutationKey: [...recipeQueryKeys.bootstrap(userId), "save-diet"],
     mutationFn: (profile: DietProfile) => saveDietProfile(profile),
-    onSuccess: (profile) => {
+    onSuccess: async (profile) => {
+      const hadBootstrap = queryClient.getQueryData(
+        recipeQueryKeys.bootstrap(userId),
+      );
       queryClient.setQueryData<RecipeBootstrap>(
         recipeQueryKeys.bootstrap(userId),
         (current) =>
@@ -19,6 +22,11 @@ export const saveDietProfileMutation = (
             ? { ...current, diet: { ...current.diet, profile } }
             : current,
       );
+      if (!hadBootstrap) {
+        await queryClient.invalidateQueries({
+          queryKey: recipeQueryKeys.bootstrap(userId),
+        });
+      }
     },
   });
 
@@ -30,7 +38,16 @@ export const saveRecipeBoxMutation = (
     mutationKey: [...recipeQueryKeys.bootstrap(userId), "save-recipe-box"],
     mutationFn: (recipeSlugs: string[]) => saveRecipeBoxProfile(recipeSlugs),
     onSuccess: async (box) => {
-      queryClient.setQueryData(recipeQueryKeys.recipeBox(userId), box);
+      queryClient.setQueryData<RecipeBootstrap>(
+        recipeQueryKeys.bootstrap(userId),
+        (current) =>
+          current
+            ? {
+                ...current,
+                recipeBox: { ...current.recipeBox, box },
+              }
+            : current,
+      );
       await queryClient.invalidateQueries({
         queryKey: recipeQueryKeys.bootstrap(userId),
       });

--- a/ui/lib/query/recipe-mutations.ts
+++ b/ui/lib/query/recipe-mutations.ts
@@ -9,7 +9,7 @@ export const saveDietProfileMutation = (
   userId: string,
 ) =>
   mutationOptions({
-    mutationKey: [...recipeQueryKeys.diet(userId), "save"],
+    mutationKey: [...recipeQueryKeys.bootstrap(userId), "save-diet"],
     mutationFn: (profile: DietProfile) => saveDietProfile(profile),
     onSuccess: (profile) => {
       queryClient.setQueryData<RecipeBootstrap>(
@@ -27,7 +27,7 @@ export const saveRecipeBoxMutation = (
   userId: string,
 ) =>
   mutationOptions({
-    mutationKey: [...recipeQueryKeys.recipeBox(userId), "save"],
+    mutationKey: [...recipeQueryKeys.bootstrap(userId), "save-recipe-box"],
     mutationFn: (recipeSlugs: string[]) => saveRecipeBoxProfile(recipeSlugs),
     onSuccess: async (box) => {
       queryClient.setQueryData(recipeQueryKeys.recipeBox(userId), box);

--- a/ui/lib/query/recipe-queries.ts
+++ b/ui/lib/query/recipe-queries.ts
@@ -38,7 +38,8 @@ export const dietOptionsQuery = (userId: string) =>
     queryKey: recipeQueryKeys.bootstrap(userId),
     queryFn: ({ signal }) => getRecipeBootstrap(signal),
     select: (bootstrap) => bootstrap.diet.options,
-    staleTime: 60 * 60_000,
+    staleTime: USER_DATA_STALE_TIME,
+    refetchOnWindowFocus: true,
   });
 
 export const recipeBootstrapQuery = (userId: string) =>

--- a/ui/lib/query/recipe-queries.ts
+++ b/ui/lib/query/recipe-queries.ts
@@ -1,11 +1,7 @@
 import { queryOptions } from "@tanstack/react-query";
-import { getDietOptions, getDietProfile } from "@/lib/api/diet";
+import { getRecipeBootstrap } from "@/lib/api/recipe-bootstrap";
 import { recipeRecordsToCards } from "@/lib/api/recipes";
-import {
-  fetchAllSavedRecipes,
-  fetchRecipeBoxRecipes,
-  getSavedRecipe,
-} from "@/lib/api/saved-recipes";
+import { fetchAllSavedRecipes, getSavedRecipe } from "@/lib/api/saved-recipes";
 import { recipeQueryKeys } from "@/lib/query/recipe-query-keys";
 
 const USER_DATA_STALE_TIME = 5 * 60_000;
@@ -21,25 +17,36 @@ export const publicRecipesQuery = () =>
 
 export const recipeBoxRecipesQuery = (userId: string) =>
   queryOptions({
-    queryKey: recipeQueryKeys.recipeBoxRecipes(userId),
-    queryFn: ({ signal }) => fetchRecipeBoxRecipes(signal),
+    queryKey: recipeQueryKeys.bootstrap(userId),
+    queryFn: ({ signal }) => getRecipeBootstrap(signal),
+    select: (bootstrap) => bootstrap.recipeBox,
     staleTime: USER_DATA_STALE_TIME,
     refetchOnWindowFocus: true,
   });
 
 export const dietProfileQuery = (userId: string) =>
   queryOptions({
-    queryKey: recipeQueryKeys.dietProfile(userId),
-    queryFn: ({ signal }) => getDietProfile(signal),
+    queryKey: recipeQueryKeys.bootstrap(userId),
+    queryFn: ({ signal }) => getRecipeBootstrap(signal),
+    select: (bootstrap) => bootstrap.diet.profile,
     staleTime: USER_DATA_STALE_TIME,
     refetchOnWindowFocus: true,
   });
 
 export const dietOptionsQuery = (userId: string) =>
   queryOptions({
-    queryKey: recipeQueryKeys.dietOptions(userId),
-    queryFn: ({ signal }) => getDietOptions(signal),
+    queryKey: recipeQueryKeys.bootstrap(userId),
+    queryFn: ({ signal }) => getRecipeBootstrap(signal),
+    select: (bootstrap) => bootstrap.diet.options,
     staleTime: 60 * 60_000,
+  });
+
+export const recipeBootstrapQuery = (userId: string) =>
+  queryOptions({
+    queryKey: recipeQueryKeys.bootstrap(userId),
+    queryFn: ({ signal }) => getRecipeBootstrap(signal),
+    staleTime: USER_DATA_STALE_TIME,
+    refetchOnWindowFocus: true,
   });
 
 export const savedRecipeQuery = (userId: string | null, slug: string) =>

--- a/ui/lib/query/recipe-query-keys.ts
+++ b/ui/lib/query/recipe-query-keys.ts
@@ -12,6 +12,8 @@ export const recipeQueryKeys = {
     [...recipeRoot, "public", "cooks", cookId] as const,
   private: () => [...recipeRoot, "private"] as const,
   user: (userId: string) => [...recipeRoot, "private", userId] as const,
+  bootstrap: (userId: string) =>
+    [...recipeRoot, "private", userId, "bootstrap"] as const,
   recipeBox: (userId: string) =>
     [...recipeRoot, "private", userId, "recipe-box"] as const,
   recipeBoxRecipes: (userId: string) =>

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -53,6 +53,10 @@ function createNextConfig(phase: string): NextConfig {
                 destination: "http://localhost:8787/api/profile/diet",
               },
               {
+                source: "/api/profile/bootstrap",
+                destination: "http://localhost:8787/api/profile/bootstrap",
+              },
+              {
                 source: "/api/profile/diet/options",
                 destination: "http://localhost:8787/api/profile/diet/options",
               },

--- a/ui/tests/components/recipes/diet-provider.test.tsx
+++ b/ui/tests/components/recipes/diet-provider.test.tsx
@@ -16,6 +16,17 @@ vi.mock("@/lib/api/diet", async (importOriginal) => ({
   ...apiMocks,
 }));
 
+vi.mock("@/lib/api/recipe-bootstrap", () => ({
+  getRecipeBootstrap: async () => ({
+    recipeBox: { recipes: [], box: { completed: true, recipeSlugs: [] } },
+    diet: {
+      profile: await apiMocks.getDietProfile(),
+      options: await apiMocks.getDietOptions(),
+    },
+    unreadNotificationCount: 0,
+  }),
+}));
+
 vi.mock("@/lib/auth-client", () => ({
   authClient: {
     useSession: authMocks.useSession,

--- a/ui/tests/components/recipes/notifications/notification-bell.test.tsx
+++ b/ui/tests/components/recipes/notifications/notification-bell.test.tsx
@@ -1,10 +1,12 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NotificationPage } from "@/lib/api/notifications";
+import { render } from "@/tests/test-utils";
 
 const mocks = vi.hoisted(() => ({
   useSession: vi.fn(),
   getNotificationPage: vi.fn(),
+  getRecipeBootstrap: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -14,6 +16,10 @@ vi.mock("@/lib/auth-client", () => ({
 vi.mock("@/lib/api/notifications", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/api/notifications")>()),
   getNotificationPage: mocks.getNotificationPage,
+}));
+
+vi.mock("@/lib/api/recipe-bootstrap", () => ({
+  getRecipeBootstrap: mocks.getRecipeBootstrap,
 }));
 
 import { NotificationBell } from "@/components/recipes/notifications/notification-bell";
@@ -31,6 +37,11 @@ describe("NotificationBell", () => {
       nextOffset: null,
       unreadCount: 5,
     });
+    mocks.getRecipeBootstrap.mockResolvedValue({
+      recipeBox: { recipes: [], box: { completed: true, recipeSlugs: [] } },
+      diet: { profile: {}, options: {} },
+      unreadNotificationCount: 5,
+    });
   });
 
   afterEach(() => {
@@ -39,9 +50,16 @@ describe("NotificationBell", () => {
 
   it("polls for requests created after the user signs in", async () => {
     vi.useFakeTimers();
-    mocks.getNotificationPage
-      .mockResolvedValueOnce({ items: [], nextOffset: null, unreadCount: 0 })
-      .mockResolvedValueOnce({ items: [], nextOffset: null, unreadCount: 1 });
+    mocks.getRecipeBootstrap.mockResolvedValueOnce({
+      recipeBox: { recipes: [], box: { completed: true, recipeSlugs: [] } },
+      diet: { profile: {}, options: {} },
+      unreadNotificationCount: 0,
+    });
+    mocks.getNotificationPage.mockResolvedValueOnce({
+      items: [],
+      nextOffset: null,
+      unreadCount: 1,
+    });
 
     render(<NotificationBell />);
     await act(async () => Promise.resolve());
@@ -67,13 +85,13 @@ describe("NotificationBell", () => {
 
     render(<NotificationBell />);
     await act(async () => Promise.resolve());
-    expect(mocks.getNotificationPage).toHaveBeenCalledOnce();
+    expect(mocks.getNotificationPage).not.toHaveBeenCalled();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(20_000);
     });
 
-    expect(mocks.getNotificationPage).toHaveBeenCalledOnce();
+    expect(mocks.getNotificationPage).not.toHaveBeenCalled();
   });
 
   it("does not refetch or flicker when the same user's session object refreshes", async () => {
@@ -85,7 +103,7 @@ describe("NotificationBell", () => {
     mocks.useSession.mockReturnValue({ data: { user: { id: "user-1" } } });
     rerender(<NotificationBell />);
 
-    expect(mocks.getNotificationPage).toHaveBeenCalledOnce();
+    expect(mocks.getNotificationPage).not.toHaveBeenCalled();
     expect(
       screen.getByRole("link", { name: "Notifications, 5 unread" }),
     ).toBeInTheDocument();
@@ -96,13 +114,17 @@ describe("NotificationBell", () => {
     const replacementPage = new Promise<NotificationPage>((resolve) => {
       resolveReplacement = resolve;
     });
-    mocks.getNotificationPage
+    mocks.getRecipeBootstrap
       .mockResolvedValueOnce({
-        items: [],
-        nextOffset: null,
-        unreadCount: 5,
+        recipeBox: { recipes: [], box: { completed: true, recipeSlugs: [] } },
+        diet: { profile: {}, options: {} },
+        unreadNotificationCount: 5,
       })
-      .mockReturnValueOnce(replacementPage);
+      .mockImplementationOnce(async () => ({
+        recipeBox: { recipes: [], box: { completed: true, recipeSlugs: [] } },
+        diet: { profile: {}, options: {} },
+        unreadNotificationCount: (await replacementPage).unreadCount,
+      }));
     const { rerender } = render(<NotificationBell />);
     expect(
       await screen.findByRole("link", { name: "Notifications, 5 unread" }),

--- a/ui/tests/components/recipes/notifications/notifications-view.test.tsx
+++ b/ui/tests/components/recipes/notifications/notifications-view.test.tsx
@@ -164,7 +164,7 @@ describe("NotificationsView", () => {
       queryKey: recipeQueryKeys.recipeBox("user-1"),
     });
     expect(invalidateQueries).toHaveBeenCalledWith({
-      queryKey: recipeQueryKeys.recipeBoxRecipes("user-1"),
+      queryKey: recipeQueryKeys.bootstrap("user-1"),
     });
   });
 

--- a/ui/tests/components/recipes/recipe-collection.test.tsx
+++ b/ui/tests/components/recipes/recipe-collection.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@/tests/test-utils";
 const mocks = vi.hoisted(() => ({
   session: { data: { user: { id: "user-1" } }, isPending: false },
   dietLoading: false,
-  fetchRecipeBoxRecipes: vi.fn(),
+  recipeBoxResult: vi.fn(),
 }));
 
 vi.mock("@/lib/auth-client", () => ({
@@ -15,8 +15,12 @@ vi.mock("@/components/recipes/diet-provider", () => ({
   useDiet: () => ({ loading: mocks.dietLoading }),
 }));
 
-vi.mock("@/lib/api/saved-recipes", () => ({
-  fetchRecipeBoxRecipes: mocks.fetchRecipeBoxRecipes,
+vi.mock("@/lib/api/recipe-bootstrap", () => ({
+  getRecipeBootstrap: async () => ({
+    recipeBox: await mocks.recipeBoxResult(),
+    diet: { profile: {}, options: {} },
+    unreadNotificationCount: 0,
+  }),
 }));
 
 vi.mock("@/lib/domain/recipe/recipeDraft", () => ({
@@ -67,7 +71,7 @@ describe("RecipeCollection", () => {
       recipes: { slug: string; title: string }[];
       box: { completed: boolean; recipeSlugs: string[] };
     }) => void;
-    mocks.fetchRecipeBoxRecipes.mockReturnValue(
+    mocks.recipeBoxResult.mockReturnValue(
       new Promise((resolve) => {
         resolveBox = resolve;
       }),
@@ -92,7 +96,7 @@ describe("RecipeCollection", () => {
   });
 
   it("does not expose one user's recipes while another user loads", async () => {
-    mocks.fetchRecipeBoxRecipes.mockResolvedValueOnce({
+    mocks.recipeBoxResult.mockResolvedValueOnce({
       recipes: [{ slug: "first", title: "First user's recipe" }],
       box: { completed: true, recipeSlugs: [] },
     });
@@ -106,9 +110,7 @@ describe("RecipeCollection", () => {
       data: { user: { id: "user-2" } },
       isPending: false,
     };
-    mocks.fetchRecipeBoxRecipes.mockReturnValueOnce(
-      new Promise(() => undefined),
-    );
+    mocks.recipeBoxResult.mockReturnValueOnce(new Promise(() => undefined));
     view.rerender(<RecipeCollection />);
 
     expect(
@@ -119,7 +121,7 @@ describe("RecipeCollection", () => {
 
   it("waits for diet preferences before rendering the recipe list", async () => {
     mocks.dietLoading = true;
-    mocks.fetchRecipeBoxRecipes.mockResolvedValue({
+    mocks.recipeBoxResult.mockResolvedValue({
       recipes: [{ slug: "starter", title: "Selected starter" }],
       box: { completed: true, recipeSlugs: ["starter"] },
     });
@@ -139,7 +141,7 @@ describe("RecipeCollection", () => {
 
   it("reports unique catalog stats from the loaded recipe box", async () => {
     const onCatalogStatsChange = vi.fn();
-    mocks.fetchRecipeBoxRecipes.mockResolvedValue({
+    mocks.recipeBoxResult.mockResolvedValue({
       recipes: [
         {
           slug: "pasta",

--- a/ui/tests/components/recipes/recipe-kitchen-shopping.test.tsx
+++ b/ui/tests/components/recipes/recipe-kitchen-shopping.test.tsx
@@ -3,7 +3,7 @@ import { act, render, screen } from "@/tests/test-utils";
 
 const mocks = vi.hoisted(() => ({
   buildKitchenCatalog: vi.fn(),
-  fetchRecipeBoxRecipes: vi.fn(),
+  recipeBoxResult: vi.fn(),
   recipeRecordsToShoppingRecipes: vi.fn(),
   useSession: vi.fn(),
 }));
@@ -16,8 +16,12 @@ vi.mock("@/components/recipes/auth-button", () => ({
   AuthButton: () => <button type="button">Log in</button>,
 }));
 
-vi.mock("@/lib/api/saved-recipes", () => ({
-  fetchRecipeBoxRecipes: mocks.fetchRecipeBoxRecipes,
+vi.mock("@/lib/api/recipe-bootstrap", () => ({
+  getRecipeBootstrap: async () => ({
+    recipeBox: await mocks.recipeBoxResult(),
+    diet: { profile: {}, options: {} },
+    unreadNotificationCount: 0,
+  }),
 }));
 
 vi.mock("@/lib/api/recipes", () => ({
@@ -64,12 +68,12 @@ describe("database-backed kitchen and shopping pages", () => {
 
     render(<RecipeShopping />);
     expect(screen.getByText("Log in to make a list")).toBeInTheDocument();
-    expect(mocks.fetchRecipeBoxRecipes).not.toHaveBeenCalled();
+    expect(mocks.recipeBoxResult).not.toHaveBeenCalled();
   });
 
   it("loads recipe-box recipes into the kitchen", async () => {
     const recipes = [{ slug: "lentil-soup" }];
-    mocks.fetchRecipeBoxRecipes.mockImplementation(async () => {
+    mocks.recipeBoxResult.mockImplementation(async () => {
       return { recipes, box: { completed: true, recipeSlugs: [] } };
     });
 
@@ -82,14 +86,14 @@ describe("database-backed kitchen and shopping pages", () => {
 
   it("shows a kitchen load error while ignoring abort errors", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    mocks.fetchRecipeBoxRecipes.mockRejectedValueOnce(new Error("offline"));
+    mocks.recipeBoxResult.mockRejectedValueOnce(new Error("offline"));
     const failedView = render(<RecipeKitchen />);
     expect(
       await screen.findByText("Your kitchen could not be loaded."),
     ).toBeInTheDocument();
     failedView.unmount();
 
-    mocks.fetchRecipeBoxRecipes.mockRejectedValueOnce(
+    mocks.recipeBoxResult.mockRejectedValueOnce(
       new DOMException("aborted", "AbortError"),
     );
     render(<RecipeKitchen />);
@@ -102,7 +106,7 @@ describe("database-backed kitchen and shopping pages", () => {
   it("loads recipe-box recipes into the shopping view", async () => {
     const records = [{ slug: "lentil-soup" }];
     const shoppingRecipes = [{ slug: "lentil-soup", title: "Lentil Soup" }];
-    mocks.fetchRecipeBoxRecipes.mockResolvedValue({
+    mocks.recipeBoxResult.mockResolvedValue({
       recipes: records,
       box: { completed: true, recipeSlugs: [] },
     });
@@ -116,14 +120,14 @@ describe("database-backed kitchen and shopping pages", () => {
 
   it("shows a shopping load error while ignoring abort errors", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
-    mocks.fetchRecipeBoxRecipes.mockRejectedValueOnce(new Error("offline"));
+    mocks.recipeBoxResult.mockRejectedValueOnce(new Error("offline"));
     const failedView = render(<RecipeShopping />);
     expect(
       await screen.findByText("Your recipes could not be loaded."),
     ).toBeInTheDocument();
     failedView.unmount();
 
-    mocks.fetchRecipeBoxRecipes.mockRejectedValueOnce(
+    mocks.recipeBoxResult.mockRejectedValueOnce(
       new DOMException("aborted", "AbortError"),
     );
     render(<RecipeShopping />);

--- a/ui/tests/components/recipes/settings/diet-panel.test.tsx
+++ b/ui/tests/components/recipes/settings/diet-panel.test.tsx
@@ -23,6 +23,17 @@ vi.mock("@/lib/api/diet", async (importOriginal) => ({
   ...apiMocks,
 }));
 
+vi.mock("@/lib/api/recipe-bootstrap", () => ({
+  getRecipeBootstrap: async () => ({
+    recipeBox: { recipes: [], box: { completed: true, recipeSlugs: [] } },
+    diet: {
+      profile: await apiMocks.getDietProfile(),
+      options: await apiMocks.getDietOptions(),
+    },
+    unreadNotificationCount: 0,
+  }),
+}));
+
 describe("DietPanel", () => {
   beforeEach(() => {
     apiMocks.getDietProfile.mockResolvedValue({
@@ -89,10 +100,14 @@ describe("DietPanel", () => {
 
     expect(await screen.findByText("saved")).toBeInTheDocument();
     expect(
-      queryClient.getQueryData(recipeQueryKeys.dietProfile("diet-user")),
+      queryClient.getQueryData(recipeQueryKeys.bootstrap("diet-user")),
     ).toEqual(
       expect.objectContaining({
-        excludedGroupKeys: ["poultry"],
+        diet: expect.objectContaining({
+          profile: expect.objectContaining({
+            excludedGroupKeys: ["poultry"],
+          }),
+        }),
       }),
     );
   });

--- a/ui/tests/functions/profile-diet-proxy.test.ts
+++ b/ui/tests/functions/profile-diet-proxy.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { RecipeApiProxyContext } from "../../../functions/api/auth/routing";
 import { onRequest as onHouseholdRequest } from "../../../functions/api/households/[[path]]";
 import { onRequest as onPantryRequest } from "../../../functions/api/pantry/[[path]]";
+import { onRequest as onBootstrapRequest } from "../../../functions/api/profile/bootstrap";
 import { onRequest } from "../../../functions/api/profile/diet";
 import { onRequest as onOptionsRequest } from "../../../functions/api/profile/diet/options";
 
@@ -13,6 +14,26 @@ afterEach(() => {
 });
 
 describe("profile diet proxy", () => {
+  it("forwards recipe profile bootstrap requests to the recipe API Worker", async () => {
+    const fetchMock = vi.fn(async (_request: Request) => new Response("ok"));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const response = await onBootstrapRequest({
+      request: new Request("https://robbiepalmer.me/api/profile/bootstrap"),
+      env: { RECIPE_API_URL: "https://recipe-api.example.test" },
+    });
+
+    expect(response.status).toBe(200);
+    const forwarded = fetchMock.mock.calls[0]?.[0];
+    expect(forwarded).toBeInstanceOf(Request);
+    if (!(forwarded instanceof Request)) {
+      throw new Error("Expected profile bootstrap proxy to forward a Request");
+    }
+    expect(forwarded.url).toBe(
+      "https://recipe-api.example.test/api/profile/bootstrap",
+    );
+  });
+
   it("forwards same-origin diet profile requests to the recipe API Worker", async () => {
     const fetchMock = vi.fn(async (_request: Request) => new Response("ok"));
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/ui/tests/lib/api/recipe-bootstrap.test.ts
+++ b/ui/tests/lib/api/recipe-bootstrap.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getRecipeBootstrap } from "@/lib/api/recipe-bootstrap";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getRecipeBootstrap", () => {
+  it("loads profile data once and selects the recipes in a completed box", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        recipeBox: {
+          ownedRecipes: [{ slug: "owned" }],
+          readableRecipes: [
+            { slug: "owned" },
+            { slug: "selected" },
+            { slug: "not-selected" },
+          ],
+          profile: { completed: true, recipeSlugs: ["selected"] },
+        },
+        diet: {
+          profile: {
+            presetDietKeys: [],
+            excludedIngredientSlugs: [],
+            excludedGroupKeys: [],
+            recipeMatchMode: "hide",
+          },
+          options: { presets: [], groups: [], ingredients: [] },
+        },
+        unreadNotificationCount: 3,
+      }),
+    );
+
+    const bootstrap = await getRecipeBootstrap();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/profile/bootstrap",
+      expect.objectContaining({ credentials: "same-origin" }),
+    );
+    expect(bootstrap.recipeBox.recipes.map((recipe) => recipe.slug)).toEqual([
+      "owned",
+      "selected",
+    ]);
+    expect(bootstrap.unreadNotificationCount).toBe(3);
+  });
+
+  it("includes all readable starter recipes before onboarding completes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        recipeBox: {
+          ownedRecipes: [{ slug: "owned" }],
+          readableRecipes: [{ slug: "owned" }, { slug: "starter" }],
+          profile: { completed: false, recipeSlugs: [] },
+        },
+        diet: { profile: {}, options: {} },
+        unreadNotificationCount: 0,
+      }),
+    );
+
+    const bootstrap = await getRecipeBootstrap();
+
+    expect(bootstrap.recipeBox.recipes.map((recipe) => recipe.slug)).toEqual([
+      "owned",
+      "starter",
+    ]);
+  });
+});

--- a/ui/tests/lib/api/saved-recipes.test.ts
+++ b/ui/tests/lib/api/saved-recipes.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  fetchAllSavedRecipes,
-  fetchRecipeBoxRecipes,
-  getSavedRecipe,
-} from "@/lib/api/saved-recipes";
+import { fetchAllSavedRecipes, getSavedRecipe } from "@/lib/api/saved-recipes";
 
 function jsonResponse(body: unknown) {
   return new Response(JSON.stringify(body), {
@@ -81,57 +77,6 @@ describe("fetchAllSavedRecipes", () => {
       message: "The recipe could not be loaded.",
       status: 422,
     });
-  });
-
-  it("combines owned recipes with starters before onboarding is complete", async () => {
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        jsonResponse({ items: [{ slug: "owned" }], nextCursor: null }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          items: [{ slug: "owned" }, { slug: "starter" }],
-          nextCursor: null,
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({ completed: false, recipeSlugs: [] }),
-      );
-
-    const result = await fetchRecipeBoxRecipes();
-
-    expect(result.recipes.map((recipe) => recipe.slug)).toEqual([
-      "owned",
-      "starter",
-    ]);
-    expect(result.box.completed).toBe(false);
-  });
-
-  it("limits completed recipe boxes to owned and selected recipes", async () => {
-    vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(
-        jsonResponse({ items: [{ slug: "owned" }], nextCursor: null }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
-          items: [
-            { slug: "owned" },
-            { slug: "selected" },
-            { slug: "not-selected" },
-          ],
-          nextCursor: null,
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({ completed: true, recipeSlugs: ["selected"] }),
-      );
-
-    const result = await fetchRecipeBoxRecipes();
-
-    expect(result.recipes.map((recipe) => recipe.slug)).toEqual([
-      "owned",
-      "selected",
-    ]);
   });
 
   it("bounds pagination when an API repeats its cursor", async () => {

--- a/workers/recipe-api/openapi.json
+++ b/workers/recipe-api/openapi.json
@@ -4201,6 +4201,143 @@
         }
       }
     },
+    "/api/profile/bootstrap": {
+      "get": {
+        "operationId": "getApiProfileBootstrap",
+        "summary": "GET /api/profile/bootstrap",
+        "description": "Recipe API operation for GET /api/profile/bootstrap.",
+        "tags": [
+          "profile"
+        ],
+        "security": [
+          {
+            "sessionCookie": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error (400)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Error (401)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error (403)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error (404)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error (409)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Error (410)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Error (415)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Error (422)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error (500)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Error (502)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Error (503)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/profile/cooking-insights": {
       "get": {
         "operationId": "getApiProfileCookingInsights",

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -2876,6 +2876,7 @@ registerRoute("get", "/api/profile/bootstrap", async (c) => {
     "query",
     "GET /api/profile/bootstrap query failed",
     async ({ db, session }) => {
+      c.header("Cache-Control", "private, no-store");
       const userId = session.user.id;
       const visibilityFilter = await readableRecipeFilter(db, userId);
       if (!visibilityFilter) {

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -205,6 +205,7 @@ const pantryOperationReceiptSchema = z
 const feedScopeSchema = z.enum(["public", "following"]);
 const feedLimitSchema = z.coerce.number().int().min(1).max(30).default(12);
 const recipeListLimitSchema = z.coerce.number().int().min(1).max(100).default(100);
+const RECIPE_BOOTSTRAP_LIMIT = 10_000;
 const publicCookIdSchema = z.string().trim().min(1).max(128);
 const PUBLIC_COOK_CONNECTION_LIMIT = 50;
 const feedViewerMembership = alias(schema.member, "feed_viewer_membership");
@@ -1149,6 +1150,19 @@ async function listRecipesPage(
     recipes: page.items.map(({ recipe }) => recipe),
     nextCursor: page.nextCursor,
   };
+}
+
+async function listBootstrapRecipes(db: Db, visibilityFilter: SQL) {
+  const page = await listRecipesPage(
+    db,
+    visibilityFilter,
+    undefined,
+    RECIPE_BOOTSTRAP_LIMIT,
+  );
+  if (page.nextCursor) {
+    throw new Error("Recipe bootstrap limit exceeded");
+  }
+  return page.recipes.map(recipeResponse);
 }
 
 async function findOwnedRecipeBySlug(
@@ -2856,6 +2870,48 @@ registerRoute("get", "/api/profile/recipe-box", async (c) => {
   );
 });
 
+registerRoute("get", "/api/profile/bootstrap", async (c) => {
+  return withRecipeSession(
+    c,
+    "query",
+    "GET /api/profile/bootstrap query failed",
+    async ({ db, session }) => {
+      const userId = session.user.id;
+      const visibilityFilter = await readableRecipeFilter(db, userId);
+      if (!visibilityFilter) {
+        throw new Error("Authenticated recipe visibility filter is missing");
+      }
+
+      const [
+        ownedRecipes,
+        readableRecipes,
+        box,
+        storedDietProfile,
+        dietOptions,
+        unreadNotificationCount,
+      ] = await Promise.all([
+        listBootstrapRecipes(db, eq(schema.recipe.userId, userId)),
+        listBootstrapRecipes(db, visibilityFilter),
+        recipeBoxResponse(db, userId),
+        findDietProfile(db, userId),
+        listDietOptions(db),
+        countUnreadNotifications(db, userId),
+      ]);
+
+      return c.json({
+        recipeBox: { ownedRecipes, readableRecipes, profile: box },
+        diet: {
+          profile: dietProfileResponse(
+            storedDietProfile ?? defaultDietProfile(userId),
+          ),
+          options: dietOptions,
+        },
+        unreadNotificationCount,
+      });
+    },
+  );
+});
+
 registerRoute("put", "/api/profile/recipe-box", async (c) => {
   const csrfFailure = validateCsrf(c);
   if (csrfFailure) return csrfFailure;
@@ -3924,6 +3980,20 @@ registerRoute("delete", "/households/:householdId", async (c) => {
   );
 });
 
+async function countUnreadNotifications(db: Db, userId: string) {
+  const [unread] = await db
+    .select({ value: count() })
+    .from(schema.notificationDelivery)
+    .where(
+      and(
+        eq(schema.notificationDelivery.recipientUserId, userId),
+        isNull(schema.notificationDelivery.readAt),
+        isNull(schema.notificationDelivery.dismissedAt),
+      ),
+    );
+  return unread?.value ?? 0;
+}
+
 registerRoute("get", "/notifications", async (c) => {
   const offset = Number(c.req.query("offset") ?? "0");
   if (!Number.isSafeInteger(offset) || offset < 0) {
@@ -3934,7 +4004,7 @@ registerRoute("get", "/notifications", async (c) => {
     "query",
     "GET /notifications failed",
     async ({ db, session }) => {
-      const [deliveries, [unread]] = await Promise.all([
+      const [deliveries, unreadCount] = await Promise.all([
         db
           .select(notificationBaseSelection)
           .from(schema.notificationDelivery)
@@ -3957,19 +4027,7 @@ registerRoute("get", "/notifications", async (c) => {
           )
           .limit(NOTIFICATION_PAGE_SIZE + 1)
           .offset(offset),
-        db
-          .select({ value: count() })
-          .from(schema.notificationDelivery)
-          .where(
-            and(
-              eq(
-                schema.notificationDelivery.recipientUserId,
-                session.user.id,
-              ),
-              isNull(schema.notificationDelivery.readAt),
-              isNull(schema.notificationDelivery.dismissedAt),
-            ),
-          ),
+        countUnreadNotifications(db, session.user.id),
       ]);
       const hasMore = deliveries.length > NOTIFICATION_PAGE_SIZE;
       const items = await hydrateNotifications(
@@ -3982,7 +4040,7 @@ registerRoute("get", "/notifications", async (c) => {
         {
           items,
           nextOffset: hasMore ? offset + NOTIFICATION_PAGE_SIZE : null,
-          unreadCount: unread?.value ?? 0,
+          unreadCount,
         },
       );
     },

--- a/workers/recipe-api/src/index.ts
+++ b/workers/recipe-api/src/index.ts
@@ -2899,8 +2899,17 @@ registerRoute("get", "/api/profile/bootstrap", async (c) => {
         countUnreadNotifications(db, userId),
       ]);
 
+      const ownedRecipeSlugs = new Set(
+        ownedRecipes.map((recipe) => recipe.slug),
+      );
       return c.json({
-        recipeBox: { ownedRecipes, readableRecipes, profile: box },
+        recipeBox: {
+          ownedRecipes,
+          readableRecipes: readableRecipes.filter(
+            (recipe) => !ownedRecipeSlugs.has(recipe.slug),
+          ),
+          profile: box,
+        },
         diet: {
           profile: dietProfileResponse(
             storedDietProfile ?? defaultDietProfile(userId),

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -4096,7 +4096,7 @@ describe("recipe profile bootstrap", () => {
     ]);
     expect(
       body.recipeBox.readableRecipes.map((recipe) => recipe.slug).sort(),
-    ).toEqual(["private-soup", "public-pasta"]);
+    ).toEqual(["public-pasta"]);
     expect(body.recipeBox.profile).toMatchObject({
       completed: false,
       recipeSlugs: [],

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -4038,6 +4038,74 @@ describe("profile recipe box", () => {
   });
 });
 
+describe("recipe profile bootstrap", () => {
+  it("requires authentication", async () => {
+    const res = await app.request("/api/profile/bootstrap", {}, env);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+  });
+
+  it("returns recipe, diet, box, and notification data together", async () => {
+    authzMock.session = sessionFor({
+      id: "owner-user",
+      email: "owner@example.test",
+      name: "Owner",
+    });
+    seedDietCatalog();
+    dbMock.state.recipes.push(
+      {
+        id: "recipe-owned",
+        slug: "private-soup",
+        title: "Private Soup",
+        description: null,
+        body: null,
+        userId: "owner-user",
+        visibility: "private",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+      {
+        id: "recipe-public",
+        slug: "public-pasta",
+        title: "Public Pasta",
+        description: null,
+        body: null,
+        userId: "other-user",
+        visibility: "public",
+        createdAt: dbMock.date,
+        updatedAt: dbMock.date,
+      },
+    );
+
+    const res = await app.request("/api/profile/bootstrap", {}, env);
+    const body = (await res.json()) as {
+      recipeBox: {
+        ownedRecipes: Array<{ slug: string }>;
+        readableRecipes: Array<{ slug: string }>;
+        profile: { completed: boolean; recipeSlugs: string[] };
+      };
+      diet: { profile: { recipeMatchMode: string }; options: { presets: unknown[] } };
+      unreadNotificationCount: number;
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.recipeBox.ownedRecipes.map((recipe) => recipe.slug)).toEqual([
+      "private-soup",
+    ]);
+    expect(
+      body.recipeBox.readableRecipes.map((recipe) => recipe.slug).sort(),
+    ).toEqual(["private-soup", "public-pasta"]);
+    expect(body.recipeBox.profile).toMatchObject({
+      completed: false,
+      recipeSlugs: [],
+    });
+    expect(body.diet.profile.recipeMatchMode).toBe("hide");
+    expect(body.diet.options.presets).toHaveLength(2);
+    expect(body.unreadNotificationCount).toBe(0);
+  });
+});
+
 describe("profile cooking insights", () => {
   const cookingEvent = {
     sessionId: "018f2b16-43b4-7e7a-8d4b-9f3559865353",

--- a/workers/recipe-api/tests/index.test.ts
+++ b/workers/recipe-api/tests/index.test.ts
@@ -4090,6 +4090,7 @@ describe("recipe profile bootstrap", () => {
     };
 
     expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
     expect(body.recipeBox.ownedRecipes.map((recipe) => recipe.slug)).toEqual([
       "private-soup",
     ]);


### PR DESCRIPTION
## Summary
- add one authenticated bootstrap endpoint for recipe-box, diet, and notification state
- share the bootstrap response through one TanStack Query cache entry
- remove the recipe-box detail request fan-out and defer notification polling

## Verification
- `mise //workers/recipe-api:check`
- `mise //ui:check`
- `mise //workers/recipe-api:test:integration`
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise //ui:test:integration` (build and 22 tests pass; Mermaid browser suite cannot start locally because pinned Chrome 152 is not installed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a profile bootstrap endpoint that provides recipe-box data, diet settings, available options and unread notification counts in one request.
  * Recipe collections now include the appropriate owned and readable recipes based on onboarding and recipe-box status.
  * Notification badges load their initial unread count from profile data.

* **Bug Fixes**
  * Improved refresh and cache updates after saving recipes, updating diet settings or adding recommendations.
  * Recipe kitchen and shopping views now correctly display recipe-box contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->