### PR TITLE
Restrict GitHub Actions token permissions

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -10,12 +10,13 @@ concurrency:
   group: neon-database-backup
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   backup:
     runs-on: ubuntu-latest
     timeout-minutes: 35
-    permissions:
-      contents: read
     environment:
       name: production-database-backup
     steps:

--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -10,13 +10,14 @@ concurrency:
   group: neon-database-backup
   cancel-in-progress: false
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   backup:
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    permissions:
+      contents: read
     environment:
       name: production-database-backup
     steps:

--- a/.github/workflows/ui-cd.yml
+++ b/.github/workflows/ui-cd.yml
@@ -17,8 +17,6 @@ on:
 
 permissions:
   contents: read
-  deployments: write
-  pull-requests: write
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

- remove unused GitHub Deployments and Pull Requests write access from UI CD
- deny token permissions by default in the database backup workflow
- grant repository read access only to the backup job and Issues write access only to its failure notifier

Closes the code changes for code-scanning alerts #89 and #90. Alert #102 was separately dismissed because the preview command requires its job-scoped Actions write permission to rerun a workflow.

## Validation

- `MISE_EXPERIMENTAL=1 mise run //:lint:yaml .github/workflows/ui-cd.yml .github/workflows/database-backup.yml`
- `MISE_EXPERIMENTAL=1 mise run //:lint:actions`
- `MISE_EXPERIMENTAL=1 mise run //:security:actions`
- pre-commit YAML and gitleaks checks

## QA

Workflow configuration only. No deployed preview QA is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved CI/CD workflow security by restricting default permissions.
  * Removed unnecessary write access for deployments and pull requests.
  * Retained read-only access where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->