### PR TITLE
docs(security): add SECURITY.md pointing at private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through
+[GitHub's private vulnerability reporting](https://github.com/Robbie-Palmer/personal-site/security/advisories/new).
+
+Do not open a public issue for anything you believe has a security impact.


### PR DESCRIPTION
## Summary

- Adds a `SECURITY.md` at the repo root that directs vulnerability reports to GitHub's private vulnerability reporting feature, with a note not to open public issues.

## Why

The OSSF Scorecard `Security-Policy` check only looks for a `SECURITY.md` file (root, `docs/`, or `.github/`) and cannot detect that private vulnerability reporting is already enabled. This file satisfies the check while routing reporters to the same private channel.