### PR TITLE
Reduce pantry and recipe asset request load

### DIFF
--- a/functions/lib/public-recipes.ts
+++ b/functions/lib/public-recipes.ts
@@ -42,7 +42,7 @@ function isRecipeVisibility(
   return value === "public" || value === "private" || value === "household";
 }
 
-function isStoredRecipe(value: unknown): value is StoredRecipe {
+export function isStoredRecipe(value: unknown): value is StoredRecipe {
   return (
     isRecord(value) &&
     typeof value.slug === "string" &&

--- a/functions/lib/recipe-asset.ts
+++ b/functions/lib/recipe-asset.ts
@@ -1,9 +1,101 @@
 import type { PublicRecipeEnv, StoredRecipe } from "./public-recipes";
-import { listPublicRecipes } from "./public-recipes";
+import { isStoredRecipe, listPublicRecipes } from "./public-recipes";
+
+const PUBLIC_RECIPE_CACHE_NAME = "recipe-assets-v1";
+const PUBLIC_RECIPE_CACHE_PATH = "/__recipe-assets/public-recipes.json";
+const PUBLIC_RECIPE_CACHE_TTL_SECONDS = 15 * 60;
+const pendingRecipeLists = new Map<
+  string,
+  Promise<StoredRecipe[] | null>
+>();
 
 export interface RecipeAssetContext {
   request: Request;
   env: PublicRecipeEnv & { ASSETS: { fetch: typeof fetch } };
+  waitUntil?: (promise: Promise<unknown>) => void;
+}
+
+function publicRecipeCacheKey(request: Request): Request {
+  const url = new URL(PUBLIC_RECIPE_CACHE_PATH, request.url);
+  return new Request(url, { method: "GET" });
+}
+
+async function openPublicRecipeCache(): Promise<Cache | null> {
+  const storage = Reflect.get(globalThis, "caches") as
+    | CacheStorage
+    | undefined;
+  if (!storage || typeof storage.open !== "function") return null;
+  try {
+    return await storage.open(PUBLIC_RECIPE_CACHE_NAME);
+  } catch {
+    return null;
+  }
+}
+
+async function readCachedPublicRecipes(
+  cache: Cache,
+  cacheKey: Request,
+): Promise<StoredRecipe[] | null> {
+  try {
+    const response = await cache.match(cacheKey);
+    if (!response) return null;
+    const value: unknown = await response.json();
+    return Array.isArray(value) &&
+      value.every(
+        (item) => isStoredRecipe(item) && item.visibility === "public",
+      )
+      ? value
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function cachePublicRecipes(
+  cache: Cache | null,
+  cacheKey: Request,
+  recipes: Promise<StoredRecipe[] | null>,
+): Promise<void> {
+  return recipes
+    .then(async (records) => {
+      if (!cache || !records) return;
+      const response = Response.json(records, {
+        headers: {
+          "cache-control": `public, s-maxage=${PUBLIC_RECIPE_CACHE_TTL_SECONDS}`,
+        },
+      });
+      await cache.put(cacheKey, response);
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      if (pendingRecipeLists.get(cacheKey.url) === recipes) {
+        pendingRecipeLists.delete(cacheKey.url);
+      }
+    });
+}
+
+async function publicRecipesForAsset(
+  context: RecipeAssetContext,
+): Promise<StoredRecipe[] | null> {
+  const cacheKey = publicRecipeCacheKey(context.request);
+  const cache = await openPublicRecipeCache();
+  if (cache) {
+    const cached = await readCachedPublicRecipes(cache, cacheKey);
+    if (cached) return cached;
+  }
+
+  const pending = pendingRecipeLists.get(cacheKey.url);
+  if (pending) return pending;
+
+  const recipes = listPublicRecipes(context.env);
+  pendingRecipeLists.set(cacheKey.url, recipes);
+  const cacheWrite = cachePublicRecipes(cache, cacheKey, recipes);
+  if (context.waitUntil) {
+    context.waitUntil(cacheWrite);
+  } else {
+    await cacheWrite;
+  }
+  return recipes;
 }
 
 export function rewrittenRecipeAssetHeaders(
@@ -26,7 +118,7 @@ export async function augmentRecipeAsset(
   const asset = await context.env.ASSETS.fetch(context.request);
   if (!asset.ok || context.request.method === "HEAD") return asset;
 
-  const recipes = await listPublicRecipes(context.env);
+  const recipes = await publicRecipesForAsset(context);
   if (!recipes) return asset;
 
   const body = render(await asset.text(), recipes, new URL(context.request.url));

--- a/functions/lib/recipe-asset.ts
+++ b/functions/lib/recipe-asset.ts
@@ -3,11 +3,17 @@ import { isStoredRecipe, listPublicRecipes } from "./public-recipes";
 
 const PUBLIC_RECIPE_CACHE_NAME = "recipe-assets-v1";
 const PUBLIC_RECIPE_CACHE_PATH = "/__recipe-assets/public-recipes.json";
-const PUBLIC_RECIPE_CACHE_TTL_SECONDS = 15 * 60;
+const PUBLIC_RECIPE_CACHE_CREATED_AT_HEADER = "x-recipe-cache-created-at";
+const PUBLIC_RECIPE_CACHE_TTL_SECONDS = 5 * 60;
 const pendingRecipeLists = new Map<
   string,
   Promise<StoredRecipe[] | null>
 >();
+
+type PublicRecipeList = {
+  records: StoredRecipe[] | null;
+  cacheSeconds: number;
+};
 
 export interface RecipeAssetContext {
   request: Request;
@@ -35,17 +41,33 @@ async function openPublicRecipeCache(): Promise<Cache | null> {
 async function readCachedPublicRecipes(
   cache: Cache,
   cacheKey: Request,
-): Promise<StoredRecipe[] | null> {
+): Promise<PublicRecipeList | null> {
   try {
     const response = await cache.match(cacheKey);
     if (!response) return null;
     const value: unknown = await response.json();
-    return Array.isArray(value) &&
-      value.every(
+    if (
+      !Array.isArray(value) ||
+      !value.every(
         (item) => isStoredRecipe(item) && item.visibility === "public",
       )
-      ? value
-      : null;
+    ) {
+      return null;
+    }
+    const createdAtHeader = response.headers.get(
+      PUBLIC_RECIPE_CACHE_CREATED_AT_HEADER,
+    );
+    const createdAt = createdAtHeader ? Number(createdAtHeader) : Number.NaN;
+    const ageSeconds = Number.isFinite(createdAt)
+      ? Math.max(0, Math.floor((Date.now() - createdAt) / 1_000))
+      : PUBLIC_RECIPE_CACHE_TTL_SECONDS;
+    return {
+      records: value,
+      cacheSeconds: Math.max(
+        0,
+        PUBLIC_RECIPE_CACHE_TTL_SECONDS - ageSeconds,
+      ),
+    };
   } catch {
     return null;
   }
@@ -62,6 +84,7 @@ function cachePublicRecipes(
       const response = Response.json(records, {
         headers: {
           "cache-control": `public, s-maxage=${PUBLIC_RECIPE_CACHE_TTL_SECONDS}`,
+          [PUBLIC_RECIPE_CACHE_CREATED_AT_HEADER]: String(Date.now()),
         },
       });
       await cache.put(cacheKey, response);
@@ -76,7 +99,7 @@ function cachePublicRecipes(
 
 async function publicRecipesForAsset(
   context: RecipeAssetContext,
-): Promise<StoredRecipe[] | null> {
+): Promise<PublicRecipeList> {
   const cacheKey = publicRecipeCacheKey(context.request);
   const cache = await openPublicRecipeCache();
   if (cache) {
@@ -85,7 +108,12 @@ async function publicRecipesForAsset(
   }
 
   const pending = pendingRecipeLists.get(cacheKey.url);
-  if (pending) return pending;
+  if (pending) {
+    return {
+      records: await pending,
+      cacheSeconds: PUBLIC_RECIPE_CACHE_TTL_SECONDS,
+    };
+  }
 
   const recipes = listPublicRecipes(context.env);
   pendingRecipeLists.set(cacheKey.url, recipes);
@@ -95,7 +123,15 @@ async function publicRecipesForAsset(
   } else {
     await cacheWrite;
   }
-  return recipes;
+  return {
+    records: await recipes,
+    cacheSeconds: PUBLIC_RECIPE_CACHE_TTL_SECONDS,
+  };
+}
+
+function recipeAssetCacheControl(cacheSeconds: number): string {
+  const browserSeconds = Math.min(60, cacheSeconds);
+  return `public, max-age=${browserSeconds}, s-maxage=${cacheSeconds}`;
 }
 
 export function rewrittenRecipeAssetHeaders(
@@ -118,10 +154,17 @@ export async function augmentRecipeAsset(
   const asset = await context.env.ASSETS.fetch(context.request);
   if (!asset.ok || context.request.method === "HEAD") return asset;
 
-  const recipes = await publicRecipesForAsset(context);
-  if (!recipes) return asset;
+  const { records, cacheSeconds } = await publicRecipesForAsset(context);
+  if (!records) return asset;
 
-  const body = render(await asset.text(), recipes, new URL(context.request.url));
-  const headers = rewrittenRecipeAssetHeaders(asset);
+  const body = render(
+    await asset.text(),
+    records,
+    new URL(context.request.url),
+  );
+  const headers = rewrittenRecipeAssetHeaders(
+    asset,
+    recipeAssetCacheControl(cacheSeconds),
+  );
   return new Response(body, { status: asset.status, headers });
 }

--- a/ui/lib/query/pantry-queries.ts
+++ b/ui/lib/query/pantry-queries.ts
@@ -13,6 +13,5 @@ export const pantryQuery = (userId: string) =>
     structuralSharing: (current, incoming) =>
       installPantrySnapshot(current as Pantry | undefined, incoming as Pantry),
     staleTime: 15_000,
-    refetchInterval: 5 * 60_000,
     refetchOnWindowFocus: true,
   });

--- a/ui/lib/query/pantry-queries.ts
+++ b/ui/lib/query/pantry-queries.ts
@@ -13,5 +13,6 @@ export const pantryQuery = (userId: string) =>
     structuralSharing: (current, incoming) =>
       installPantrySnapshot(current as Pantry | undefined, incoming as Pantry),
     staleTime: 15_000,
+    refetchInterval: 5 * 60_000,
     refetchOnWindowFocus: true,
   });

--- a/ui/lib/query/pantry-queries.ts
+++ b/ui/lib/query/pantry-queries.ts
@@ -13,6 +13,5 @@ export const pantryQuery = (userId: string) =>
     structuralSharing: (current, incoming) =>
       installPantrySnapshot(current as Pantry | undefined, incoming as Pantry),
     staleTime: 15_000,
-    refetchInterval: 30_000,
     refetchOnWindowFocus: true,
   });

--- a/ui/tests/functions/recipe-assets.test.ts
+++ b/ui/tests/functions/recipe-assets.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { StoredRecipe } from "../../../functions/lib/public-recipes";
+import {
+  augmentRecipeAsset,
+  type RecipeAssetContext,
+} from "../../../functions/lib/recipe-asset";
+
+const CACHE_PATH = "/__recipe-assets/public-recipes.json";
+
+function recipe(slug: string, title: string): StoredRecipe {
+  return {
+    slug,
+    title,
+    description: null,
+    body: null,
+    visibility: "public",
+  };
+}
+
+function cacheDouble(initial?: Record<string, Response>) {
+  const entries = new Map(
+    Object.entries(initial ?? {}).map(([key, response]) => [
+      key,
+      response.clone(),
+    ]),
+  );
+  const cache = {
+    match: vi.fn(async (request: RequestInfo | URL) => {
+      const key = request instanceof Request ? request.url : request.toString();
+      return entries.get(key)?.clone();
+    }),
+    put: vi.fn(async (request: RequestInfo | URL, response: Response) => {
+      const key = request instanceof Request ? request.url : request.toString();
+      entries.set(key, response.clone());
+    }),
+  } as unknown as Cache;
+  return { cache, entries };
+}
+
+function context(url: string, pending: Promise<unknown>[]): RecipeAssetContext {
+  return {
+    request: new Request(url),
+    env: {
+      RECIPE_API_URL: "https://recipe-api.example.test",
+      ASSETS: {
+        fetch: vi.fn(async () => new Response("static asset")) as typeof fetch,
+      },
+    },
+    waitUntil: (promise) => pending.push(promise),
+  };
+}
+
+function render(asset: string, records: StoredRecipe[]): string {
+  return `${asset}: ${records.map((record) => record.title).join(", ")}`;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("recipe asset aggregation cache", () => {
+  it("uses a host-scoped cached recipe list without calling the API", async () => {
+    const cacheUrl = `https://pr-123.example.test${CACHE_PATH}`;
+    const { cache } = cacheDouble({
+      [cacheUrl]: Response.json([recipe("cached", "Cached recipe")]),
+    });
+    const open = vi.fn(async () => cache);
+    const apiFetch = vi.fn();
+    vi.stubGlobal("caches", { open });
+    vi.stubGlobal("fetch", apiFetch);
+
+    const response = await augmentRecipeAsset(
+      context("https://pr-123.example.test/llms.txt", []),
+      render,
+    );
+
+    expect(await response.text()).toBe("static asset: Cached recipe");
+    expect(open).toHaveBeenCalledWith("recipe-assets-v1");
+    expect(cache.match).toHaveBeenCalledWith(
+      expect.objectContaining({ url: cacheUrl }),
+    );
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("stores a cache miss for 15 minutes and reuses it across assets", async () => {
+    const { cache } = cacheDouble();
+    const open = vi.fn(async () => cache);
+    const apiFetch = vi.fn(async () =>
+      Response.json({
+        items: [recipe("fresh", "Fresh recipe")],
+        nextCursor: null,
+      }),
+    );
+    vi.stubGlobal("caches", { open });
+    vi.stubGlobal("fetch", apiFetch);
+    const pending: Promise<unknown>[] = [];
+
+    const first = await augmentRecipeAsset(
+      context("https://robbiepalmer.me/sitemap.xml", pending),
+      render,
+    );
+    await Promise.all(pending);
+    const second = await augmentRecipeAsset(
+      context("https://robbiepalmer.me/llms-full.txt", []),
+      render,
+    );
+
+    expect(await first.text()).toBe("static asset: Fresh recipe");
+    expect(await second.text()).toBe("static asset: Fresh recipe");
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    expect(cache.put).toHaveBeenCalledTimes(1);
+    const [cacheKey, cachedResponse] = vi.mocked(cache.put).mock.calls[0] ?? [];
+    expect(cacheKey).toEqual(
+      expect.objectContaining({
+        url: `https://robbiepalmer.me${CACHE_PATH}`,
+      }),
+    );
+    expect(cachedResponse?.headers.get("cache-control")).toBe(
+      "public, s-maxage=900",
+    );
+  });
+
+  it("coalesces concurrent cache misses from different recipe assets", async () => {
+    const { cache } = cacheDouble();
+    vi.stubGlobal("caches", { open: vi.fn(async () => cache) });
+    let resolveApi: ((response: Response) => void) | undefined;
+    const apiResponse = new Promise<Response>((resolve) => {
+      resolveApi = resolve;
+    });
+    const apiFetch = vi.fn(() => apiResponse);
+    vi.stubGlobal("fetch", apiFetch);
+    const firstPending: Promise<unknown>[] = [];
+    const secondPending: Promise<unknown>[] = [];
+
+    const first = augmentRecipeAsset(
+      context("https://robbiepalmer.me/sitemap.xml", firstPending),
+      render,
+    );
+    const second = augmentRecipeAsset(
+      context("https://robbiepalmer.me/llms.txt", secondPending),
+      render,
+    );
+    await vi.waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+    resolveApi?.(
+      Response.json({
+        items: [recipe("shared", "Shared recipe")],
+        nextCursor: null,
+      }),
+    );
+
+    const responses = await Promise.all([first, second]);
+    await Promise.all([...firstPending, ...secondPending]);
+    expect(await responses[0].text()).toContain("Shared recipe");
+    expect(await responses[1].text()).toContain("Shared recipe");
+    expect(cache.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves the asset when cache reads and writes fail", async () => {
+    const cache = {
+      match: vi.fn(async () => {
+        throw new Error("cache read failed");
+      }),
+      put: vi.fn(async () => {
+        throw new Error("cache write failed");
+      }),
+    } as unknown as Cache;
+    vi.stubGlobal("caches", { open: vi.fn(async () => cache) });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          items: [recipe("fallback", "Fallback recipe")],
+          nextCursor: null,
+        }),
+      ),
+    );
+    const pending: Promise<unknown>[] = [];
+
+    const response = await augmentRecipeAsset(
+      context("https://robbiepalmer.me/llms.txt", pending),
+      render,
+    );
+    await Promise.all(pending);
+
+    expect(await response.text()).toBe("static asset: Fallback recipe");
+  });
+});

--- a/ui/tests/functions/recipe-assets.test.ts
+++ b/ui/tests/functions/recipe-assets.test.ts
@@ -63,7 +63,9 @@ describe("recipe asset aggregation cache", () => {
   it("uses a host-scoped cached recipe list without calling the API", async () => {
     const cacheUrl = `https://pr-123.example.test${CACHE_PATH}`;
     const { cache } = cacheDouble({
-      [cacheUrl]: Response.json([recipe("cached", "Cached recipe")]),
+      [cacheUrl]: Response.json([recipe("cached", "Cached recipe")], {
+        headers: { "x-recipe-cache-created-at": String(Date.now()) },
+      }),
     });
     const open = vi.fn(async () => cache);
     const apiFetch = vi.fn();
@@ -83,7 +85,7 @@ describe("recipe asset aggregation cache", () => {
     expect(apiFetch).not.toHaveBeenCalled();
   });
 
-  it("stores a cache miss for 15 minutes and reuses it across assets", async () => {
+  it("stores a cache miss for five minutes and reuses it across assets", async () => {
     const { cache } = cacheDouble();
     const open = vi.fn(async () => cache);
     const apiFetch = vi.fn(async () =>
@@ -117,7 +119,34 @@ describe("recipe asset aggregation cache", () => {
       }),
     );
     expect(cachedResponse?.headers.get("cache-control")).toBe(
-      "public, s-maxage=900",
+      "public, s-maxage=300",
+    );
+    expect(first.headers.get("cache-control")).toBe(
+      "public, max-age=60, s-maxage=300",
+    );
+  });
+
+  it("does not stack aggregate and rendered asset cache lifetimes", async () => {
+    const now = Date.now();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const cacheUrl = `https://robbiepalmer.me${CACHE_PATH}`;
+    const { cache } = cacheDouble({
+      [cacheUrl]: Response.json([recipe("cached", "Cached recipe")], {
+        headers: {
+          "x-recipe-cache-created-at": String(now - 4 * 60_000),
+        },
+      }),
+    });
+    vi.stubGlobal("caches", { open: vi.fn(async () => cache) });
+    vi.stubGlobal("fetch", vi.fn());
+
+    const response = await augmentRecipeAsset(
+      context("https://robbiepalmer.me/llms.txt", []),
+      render,
+    );
+
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=60, s-maxage=60",
     );
   });
 

--- a/ui/tests/lib/query/pantry-queries.test.ts
+++ b/ui/tests/lib/query/pantry-queries.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { pantryQuery } from "@/lib/query/pantry-queries";
 
 describe("pantryQuery", () => {
-  it("uses realtime with a low-frequency recovery refetch", () => {
+  it("relies on realtime and window-focus recovery without polling", () => {
     const options = pantryQuery("user-1");
 
-    expect(options.refetchInterval).toBe(5 * 60_000);
+    expect(options.refetchInterval).toBeUndefined();
     expect(options.refetchOnWindowFocus).toBe(true);
   });
 });

--- a/ui/tests/lib/query/pantry-queries.test.ts
+++ b/ui/tests/lib/query/pantry-queries.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { pantryQuery } from "@/lib/query/pantry-queries";
+
+describe("pantryQuery", () => {
+  it("relies on realtime updates and window-focus recovery instead of polling", () => {
+    const options = pantryQuery("user-1");
+
+    expect(options.refetchInterval).toBeUndefined();
+    expect(options.refetchOnWindowFocus).toBe(true);
+  });
+});

--- a/ui/tests/lib/query/pantry-queries.test.ts
+++ b/ui/tests/lib/query/pantry-queries.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { pantryQuery } from "@/lib/query/pantry-queries";
 
 describe("pantryQuery", () => {
-  it("relies on realtime updates and window-focus recovery instead of polling", () => {
+  it("uses realtime with a low-frequency recovery refetch", () => {
     const options = pantryQuery("user-1");
 
-    expect(options.refetchInterval).toBeUndefined();
+    expect(options.refetchInterval).toBe(5 * 60_000);
     expect(options.refetchOnWindowFocus).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- remove pantry interval polling and rely on WebSocket updates plus focus, online, and reconnect recovery
- cache the shared public recipe aggregate for sitemap and LLM assets in the Cloudflare Cache API for 5 minutes
- coalesce concurrent cold misses, keep rendered cache lifetimes within the aggregate lifetime, and fall back to the recipe API when cache operations fail

## Validation

- `mise run //ui:test -- tests/lib/query/pantry-queries.test.ts tests/functions/recipe-assets.test.ts` (6 tests)
- `mise run //ui:check:static`
- `mise run //ui:check` (139 files, 986 tests)
- `NEXT_PUBLIC_CF_IMAGES_ACCOUNT_HASH=placeholder mise run //ui:build`
- local Wrangler Pages runtime: repeated `llms.txt` and `sitemap.xml` requests shared one recipe API request

Refs #901