### PR TITLE
Manage Cloudflare notification policies for Slack delivery

### DIFF
--- a/.github/workflows/infra-cd.yml
+++ b/.github/workflows/infra-cd.yml
@@ -48,6 +48,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           TF_VAR_posthog_project_id: ${{ vars.POSTHOG_PROJECT_ID }}
           TF_VAR_cloudflare_pages_preview_access_application_id: ${{ vars.CF_PAGES_PREVIEW_ACCESS_APPLICATION_ID }}
+          TF_VAR_slack_webhook_url: ${{ secrets.CLOUDFLARE_SLACK_WEBHOOK_URL }}
 
       - name: Add Terraform Plan to Summary
         uses: borchero/terraform-plan-comment@f585438eda2fa77c6f275994b92aeccd86ef3542 # v3
@@ -70,3 +71,4 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           TF_VAR_posthog_project_id: ${{ vars.POSTHOG_PROJECT_ID }}
           TF_VAR_cloudflare_pages_preview_access_application_id: ${{ vars.CF_PAGES_PREVIEW_ACCESS_APPLICATION_ID }}
+          TF_VAR_slack_webhook_url: ${{ secrets.CLOUDFLARE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -56,6 +56,7 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           TF_VAR_posthog_project_id: ${{ vars.POSTHOG_PROJECT_ID }}
           TF_VAR_cloudflare_pages_preview_access_application_id: ${{ vars.CF_PAGES_PREVIEW_ACCESS_APPLICATION_ID }}
+          TF_VAR_slack_webhook_url: ${{ secrets.CLOUDFLARE_SLACK_WEBHOOK_URL }}
 
       - name: Add Terraform Plan to PR Comment
         uses: borchero/terraform-plan-comment@f585438eda2fa77c6f275994b92aeccd86ef3542 # v3

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -182,6 +182,7 @@ deploy credentials or privileged GCP credentials:
 
 - `CF_PAGES_PREVIEW_ACCESS_APPLICATION_ID` (unmasked)
 - `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_SLACK_WEBHOOK_URL`
 - `GITHUB_TOKEN` or `MISE_GITHUB_TOKEN`
 - `TF_API_TOKEN`
 - `NEON_API_KEY`
@@ -314,6 +315,7 @@ into each service-specific Doppler config.
 - `CF_PAGES_PREVIEW_ACCESS_APPLICATION_ID` (unmasked; syncs to a GitHub Actions variable)
 - `CLOUDFLARE_API_TOKEN`
 - `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_SLACK_WEBHOOK_URL`
 - `CF_IMAGES_ACCOUNT_HASH`
 - `POSTHOG_KEY`
 - `MISE_GITHUB_TOKEN`

--- a/infra/README.md
+++ b/infra/README.md
@@ -245,12 +245,42 @@ SSL certificate events; and an R2 storage usage threshold. The account's
 auto-created budget email alert remains in place.
 
 The Pages deployment-failure policy is not yet Terraform-managed: the API
-rejects every `pages_event_alert` `event` filter value, so the policy must be
-created once in the dashboard (Pages project, production environment,
-"Deployment failed") and then imported:
+rejects every `pages_event_alert` `event` filter value, so it cannot be created
+through Terraform. To bring it under management, create it once in the
+dashboard (Notifications → Pages → project `personal-site`, production
+environment, "Deployment failed", Slack destination), then declare the resource
+in `cloudflare_alerts.tf` using the filters the created policy reports:
+
+```bash
+curl -s "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/alerting/v3/policies" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | jq '.result[] | select(.alert_type == "pages_event_alert")'
+```
+
+```hcl
+resource "cloudflare_notification_policy" "pages_deployments" {
+  account_id  = var.cloudflare_account_id
+  name        = "Pages deployment failures"
+  description = "Failed production Pages deployments"
+  enabled     = true
+  alert_type  = "pages_event_alert"
+
+  filters {
+    project_id  = ["54cc1492-569c-4072-a77b-47520974c731"]
+    environment = ["production"]
+    event       = ["<values reported by the created policy>"]
+  }
+
+  webhooks_integration {
+    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+  }
+}
+```
+
+Import it, then apply to confirm zero drift:
 
 ```bash
 terraform import 'cloudflare_notification_policy.pages_deployments' '<account-id>/<policy-id>'
+mise run //infra:plan
 ```
 
 Test the destination after applying via Notifications → Destinations →

--- a/infra/README.md
+++ b/infra/README.md
@@ -230,6 +230,32 @@ After import, `mise run //infra:plan` should show no PostHog changes. Do not
 edit managed dashboards or insights in the PostHog UI without also updating
 `posthog_resources.json`, because Terraform will treat that as drift.
 
+## Cloudflare Notifications
+
+Cloudflare notification policies are managed in `cloudflare_alerts.tf` and
+deliver to the shared `#production-alerts` Slack channel through a
+`cloudflare_notification_policy_webhooks` destination. The Slack incoming
+webhook URL is a sensitive variable (`slack_webhook_url`) sourced from Doppler
+(`CLOUDFLARE_SLACK_WEBHOOK_URL` in `dev_infra` and `prd_infra`) and mapped by
+`scripts/doppler-terraform-env`.
+
+The managed policies cover major/critical Cloudflare incidents affecting
+Pages, Workers, R2, SSL, and DNS; expiring Access service tokens; Universal
+SSL certificate events; and an R2 storage usage threshold. The account's
+auto-created budget email alert remains in place.
+
+The Pages deployment-failure policy is not yet Terraform-managed: the API
+rejects every `pages_event_alert` `event` filter value, so the policy must be
+created once in the dashboard (Pages project, production environment,
+"Deployment failed") and then imported:
+
+```bash
+terraform import 'cloudflare_notification_policy.pages_deployments' '<account-id>/<policy-id>'
+```
+
+Test the destination after applying via Notifications → Destinations →
+Webhooks → Send test; the message should reach `#production-alerts`.
+
 ## Neon Database
 
 ### `recipes`

--- a/infra/cloudflare_alerts.tf
+++ b/infra/cloudflare_alerts.tf
@@ -1,0 +1,68 @@
+locals {
+  slack_webhook_parts = regex("^(?P<base>https://hooks\\.slack\\.com/services/[^/]+/[^/]+)/(?P<secret>[^/]+)$", var.slack_webhook_url)
+}
+
+resource "cloudflare_notification_policy_webhooks" "slack_production_alerts" {
+  account_id = var.cloudflare_account_id
+  name       = "Slack #production-alerts"
+  url        = "${local.slack_webhook_parts.base}/"
+  secret     = local.slack_webhook_parts.secret
+}
+
+resource "cloudflare_notification_policy" "cloudflare_incidents" {
+  account_id  = var.cloudflare_account_id
+  name        = "Cloudflare incidents affecting our services"
+  description = "Major or critical Cloudflare incidents affecting Pages, Workers, R2, SSL, or DNS"
+  enabled     = true
+  alert_type  = "incident_alert"
+
+  filters {
+    affected_components = ["Pages", "Workers", "R2", "SSL Certificate Provisioning", "Authoritative DNS"]
+    incident_impact     = ["INCIDENT_IMPACT_MAJOR", "INCIDENT_IMPACT_CRITICAL"]
+  }
+
+  webhooks_integration {
+    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+  }
+}
+
+resource "cloudflare_notification_policy" "expiring_service_tokens" {
+  account_id  = var.cloudflare_account_id
+  name        = "Access service token expiring"
+  description = "Service token expires within 7 days"
+  enabled     = true
+  alert_type  = "expiring_service_token_alert"
+
+  webhooks_integration {
+    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+  }
+}
+
+resource "cloudflare_notification_policy" "universal_ssl_events" {
+  account_id  = var.cloudflare_account_id
+  name        = "Universal SSL certificate events"
+  description = "Universal certificate validation, issuance, renewal, and expiration notices"
+  enabled     = true
+  alert_type  = "universal_ssl_event_type"
+
+  webhooks_integration {
+    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+  }
+}
+
+resource "cloudflare_notification_policy" "r2_usage" {
+  account_id  = var.cloudflare_account_id
+  name        = "R2 storage usage threshold"
+  description = "R2 billing usage exceeds the configured threshold"
+  enabled     = true
+  alert_type  = "billing_usage_alert"
+
+  filters {
+    product = ["r2_storage"]
+    limit   = ["50"]
+  }
+
+  webhooks_integration {
+    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+  }
+}

--- a/infra/scripts/doppler-terraform-env
+++ b/infra/scripts/doppler-terraform-env
@@ -45,5 +45,6 @@ set_if_unset TF_VAR_recipe_api_preview_origin_template "${RECIPE_API_PREVIEW_ORI
 set_if_unset TF_VAR_recipe_api_url "${RECIPE_API_URL:-}"
 set_if_unset TF_VAR_cf_pages_host "${CF_PAGES_HOST:-}"
 set_if_unset TF_VAR_cloudflare_pages_preview_access_application_id "${CF_PAGES_PREVIEW_ACCESS_APPLICATION_ID:-}"
+set_if_unset TF_VAR_slack_webhook_url "${CLOUDFLARE_SLACK_WEBHOOK_URL:-}"
 
 exec "$@"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -215,3 +215,14 @@ variable "neon_pg_version" {
   type        = number
   default     = 17
 }
+
+variable "slack_webhook_url" {
+  description = "Slack incoming webhook URL used by Cloudflare notification policies"
+  type        = string
+  sensitive   = true
+
+  validation {
+    condition     = can(regex("^https://hooks\\.slack\\.com/services/[^/]+/[^/]+/[^/]+$", var.slack_webhook_url))
+    error_message = "slack_webhook_url must be a Slack incoming webhook URL of the form https://hooks.slack.com/services/T.../B.../...."
+  }
+}


### PR DESCRIPTION
## Summary

Implements the Cloudflare-to-Slack complementary path from [ADR 063](https://github.com/Robbie-Palmer/personal-site/blob/main/ui/content/projects/recipe-site/adrs/063-posthog-alerting-and-slack.mdx) (its remaining checklist).

- New `infra/cloudflare_alerts.tf`: a `cloudflare_notification_policy_webhooks` Slack destination (URL/secret split per Cloudflare's Terraform guidance) plus four `cloudflare_notification_policy` resources:
  - major/critical Cloudflare incidents filtered to Pages, Workers, R2, SSL Certificate Provisioning, and Authoritative DNS
  - expiring Access service tokens
  - Universal SSL certificate events
  - R2 storage usage threshold (`limit = ["50"]`)
- Sensitive `slack_webhook_url` variable (Slack-format validation) sourced from Doppler `CLOUDFLARE_SLACK_WEBHOOK_URL` via `scripts/doppler-terraform-env` and passed as a GitHub secret in infra CI/CD.
- Docs: Doppler inventory entries and a new Cloudflare Notifications section in `infra/README.md`.

## Entitlement verification (done against the live account)

- Token: `personal-site-terraform` now has Notifications Read/Edit (write probe returns validation, not auth, errors).
- Webhook delivery: eligible (`/alerting/v3/destinations/eligible` → `webhooks: eligible, ready`) and **proven end-to-end** — Cloudflare's destination auto-test reached Slack.
- Incident, service-token, Universal SSL, and billing policies all confirmed creatable via API round-trips.
- `billing_usage_alert`: Workers/Images product strings are API-rejected; `r2_storage` works, so the policy uses R2.
- **Pages**: the API rejects every `pages_event_alert` `event` filter value (18 candidates tried), so the policy is intentionally absent and documented for one-time dashboard creation + `terraform import` (see README).

## Validation

- `mise run //infra:format:check`, `//infra:precommit-lint` (init + validate), `//infra:lint:tflint` — all pass.
- Workflow YAML parses; slack var present in CI plan and CD plan+apply env blocks.
- No secrets in the diff; webhook URL lives only in Doppler/GitHub secrets.

## QA requirements

- No preview/backend QA applies (infra-only change).
- Post-merge: verify the infra-cd plan creates the 5 resources, then Notifications → Destinations → Webhooks → **Send test** should land in `#production-alerts`.
- Follow-up (not this PR): create the Pages deployment-failure policy in the dashboard and import it per the README; then close out ADR 063's remaining checklist.