### PR TITLE
chore: lint MDX files with Vale

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -26,7 +26,7 @@ verbose = false
 [tools]
 node = "lts"
 "github:pnpm/pnpm" = "11.24.0"
-vale = "3.12.0"
+vale = "3.19.0"
 terraform = "1.16.0"
 tflint = "0.64.0"
 actionlint = "1.7.12"
@@ -104,28 +104,28 @@ fi
 """
 
 [tasks."lint:prose"]
-description = "Lint changed lines in Markdown files with Vale (optionally pass files as args; vendored .vale styles are excluded)"
+description = "Lint changed lines in Markdown and MDX files with Vale (optionally pass files as args; vendored .vale styles are excluded)"
 run = """
 #!/usr/bin/env bash
 if [ $# -eq 0 ]; then
-  set -- $(git ls-files '*.md')
+  set -- $(git ls-files '*.md' '*.mdx')
 fi
 pnpm exec tsx scripts/prose-lint.ts "$@"
 """
 
 [tasks."lint:prose:staged"]
-description = "Lint staged Markdown changes with Vale"
+description = "Lint staged Markdown and MDX changes with Vale"
 run = """
 #!/usr/bin/env bash
 if [ $# -eq 0 ]; then
-  set -- $(git diff --cached --name-only -- '*.md')
+  set -- $(git diff --cached --name-only -- '*.md' '*.mdx')
 fi
 pnpm exec tsx scripts/prose-lint.ts --staged "$@"
 """
 
 [tasks."lint:prose:check"]
-description = "Lint all tracked Markdown files with Vale, failing on any alert"
-run = "pnpm exec tsx scripts/prose-lint.ts --strict --all $(git ls-files '*.md')"
+description = "Lint all tracked Markdown and MDX files with Vale, failing on any alert"
+run = "pnpm exec tsx scripts/prose-lint.ts --strict --all $(git ls-files '*.md' '*.mdx')"
 
 [tasks."lint:knip"]
 description = "Detect unused files, dependencies, and exports across the monorepo with Knip"

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,10 +2,10 @@ StylesPath = .vale/styles
 
 MinAlertLevel = suggestion
 
-# MDX is not linted: Vale needs the separate `mdx2vast` companion binary
-# (https://vale.sh/docs/formats/mdx) to convert MDX, so prose checks are
-# scoped to Markdown only for now.
 [*.md]
+BasedOnStyles = Unslop, write-good, proselint
+
+[*.mdx]
 BasedOnStyles = Unslop, write-good, proselint
 
 # Vendored style licenses live alongside each style directory.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "mise run //:lint:prose:staged"
     ],
     "**/*.mdx": [
-      "mise run //:lint:mdx"
+      "mise run //:lint:mdx",
+      "mise run //:lint:prose:staged"
     ],
     "*.{yml,yaml}": [
       "mise run //:lint:yaml"


### PR DESCRIPTION
## Summary

Vale has parsed MDX natively since v3.18.0, so the `mdx2vast` companion binary the prose-lint config previously called for is no longer needed and the MDX exclusion goes away.

- Upgrade Vale 3.12.0 → 3.19.0 in `.mise.toml` (native MDX parsing, plus JSX-children linting from 3.19)
- Add an `[*.mdx]` section to `.vale.ini` with the same styles as Markdown (`Unslop, write-good, proselint`) and drop the stale `mdx2vast` comment
- Extend `lint:prose`, `lint:prose:staged`, and `lint:prose:check` mise tasks to glob `*.mdx`
- Run the changed-line prose lint on staged `.mdx` files in the pre-commit hook (alongside remark)

Enforcement stays diff-scoped (per the existing prose-lint design), so pre-existing MDX prose is not flooded; it is cleaned up incrementally as files are edited. `lint:prose:check` is a manual audit (not CI-wired) and now surfaces the pre-existing MDX alert volume.

## Validation

- `vale 3.19.0` parses all 211 tracked MDX files (imports, JSX components, inline expressions) with no parse errors
- Deliberate violation added to an MDX file is flagged on the changed line only; clean change exits 0
- `lint:prose:staged` path exercised via the pre-commit hook (lint-staged + gitleaks pass on the commit)
- No remaining references to `mdx2vast` in the repo

## QA

No UI or runtime behavior changes — tooling config only. Preview QA not required.