### PR TITLE
Bring the Pages deployment-failure notification under Terraform

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -244,46 +244,16 @@ Pages, Workers, R2, SSL, and DNS; expiring Access service tokens; Universal
 SSL certificate events; and an R2 storage usage threshold. The account's
 auto-created budget email alert remains in place.
 
-The Pages deployment-failure policy is not yet Terraform-managed: the API
-rejects every `pages_event_alert` `event` filter value, so it cannot be created
-through Terraform. To bring it under management, create it once in the
-dashboard (Notifications → Pages → project `personal-site`, production
-environment, "Deployment failed", Slack destination), then declare the resource
-in `cloudflare_alerts.tf` using the filters the created policy reports:
+All five notification policies, including Pages deployment failures, are
+Terraform-managed in `cloudflare_alerts.tf`. The Pages `event` and
+`environment` filter values use undocumented uppercase enums
+(`EVENT_DEPLOYMENT_FAILED`, `ENVIRONMENT_PRODUCTION`); the API rejects every
+other casing, so these were captured from the dashboard-created policy.
+Mechanism IDs must be passed undashed because the alerting API normalizes
+destination UUIDs, and each `webhooks_integration` block repeats the
+destination `name` so the provider's set hash matches its read-back.
 
-```bash
-curl -s "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/alerting/v3/policies" \
-  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | jq '.result[] | select(.alert_type == "pages_event_alert")'
-```
-
-```hcl
-resource "cloudflare_notification_policy" "pages_deployments" {
-  account_id  = var.cloudflare_account_id
-  name        = "Pages deployment failures"
-  description = "Failed production Pages deployments"
-  enabled     = true
-  alert_type  = "pages_event_alert"
-
-  filters {
-    project_id  = ["54cc1492-569c-4072-a77b-47520974c731"]
-    environment = ["production"]
-    event       = ["<values reported by the created policy>"]
-  }
-
-  webhooks_integration {
-    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
-  }
-}
-```
-
-Import it, then apply to confirm zero drift:
-
-```bash
-terraform import 'cloudflare_notification_policy.pages_deployments' '<account-id>/<policy-id>'
-mise run //infra:plan
-```
-
-Test the destination after applying via Notifications → Destinations →
+Test the destination after material changes via Notifications → Destinations →
 Webhooks → Send test; the message should reach `#production-alerts`.
 
 ## Neon Database

--- a/infra/cloudflare_alerts.tf
+++ b/infra/cloudflare_alerts.tf
@@ -5,8 +5,27 @@ locals {
 resource "cloudflare_notification_policy_webhooks" "slack_production_alerts" {
   account_id = var.cloudflare_account_id
   name       = "Slack #production-alerts"
-  url        = "${local.slack_webhook_parts.base}/"
+  url        = local.slack_webhook_parts.base
   secret     = local.slack_webhook_parts.secret
+}
+
+resource "cloudflare_notification_policy" "pages_deployments" {
+  account_id  = var.cloudflare_account_id
+  name        = "Pages deployment failures"
+  description = "Failed production Pages deployments"
+  enabled     = true
+  alert_type  = "pages_event_alert"
+
+  filters {
+    project_id  = ["54cc1492-569c-4072-a77b-47520974c731"]
+    environment = ["ENVIRONMENT_PRODUCTION"]
+    event       = ["EVENT_DEPLOYMENT_FAILED"]
+  }
+
+  webhooks_integration {
+    id   = replace(cloudflare_notification_policy_webhooks.slack_production_alerts.id, "-", "")
+    name = cloudflare_notification_policy_webhooks.slack_production_alerts.name
+  }
 }
 
 resource "cloudflare_notification_policy" "cloudflare_incidents" {
@@ -22,7 +41,8 @@ resource "cloudflare_notification_policy" "cloudflare_incidents" {
   }
 
   webhooks_integration {
-    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+    id   = replace(cloudflare_notification_policy_webhooks.slack_production_alerts.id, "-", "")
+    name = cloudflare_notification_policy_webhooks.slack_production_alerts.name
   }
 }
 
@@ -34,7 +54,8 @@ resource "cloudflare_notification_policy" "expiring_service_tokens" {
   alert_type  = "expiring_service_token_alert"
 
   webhooks_integration {
-    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+    id   = replace(cloudflare_notification_policy_webhooks.slack_production_alerts.id, "-", "")
+    name = cloudflare_notification_policy_webhooks.slack_production_alerts.name
   }
 }
 
@@ -46,7 +67,8 @@ resource "cloudflare_notification_policy" "universal_ssl_events" {
   alert_type  = "universal_ssl_event_type"
 
   webhooks_integration {
-    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+    id   = replace(cloudflare_notification_policy_webhooks.slack_production_alerts.id, "-", "")
+    name = cloudflare_notification_policy_webhooks.slack_production_alerts.name
   }
 }
 
@@ -63,6 +85,7 @@ resource "cloudflare_notification_policy" "r2_usage" {
   }
 
   webhooks_integration {
-    id = cloudflare_notification_policy_webhooks.slack_production_alerts.id
+    id   = replace(cloudflare_notification_policy_webhooks.slack_production_alerts.id, "-", "")
+    name = cloudflare_notification_policy_webhooks.slack_production_alerts.name
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1120. The Pages deployment-failure policy was created once in the dashboard (the API rejects every lowercase `event` value) and is now:

- declared in `infra/cloudflare_alerts.tf` with the discovered uppercase enums (`EVENT_DEPLOYMENT_FAILED`, `ENVIRONMENT_PRODUCTION`)
- imported into Terraform Cloud state
- fixed for perpetual drift: mechanism IDs are passed undashed (the alerting API normalizes destination UUIDs) and the destination `name` is repeated in each `webhooks_integration` block so the provider's set hash matches its read-back

`terraform plan` now reports **No changes. Your infrastructure matches the configuration.**

## Validation

- Local plan after import + apply: no changes (verified post-apply too)
- `mise run //infra:format:check` and `//infra:lint:tflint` pass
- README updated: the import walkthrough is replaced with the settled state plus the enum/dash-hash gotchas

## QA requirements

- Infra-only; no preview/backend QA. CI's terraform plan should show no changes.