### PR TITLE
Fix project tab URLs on static exports

### DIFF
--- a/ui/app/(site)/projects/[slug]/page.tsx
+++ b/ui/app/(site)/projects/[slug]/page.tsx
@@ -148,6 +148,7 @@ export default async function ProjectPage({ params }: Readonly<PageProps>) {
         {project.adrs.length > 0 ? (
           <Suspense fallback={<ProjectTabsSkeleton />}>
             <ProjectTabs
+              projectSlug={project.slug}
               adrCount={project.adrs.length}
               overview={
                 <Markdown

--- a/ui/components/projects/project-tabs.tsx
+++ b/ui/components/projects/project-tabs.tsx
@@ -1,23 +1,24 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface ProjectTabsProps {
+  projectSlug: string;
   overview: React.ReactNode;
   adrs: React.ReactNode;
   adrCount: number;
 }
 
 export function ProjectTabs({
+  projectSlug,
   overview,
   adrs,
   adrCount,
 }: Readonly<ProjectTabsProps>) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const pathname = usePathname();
 
   const currentTab = searchParams.get("tab") || "overview";
 
@@ -26,7 +27,10 @@ export function ProjectTabs({
     params.set("tab", value);
     // Use replace to avoid filling history stack with tab changes,
     // scroll: false to maintain scroll position when switching tabs
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    router.replace(
+      `/projects/${encodeURIComponent(projectSlug)}?${params.toString()}`,
+      { scroll: false },
+    );
   };
 
   return (

--- a/ui/components/projects/projects-page-tabs.tsx
+++ b/ui/components/projects/projects-page-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 interface ProjectsPageTabsProps {
@@ -14,7 +14,6 @@ export function ProjectsPageTabs({
 }: Readonly<ProjectsPageTabsProps>) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const pathname = usePathname();
 
   const currentTab = searchParams.get("tab") || "projects";
 
@@ -23,7 +22,7 @@ export function ProjectsPageTabs({
     params.set("tab", value);
     // Use replace to avoid filling history stack with tab changes,
     // scroll: false to maintain scroll position when switching tabs
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    router.replace(`/projects?${params.toString()}`, { scroll: false });
   };
 
   return (

--- a/ui/tests/components/projects/project-tabs.test.tsx
+++ b/ui/tests/components/projects/project-tabs.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectTabs } from "@/components/projects/project-tabs";
+import { ProjectsPageTabs } from "@/components/projects/projects-page-tabs";
 
 const replaceMock = vi.fn();
 
@@ -31,6 +32,22 @@ describe("ProjectTabs", () => {
     );
 
     expect(replaceMock).toHaveBeenCalledWith("/projects/recipe-site?tab=adrs", {
+      scroll: false,
+    });
+  });
+
+  it("uses the canonical projects URL when selecting the philosophy tab", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProjectsPageTabs
+        projects={<div>Projects content</div>}
+        philosophy={<div>Philosophy content</div>}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Building Philosophy" }));
+
+    expect(replaceMock).toHaveBeenCalledWith("/projects?tab=philosophy", {
       scroll: false,
     });
   });

--- a/ui/tests/components/projects/project-tabs.test.tsx
+++ b/ui/tests/components/projects/project-tabs.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectTabs } from "@/components/projects/project-tabs";
+
+const replaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("ProjectTabs", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+  });
+
+  it("uses the canonical project URL when selecting the ADR tab", async () => {
+    const user = userEvent.setup();
+    render(
+      <ProjectTabs
+        projectSlug="recipe-site"
+        adrCount={2}
+        overview={<div>Overview content</div>}
+        adrs={<div>ADR content</div>}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("tab", { name: /Architecture Decisions/ }),
+    );
+
+    expect(replaceMock).toHaveBeenCalledWith("/projects/recipe-site?tab=adrs", {
+      scroll: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Build project tab destinations from the canonical project slug instead of the internal pathname.
- Apply the same fix to the top-level Projects tabs.
- Add regression tests for both affected tab routes.

## Why

The static export uses .txt files for React Server Component data. Reusing that internal pathname for tab navigation leaked recipe-site.txt into the visible URL.

## Validation

- mise run //ui:check
- mise run //ui:test:coverage
- 975 unit tests passed
- Both changed tab components have 100% line and branch coverage
- Production static build passed
- Browser QA confirmed that the ADR tab displays and the visible URL is /projects/recipe-site?tab=adrs

## Preview QA

1. Open /projects/recipe-site.
2. Select Architecture Decisions.
3. Confirm the ADR list appears and the URL ends with /projects/recipe-site?tab=adrs.